### PR TITLE
feat: add capability-scoped Lua agent workflows

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	workflowpkg "github.com/samsaffron/term-llm/internal/workflow"
+	"github.com/spf13/cobra"
+)
+
+var (
+	workflowRunInputs        []string
+	workflowRunInputJSON     string
+	workflowRunAgent         string
+	workflowRunProvider      string
+	workflowRunConcurrency   int
+	workflowRunAgentTimeout  time.Duration
+	workflowRunTimeout       time.Duration
+	workflowRunJSON          bool
+	workflowRunAgentTools    []string
+	workflowRunAgentRead     []string
+	workflowRunAgentWrite    []string
+	workflowRunAgentShell    []string
+	workflowRunWorkspaceRoot []string
+	workflowValidateJSON     bool
+)
+
+var workflowCmd = &cobra.Command{
+	Use:   "workflow",
+	Short: "Run capability-scoped Lua workflows",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
+}
+
+var workflowRunCmd = &cobra.Command{
+	Use:   "run <path.lua>",
+	Short: "Run one explicit Lua workflow file",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWorkflow,
+}
+
+var workflowValidateCmd = &cobra.Command{
+	Use:   "validate <path.lua>",
+	Short: "Validate workflow syntax and metadata without executing it",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWorkflowValidate,
+}
+
+func init() {
+	workflowRunCmd.Flags().StringArrayVar(&workflowRunInputs, "input", nil, "Workflow input as key=value (repeatable)")
+	workflowRunCmd.Flags().StringVar(&workflowRunInputJSON, "input-json", "", "Workflow inputs as a JSON object")
+	workflowRunCmd.Flags().StringVar(&workflowRunAgent, "agent", "", "Override the agent for every agent task")
+	workflowRunCmd.Flags().StringVar(&workflowRunProvider, "provider", "", "Override the provider for every agent task")
+	workflowRunCmd.Flags().IntVar(&workflowRunConcurrency, "concurrency", 4, "Maximum concurrent agent tasks")
+	workflowRunCmd.Flags().DurationVar(&workflowRunAgentTimeout, "agent-timeout", 5*time.Minute, "Maximum duration of each agent task")
+	workflowRunCmd.Flags().DurationVar(&workflowRunTimeout, "timeout", 30*time.Minute, "Maximum duration of the whole workflow")
+	workflowRunCmd.Flags().StringSliceVar(&workflowRunAgentTools, "agent-tool", nil, "Tool capability ceiling for dynamic run_agent tasks")
+	workflowRunCmd.Flags().StringSliceVar(&workflowRunAgentRead, "agent-read-dir", nil, "Read-directory capability ceiling for dynamic run_agent tasks")
+	workflowRunCmd.Flags().StringSliceVar(&workflowRunAgentWrite, "agent-write-dir", nil, "Write-directory capability ceiling for dynamic run_agent tasks")
+	workflowRunCmd.Flags().StringSliceVar(&workflowRunAgentShell, "agent-shell-allow", nil, "Shell pattern capability ceiling for dynamic run_agent tasks")
+	workflowRunCmd.Flags().StringSliceVar(&workflowRunWorkspaceRoot, "workspace-root", nil, "Destination root ceiling for create_workspace")
+	workflowRunCmd.Flags().BoolVar(&workflowRunJSON, "json", false, "Print the full workflow result as JSON")
+	workflowValidateCmd.Flags().BoolVar(&workflowValidateJSON, "json", false, "Print metadata as JSON")
+	workflowCmd.AddCommand(workflowRunCmd, workflowValidateCmd)
+	rootCmd.AddCommand(workflowCmd)
+}
+
+type workflowRunOutput struct {
+	Name       string `json:"name"`
+	SourcePath string `json:"source_path"`
+	SHA256     string `json:"source_sha256"`
+	DurationMS int64  `json:"duration_ms"`
+	Result     any    `json:"result"`
+}
+
+func runWorkflowValidate(cmd *cobra.Command, args []string) error {
+	definition, err := workflowpkg.ParseDefinitionFile(args[0])
+	if err != nil {
+		return err
+	}
+	if workflowValidateJSON {
+		return writeWorkflowJSON(cmd, definition)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s: valid (%s)\n", definition.Name, definition.SHA256)
+	return nil
+}
+
+func runWorkflow(cmd *cobra.Command, args []string) error {
+	if workflowRunConcurrency < 1 {
+		return fmt.Errorf("--concurrency must be at least 1")
+	}
+	if workflowRunAgentTimeout <= 0 {
+		return fmt.Errorf("--agent-timeout must be greater than zero")
+	}
+	if workflowRunTimeout <= 0 {
+		return fmt.Errorf("--timeout must be greater than zero")
+	}
+	inputs, err := parseWorkflowInputs(workflowRunInputJSON, workflowRunInputs)
+	if err != nil {
+		return err
+	}
+	path, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("resolve workflow path: %w", err)
+	}
+	definition, err := workflowpkg.ParseDefinitionFile(path)
+	if err != nil {
+		return err
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve term-llm executable: %w", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve workflow CWD: %w", err)
+	}
+	engine := workflowpkg.Engine{Executor: workflowpkg.CommandExecutor{Executable: executable}}
+	runCtx, cancel := context.WithTimeout(cmd.Context(), workflowRunTimeout)
+	defer cancel()
+	started := time.Now()
+	result, err := engine.Execute(runCtx, definition.Source, workflowpkg.ExecuteOptions{
+		Inputs:           inputs,
+		Agent:            workflowRunAgent,
+		Provider:         workflowRunProvider,
+		Concurrency:      workflowRunConcurrency,
+		AgentTimeout:     workflowRunAgentTimeout,
+		CWD:              cwd,
+		AllowedTools:     workflowRunAgentTools,
+		AllowedRead:      workflowRunAgentRead,
+		AllowedWrite:     workflowRunAgentWrite,
+		AllowedShell:     workflowRunAgentShell,
+		AllowedWorkspace: workflowRunWorkspaceRoot,
+	})
+	if err != nil {
+		return err
+	}
+	output := workflowRunOutput{
+		Name:       definition.Name,
+		SourcePath: definition.Path,
+		SHA256:     definition.SHA256,
+		DurationMS: time.Since(started).Milliseconds(),
+		Result:     result,
+	}
+	if workflowRunJSON {
+		return writeWorkflowJSON(cmd, output)
+	}
+	if text, ok := result.(string); ok {
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), text)
+		return err
+	}
+	return writeWorkflowJSON(cmd, output)
+}
+
+func parseWorkflowInputs(inputJSON string, pairs []string) (map[string]any, error) {
+	inputs := make(map[string]any)
+	if strings.TrimSpace(inputJSON) != "" {
+		decoder := json.NewDecoder(strings.NewReader(inputJSON))
+		if err := decoder.Decode(&inputs); err != nil {
+			return nil, fmt.Errorf("parse --input-json: %w", err)
+		}
+		var trailing any
+		if err := decoder.Decode(&trailing); err != io.EOF {
+			if err == nil {
+				return nil, fmt.Errorf("parse --input-json: trailing JSON value")
+			}
+			return nil, fmt.Errorf("parse --input-json: %w", err)
+		}
+		if inputs == nil {
+			inputs = make(map[string]any)
+		}
+	}
+	for _, pair := range pairs {
+		key, value, ok := strings.Cut(pair, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid --input %q (expected key=value)", pair)
+		}
+		inputs[key] = value
+	}
+	return inputs, nil
+}
+
+func writeWorkflowJSON(cmd *cobra.Command, value any) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(value)
+}

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkflowCommandsAndCapabilityFlagsAreRegistered(t *testing.T) {
+	if workflowCmd.Commands()[0] == nil || workflowRunCmd == nil || workflowValidateCmd == nil {
+		t.Fatal("workflow commands are not registered")
+	}
+	for _, name := range []string{"input", "input-json", "agent", "provider", "concurrency", "agent-timeout", "timeout", "agent-tool", "agent-read-dir", "agent-write-dir", "agent-shell-allow", "workspace-root", "json"} {
+		if workflowRunCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("workflow run flag --%s is not registered", name)
+		}
+	}
+	if rootCmd.PersistentFlags().Lookup("workflow-db") != nil || rootCmd.PersistentFlags().Lookup("workflow-dir") != nil {
+		t.Fatal("minimal workflow command must not register persistence flags")
+	}
+}
+
+func TestParseWorkflowInputsMergesJSONAndRepeatablePairs(t *testing.T) {
+	inputs, err := parseWorkflowInputs(`{"topic":"old","count":2,"nested":{"ok":true}}`, []string{"topic=new", "empty="})
+	if err != nil {
+		t.Fatalf("parseWorkflowInputs: %v", err)
+	}
+	if inputs["topic"] != "new" || inputs["empty"] != "" || inputs["count"] != float64(2) {
+		t.Fatalf("inputs = %#v", inputs)
+	}
+	if _, err := parseWorkflowInputs(`{"ok":true} {"extra":true}`, nil); err == nil {
+		t.Fatal("parseWorkflowInputs accepted trailing JSON")
+	}
+	if _, err := parseWorkflowInputs("", []string{"missing-separator"}); err == nil {
+		t.Fatal("parseWorkflowInputs accepted malformed key=value")
+	}
+}
+
+func TestWorkflowValidateReadsExplicitFileWithoutExecutingBody(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "review.lua")
+	source := `workflow { name = "review", description = "test" }
+error("must not execute")
+`
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	oldJSON := workflowValidateJSON
+	workflowValidateJSON = false
+	t.Cleanup(func() { workflowValidateJSON = oldJSON })
+	oldOutput := workflowValidateCmd.OutOrStdout()
+	workflowValidateCmd.SetOut(&output)
+	t.Cleanup(func() { workflowValidateCmd.SetOut(oldOutput) })
+	if err := runWorkflowValidate(workflowValidateCmd, []string{path}); err != nil {
+		t.Fatalf("runWorkflowValidate: %v", err)
+	}
+	if !strings.Contains(output.String(), "review: valid") {
+		t.Fatalf("output = %q", output.String())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/yuin/goldmark v1.8.2
+	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.39.0
 	golang.org/x/net v0.53.0
 	golang.org/x/sys v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT0
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/workflow/README.md
+++ b/internal/workflow/README.md
@@ -1,0 +1,118 @@
+# Lua workflows
+
+`term-llm workflow` runs an explicit Lua file as a temporary team of agents. It
+is deliberately a small orchestration surface, not a workflow database or
+scheduler: files live in Git, runs live in the invoking process, and a stopped
+process is not resumed.
+
+## Example
+
+```lua
+workflow {
+  name = "regression-review",
+  description = "Ask isolated specialists for executable evidence",
+  inputs = { source = "Source tree to review" },
+}
+
+local source = input("source")
+local workspace = create_workspace {
+  source = source,
+  root = "/tmp/term-llm-workflows",
+  name = "concurrency-review",
+}
+
+local results = parallel_settled {
+  run_agent {
+    label = "race-reviewer",
+    system = "Find one concurrency bug and prove it with a regression test.",
+    prompt = "Inspect the package in your current directory.",
+    tools = { "read_file", "write_file", "shell" },
+    read_dirs = { workspace },
+    write_dirs = { workspace },
+    shell_allow = { "go test *", "gofmt *" },
+    cwd = workspace,
+    max_turns = 12,
+    require = {
+      command = "go test -race .",
+      exit_code = 1,
+      repetitions = 3,
+      output_contains = "FAIL",
+      artifact_glob = "*_test.go",
+    },
+  },
+}
+
+return results
+```
+
+The invocation grants the maximum capabilities the Lua file may use:
+
+```sh
+term-llm workflow validate review.lua
+
+term-llm workflow run review.lua \
+  --input source="$PWD" \
+  --workspace-root /tmp/term-llm-workflows \
+  --agent-tool read_file,write_file,shell \
+  --agent-read-dir /tmp/term-llm-workflows \
+  --agent-write-dir /tmp/term-llm-workflows \
+  --agent-shell-allow 'go test *' \
+  --agent-shell-allow 'gofmt *' \
+  --concurrency 4 \
+  --json
+```
+
+## Lua surface
+
+- `workflow { name=..., description=..., inputs={...}, phases={...} }` declares
+  metadata. `workflow` must be the first statement.
+- `input(name[, default])` reads an input supplied by `--input` or
+  `--input-json`.
+- `agent { prompt=..., agent=..., provider=..., label=... }` creates a lazy,
+  one-shot model task.
+- `run_agent { ... }` creates a lazy tool-using agent. It accepts `system`,
+  `prompt`, `agent`, `provider`, `label`, `tools`, `read_dirs`, `write_dirs`,
+  `shell_allow`, `cwd`, `max_turns`, and `require`.
+- `create_workspace { source=..., root=..., name=... }` copies a source tree to
+  an authorized destination and returns its path.
+- `await(task)` executes one lazy task.
+- `parallel { task, ... }` executes tasks with bounded concurrency, preserves
+  input order, and fails when any task fails.
+- `parallel_settled { task, ... }` preserves every outcome as
+  `{ ok, result, error }`.
+- `join(values, separator)` joins task output for simple reductions.
+- The top-level returned Lua value becomes the command result.
+
+A successful `run_agent` result is structured data containing its final text,
+exit reason, actual tool calls, completion-command evidence, and hashed
+artifacts. The harness runs `require.command` after the agent exits. Evidence
+must match the expected exit code and output for every repetition; model prose
+cannot satisfy the contract. Valid evidence may satisfy the task even if the
+agent itself exhausted its turn budget.
+
+## Capability boundary
+
+Lua has no ambient filesystem, process, package-loading, clock, or randomness
+APIs. Dynamic agents may only narrow the ceilings supplied by:
+
+- `--agent-tool`
+- `--agent-read-dir`
+- `--agent-write-dir`
+- `--agent-shell-allow`
+- `--workspace-root`
+
+A workflow cannot grant itself a missing tool, path, shell pattern, or workspace
+destination. Child agents run non-interactively only after this intersection is
+checked.
+
+This policy is capability control, not an OS sandbox. An allowed command such
+as `go test *` can compile and execute arbitrary code from the workspace. Use
+containers or another operating-system sandbox when running untrusted source or
+untrusted workflow files.
+
+## Non-goals
+
+The initial surface intentionally has no CRUD registry, SQLite store, TUI,
+scheduler, pause/resume, replay, or crash recovery. `workflow run <path.lua>`
+and `workflow validate <path.lua>` operate directly on files so storage and
+versioning remain ordinary Git concerns.

--- a/internal/workflow/definition.go
+++ b/internal/workflow/definition.go
@@ -1,0 +1,249 @@
+// Package workflow executes capability-scoped Lua workflows.
+package workflow
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+const maxWorkflowSourceBytes = 1 << 20
+
+// Metadata is declared by the leading workflow{...} call in a definition.
+type Metadata struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Inputs      any      `json:"inputs,omitempty"`
+	Phases      []string `json:"phases,omitempty"`
+}
+
+// Definition is an exact Lua source file and its parsed metadata.
+type Definition struct {
+	Metadata
+	Path   string `json:"path"`
+	Source string `json:"source"`
+	SHA256 string `json:"sha256"`
+}
+
+// ParseDefinition validates Lua syntax and captures the leading workflow declaration.
+// The workflow body is compiled but never executed during validation.
+func ParseDefinition(path string, source []byte) (*Definition, error) {
+	if len(source) > maxWorkflowSourceBytes {
+		return nil, fmt.Errorf("workflow source exceeds %d bytes", maxWorkflowSourceBytes)
+	}
+	if err := validateWorkflowPrefix(string(source)); err != nil {
+		return nil, err
+	}
+
+	L := lua.NewState(lua.Options{SkipOpenLibs: true})
+	defer L.Close()
+	validationCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	L.SetContext(validationCtx)
+
+	chunk, err := L.LoadString(string(source))
+	if err != nil {
+		return nil, fmt.Errorf("parse Lua: %w", err)
+	}
+	var metadata *Metadata
+	L.SetGlobal("workflow", L.NewFunction(func(L *lua.LState) int {
+		table := L.CheckTable(1)
+		parsed, err := metadataFromTable(table)
+		if err != nil {
+			L.RaiseError("invalid workflow metadata: %v", err)
+		}
+		metadata = &parsed
+		// Validation must not execute the workflow body. The leading declaration
+		// is captured using Lua's own parser, then execution stops here.
+		L.RaiseError("workflow metadata captured")
+		return 0
+	}))
+
+	L.Push(chunk)
+	callErr := L.PCall(0, 0, nil)
+	if metadata == nil {
+		if callErr != nil {
+			return nil, fmt.Errorf("validate workflow declaration: %w", callErr)
+		}
+		return nil, fmt.Errorf("workflow metadata declaration is required")
+	}
+
+	sum := sha256.Sum256(source)
+	return &Definition{
+		Metadata: *metadata,
+		Path:     path,
+		Source:   string(source),
+		SHA256:   hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+// ParseDefinitionFile reads and validates one explicit Lua workflow file.
+func ParseDefinitionFile(path string) (*Definition, error) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read workflow: %w", err)
+	}
+	return ParseDefinition(path, source)
+}
+
+func validateWorkflowPrefix(source string) error {
+	index, err := skipLuaWhitespaceAndComments(source, 0)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(source[index:], "workflow") {
+		return fmt.Errorf("workflow definition must begin with workflow { ... }")
+	}
+	index += len("workflow")
+	if index < len(source) && !isLuaSpace(source[index]) && source[index] != '{' {
+		return fmt.Errorf("workflow definition must begin with workflow { ... }")
+	}
+	index, err = skipLuaWhitespaceAndComments(source, index)
+	if err != nil {
+		return err
+	}
+	if index >= len(source) || source[index] != '{' {
+		return fmt.Errorf("workflow definition must begin with workflow { ... }")
+	}
+	return nil
+}
+
+func skipLuaWhitespaceAndComments(source string, index int) (int, error) {
+	for index < len(source) {
+		if isLuaSpace(source[index]) {
+			index++
+			continue
+		}
+		if strings.HasPrefix(source[index:], "--[[") {
+			end := strings.Index(source[index+4:], "]]")
+			if end < 0 {
+				return 0, fmt.Errorf("unterminated leading Lua block comment")
+			}
+			index += 4 + end + 2
+			continue
+		}
+		if strings.HasPrefix(source[index:], "--") {
+			end := strings.IndexByte(source[index:], '\n')
+			if end < 0 {
+				return len(source), nil
+			}
+			index += end + 1
+			continue
+		}
+		break
+	}
+	return index, nil
+}
+
+func isLuaSpace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n'
+}
+
+func metadataFromTable(table *lua.LTable) (Metadata, error) {
+	nameValue := table.RawGetString("name")
+	name, ok := nameValue.(lua.LString)
+	if !ok || strings.TrimSpace(string(name)) == "" {
+		return Metadata{}, fmt.Errorf("name must be a non-empty string")
+	}
+
+	metadata := Metadata{Name: strings.TrimSpace(string(name))}
+	if value := table.RawGetString("description"); value != lua.LNil {
+		description, ok := value.(lua.LString)
+		if !ok {
+			return Metadata{}, fmt.Errorf("description must be a string")
+		}
+		metadata.Description = string(description)
+	}
+	if value := table.RawGetString("inputs"); value != lua.LNil {
+		converted, err := luaValueToGo(value)
+		if err != nil {
+			return Metadata{}, fmt.Errorf("inputs: %w", err)
+		}
+		metadata.Inputs = converted
+	}
+	if value := table.RawGetString("phases"); value != lua.LNil {
+		phases, ok := value.(*lua.LTable)
+		if !ok {
+			return Metadata{}, fmt.Errorf("phases must be a table")
+		}
+		for i := 1; i <= phases.Len(); i++ {
+			phase, ok := phases.RawGetInt(i).(lua.LString)
+			if !ok || strings.TrimSpace(string(phase)) == "" {
+				return Metadata{}, fmt.Errorf("phases[%d] must be a non-empty string", i)
+			}
+			metadata.Phases = append(metadata.Phases, string(phase))
+		}
+	}
+	return metadata, nil
+}
+
+func luaValueToGo(value lua.LValue) (any, error) {
+	switch value := value.(type) {
+	case *lua.LNilType:
+		return nil, nil
+	case lua.LBool:
+		return bool(value), nil
+	case lua.LString:
+		return string(value), nil
+	case lua.LNumber:
+		return float64(value), nil
+	case *lua.LTable:
+		length := value.Len()
+		array := make([]any, length)
+		isArray := length > 0
+		seen := 0
+		var conversionErr error
+		value.ForEach(func(key, item lua.LValue) {
+			if conversionErr != nil {
+				return
+			}
+			index, ok := key.(lua.LNumber)
+			if !ok || int(index) < 1 || int(index) > length || float64(int(index)) != float64(index) {
+				isArray = false
+				return
+			}
+			converted, err := luaValueToGo(item)
+			if err != nil {
+				conversionErr = err
+				return
+			}
+			array[int(index)-1] = converted
+			seen++
+		})
+		if conversionErr != nil {
+			return nil, conversionErr
+		}
+		if isArray && seen == length {
+			return array, nil
+		}
+		object := make(map[string]any)
+		value.ForEach(func(key, item lua.LValue) {
+			if conversionErr != nil {
+				return
+			}
+			keyString, ok := key.(lua.LString)
+			if !ok {
+				conversionErr = fmt.Errorf("table key %s is not a string", key.String())
+				return
+			}
+			converted, err := luaValueToGo(item)
+			if err != nil {
+				conversionErr = err
+				return
+			}
+			object[string(keyString)] = converted
+		})
+		if conversionErr != nil {
+			return nil, conversionErr
+		}
+		return object, nil
+	default:
+		return nil, fmt.Errorf("unsupported Lua value %s", value.Type().String())
+	}
+}

--- a/internal/workflow/definition_test.go
+++ b/internal/workflow/definition_test.go
@@ -1,0 +1,91 @@
+package workflow
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const testDefinition = `workflow {
+  name = "research",
+  description = "Compare two answers",
+  inputs = { topic = "Topic to investigate" },
+  phases = { "draft", "synthesis" },
+}
+
+local topic = input("topic", "Lua")
+local answers = parallel {
+  agent { prompt = "first " .. topic, label = "first" },
+  agent { prompt = "second " .. topic, label = "second" },
+}
+return join(answers, "\n")
+`
+
+func TestParseDefinitionCapturesMetadataAndExactSource(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "research.lua")
+	definition, err := ParseDefinition(path, []byte(testDefinition))
+	if err != nil {
+		t.Fatalf("ParseDefinition: %v", err)
+	}
+	if definition.Name != "research" || definition.Description != "Compare two answers" {
+		t.Fatalf("metadata = %#v", definition.Metadata)
+	}
+	if len(definition.Phases) != 2 || definition.Phases[1] != "synthesis" {
+		t.Fatalf("phases = %#v", definition.Phases)
+	}
+	if definition.Source != testDefinition {
+		t.Fatal("definition did not preserve exact source")
+	}
+	sum := sha256.Sum256([]byte(testDefinition))
+	if definition.SHA256 != hex.EncodeToString(sum[:]) {
+		t.Fatalf("SHA256 = %q", definition.SHA256)
+	}
+}
+
+func TestParseDefinitionFileReadsExplicitPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "workflow.lua")
+	if err := os.WriteFile(path, []byte(testDefinition), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	definition, err := ParseDefinitionFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if definition.Path != path || definition.Source != testDefinition {
+		t.Fatalf("definition = %#v", definition)
+	}
+}
+
+func TestParseDefinitionDoesNotExecuteWorkflowBody(t *testing.T) {
+	source := []byte(`workflow { name = "safe-validation" }
+error("workflow body executed during validation")`)
+	if _, err := ParseDefinition("safe.lua", source); err != nil {
+		t.Fatalf("ParseDefinition executed workflow body: %v", err)
+	}
+}
+
+func TestParseDefinitionUsesLuaParserForMetadataTable(t *testing.T) {
+	source := []byte(`workflow {
+  name = "lua-syntax",
+  description = [=[a long string containing } braces]=],
+}
+error("body must not run")`)
+	definition, err := ParseDefinition("syntax.lua", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if definition.Description != "a long string containing } braces" {
+		t.Fatalf("description = %q", definition.Description)
+	}
+}
+
+func TestParseDefinitionRequiresLeadingMetadataDeclaration(t *testing.T) {
+	source := []byte(`local value = "before"
+workflow { name = "late" }
+return value`)
+	if _, err := ParseDefinition("late.lua", source); err == nil {
+		t.Fatal("ParseDefinition accepted a non-leading workflow declaration")
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1,0 +1,584 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+const taskTypeName = "term_llm_workflow_task"
+
+// Engine executes one Lua workflow in-process.
+type Engine struct {
+	Executor AgentExecutor
+}
+
+// ExecuteOptions defines one workflow execution.
+type ExecuteOptions struct {
+	Inputs           map[string]any
+	Agent            string
+	Provider         string
+	Concurrency      int
+	AgentTimeout     time.Duration
+	CWD              string
+	AllowedTools     []string
+	AllowedRead      []string
+	AllowedWrite     []string
+	AllowedShell     []string
+	AllowedWorkspace []string
+}
+
+// Execute evaluates source and returns the value from its top-level return.
+func (e *Engine) Execute(ctx context.Context, source string, options ExecuteOptions) (any, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if e.Executor == nil {
+		return nil, fmt.Errorf("workflow agent executor is required")
+	}
+	if options.Concurrency <= 0 {
+		options.Concurrency = 4
+	}
+	if options.Inputs == nil {
+		options.Inputs = map[string]any{}
+	}
+
+	L := lua.NewState(lua.Options{SkipOpenLibs: true})
+	defer L.Close()
+	if err := openWorkflowLibraries(L); err != nil {
+		return nil, err
+	}
+	L.SetContext(ctx)
+
+	runtime := &luaRuntime{
+		engine:  e,
+		options: options,
+	}
+	runtime.install(L)
+
+	chunk, err := L.LoadString(source)
+	if err != nil {
+		return nil, fmt.Errorf("parse Lua: %w", err)
+	}
+	L.Push(chunk)
+	if err := L.PCall(0, 1, nil); err != nil {
+		return nil, fmt.Errorf("execute Lua: %w", err)
+	}
+	value := L.Get(-1)
+	result, err := luaValueToGo(value)
+	if err != nil {
+		return nil, fmt.Errorf("convert workflow result: %w", err)
+	}
+	return result, nil
+}
+
+type luaRuntime struct {
+	engine  *Engine
+	options ExecuteOptions
+}
+
+func openWorkflowLibraries(L *lua.LState) error {
+	libraries := []struct {
+		name string
+		open lua.LGFunction
+	}{
+		{lua.BaseLibName, lua.OpenBase},
+		{lua.TabLibName, lua.OpenTable},
+		{lua.StringLibName, lua.OpenString},
+		{lua.MathLibName, lua.OpenMath},
+	}
+	for _, library := range libraries {
+		if err := L.CallByParam(lua.P{
+			Fn:      L.NewFunction(library.open),
+			NRet:    0,
+			Protect: true,
+		}, lua.LString(library.name)); err != nil {
+			return fmt.Errorf("open Lua %s library: %w", library.name, err)
+		}
+	}
+
+	// Workflows orchestrate agents; they do not get ambient filesystem, process,
+	// package-loading, clock, or randomness capabilities. Agents hold those tools.
+	L.SetGlobal("dofile", lua.LNil)
+	L.SetGlobal("loadfile", lua.LNil)
+	L.SetGlobal("load", lua.LNil)
+	L.SetGlobal("loadstring", lua.LNil)
+	if mathTable, ok := L.GetGlobal(lua.MathLibName).(*lua.LTable); ok {
+		mathTable.RawSetString("random", lua.LNil)
+		mathTable.RawSetString("randomseed", lua.LNil)
+	}
+	return nil
+}
+
+func (r *luaRuntime) install(L *lua.LState) {
+	L.SetGlobal("workflow", L.NewFunction(func(L *lua.LState) int {
+		L.CheckTable(1)
+		return 0
+	}))
+	L.SetGlobal("input", L.NewFunction(r.input))
+	L.SetGlobal("agent", L.NewFunction(r.agent))
+	L.SetGlobal("run_agent", L.NewFunction(r.runAgent))
+	L.SetGlobal("create_workspace", L.NewFunction(r.createWorkspace))
+	L.SetGlobal("await", L.NewFunction(r.await))
+	L.SetGlobal("parallel", L.NewFunction(r.parallel))
+	L.SetGlobal("parallel_settled", L.NewFunction(r.parallelSettled))
+	L.SetGlobal("join", L.NewFunction(luaJoin))
+
+	metatable := L.NewTypeMetatable(taskTypeName)
+	L.SetField(metatable, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{}))
+}
+
+func (r *luaRuntime) createWorkspace(L *lua.LState) int {
+	table := L.CheckTable(1)
+	source := tableString(L, table, "source")
+	if !pathWithinAny(source, r.options.AllowedRead) {
+		L.RaiseError("workspace source %q exceeds the workflow read ceiling", source)
+	}
+	root := tableString(L, table, "root")
+	if root == "" {
+		if len(r.options.AllowedWorkspace) == 0 {
+			L.RaiseError("workspace root is required")
+		}
+		root = r.options.AllowedWorkspace[0]
+	}
+	if !pathWithinAny(root, r.options.AllowedWorkspace) {
+		L.RaiseError("workspace root %q exceeds the workspace ceiling", root)
+	}
+	if pathWithinAny(root, []string{source}) {
+		L.RaiseError("workspace root %q must not be inside source %q", root, source)
+	}
+	name := tableString(L, table, "name")
+	if name == "" {
+		name = "workflow"
+	}
+	name = sanitizeWorkspaceName(name)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		L.RaiseError("create workspace root: %v", err)
+	}
+	destination, err := os.MkdirTemp(root, name+"-")
+	if err != nil {
+		L.RaiseError("create workspace: %v", err)
+	}
+	if err := os.CopyFS(destination, os.DirFS(source)); err != nil {
+		_ = os.RemoveAll(destination)
+		L.RaiseError("copy workspace: %v", err)
+	}
+	L.Push(lua.LString(destination))
+	return 1
+}
+
+func sanitizeWorkspaceName(name string) string {
+	var result strings.Builder
+	for _, character := range name {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '-' || character == '_' {
+			result.WriteRune(character)
+		} else {
+			result.WriteByte('-')
+		}
+	}
+	if result.Len() == 0 {
+		return "workflow"
+	}
+	return result.String()
+}
+
+func (r *luaRuntime) input(L *lua.LState) int {
+	name := L.CheckString(1)
+	if value, ok := r.options.Inputs[name]; ok {
+		converted, err := goValueToLua(L, value)
+		if err != nil {
+			L.RaiseError("input %q: %v", name, err)
+		}
+		L.Push(converted)
+		return 1
+	}
+	if L.GetTop() >= 2 {
+		L.Push(L.Get(2))
+		return 1
+	}
+	L.RaiseError("required input %q was not provided", name)
+	return 0
+}
+
+func (r *luaRuntime) agent(L *lua.LState) int {
+	return r.makeAgentTask(L, false)
+}
+
+func (r *luaRuntime) runAgent(L *lua.LState) int {
+	return r.makeAgentTask(L, true)
+}
+
+func (r *luaRuntime) makeAgentTask(L *lua.LState, dynamic bool) int {
+	table := L.CheckTable(1)
+	prompt := tableString(L, table, "prompt")
+	if strings.TrimSpace(prompt) == "" {
+		L.RaiseError("agent prompt is required")
+	}
+	request := AgentRequest{
+		Prompt:   prompt,
+		Agent:    tableString(L, table, "agent"),
+		Provider: tableString(L, table, "provider"),
+		Label:    tableString(L, table, "label"),
+		CWD:      r.options.CWD,
+	}
+	if dynamic {
+		request.Dynamic = true
+		request.SystemMessage = tableString(L, table, "system")
+		request.Tools = tableStringSlice(L, table, "tools")
+		request.ReadDirs = tableStringSlice(L, table, "read_dirs")
+		request.WriteDirs = tableStringSlice(L, table, "write_dirs")
+		request.ShellAllow = tableStringSlice(L, table, "shell_allow")
+		request.MaxTurns = tableInt(L, table, "max_turns")
+		request.Require = tableRequirement(L, table, "require")
+		if cwd := tableString(L, table, "cwd"); cwd != "" {
+			request.CWD = cwd
+		}
+		if err := r.authorizeAgentRequest(&request); err != nil {
+			L.RaiseError("authorize run_agent: %v", err)
+		}
+	}
+	if r.options.Agent != "" {
+		request.Agent = r.options.Agent
+	}
+	if r.options.Provider != "" {
+		request.Provider = r.options.Provider
+	}
+
+	task := &agentTask{runtime: r, request: request}
+	userData := L.NewUserData()
+	userData.Value = task
+	L.SetMetatable(userData, L.GetTypeMetatable(taskTypeName))
+	L.Push(userData)
+	return 1
+}
+
+func (r *luaRuntime) await(L *lua.LState) int {
+	task := checkAgentTask(L, 1)
+	result, err := task.run(L.Context())
+	if err != nil {
+		L.RaiseError("agent task failed: %v", err)
+	}
+	if task.request.Dynamic {
+		value, conversionErr := goValueToLua(L, agentResultMap(result))
+		if conversionErr != nil {
+			L.RaiseError("convert agent result: %v", conversionErr)
+		}
+		L.Push(value)
+	} else {
+		L.Push(lua.LString(result.Stdout))
+	}
+	return 1
+}
+
+type taskOutcome struct {
+	result AgentResult
+	err    error
+}
+
+func (r *luaRuntime) parallel(L *lua.LState) int {
+	tasks, outcomes := r.executeParallel(L)
+	values := L.NewTable()
+	for index, outcome := range outcomes {
+		if outcome.err != nil {
+			L.RaiseError("parallel agent task %d failed: %v", index+1, outcome.err)
+		}
+		if tasks[index].request.Dynamic {
+			value, err := goValueToLua(L, agentResultMap(outcome.result))
+			if err != nil {
+				L.RaiseError("convert parallel agent result: %v", err)
+			}
+			values.Append(value)
+		} else {
+			values.Append(lua.LString(outcome.result.Stdout))
+		}
+	}
+	L.Push(values)
+	return 1
+}
+
+func (r *luaRuntime) parallelSettled(L *lua.LState) int {
+	_, outcomes := r.executeParallel(L)
+	values := L.NewTable()
+	for _, outcome := range outcomes {
+		item := map[string]any{"ok": outcome.err == nil, "result": agentResultMap(outcome.result)}
+		if outcome.err != nil {
+			item["error"] = outcome.err.Error()
+		}
+		value, err := goValueToLua(L, item)
+		if err != nil {
+			L.RaiseError("convert settled agent result: %v", err)
+		}
+		values.Append(value)
+	}
+	L.Push(values)
+	return 1
+}
+
+func (r *luaRuntime) executeParallel(L *lua.LState) ([]*agentTask, []taskOutcome) {
+	table := L.CheckTable(1)
+	tasks := make([]*agentTask, table.Len())
+	for index := range tasks {
+		value := table.RawGetInt(index + 1)
+		userData, ok := value.(*lua.LUserData)
+		if !ok {
+			L.ArgError(1, fmt.Sprintf("item %d is not an agent task", index+1))
+		}
+		task, ok := userData.Value.(*agentTask)
+		if !ok {
+			L.ArgError(1, fmt.Sprintf("item %d is not an agent task", index+1))
+		}
+		tasks[index] = task
+	}
+
+	outcomes := make([]taskOutcome, len(tasks))
+	if len(tasks) == 0 {
+		return tasks, outcomes
+	}
+	workerCount := min(r.options.Concurrency, len(tasks))
+	indices := make(chan int)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	ctx := L.Context()
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range indices {
+				outcomes[index].result, outcomes[index].err = tasks[index].run(ctx)
+			}
+		}()
+	}
+	for index := range tasks {
+		indices <- index
+	}
+	close(indices)
+	workers.Wait()
+	return tasks, outcomes
+}
+
+func agentResultMap(result AgentResult) map[string]any {
+	encoded, _ := json.Marshal(result)
+	var value map[string]any
+	_ = json.Unmarshal(encoded, &value)
+	return value
+}
+
+type agentTask struct {
+	runtime *luaRuntime
+	request AgentRequest
+	once    sync.Once
+	result  AgentResult
+	err     error
+}
+
+func (t *agentTask) run(ctx context.Context) (AgentResult, error) {
+	t.once.Do(func() {
+		executeCtx := ctx
+		cancel := func() {}
+		if t.runtime.options.AgentTimeout > 0 {
+			executeCtx, cancel = context.WithTimeout(ctx, t.runtime.options.AgentTimeout)
+		}
+		defer cancel()
+		t.result, t.err = t.runtime.engine.Executor.Execute(executeCtx, t.request)
+	})
+	return t.result, t.err
+}
+
+func checkAgentTask(L *lua.LState, index int) *agentTask {
+	userData := L.CheckUserData(index)
+	if task, ok := userData.Value.(*agentTask); ok {
+		return task
+	}
+	L.ArgError(index, "agent task expected")
+	return nil
+}
+
+func (r *luaRuntime) authorizeAgentRequest(request *AgentRequest) error {
+	if err := requireSubset("tool", request.Tools, r.options.AllowedTools); err != nil {
+		return err
+	}
+	if err := requireSubset("shell pattern", request.ShellAllow, r.options.AllowedShell); err != nil {
+		return err
+	}
+	for _, directory := range request.ReadDirs {
+		if !pathWithinAny(directory, r.options.AllowedRead) {
+			return fmt.Errorf("read directory %q exceeds the workflow capability ceiling", directory)
+		}
+	}
+	for _, directory := range request.WriteDirs {
+		if !pathWithinAny(directory, r.options.AllowedWrite) {
+			return fmt.Errorf("write directory %q exceeds the workflow capability ceiling", directory)
+		}
+	}
+	if request.CWD != r.options.CWD && !pathWithinAny(request.CWD, append(append([]string{}, r.options.AllowedRead...), r.options.AllowedWrite...)) {
+		return fmt.Errorf("working directory %q exceeds the workflow capability ceiling", request.CWD)
+	}
+	return nil
+}
+
+func requireSubset(kind string, requested, allowed []string) error {
+	ceiling := make(map[string]struct{}, len(allowed))
+	for _, value := range allowed {
+		ceiling[value] = struct{}{}
+	}
+	for _, value := range requested {
+		if _, ok := ceiling[value]; !ok {
+			return fmt.Errorf("%s %q exceeds the workflow capability ceiling", kind, value)
+		}
+	}
+	return nil
+}
+
+func pathWithinAny(path string, roots []string) bool {
+	path = canonicalCapabilityPath(path)
+	for _, root := range roots {
+		root = canonicalCapabilityPath(root)
+		relative, err := filepath.Rel(root, path)
+		if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalCapabilityPath(path string) string {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	absolute = filepath.Clean(absolute)
+	for existing := absolute; ; existing = filepath.Dir(existing) {
+		if evaluated, evalErr := filepath.EvalSymlinks(existing); evalErr == nil {
+			remainder, relErr := filepath.Rel(existing, absolute)
+			if relErr == nil {
+				return filepath.Clean(filepath.Join(evaluated, remainder))
+			}
+			break
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			break
+		}
+	}
+	return absolute
+}
+
+func tableStringSlice(L *lua.LState, table *lua.LTable, key string) []string {
+	value := table.RawGetString(key)
+	if value == lua.LNil {
+		return nil
+	}
+	items, ok := value.(*lua.LTable)
+	if !ok {
+		L.RaiseError("agent %s must be an array of strings", key)
+	}
+	result := make([]string, 0, items.Len())
+	for index := 1; index <= items.Len(); index++ {
+		item, ok := items.RawGetInt(index).(lua.LString)
+		if !ok {
+			L.RaiseError("agent %s item %d must be a string", key, index)
+		}
+		result = append(result, string(item))
+	}
+	return result
+}
+
+func tableRequirement(L *lua.LState, table *lua.LTable, key string) *CommandRequirement {
+	value := table.RawGetString(key)
+	if value == lua.LNil {
+		return nil
+	}
+	requirementTable, ok := value.(*lua.LTable)
+	if !ok {
+		L.RaiseError("agent %s must be a table", key)
+	}
+	return &CommandRequirement{
+		Command:        tableString(L, requirementTable, "command"),
+		ExitCode:       tableInt(L, requirementTable, "exit_code"),
+		Repetitions:    tableInt(L, requirementTable, "repetitions"),
+		OutputContains: tableString(L, requirementTable, "output_contains"),
+		ArtifactGlob:   tableString(L, requirementTable, "artifact_glob"),
+	}
+}
+
+func tableInt(L *lua.LState, table *lua.LTable, key string) int {
+	value := table.RawGetString(key)
+	if value == lua.LNil {
+		return 0
+	}
+	number, ok := value.(lua.LNumber)
+	if !ok || number < 0 || number != lua.LNumber(int(number)) {
+		L.RaiseError("agent %s must be a non-negative integer", key)
+	}
+	return int(number)
+}
+
+func tableString(L *lua.LState, table *lua.LTable, key string) string {
+	value := table.RawGetString(key)
+	if value == lua.LNil {
+		return ""
+	}
+	if text, ok := value.(lua.LString); ok {
+		return string(text)
+	}
+	L.RaiseError("agent %s must be a string", key)
+	return ""
+}
+
+func luaJoin(L *lua.LState) int {
+	values := L.CheckTable(1)
+	separator := L.OptString(2, "")
+	parts := make([]string, 0, values.Len())
+	for index := 1; index <= values.Len(); index++ {
+		parts = append(parts, values.RawGetInt(index).String())
+	}
+	L.Push(lua.LString(strings.Join(parts, separator)))
+	return 1
+}
+
+func goValueToLua(L *lua.LState, value any) (lua.LValue, error) {
+	switch value := value.(type) {
+	case nil:
+		return lua.LNil, nil
+	case bool:
+		return lua.LBool(value), nil
+	case string:
+		return lua.LString(value), nil
+	case float64:
+		return lua.LNumber(value), nil
+	case float32:
+		return lua.LNumber(value), nil
+	case int:
+		return lua.LNumber(value), nil
+	case int64:
+		return lua.LNumber(value), nil
+	case []any:
+		table := L.NewTable()
+		for _, item := range value {
+			converted, err := goValueToLua(L, item)
+			if err != nil {
+				return nil, err
+			}
+			table.Append(converted)
+		}
+		return table, nil
+	case map[string]any:
+		table := L.NewTable()
+		for key, item := range value {
+			converted, err := goValueToLua(L, item)
+			if err != nil {
+				return nil, err
+			}
+			table.RawSetString(key, converted)
+		}
+		return table, nil
+	default:
+		return nil, fmt.Errorf("unsupported Go value %T", value)
+	}
+}

--- a/internal/workflow/executor.go
+++ b/internal/workflow/executor.go
@@ -1,0 +1,306 @@
+package workflow
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/samsaffron/term-llm/internal/procutil"
+)
+
+const (
+	maxAgentOutputBytes    = 8 << 20
+	maxEvidenceOutputBytes = 1 << 20
+	maxArtifactBytes       = 16 << 20
+)
+
+// AgentRequest describes one lazy Lua agent task.
+type AgentRequest struct {
+	Prompt        string              `json:"prompt"`
+	SystemMessage string              `json:"system_message,omitempty"`
+	Agent         string              `json:"agent,omitempty"`
+	Provider      string              `json:"provider,omitempty"`
+	Label         string              `json:"label,omitempty"`
+	CWD           string              `json:"cwd"`
+	Tools         []string            `json:"tools,omitempty"`
+	ReadDirs      []string            `json:"read_dirs,omitempty"`
+	WriteDirs     []string            `json:"write_dirs,omitempty"`
+	ShellAllow    []string            `json:"shell_allow,omitempty"`
+	MaxTurns      int                 `json:"max_turns,omitempty"`
+	Dynamic       bool                `json:"dynamic,omitempty"`
+	Require       *CommandRequirement `json:"require,omitempty"`
+}
+
+// CommandRequirement is deterministic evidence checked after an agent exits.
+type CommandRequirement struct {
+	Command        string `json:"command"`
+	ExitCode       int    `json:"exit_code"`
+	Repetitions    int    `json:"repetitions"`
+	OutputContains string `json:"output_contains,omitempty"`
+	ArtifactGlob   string `json:"artifact_glob,omitempty"`
+}
+
+// ToolCall records one actual tool execution reported by the child event stream.
+type ToolCall struct {
+	CallID  string         `json:"call_id"`
+	Name    string         `json:"name"`
+	Args    map[string]any `json:"args,omitempty"`
+	Success bool           `json:"success"`
+}
+
+// Artifact records a file selected by the completion contract.
+type Artifact struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+	Bytes  int64  `json:"bytes"`
+}
+
+// CommandEvidence records one harness-executed completion check.
+type CommandEvidence struct {
+	Command  string `json:"command"`
+	ExitCode int    `json:"exit_code"`
+	Output   string `json:"output"`
+}
+
+// AgentResult captures both output streams from an agent subprocess.
+type AgentResult struct {
+	Stdout     string            `json:"text"`
+	Stderr     string            `json:"stderr,omitempty"`
+	ExitReason string            `json:"exit_reason,omitempty"`
+	ToolCalls  []ToolCall        `json:"tool_calls,omitempty"`
+	Artifacts  []Artifact        `json:"artifacts,omitempty"`
+	Evidence   []CommandEvidence `json:"evidence,omitempty"`
+}
+
+// AgentExecutor executes one agent request. Tests can inject a fake executor.
+type AgentExecutor interface {
+	Execute(context.Context, AgentRequest) (AgentResult, error)
+}
+
+// CommandExecutor runs agents by spawning the term-llm executable.
+type CommandExecutor struct {
+	Executable string
+}
+
+// Execute invokes: term-llm --no-session ask --porcelain [overrides] <prompt>.
+func (e CommandExecutor) Execute(ctx context.Context, request AgentRequest) (AgentResult, error) {
+	if strings.TrimSpace(e.Executable) == "" {
+		return AgentResult{}, fmt.Errorf("workflow agent executable is required")
+	}
+	args := []string{"--no-session", "ask", "--no-search", "--skills", "none"}
+	if request.Dynamic {
+		args = append(args, "--json")
+	} else {
+		args = append(args, "--porcelain")
+	}
+	if request.Agent != "" {
+		args = append(args, "--agent", request.Agent)
+	}
+	if request.Provider != "" {
+		args = append(args, "--provider", request.Provider)
+	}
+	if request.SystemMessage != "" {
+		args = append(args, "--system-message", request.SystemMessage)
+	}
+	if request.MaxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprint(request.MaxTurns))
+	}
+	if len(request.Tools) > 0 {
+		args = append(args, "--tools", strings.Join(request.Tools, ","), "--yolo")
+	}
+	for _, directory := range request.ReadDirs {
+		args = append(args, "--read-dir", directory)
+	}
+	for _, directory := range request.WriteDirs {
+		args = append(args, "--write-dir", directory)
+	}
+	for _, pattern := range request.ShellAllow {
+		args = append(args, "--shell-allow", pattern)
+	}
+	args = append(args, "--", request.Prompt)
+
+	command := exec.CommandContext(ctx, e.Executable, args...)
+	procutil.ConfigureDetachedCommand(command)
+	command.Dir = request.CWD
+	stdout := procutil.NewLimitedBuffer(maxAgentOutputBytes)
+	stderr := procutil.NewLimitedBuffer(maxAgentOutputBytes)
+	command.Stdout = stdout
+	command.Stderr = stderr
+	commandErr := command.Run()
+	result := AgentResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitReason: "completed"}
+	var protocolErr error
+	if stdout.Truncated() || stderr.Truncated() {
+		protocolErr = fmt.Errorf("agent output exceeded %d bytes", maxAgentOutputBytes)
+	} else if request.Dynamic {
+		result, protocolErr = parseAgentJSONL(stdout.String(), stderr.String())
+	}
+	agentErr := commandErr
+	if protocolErr != nil {
+		if agentErr == nil {
+			agentErr = protocolErr
+		} else {
+			agentErr = fmt.Errorf("%v; parse agent event stream: %w", agentErr, protocolErr)
+		}
+	}
+	if agentErr != nil {
+		result.ExitReason = "agent_error"
+	}
+
+	if request.Require != nil {
+		evidenceErr := verifyCommandRequirement(ctx, request, &result)
+		if evidenceErr == nil {
+			result.ExitReason = "requirement_satisfied"
+			return result, nil
+		}
+		if agentErr != nil {
+			return result, fmt.Errorf("agent command failed: %v; completion requirement: %w", agentErr, evidenceErr)
+		}
+		return result, evidenceErr
+	}
+	if agentErr != nil {
+		message := fmt.Sprintf("agent command failed: %v", agentErr)
+		if trimmed := strings.TrimSpace(result.Stderr); trimmed != "" {
+			message += ": " + trimmed
+		}
+		return result, fmt.Errorf("%s", message)
+	}
+	return result, nil
+}
+
+func parseAgentJSONL(raw, stderr string) (AgentResult, error) {
+	result := AgentResult{Stderr: stderr, ExitReason: "completed"}
+	calls := make(map[string]int)
+	sawDone := false
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		var event map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			return result, fmt.Errorf("invalid agent JSONL at line %d: %w", line, err)
+		}
+		typeName, _ := event["type"].(string)
+		switch typeName {
+		case "text.delta":
+			if text, ok := event["text"].(string); ok {
+				result.Stdout += text
+			}
+		case "tool.started":
+			call := ToolCall{CallID: stringField(event, "call_id"), Name: stringField(event, "name")}
+			if args, ok := event["args"].(map[string]any); ok {
+				call.Args = args
+			}
+			calls[call.CallID] = len(result.ToolCalls)
+			result.ToolCalls = append(result.ToolCalls, call)
+		case "tool.completed":
+			if index, ok := calls[stringField(event, "call_id")]; ok {
+				result.ToolCalls[index].Success, _ = event["success"].(bool)
+			}
+		case "done":
+			sawDone = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return result, fmt.Errorf("scan agent JSONL: %w", err)
+	}
+	if !sawDone {
+		return result, fmt.Errorf("agent JSONL ended without a done event")
+	}
+	return result, nil
+}
+
+func stringField(values map[string]any, key string) string {
+	value, _ := values[key].(string)
+	return value
+}
+
+func verifyCommandRequirement(ctx context.Context, request AgentRequest, result *AgentResult) error {
+	requirement := request.Require
+	if strings.TrimSpace(requirement.Command) == "" {
+		return fmt.Errorf("completion requirement command is empty")
+	}
+	allowed := false
+	for _, pattern := range request.ShellAllow {
+		if matched, _ := doublestar.Match(pattern, requirement.Command); matched {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("completion command %q is not allowed by the dynamic agent shell policy", requirement.Command)
+	}
+	repetitions := requirement.Repetitions
+	if repetitions <= 0 {
+		repetitions = 1
+	}
+	for range repetitions {
+		command := exec.CommandContext(ctx, "sh", "-c", requirement.Command)
+		procutil.ConfigureDetachedCommand(command)
+		command.Dir = request.CWD
+		output := procutil.NewLimitedBuffer(maxEvidenceOutputBytes)
+		command.Stdout = output
+		command.Stderr = output
+		err := command.Run()
+		if output.Truncated() {
+			return fmt.Errorf("completion command output exceeded %d bytes", maxEvidenceOutputBytes)
+		}
+		exitCode := 0
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			} else {
+				return fmt.Errorf("run completion command: %w", err)
+			}
+		}
+		text := output.String()
+		result.Evidence = append(result.Evidence, CommandEvidence{Command: requirement.Command, ExitCode: exitCode, Output: text})
+		if exitCode != requirement.ExitCode {
+			return fmt.Errorf("completion command exit code %d, want %d", exitCode, requirement.ExitCode)
+		}
+		if requirement.OutputContains != "" && !strings.Contains(text, requirement.OutputContains) {
+			return fmt.Errorf("completion command output does not contain %q", requirement.OutputContains)
+		}
+	}
+	if requirement.ArtifactGlob != "" {
+		matches, err := filepath.Glob(filepath.Join(request.CWD, requirement.ArtifactGlob))
+		if err != nil {
+			return fmt.Errorf("match completion artifacts: %w", err)
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("completion artifact glob %q matched no files", requirement.ArtifactGlob)
+		}
+		for _, match := range matches {
+			if !pathWithinAny(match, []string{request.CWD}) {
+				return fmt.Errorf("completion artifact %q escapes working directory", match)
+			}
+			info, err := os.Stat(match)
+			if err != nil {
+				return fmt.Errorf("stat completion artifact: %w", err)
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("completion artifact %q is not a regular file", match)
+			}
+			if info.Size() > maxArtifactBytes {
+				return fmt.Errorf("completion artifact %q exceeds %d bytes", match, maxArtifactBytes)
+			}
+			content, err := os.ReadFile(match)
+			if err != nil {
+				return fmt.Errorf("read completion artifact: %w", err)
+			}
+			digest := sha256.Sum256(content)
+			result.Artifacts = append(result.Artifacts, Artifact{Path: match, SHA256: hex.EncodeToString(digest[:]), Bytes: info.Size()})
+		}
+		slices.SortFunc(result.Artifacts, func(a, b Artifact) int { return strings.Compare(a.Path, b.Path) })
+	}
+	return nil
+}

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -1,0 +1,325 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type countingExecutor struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (e *countingExecutor) Execute(context.Context, AgentRequest) (AgentResult, error) {
+	e.mu.Lock()
+	e.calls++
+	e.mu.Unlock()
+	return AgentResult{Stdout: "unexpected"}, nil
+}
+
+type captureExecutor struct {
+	request AgentRequest
+}
+
+func (e *captureExecutor) Execute(_ context.Context, request AgentRequest) (AgentResult, error) {
+	e.request = request
+	return AgentResult{Stdout: "ok"}, nil
+}
+
+func TestRunAgentBuildsCapabilityScopedDynamicAgent(t *testing.T) {
+	root := t.TempDir()
+	executor := &captureExecutor{}
+	engine := &Engine{Executor: executor}
+	result, err := engine.Execute(context.Background(), `workflow { name = "dynamic" }
+return await(run_agent {
+  label = "tester",
+  system = "compile and run the regression test",
+  prompt = "work until go test fails for the expected reason",
+  provider = "qwen-local",
+  tools = { "read_file", "write_file", "shell" },
+  read_dirs = { "`+root+`" },
+  write_dirs = { "`+root+`" },
+  shell_allow = { "go test *", "gofmt *" },
+  cwd = "`+root+`",
+  max_turns = 12,
+})`, ExecuteOptions{
+		CWD:          root,
+		AllowedTools: []string{"read_file", "write_file", "shell"},
+		AllowedRead:  []string{root},
+		AllowedWrite: []string{root},
+		AllowedShell: []string{"go test *", "gofmt *"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	resultMap, ok := result.(map[string]any)
+	if !ok || resultMap["text"] != "ok" {
+		t.Fatalf("result = %#v", result)
+	}
+	request := executor.request
+	if request.SystemMessage != "compile and run the regression test" || request.Provider != "qwen-local" || request.MaxTurns != 12 || request.CWD != root {
+		t.Fatalf("request metadata = %#v", request)
+	}
+	if !reflect.DeepEqual(request.Tools, []string{"read_file", "write_file", "shell"}) || !reflect.DeepEqual(request.ShellAllow, []string{"go test *", "gofmt *"}) {
+		t.Fatalf("request capabilities = %#v", request)
+	}
+}
+
+func TestRunAgentRejectsCapabilityEscalation(t *testing.T) {
+	root := t.TempDir()
+	engine := &Engine{Executor: &captureExecutor{}}
+	_, err := engine.Execute(context.Background(), `workflow { name = "denied" }
+return await(run_agent { prompt = "escape", tools = { "shell" }, shell_allow = { "rm -rf *" } })`, ExecuteOptions{
+		CWD:          root,
+		AllowedTools: []string{"shell"},
+		AllowedShell: []string{"go test *"},
+	})
+	if err == nil || !strings.Contains(err.Error(), `shell pattern "rm -rf *" exceeds the workflow capability ceiling`) {
+		t.Fatalf("Execute error = %v", err)
+	}
+}
+
+type selectiveExecutor struct{}
+
+func (selectiveExecutor) Execute(_ context.Context, request AgentRequest) (AgentResult, error) {
+	if request.Prompt == "fail" {
+		return AgentResult{Stdout: "partial", ExitReason: "agent_error"}, errors.New("deliberate failure")
+	}
+	return AgentResult{Stdout: request.Prompt, ExitReason: "completed"}, nil
+}
+
+func TestParallelSettledPreservesIndependentFailures(t *testing.T) {
+	engine := &Engine{Executor: selectiveExecutor{}}
+	result, err := engine.Execute(context.Background(), `workflow { name = "settled" }
+return parallel_settled {
+  agent { prompt = "ok" },
+  agent { prompt = "fail" },
+}`, ExecuteOptions{CWD: t.TempDir(), Concurrency: 2})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	items, ok := result.([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+	first := items[0].(map[string]any)
+	second := items[1].(map[string]any)
+	if first["ok"] != true || second["ok"] != false || !strings.Contains(second["error"].(string), "deliberate failure") {
+		t.Fatalf("settled outcomes = %#v", items)
+	}
+}
+
+func TestEmptyParallelCollectionsReturnImmediately(t *testing.T) {
+	engine := &Engine{Executor: &countingExecutor{}}
+	for _, source := range []string{
+		`workflow { name = "empty" }; return parallel {}`,
+		`workflow { name = "empty-settled" }; return parallel_settled {}`,
+	} {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		result, err := engine.Execute(ctx, source, ExecuteOptions{Concurrency: 2})
+		cancel()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result, map[string]any{}) && !reflect.DeepEqual(result, []any{}) {
+			t.Fatalf("empty parallel result = %#v", result)
+		}
+	}
+}
+
+func TestCapabilityPathResolvesSymlinkedParentForMissingTarget(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if pathWithinAny(filepath.Join(link, "future.txt"), []string{root}) {
+		t.Fatal("path through symlinked parent was accepted inside capability root")
+	}
+}
+
+func TestCreateWorkspaceCopiesWithinCeiling(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "source.txt"), []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	engine := &Engine{Executor: &captureExecutor{}}
+	result, err := engine.Execute(context.Background(), `workflow { name = "workspace" }
+return create_workspace { source = "`+source+`", root = "`+root+`", name = "specialist" }`, ExecuteOptions{
+		CWD:              source,
+		AllowedRead:      []string{source},
+		AllowedWorkspace: []string{root},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	workspace := result.(string)
+	content, err := os.ReadFile(filepath.Join(workspace, "source.txt"))
+	if err != nil || string(content) != "content" {
+		t.Fatalf("workspace content = %q, %v", content, err)
+	}
+}
+
+func TestCommandExecutorAcceptsSatisfiedRequirementAfterAgentError(t *testing.T) {
+	root := t.TempDir()
+	script := filepath.Join(root, "fake-term-llm")
+	body := `#!/bin/sh
+printf '%s\n' '{"type":"text.delta","text":"worked"}'
+printf '%s\n' '{"type":"tool.started","call_id":"c1","name":"shell","args":{"command":"test -f generated.txt"}}'
+printf '%s\n' '{"type":"tool.completed","call_id":"c1","name":"shell","success":true}'
+printf artifact > generated.txt
+exit 1
+`
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	executor := CommandExecutor{Executable: script}
+	result, err := executor.Execute(context.Background(), AgentRequest{
+		Prompt:     "generate",
+		CWD:        root,
+		Dynamic:    true,
+		ShellAllow: []string{"test*"},
+		Require: &CommandRequirement{
+			Command:      "test -f generated.txt",
+			ExitCode:     0,
+			Repetitions:  2,
+			ArtifactGlob: "generated.txt",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Stdout != "worked" || result.ExitReason != "requirement_satisfied" || len(result.ToolCalls) != 1 || !result.ToolCalls[0].Success || len(result.Evidence) != 2 || len(result.Artifacts) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestCommandRequirementRejectsArtifactOutsideWorkingDirectory(t *testing.T) {
+	parent := t.TempDir()
+	cwd := filepath.Join(parent, "workspace")
+	if err := os.Mkdir(cwd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	request := AgentRequest{
+		CWD:        cwd,
+		ShellAllow: []string{"true"},
+		Require: &CommandRequirement{
+			Command:      "true",
+			ArtifactGlob: "../secret.txt",
+		},
+	}
+	var result AgentResult
+	if err := verifyCommandRequirement(context.Background(), request, &result); err == nil || !strings.Contains(err.Error(), "escapes working directory") {
+		t.Fatalf("verifyCommandRequirement error = %v", err)
+	}
+}
+
+func TestParseAgentJSONLRequiresValidTerminalStream(t *testing.T) {
+	result, err := parseAgentJSONL("{\"type\":\"text.delta\",\"text\":\"ok\"}\n{\"type\":\"done\"}\n", "")
+	if err != nil || result.Stdout != "ok" {
+		t.Fatalf("valid stream result = %#v, err = %v", result, err)
+	}
+	for _, raw := range []string{
+		"not-json\n{\"type\":\"done\"}\n",
+		"{\"type\":\"text.delta\",\"text\":\"partial\"}\n",
+	} {
+		if _, err := parseAgentJSONL(raw, ""); err == nil {
+			t.Fatalf("parseAgentJSONL accepted %q", raw)
+		}
+	}
+}
+
+func TestAgentTasksRemainLazyUntilAwaited(t *testing.T) {
+	executor := &countingExecutor{}
+	engine := &Engine{Executor: executor}
+	result, err := engine.Execute(context.Background(), `workflow { name = "lazy" }
+local unused = agent { prompt = "do not execute" }
+return "done"`, ExecuteOptions{Concurrency: 1, CWD: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result != "done" {
+		t.Fatalf("result = %#v", result)
+	}
+	executor.mu.Lock()
+	calls := executor.calls
+	executor.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("executor calls = %d, want 0 for unawaited task", calls)
+	}
+}
+
+func TestWorkflowLuaSandboxOmitsAmbientCapabilities(t *testing.T) {
+	engine := &Engine{Executor: &countingExecutor{}}
+	result, err := engine.Execute(context.Background(), `workflow { name = "sandbox" }
+return {
+  os = os == nil,
+  io = io == nil,
+  package = package == nil,
+  debug = debug == nil,
+  dofile = dofile == nil,
+  loadfile = loadfile == nil,
+  load = load == nil,
+  loadstring = loadstring == nil,
+  random = math.random == nil,
+  table = table.concat({"o", "k"}, "")
+}`, ExecuteOptions{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	values, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	for _, key := range []string{"os", "io", "package", "debug", "dofile", "loadfile", "load", "loadstring", "random"} {
+		if values[key] != true {
+			t.Fatalf("sandbox capability %q remained available: %#v", key, values[key])
+		}
+	}
+	if values["table"] != "ok" {
+		t.Fatalf("safe table library unavailable: %#v", values)
+	}
+}
+
+type blockingExecutor struct{}
+
+func (blockingExecutor) Execute(ctx context.Context, _ AgentRequest) (AgentResult, error) {
+	<-ctx.Done()
+	return AgentResult{}, ctx.Err()
+}
+
+func TestWorkflowContextTimeoutStopsInfiniteLuaLoop(t *testing.T) {
+	engine := &Engine{Executor: &countingExecutor{}}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := engine.Execute(ctx, `workflow { name = "infinite" }
+while true do end`, ExecuteOptions{CWD: t.TempDir()})
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(fmt.Sprint(err), context.DeadlineExceeded.Error()) {
+		t.Fatalf("Execute error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestAgentTimeoutFailsTask(t *testing.T) {
+	engine := &Engine{Executor: blockingExecutor{}}
+	_, err := engine.Execute(context.Background(), `workflow { name = "timeout" }
+return await(agent { prompt = "block" })`, ExecuteOptions{
+		CWD:          t.TempDir(),
+		AgentTimeout: 10 * time.Millisecond,
+	})
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(fmt.Sprint(err), context.DeadlineExceeded.Error()) {
+		t.Fatalf("Execute error = %v, want deadline exceeded", err)
+	}
+}


### PR DESCRIPTION
## What this adds

A deliberately small programmable orchestration surface:

```sh
term-llm workflow validate review.lua
term-llm workflow run review.lua --input source="$PWD" \
  --agent-tool read_file,write_file,shell \
  --agent-read-dir /tmp/reviews \
  --agent-write-dir /tmp/reviews \
  --agent-shell-allow 'go test *' \
  --workspace-root /tmp/reviews
```

Lua workflows can create lazy one-shot or tool-using agent tasks, await them, run them concurrently, preserve settled failures, and create isolated source copies:

```lua
local workspace = create_workspace {
  source = input("source"),
  root = "/tmp/reviews",
  name = "race-review",
}

return parallel_settled {
  run_agent {
    system = "Find a concurrency bug and prove it with a regression test.",
    prompt = "Inspect this package.",
    tools = { "read_file", "write_file", "shell" },
    read_dirs = { workspace },
    write_dirs = { workspace },
    shell_allow = { "go test *" },
    cwd = workspace,
    require = {
      command = "go test -race .",
      exit_code = 1,
      repetitions = 3,
      output_contains = "FAIL",
      artifact_glob = "*_test.go",
    },
  },
}
```

The important primitive is `require`: the harness reruns the completion command and records its actual output, exit code, repetitions, and hashed artifacts. Model prose cannot satisfy the contract. Objective evidence can still satisfy a task when an agent exhausts its turns after producing valid work.

## Scope

This is file-based and process-local on purpose. It adds only:

- `workflow run <path.lua>` and `workflow validate <path.lua>`
- `agent`, `run_agent`, `await`, `parallel`, and `parallel_settled`
- `create_workspace`
- structured child results, tool records, evidence, and artifact hashes
- invocation-level capability ceilings

It does **not** add workflow CRUD, SQLite state, migrations, a registry, scheduler, TUI, pause/resume, replay, or crash recovery. Workflow files and their history remain ordinary Git concerns.

## Capability boundary

Lua has no ambient filesystem, process, package-loading, clock, or randomness APIs. A workflow may narrow, but cannot widen, the invocation's tool/path/shell/workspace ceilings. Dynamic child agents run non-interactively only after that intersection is checked.

This is capability control, not an OS sandbox. In particular, allowing `go test *` permits arbitrary Go test code to execute. Untrusted source still needs a container or another OS sandbox. Source, child output, evidence output, and artifacts have explicit size limits; path authorization resolves symlinked parents.

## Why Lua

It keeps branching, loops, fan-out, retries, and result reduction in a readable user-owned file while Go retains authority over agent execution, concurrency, timeouts, capability checks, subprocess cancellation, and evidence validation. The stripped binary cost measured during the prototype was 880 KiB (1.48%), 360 KiB gzipped.

## Prototype evidence

A self-hosted Qwen experiment seeded ten bugs into the same 176-line Go package and accepted a test only when it failed three times on the buggy source, passed three times on the corrected source, and left production hashes unchanged.

- one generalist invocation: **4/10** bugs proved, 40.6s
- adaptive specialist workflow: **10/10** bugs proved, 15 invocations, 284.7s

This is not equal-compute model benchmarking—the workflow spent roughly 7x the wall time and 15x the invocations. It demonstrates the intended mechanism: narrow parallel attempts plus mechanical filtering and targeted retries can turn a weak local model's inconsistent candidates into complete executable evidence.

## Validation

- `go test -race ./internal/workflow -count=1`
- `go test ./...` in an isolated HOME/XDG environment
- `go vet ./...`
- full `go build`
- live `workflow validate`
- live `workflow run` covering `create_workspace` and empty `parallel_settled`
- `git diff --check`

A separate default-model review found an empty-parallel deadlock, malformed/truncated JSONL acceptance, symlinked-parent path authorization, and unbounded outputs/artifacts. Those were fixed with regression coverage before publication.
