### PR TITLE
fix(web): reserve uploaded image space

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -875,6 +875,8 @@ type sessionMessagePartEntry struct {
 	Images          []string                       `json:"images,omitempty"`
 	ToolError       bool                           `json:"tool_error,omitempty"`
 	MimeType        string                         `json:"mime_type,omitempty"`
+	Width           int                            `json:"width,omitempty"`
+	Height          int                            `json:"height,omitempty"`
 }
 
 type sessionMessageEntry struct {
@@ -997,19 +999,50 @@ func (s *serveServer) materializeInlineSessionImage(mediaType, base64Data string
 	return destPath, true
 }
 
-func (s *serveServer) sessionMessageImageURL(part llm.Part) string {
+func imageDimensionsFromReader(reader io.Reader) (width, height int) {
+	metadata, err := io.ReadAll(io.LimitReader(reader, maxImageMetadataBytes))
+	if err != nil {
+		return 0, 0
+	}
+	return imageDisplayDimensions(metadata)
+}
+
+func sessionMessageImageDimensions(part llm.Part, serveablePath string) (width, height int) {
+	if part.ImageData != nil && part.ImageData.Width > 0 && part.ImageData.Height > 0 {
+		return part.ImageData.Width, part.ImageData.Height
+	}
+	if part.ImageData != nil && strings.TrimSpace(part.ImageData.Base64) != "" {
+		decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(part.ImageData.Base64))
+		if width, height := imageDimensionsFromReader(decoder); width > 0 && height > 0 {
+			return width, height
+		}
+	}
+	// The caller supplies only a canonical path already approved by
+	// ensureImageServeable; never inspect an arbitrary path from session data.
+	if strings.TrimSpace(serveablePath) == "" {
+		return 0, 0
+	}
+	f, err := os.Open(serveablePath)
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+	return imageDimensionsFromReader(f)
+}
+
+func (s *serveServer) sessionMessageImageURL(part llm.Part) (url, serveablePath string) {
 	if part.ImagePath != "" {
 		if served, ok := s.ensureImageServeable(part.ImagePath); ok {
-			return serveRoutePath(s.cfg.imagesRoute(), s.imageOutputDir(), served)
+			return serveRoutePath(s.cfg.imagesRoute(), s.imageOutputDir(), served), served
 		}
 	}
 	if part.ImageData == nil || strings.TrimSpace(part.ImageData.Base64) == "" {
-		return ""
+		return "", ""
 	}
 	if served, ok := s.materializeInlineSessionImage(part.ImageData.MediaType, part.ImageData.Base64); ok {
-		return serveRoutePath(s.cfg.imagesRoute(), s.imageOutputDir(), served)
+		return serveRoutePath(s.cfg.imagesRoute(), s.imageOutputDir(), served), served
 	}
-	return ""
+	return "", ""
 }
 
 func sessionSummaryProviderKey(cfg *config.Config, sess session.SessionSummary) string {
@@ -1477,15 +1510,18 @@ func (s *serveServer) sessionMessageEntries(msgs []session.Message) []sessionMes
 					})
 				}
 			case llm.PartImage:
-				if imageURL := s.sessionMessageImageURL(p); imageURL != "" {
+				if imageURL, serveablePath := s.sessionMessageImageURL(p); imageURL != "" {
 					mimeType := ""
 					if p.ImageData != nil {
 						mimeType = p.ImageData.MediaType
 					}
+					width, height := sessionMessageImageDimensions(p, serveablePath)
 					entry.Parts = append(entry.Parts, sessionMessagePartEntry{
 						Type:     "image",
 						ImageURL: imageURL,
 						MimeType: mimeType,
+						Width:    width,
+						Height:   height,
 					})
 				}
 			case llm.PartToolActivity:

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -6,9 +6,11 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"image"
 	"io"
 	"mime"
 	"net/http"
@@ -336,6 +338,123 @@ func looksLikePlainText(raw []byte) bool {
 	return printable*100/checkLen >= 95
 }
 
+const maxImageMetadataBytes = 1 << 20
+
+func imageDisplayDimensions(raw []byte) (width, height int) {
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil || cfg.Width <= 0 || cfg.Height <= 0 {
+		return 0, 0
+	}
+	width, height = cfg.Width, cfg.Height
+	if orientation := jpegEXIFOrientation(raw); orientation >= 5 && orientation <= 8 {
+		width, height = height, width
+	}
+	return width, height
+}
+
+func uploadedImageDimensions(raw []byte, clientWidth, clientHeight int) (width, height int) {
+	width, height = imageDisplayDimensions(raw)
+	if width <= 0 || height <= 0 {
+		return 0, 0
+	}
+	// Browser dimensions account for EXIF orientation. Only accept an exact match
+	// for the server-derived display dimensions, so callers cannot reserve
+	// arbitrary or incorrectly rotated geometry.
+	if clientWidth == width && clientHeight == height {
+		return clientWidth, clientHeight
+	}
+	return width, height
+}
+
+func jsonImageDimension(raw json.RawMessage) int {
+	var value int64
+	if len(raw) == 0 || json.Unmarshal(raw, &value) != nil || value <= 0 || value > int64(^uint(0)>>1) {
+		return 0
+	}
+	return int(value)
+}
+
+func jpegEXIFOrientation(raw []byte) int {
+	if len(raw) < 4 || raw[0] != 0xff || raw[1] != 0xd8 {
+		return 0
+	}
+	for offset := 2; offset+4 <= len(raw); {
+		if raw[offset] != 0xff {
+			offset++
+			continue
+		}
+		for offset < len(raw) && raw[offset] == 0xff {
+			offset++
+		}
+		if offset >= len(raw) {
+			return 0
+		}
+		marker := raw[offset]
+		offset++
+		if marker == 0xd9 || marker == 0xda {
+			return 0
+		}
+		if marker == 0x00 || marker == 0x01 || (marker >= 0xd0 && marker <= 0xd7) {
+			continue
+		}
+		if offset+2 > len(raw) {
+			return 0
+		}
+		segmentLength := int(binary.BigEndian.Uint16(raw[offset : offset+2]))
+		if segmentLength < 2 || offset+segmentLength > len(raw) {
+			return 0
+		}
+		payload := raw[offset+2 : offset+segmentLength]
+		if marker == 0xe1 && len(payload) >= 6 && bytes.Equal(payload[:6], []byte("Exif\x00\x00")) {
+			if orientation := tiffOrientation(payload[6:]); orientation != 0 {
+				return orientation
+			}
+		}
+		offset += segmentLength
+	}
+	return 0
+}
+
+func tiffOrientation(tiff []byte) int {
+	if len(tiff) < 8 {
+		return 0
+	}
+	var order binary.ByteOrder
+	switch string(tiff[:2]) {
+	case "II":
+		order = binary.LittleEndian
+	case "MM":
+		order = binary.BigEndian
+	default:
+		return 0
+	}
+	if order.Uint16(tiff[2:4]) != 42 {
+		return 0
+	}
+	ifdOffset := uint64(order.Uint32(tiff[4:8]))
+	if ifdOffset+2 > uint64(len(tiff)) {
+		return 0
+	}
+	entryCount := uint64(order.Uint16(tiff[ifdOffset : ifdOffset+2]))
+	entriesStart := ifdOffset + 2
+	if entryCount > (uint64(len(tiff))-entriesStart)/12 {
+		return 0
+	}
+	for index := uint64(0); index < entryCount; index++ {
+		entryOffset := entriesStart + index*12
+		entry := tiff[entryOffset : entryOffset+12]
+		if order.Uint16(entry[0:2]) != 0x0112 || order.Uint16(entry[2:4]) != 3 || order.Uint32(entry[4:8]) != 1 {
+			continue
+		}
+		orientation := int(order.Uint16(entry[8:10]))
+		if orientation >= 1 && orientation <= 8 {
+			return orientation
+		}
+		return 0
+	}
+	return 0
+}
+
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
 // Chat Completions-style text/image_url parts are also accepted.
@@ -402,9 +521,17 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 						}
 					}
 
+					clientWidth := jsonImageDimension(part["width"])
+					clientHeight := jsonImageDimension(part["height"])
+					width, height := uploadedImageDimensions(raw, clientWidth, clientHeight)
 					llmParts = append(llmParts, llm.Part{
-						Type:      llm.PartImage,
-						ImageData: &llm.ToolImageData{MediaType: sendMT, Base64: sendB64},
+						Type: llm.PartImage,
+						ImageData: &llm.ToolImageData{
+							MediaType: sendMT,
+							Base64:    sendB64,
+							Width:     width,
+							Height:    height,
+						},
 						ImagePath: path,
 					})
 				} else {

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -20,6 +20,30 @@ import (
 
 const onePixelPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+KDvV3wAAAABJRU5ErkJggg=="
 
+func makeOrientation6JPEG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	var encoded bytes.Buffer
+	if err := jpeg.Encode(&encoded, img, &jpeg.Options{Quality: 80}); err != nil {
+		t.Fatalf("jpeg.Encode() error = %v", err)
+	}
+	raw := encoded.Bytes()
+	exif := []byte{
+		'E', 'x', 'i', 'f', 0, 0,
+		'M', 'M', 0, 42, 0, 0, 0, 8,
+		0, 1,
+		0x01, 0x12, 0, 3, 0, 0, 0, 1, 0, 6, 0, 0,
+		0, 0, 0, 0,
+	}
+	segmentLength := len(exif) + 2
+	withEXIF := make([]byte, 0, len(raw)+len(exif)+4)
+	withEXIF = append(withEXIF, raw[:2]...)
+	withEXIF = append(withEXIF, 0xff, 0xe1, byte(segmentLength>>8), byte(segmentLength))
+	withEXIF = append(withEXIF, exif...)
+	withEXIF = append(withEXIF, raw[2:]...)
+	return withEXIF
+}
+
 func TestNormalizeProviderModelEffort_ExplicitEffortWinsOverSuffix(t *testing.T) {
 	model, effort := normalizeProviderModelEffort("chatgpt", "gpt-5.5-medium", "xhigh")
 	if model != "gpt-5.5" || effort != "xhigh" {
@@ -138,6 +162,69 @@ func TestParseUserMessageContent_RejectsTooManyInlineImages(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), fmt.Sprintf("too many attachments (max %d)", maxAttachments)) {
 		t.Fatalf("parseUserMessageContent() error = %v, want attachment limit error", err)
+	}
+}
+
+func TestParseUserMessageContent_RejectsUntrustedImageDimensions(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var encoded bytes.Buffer
+	if err := jpeg.Encode(&encoded, image.NewRGBA(image.Rect(0, 0, 400, 200)), &jpeg.Options{Quality: 80}); err != nil {
+		t.Fatalf("jpeg.Encode() error = %v", err)
+	}
+
+	content, err := json.Marshal([]map[string]any{{
+		"type":      "input_image",
+		"image_url": "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(encoded.Bytes()),
+		"filename":  "landscape.jpg",
+		"width":     200,
+		"height":    400,
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	msg, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent() error = %v", err)
+	}
+	if len(msg.Parts) != 1 || msg.Parts[0].ImageData == nil {
+		t.Fatalf("message parts = %#v, want one image", msg.Parts)
+	}
+	if got := msg.Parts[0].ImageData; got.Width != 400 || got.Height != 200 {
+		t.Fatalf("image dimensions = %dx%d, want decoded 400x200 rather than untrusted swapped values", got.Width, got.Height)
+	}
+}
+
+func TestParseUserMessageContent_PersistsEXIFOrientedImageDimensions(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	raw := makeOrientation6JPEG(t, 400, 200)
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("image.DecodeConfig() error = %v", err)
+	}
+	if cfg.Width != 400 || cfg.Height != 200 {
+		t.Fatalf("stored JPEG dimensions = %dx%d, want 400x200", cfg.Width, cfg.Height)
+	}
+
+	content, err := json.Marshal([]map[string]any{{
+		"type":      "input_image",
+		"image_url": "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(raw),
+		"filename":  "rotated.jpg",
+		"width":     200,
+		"height":    400,
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	msg, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent() error = %v", err)
+	}
+	if len(msg.Parts) != 1 || msg.Parts[0].ImageData == nil {
+		t.Fatalf("message parts = %#v, want one image", msg.Parts)
+	}
+	if got := msg.Parts[0].ImageData; got.Width != 200 || got.Height != 400 {
+		t.Fatalf("display dimensions = %dx%d, want EXIF-oriented 200x400", got.Width, got.Height)
 	}
 }
 

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -2166,10 +2166,15 @@ func interjectionAttachmentsForEvent(msg llm.Message) []map[string]any {
 		if part.ImageData != nil && part.ImageData.MediaType != "" {
 			mediaType = part.ImageData.MediaType
 		}
-		out = append(out, map[string]any{
+		attachment := map[string]any{
 			"name": fmt.Sprintf("image %d", imageCount),
 			"type": mediaType,
-		})
+		}
+		if part.ImageData != nil && part.ImageData.Width > 0 && part.ImageData.Height > 0 {
+			attachment["width"] = part.ImageData.Width
+			attachment["height"] = part.ImageData.Height
+		}
+		out = append(out, attachment)
 	}
 	return out
 }

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -1126,7 +1126,12 @@ func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{Type: llm.EventTextDelta, Text: "before"}); err != nil {
 		t.Fatalf("appendTextDeltaSegmentEvent before: %v", err)
 	}
-	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{Type: llm.EventInterjection, Text: "check X", InterjectionID: "client-check-x"}); err != nil {
+	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{
+		Type: llm.EventInterjection, Text: "check X", InterjectionID: "client-check-x",
+		Message: llm.Message{Parts: []llm.Part{{
+			Type: llm.PartImage, ImageData: &llm.ToolImageData{MediaType: "image/jpeg", Width: 200, Height: 400},
+		}}},
+	}); err != nil {
 		t.Fatalf("append interjection: %v", err)
 	}
 	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{Type: llm.EventTextDelta, Text: "after"}); err != nil {
@@ -1158,6 +1163,10 @@ func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	}
 	if got := messages[1]["interruptState"]; got != "interject" {
 		t.Fatalf("messages[1].interruptState = %v, want interject", got)
+	}
+	interjectionAttachments, ok := messages[1]["attachments"].([]map[string]any)
+	if !ok || len(interjectionAttachments) != 1 || interjectionAttachments[0]["width"] != 200 || interjectionAttachments[0]["height"] != 400 {
+		t.Fatalf("messages[1].attachments = %#v, want orientation-correct 200x400 metadata", messages[1]["attachments"])
 	}
 	if got := messages[2]["content"]; got != "after" {
 		t.Fatalf("messages[2].content = %v, want after", got)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -6553,7 +6553,8 @@ func TestHandleSessionMessages_OmitsCompactionMetadataWhenUncompacted(t *testing
 	}
 }
 
-func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
+func TestHandleSessionMessages_IncludesOrientationCorrectImageParts(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
 	if err != nil {
@@ -6570,13 +6571,22 @@ func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	msg := session.NewMessage("sess-image", llm.Message{
-		Role: llm.RoleUser,
-		Parts: []llm.Part{
-			{Type: llm.PartImage, ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: "aGVsbG8="}},
-			{Type: llm.PartText, Text: "describe this"},
+	rawImage := makeOrientation6JPEG(t, 400, 200)
+	content, err := json.Marshal([]map[string]any{
+		{
+			"type": "input_image", "image_url": "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(rawImage),
+			"filename": "rotated.jpg", "width": 200, "height": 400,
 		},
-	}, -1)
+		{"type": "input_text", "text": "describe this"},
+	})
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+	parsed, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent: %v", err)
+	}
+	msg := session.NewMessage("sess-image", parsed, -1)
 	if err := store.AddMessage(ctx, "sess-image", msg); err != nil {
 		t.Fatalf("AddMessage: %v", err)
 	}
@@ -6600,6 +6610,8 @@ func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
 				Text     string `json:"text"`
 				ImageURL string `json:"image_url"`
 				MimeType string `json:"mime_type"`
+				Width    int    `json:"width"`
+				Height   int    `json:"height"`
 			} `json:"parts"`
 		} `json:"messages"`
 	}
@@ -6620,11 +6632,14 @@ func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
 	if m.Parts[0].Type != "image" {
 		t.Fatalf("part[0].type = %q, want image", m.Parts[0].Type)
 	}
-	if !strings.HasPrefix(m.Parts[0].ImageURL, "/images/history-") {
-		t.Fatalf("part[0].image_url = %q, want /images/history-*", m.Parts[0].ImageURL)
+	if !strings.HasPrefix(m.Parts[0].ImageURL, "/images/") {
+		t.Fatalf("part[0].image_url = %q, want /images/*", m.Parts[0].ImageURL)
 	}
-	if m.Parts[0].MimeType != "image/png" {
-		t.Fatalf("part[0].mime_type = %q, want image/png", m.Parts[0].MimeType)
+	if m.Parts[0].MimeType != "image/jpeg" {
+		t.Fatalf("part[0].mime_type = %q, want image/jpeg", m.Parts[0].MimeType)
+	}
+	if m.Parts[0].Width != 200 || m.Parts[0].Height != 400 {
+		t.Fatalf("part[0] dimensions = %dx%d, want EXIF-oriented 200x400", m.Parts[0].Width, m.Parts[0].Height)
 	}
 	if m.Parts[1].Type != "text" || m.Parts[1].Text != "describe this" {
 		t.Fatalf("part[1] = %+v, want trailing text part", m.Parts[1])
@@ -6636,8 +6651,29 @@ func TestHandleSessionMessages_IncludesImageParts(t *testing.T) {
 	if imgRR.Code != http.StatusOK {
 		t.Fatalf("image status = %d, want 200", imgRR.Code)
 	}
-	if got := imgRR.Body.String(); got != "hello" {
-		t.Fatalf("image body = %q, want %q", got, "hello")
+	if got := imgRR.Body.Bytes(); !bytes.Equal(got, rawImage) {
+		t.Fatalf("image body differs from persisted orientation-6 JPEG")
+	}
+}
+
+func TestSessionMessageImageDimensionsPrefersInlineBase64AndAppliesEXIF(t *testing.T) {
+	fallback, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(onePixelPNGDataURL, "data:image/png;base64,"))
+	if err != nil {
+		t.Fatalf("decode PNG fallback: %v", err)
+	}
+	fallbackPath := filepath.Join(t.TempDir(), "fallback.png")
+	if err := os.WriteFile(fallbackPath, fallback, 0o600); err != nil {
+		t.Fatalf("write PNG fallback: %v", err)
+	}
+	rotated := makeOrientation6JPEG(t, 400, 200)
+	part := llm.Part{
+		Type:      llm.PartImage,
+		ImagePath: filepath.Join(t.TempDir(), "untrusted-session-path.jpg"),
+		ImageData: &llm.ToolImageData{MediaType: "image/jpeg", Base64: base64.StdEncoding.EncodeToString(rotated)},
+	}
+	width, height := sessionMessageImageDimensions(part, fallbackPath)
+	if width != 200 || height != 400 {
+		t.Fatalf("session image dimensions = %dx%d, want inline EXIF-oriented 200x400", width, height)
 	}
 }
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -482,11 +482,13 @@ const (
 	ToolContentPartImageData ToolContentPartType = "image_data"
 )
 
-// ToolImageData represents base64-encoded image data in tool output.
+// ToolImageData represents base64-encoded image data in user input or tool output.
 type ToolImageData struct {
 	MediaType string `json:"media_type,omitempty"`
 	Base64    string `json:"base64,omitempty"`
 	Detail    string `json:"detail,omitempty"`
+	Width     int    `json:"width,omitempty"`
+	Height    int    `json:"height,omitempty"`
 }
 
 // ToolFileData represents base64-encoded file data in user input.

--- a/internal/serveui/browser_lifecycle.spec.js
+++ b/internal/serveui/browser_lifecycle.spec.js
@@ -10,6 +10,121 @@ async function openUI(page) {
   return errors;
 }
 
+test('user image measurement propagates and reserves landscape and portrait geometry during delayed loads', async ({ page }) => {
+  const fixtures = {
+    landscape: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAyAAAAGQAQAAAAB+XjmZAAAAPklEQVR42u3BMQEAAADCoPVPbQ0PoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4NndAAAYtfwy0AAAAASUVORK5CYII=', 'base64'),
+    portrait: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAZAAAAMgAQAAAAAlkQk9AAAAPklEQVR42u3BgQAAAADDoPlTH+ECVQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMA3n2AAARZ+looAAAAASUVORK5CYII=', 'base64'),
+  };
+  await page.route('**/reserved-*.png', async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname.includes('missing')) {
+      await route.fulfill({ status: 404, contentType: 'image/png', body: 'missing' });
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: pathname.includes('portrait') ? fixtures.portrait : fixtures.landscape,
+    });
+  });
+  const errors = await openUI(page);
+
+  const before = await page.evaluate(async ({ landscapeDataURL, portraitDataURL }) => {
+    const app = window.TermLLMApp;
+    const attachments = [
+      { id: 'pw-landscape', name: 'landscape.png', type: 'image/png', previewURL: '/reserved-preview-landscape.png', dataURL: landscapeDataURL },
+      { id: 'pw-portrait', name: 'portrait.png', type: 'image/png', previewURL: '/reserved-preview-portrait.png', dataURL: portraitDataURL },
+      { id: 'pw-missing', name: 'missing.png', type: 'image/png', previewURL: '/reserved-missing.png', dataURL: landscapeDataURL },
+    ];
+    const [landscapeParts, portraitParts, missingParts] = await Promise.all(
+      attachments.map((attachment) => app.buildAttachmentInputParts([attachment]))
+    );
+
+    const fixture = document.createElement('div');
+    fixture.id = 'pw-image-geometry';
+    fixture.style.cssText = 'position:fixed;left:-2000px;top:0;width:1000px';
+    document.body.appendChild(fixture);
+
+    const renderTransition = (attachment, imagePart, index) => {
+      const optimistic = app.createMessageNode({
+        id: `pw-optimistic-${index}`, role: 'user', content: '', created: Date.now(),
+        attachments: [app.cloneAttachmentForMessage(attachment)],
+      });
+      fixture.appendChild(optimistic);
+      const optimisticRect = optimistic.querySelector('img').getBoundingClientRect();
+      const [durableMessage] = app.convertServerMessages([{
+        id: index + 1, sequence: index + 1, role: 'user', created_at: Date.now(),
+        parts: [{
+          type: 'image', image_url: `/reserved-durable-${index === 0 ? 'landscape' : 'portrait'}.png`, mime_type: 'image/png',
+          width: imagePart.width, height: imagePart.height,
+        }],
+      }]);
+      const durable = app.createMessageNode(durableMessage);
+      durable.dataset.kind = 'durable';
+      durable.dataset.orientation = index === 0 ? 'landscape' : 'portrait';
+      optimistic.replaceWith(durable);
+      const durableImage = durable.querySelector('img');
+      const durableRect = durableImage.getBoundingClientRect();
+      return {
+        part: { width: imagePart.width, height: imagePart.height },
+        optimistic: { width: optimisticRect.width, height: optimisticRect.height },
+        durable: { width: durableRect.width, height: durableRect.height },
+        durableComplete: durableImage.complete,
+      };
+    };
+
+    const landscape = renderTransition(attachments[0], landscapeParts[0], 0);
+    const portrait = renderTransition(attachments[1], portraitParts[0], 1);
+    const unavailableNode = app.createMessageNode({
+      id: 'pw-unavailable', role: 'user', content: '', created: Date.now(),
+      attachments: [app.cloneAttachmentForMessage(attachments[2])],
+    });
+    fixture.appendChild(unavailableNode);
+    const unavailableImage = unavailableNode.querySelector('img');
+    return {
+      landscape,
+      portrait,
+      unavailable: {
+        partHasWidth: Object.prototype.hasOwnProperty.call(missingParts[0], 'width'),
+        partHasHeight: Object.prototype.hasOwnProperty.call(missingParts[0], 'height'),
+        widthAttribute: unavailableImage.getAttribute('width'),
+        heightAttribute: unavailableImage.getAttribute('height'),
+      },
+    };
+  }, {
+    landscapeDataURL: `data:image/png;base64,${fixtures.landscape.toString('base64')}`,
+    portraitDataURL: `data:image/png;base64,${fixtures.portrait.toString('base64')}`,
+  });
+
+  expect(before.landscape.part).toEqual({ width: 800, height: 400 });
+  expect(before.landscape.optimistic.width).toBeCloseTo(360, 1);
+  expect(before.landscape.optimistic.height).toBeCloseTo(180, 1);
+  expect(before.landscape.durable.width).toBeCloseTo(before.landscape.optimistic.width, 1);
+  expect(before.landscape.durable.height).toBeCloseTo(before.landscape.optimistic.height, 1);
+  expect(before.landscape.durableComplete).toBe(false);
+  expect(before.portrait.part).toEqual({ width: 400, height: 800 });
+  expect(before.portrait.optimistic.width).toBeCloseTo(135, 1);
+  expect(before.portrait.optimistic.height).toBeCloseTo(270, 1);
+  expect(before.portrait.durable.width).toBeCloseTo(before.portrait.optimistic.width, 1);
+  expect(before.portrait.durable.height).toBeCloseTo(before.portrait.optimistic.height, 1);
+  expect(before.portrait.durableComplete).toBe(false);
+  expect(before.unavailable).toEqual({ partHasWidth: false, partHasHeight: false, widthAttribute: null, heightAttribute: null });
+
+  await page.waitForFunction(() => Array.from(document.querySelectorAll('#pw-image-geometry [data-kind="durable"] img')).every((image) => image.complete));
+  const after = await page.evaluate(() => Object.fromEntries(
+    Array.from(document.querySelectorAll('#pw-image-geometry [data-kind="durable"]')).map((node) => {
+      const rect = node.querySelector('img').getBoundingClientRect();
+      return [node.dataset.orientation, { width: rect.width, height: rect.height }];
+    })
+  ));
+  expect(after.landscape.width).toBeCloseTo(before.landscape.durable.width, 1);
+  expect(after.landscape.height).toBeCloseTo(before.landscape.durable.height, 1);
+  expect(after.portrait.width).toBeCloseTo(before.portrait.durable.width, 1);
+  expect(after.portrait.height).toBeCloseTo(before.portrait.durable.height, 1);
+  expect(errors).toEqual([]);
+});
+
 test('scroll gaps remain bounded and tail materializes', async ({ page }) => {
   const errors = await openUI(page);
   const state = await page.evaluate(async () => {

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -106,6 +107,32 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 				t.Fatalf("pure lifecycle module %s accesses forbidden effect %q", name, forbidden)
 			}
 		}
+	}
+}
+
+func TestAttachmentImageSizeLimitsStayCoupled(t *testing.T) {
+	renderJS, err := StaticAsset("app-render.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css, err := StaticAsset("app.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := func(name, source, pattern string) string {
+		t.Helper()
+		match := regexp.MustCompile(pattern).FindStringSubmatch(source)
+		if len(match) != 2 {
+			t.Fatalf("%s limit not found", name)
+		}
+		return match[1]
+	}
+	jsWidth := capture("JavaScript width", string(renderJS), `ATTACHMENT_IMAGE_MAX_WIDTH\s*=\s*(\d+)`)
+	jsHeight := capture("JavaScript height", string(renderJS), `ATTACHMENT_IMAGE_MAX_HEIGHT\s*=\s*(\d+)`)
+	cssWidth := capture("CSS width", string(css), `(?s)\.message-attachments img\s*\{[^}]*max-width:\s*min\((\d+)px`)
+	cssHeight := capture("CSS height", string(css), `(?s)\.message-attachments img\s*\{[^}]*max-height:\s*(\d+)px`)
+	if jsWidth != cssWidth || jsHeight != cssHeight {
+		t.Fatalf("attachment image limits drifted: JavaScript=%sx%s CSS=%sx%s", jsWidth, jsHeight, cssWidth, cssHeight)
 	}
 }
 

--- a/internal/serveui/static/app-attachments.js
+++ b/internal/serveui/static/app-attachments.js
@@ -14,6 +14,31 @@ const refreshSendButtonState = () => {
 
 const getAttachmentPreviewURL = (att) => String(att?.previewURL || att?.dataURL || '');
 
+const getAttachmentImageDimensions = (att) => {
+  const width = Number(att?.width), height = Number(att?.height);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+  return { width: Math.round(width), height: Math.round(height) };
+};
+const setAttachmentImageDimensions = (att, width, height) => {
+  const dimensions = getAttachmentImageDimensions({ width, height }); if (att && dimensions) Object.assign(att, dimensions); return dimensions;
+};
+
+const imageDimensionLoads = new WeakMap();
+const loadAttachmentImageDimensions = (att) => {
+  const existing = getAttachmentImageDimensions(att);
+  if (existing || !att || typeof att !== 'object' || !String(att.type || '').startsWith('image/')) return Promise.resolve(existing);
+  if (imageDimensionLoads.has(att)) return imageDimensionLoads.get(att);
+  const previewURL = getAttachmentPreviewURL(att), ImageCtor = window.Image || globalThis.Image;
+  if (!previewURL || typeof ImageCtor !== 'function') return Promise.resolve(null);
+  const load = new Promise((resolve) => {
+    const image = new ImageCtor();
+    image.onload = () => resolve(setAttachmentImageDimensions(att, image.naturalWidth, image.naturalHeight));
+    image.onerror = () => resolve(null); image.src = previewURL;
+  });
+  imageDimensionLoads.set(att, load);
+  return load.finally(() => imageDimensionLoads.delete(att));
+};
+
 const createAttachmentPreviewURL = (file) => {
   const urlAPI = window.URL || globalThis.URL;
   if (!urlAPI || typeof urlAPI.createObjectURL !== 'function') return '';
@@ -119,12 +144,14 @@ const materializeAttachmentDataURL = async (att, signal, options = {}) => {
 };
 
 const buildAttachmentInputParts = async (attachments, signal, options = {}) => {
-  const materialized = await Promise.all((attachments || []).map(att => materializeAttachmentDataURL(att, signal, options)));
-  return materialized.filter(Boolean).map(att => (
-    att.type.startsWith('image/')
-      ? { type: 'input_image', image_url: att.dataURL, filename: att.name }
-      : { type: 'input_file', file_data: att.dataURL, filename: att.name }
-  ));
+  const materialized = await Promise.all((attachments || []).map(async (att) => {
+    const [data] = await Promise.all([materializeAttachmentDataURL(att, signal, options), loadAttachmentImageDimensions(att)]);
+    return data ? { att, data } : null;
+  }));
+  return materialized.filter(Boolean).map(({ att, data }) => {
+    if (!data.type.startsWith('image/')) return { type: 'input_file', file_data: data.dataURL, filename: data.name };
+    return { type: 'input_image', image_url: data.dataURL, filename: data.name, ...(getAttachmentImageDimensions(att) || {}) };
+  });
 };
 
 const cloneAttachmentForMessage = (att) => {
@@ -136,6 +163,8 @@ const cloneAttachmentForMessage = (att) => {
   if (Number.isFinite(Number(att?.size))) {
     cloned.size = Number(att.size);
   }
+  const dimensions = getAttachmentImageDimensions(att);
+  if (dimensions) Object.assign(cloned, dimensions);
   const previewURL = String(att?.previewURL || '');
   if (previewURL) {
     cloned.previewURL = previewURL;
@@ -209,20 +238,23 @@ const handleFiles = (fileList) => {
       alert(`${file.name} exceeds the 20 MB file size limit.`);
       continue;
     }
-    state.attachments.push({
+    const attachment = {
       id: generateId('att'),
       name: file.name,
       type: file.type || 'application/octet-stream',
       size: file.size,
       file,
       previewURL: (file.type || '').startsWith('image/') ? createAttachmentPreviewURL(file) : ''
-    });
+    };
+    state.attachments.push(attachment);
     renderAttachments();
   }
 };
 
 Object.assign(app, {
   getAttachmentPreviewURL,
+  getAttachmentImageDimensions,
+  loadAttachmentImageDimensions,
   createAttachmentPreviewURL,
   revokeAttachmentPreviewURL,
   discardPendingAttachments,

--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -5,7 +5,7 @@
 const app = window.TermLLMApp;
 const {
   UI_PREFIX, state, elements, INTERJECTION_PHASE, saveSessions, persistAndRefreshShell, conversationDOMFor,
-  cloneAttachmentForMessage
+  cloneAttachmentForMessage, getAttachmentImageDimensions
 } = app;
 const {
   requestHeaders, normalizeError, isSessionVisible, sendMessage
@@ -125,6 +125,19 @@ const setInterjectionPhase = (_session, messageId, phase) => {
   }
 };
 
+const mergeCommittedInterjectionAttachments = (localAttachments, committedAttachments) => {
+  const local = Array.isArray(localAttachments) ? localAttachments : [];
+  const committed = Array.isArray(committedAttachments) ? committedAttachments : [];
+  return Array.from({ length: Math.max(local.length, committed.length) }, (_, index) => {
+    if (!local[index]) return cloneAttachmentForMessage(committed[index]);
+    const attachment = cloneAttachmentForMessage(local[index]), metadata = committed[index];
+    const dimensions = getAttachmentImageDimensions(metadata);
+    if (dimensions) Object.assign(attachment, dimensions);
+    for (const key of ['previewURL', 'dataURL']) if (metadata?.[key]) attachment[key] = String(metadata[key]);
+    return attachment;
+  });
+};
+
 const materializeCommittedInterjection = (session, messageId, committedMessage = null) => {
   const id = String(messageId || '').trim();
   if (!session || !id) return null;
@@ -133,7 +146,7 @@ const materializeCommittedInterjection = (session, messageId, committedMessage =
   if (existing) {
     existing.interruptState = 'interject';
     if (Array.isArray(committedMessage?.attachments) && committedMessage.attachments.length > 0) {
-      existing.attachments = committedMessage.attachments.map(cloneAttachmentForMessage);
+      existing.attachments = mergeCommittedInterjectionAttachments(existing.attachments, committedMessage.attachments);
     }
     return existing;
   }
@@ -149,12 +162,9 @@ const materializeCommittedInterjection = (session, messageId, committedMessage =
     created: Number(committedMessage?.created) || Date.now(),
     interruptState: 'interject'
   };
-  const attachments = Array.isArray(committedMessage?.attachments) && committedMessage.attachments.length > 0
-    ? committedMessage.attachments
-    : pending?.attachments;
-  if (Array.isArray(attachments) && attachments.length > 0) {
-    message.attachments = attachments.map(cloneAttachmentForMessage);
-  }
+  const committedAttachments = Array.isArray(committedMessage?.attachments) ? committedMessage.attachments : [], localAttachments = Array.isArray(pending?.attachments) ? pending.attachments : [];
+  const attachments = mergeCommittedInterjectionAttachments(localAttachments, committedAttachments);
+  if (attachments.length > 0) message.attachments = attachments;
   return app.trackPendingIntent?.(session, message) || message;
 };
 

--- a/internal/serveui/static/app-message-convert.js
+++ b/internal/serveui/static/app-message-convert.js
@@ -415,11 +415,8 @@ const convertServerMessages = (serverMessages, options = {}) => {
       const textParts = [];
       for (const part of parts) {
         if (part.type === 'image' && part.image_url) {
-          attachments.push({
-            name: 'image',
-            type: part.mime_type || 'image/*',
-            dataURL: rebaseMessageAssetURL(part.image_url)
-          });
+          const width = Number(part.width), height = Number(part.height), validDimensions = Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0;
+          attachments.push({ name: 'image', type: part.mime_type || 'image/*', dataURL: rebaseMessageAssetURL(part.image_url), ...(validDimensions ? { width: Math.round(width), height: Math.round(height) } : {}) });
         } else if (part.type === 'file' && part.text) {
           attachments.push({
             name: part.text,

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1771,6 +1771,18 @@ const copyTextWithFeedback = async (button, text, idleLabel, timerKey) => {
   }
 };
 
+const ATTACHMENT_IMAGE_MAX_WIDTH = 360, ATTACHMENT_IMAGE_MAX_HEIGHT = 270;
+
+const applyAttachmentImageDimensions = (img, attachment) => {
+  const width = Number(attachment?.width), height = Number(attachment?.height);
+  if (!img || !Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return;
+  const intrinsicWidth = Math.round(width), intrinsicHeight = Math.round(height);
+  img.setAttribute('width', String(intrinsicWidth)); img.setAttribute('height', String(intrinsicHeight));
+  img.style.width = `${Math.min(intrinsicWidth, ATTACHMENT_IMAGE_MAX_WIDTH, (ATTACHMENT_IMAGE_MAX_HEIGHT * intrinsicWidth) / intrinsicHeight)}px`;
+  img.style.height = 'auto';
+  img.style.aspectRatio = `${intrinsicWidth} / ${intrinsicHeight}`;
+};
+
 const createMessageNode = (message) => {
   if (message.role === 'transcript-gap') return createTranscriptGapNode(message);
   if (message.role === 'skill-run') return createSkillRunNode(message);
@@ -1802,6 +1814,7 @@ const createMessageNode = (message) => {
         const previewURL = rebaseAssetURL(rawPreviewURL);
         if (att.type && att.type.startsWith('image/') && previewURL) {
           const img = document.createElement('img');
+          applyAttachmentImageDimensions(img, att);
           img.src = previewURL;
           img.alt = att.name || 'Attached image';
           img.style.cursor = 'pointer';
@@ -2626,7 +2639,9 @@ const messageRenderKey = (message) => {
             name: attachment?.name || '',
             type: attachment?.type || '',
             previewURL: attachment?.previewURL || '',
-            dataURL: attachment?.dataURL || ''
+            dataURL: attachment?.dataURL || '',
+            width: Number(attachment?.width) || 0,
+            height: Number(attachment?.height) || 0
           }))
           : []
       });

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -4283,8 +4283,11 @@
     }
 
     .message-attachments img {
-      max-width: 360px;
+      /* Keep these caps coupled to app-render.js; TestAttachmentImageSizeLimitsStayCoupled enforces it. */
+      display: block;
+      max-width: min(360px, 100%);
       max-height: 270px;
+      height: auto;
       border-radius: 8px;
       border: 1px solid var(--border);
       object-fit: cover;

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -600,20 +600,46 @@ async function run(name, fn) {
     assertEqual(sources[0]?.src, '/hub/node/alpha/files/movie.webm', 'video source src');
   });
 
-  await run('rebases user attachment image URLs before rendering', () => {
+  await run('rebases user attachment image URLs and reserves intrinsic geometry before rendering', () => {
     const { app } = createHarness({
-      rebaseHubAssetURL(url) { return String(url || '').replace('/ui/images/', '/hub/node/alpha/images/'); }
+      rebaseHubAssetURL(u) { return String(u || '').replace('/ui/images/', '/hub/node/alpha/images/'); }
     });
     const node = app.createMessageNode({
       id: 'u_img',
       role: 'user',
       content: 'see image',
       created: Date.now(),
-      attachments: [{ name: 'image', type: 'image/png', dataURL: '/ui/images/upload.png' }]
+      attachments: [{ name: 'image', type: 'image/png', dataURL: '/ui/images/upload.png', width: 800, height: 400 }]
     });
     const img = node.querySelector('img');
     assert(img, 'expected attachment img');
     assertEqual(img.src, '/hub/node/alpha/images/upload.png', 'attachment image src');
+    assertEqual(img.getAttribute('width'), '800', 'intrinsic image width');
+    assertEqual(img.getAttribute('height'), '400', 'intrinsic image height');
+    assertEqual(img.style.width, '360px', 'landscape reserved display width');
+    assertEqual(img.style.height, 'auto', 'responsive display height');
+    assertEqual(img.style.aspectRatio, '800 / 400', 'reserved aspect ratio');
+  });
+
+  await run('reserves portrait geometry and leaves unavailable dimensions unforced', () => {
+    const { app } = createHarness();
+    const node = app.createMessageNode({
+      id: 'u_portrait', role: 'user', content: '', created: Date.now(),
+      attachments: [
+        { name: 'portrait', type: 'image/jpeg', dataURL: '/portrait.jpg', width: 400, height: 800 },
+        { name: 'unknown', type: 'image/png', dataURL: '/unknown.png' }
+      ]
+    });
+    const images = node.querySelectorAll('img');
+    assertEqual(images.length, 2, 'rendered image count');
+    assertEqual(images[0].getAttribute('width'), '400', 'portrait intrinsic width');
+    assertEqual(images[0].getAttribute('height'), '800', 'portrait intrinsic height');
+    assertEqual(images[0].style.width, '135px', 'portrait height-capped display width');
+    assertEqual(images[0].style.height, 'auto', 'portrait responsive display height');
+    assertEqual(images[0].style.aspectRatio, '400 / 800', 'portrait reserved aspect ratio');
+    assertEqual(images[1].getAttribute('width'), null, 'unknown width omitted');
+    assertEqual(images[1].getAttribute('height'), null, 'unknown height omitted');
+    assertEqual(images[1].style.aspectRatio, undefined, 'unknown aspect ratio omitted');
   });
 
   await run('rebases tool artifact image URLs before rendering', () => {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -3057,7 +3057,7 @@ async function testConvertServerMessagesRebasesHubImageURLs() {
       role: 'user',
       created_at: 1000,
       parts: [
-        { type: 'image', image_url: '/ui/images/upload.png', mime_type: 'image/png' },
+        { type: 'image', image_url: '/ui/images/upload.png', mime_type: 'image/png', width: 1200, height: 800 },
         { type: 'text', text: 'look at this' },
       ],
     },
@@ -3074,9 +3074,14 @@ async function testConvertServerMessagesRebasesHubImageURLs() {
   ]);
 
   const user = converted.find((message) => message.role === 'user');
-  const userImage = user?.attachments?.[0]?.dataURL;
+  const userAttachment = user?.attachments?.[0];
+  const userImage = userAttachment?.dataURL;
   if (userImage !== '/hub/node/alpha/images/upload.png') {
     fail(name, `user image URL = ${JSON.stringify(userImage)}`, JSON.stringify(converted));
+    return;
+  }
+  if (userAttachment?.width !== 1200 || userAttachment?.height !== 800) {
+    fail(name, 'server image dimensions were not preserved during conversion', JSON.stringify(converted));
     return;
   }
 

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -689,6 +689,7 @@ function createHarness(options = {}) {
     URL: urlAPI,
     URLSearchParams,
     Blob,
+    Image: options.Image,
     CSS: options.CSS,
     performance: { now: () => Date.now() },
     navigator: navigatorObj,
@@ -702,6 +703,7 @@ function createHarness(options = {}) {
   windowObj.navigator = navigatorObj;
   windowObj.localStorage = localStorage;
   windowObj.URL = urlAPI;
+  windowObj.Image = options.Image;
   windowObj.CSS = options.CSS;
   windowObj.fetch = async function fetch(url, requestOptions = {}) {
     fetchCalls.push({
@@ -5487,10 +5489,17 @@ async function testInterjectionClosesToolGroupAndInsertsUserMessageAtTail() {
   const harness = createHarness();
   const { app, state, cleanup } = harness;
 
+  const localAttachment = {
+    id: 'att_interject', name: 'rotated.jpg', type: 'image/jpeg', previewURL: 'blob:rotated-preview',
+    file: { name: 'rotated.jpg' },
+  };
   const session = {
     id: 'session_interject',
     title: 'Interject test',
-    messages: [{ id: 'msg_pending', clientMessageId: 'msg_pending', role: 'user', content: 'please also check X', created: 1, interruptState: 'pending_interject' }],
+    messages: [{
+      id: 'msg_pending', clientMessageId: 'msg_pending', role: 'user', content: 'please also check X', created: 1,
+      interruptState: 'pending_interject', attachments: [localAttachment],
+    }],
     lastResponseId: null,
     activeResponseId: 'resp_int',
     lastSequenceNumber: 0,
@@ -5500,10 +5509,10 @@ async function testInterjectionClosesToolGroupAndInsertsUserMessageAtTail() {
   state.activeSessionId = session.id;
 
   state.pendingInterjections = [
-    { sessionId: session.id, prompt: 'please also check X', messageId: 'msg_pending', action: 'interject' },
+    { sessionId: session.id, prompt: 'please also check X', messageId: 'msg_pending', action: 'interject', attachments: [localAttachment] },
   ];
   state.pendingInterruptCommits = [
-    { sessionId: session.id, prompt: 'please also check X', messageId: 'msg_pending' },
+    { sessionId: session.id, prompt: 'please also check X', messageId: 'msg_pending', attachments: [localAttachment] },
   ];
 
   const streamState = app.createResponseStreamState(session);
@@ -5518,6 +5527,7 @@ async function testInterjectionClosesToolGroupAndInsertsUserMessageAtTail() {
     response_id: 'resp_int',
     client_message_id: 'msg_pending',
     text: 'please also check X',
+    attachments: [{ name: 'image 1', type: 'image/jpeg', width: 200, height: 400 }],
   });
 
   const userMessages = projectedMessages(session).filter((m) => m.role === 'user');
@@ -5533,6 +5543,17 @@ async function testInterjectionClosesToolGroupAndInsertsUserMessageAtTail() {
   }
   if (userMessages[0].interruptState !== 'interject') {
     fail(name, `interruptState = ${userMessages[0].interruptState}, want "interject"`);
+    await cleanup();
+    return;
+  }
+  const committedAttachment = userMessages[0].attachments?.[0];
+  if (committedAttachment?.previewURL !== 'blob:rotated-preview' || !committedAttachment?.file) {
+    fail(name, 'URL-less committed metadata replaced the local preview attachment', JSON.stringify(committedAttachment));
+    await cleanup();
+    return;
+  }
+  if (committedAttachment.width !== 200 || committedAttachment.height !== 400) {
+    fail(name, 'committed dimensions were not merged into the local preview attachment', JSON.stringify(committedAttachment));
     await cleanup();
     return;
   }
@@ -6810,8 +6831,26 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     }
   }
 
+  class MockImage {
+    constructor() {
+      this.onload = null;
+      this.onerror = null;
+      this.naturalWidth = 0;
+      this.naturalHeight = 0;
+    }
+
+    set src(_value) {
+      setTimeout(() => {
+        this.naturalWidth = 800;
+        this.naturalHeight = 400;
+        if (this.onload) this.onload();
+      }, 0);
+    }
+  }
+
   const harness = createHarness({
     FileReader: MockFileReader,
+    Image: MockImage,
     onCreateMessageNode(message) {
       if (message?.role !== 'user') return;
       const previewURL = message?.attachments?.[0]?.previewURL || '';
@@ -6910,6 +6949,11 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     await cleanup();
     return;
   }
+  if (storedAttachment.width !== 800 || storedAttachment.height !== 400) {
+    fail(name, 'optimistic attachment should retain intrinsic image dimensions', JSON.stringify(storedAttachment));
+    await cleanup();
+    return;
+  }
 
   const postCall = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
   if (!postCall || !postCall.body) {
@@ -6934,7 +6978,46 @@ async function testSendMessageLazilyMaterializesAttachmentDataURLs() {
     await cleanup();
     return;
   }
+  if (imagePart.width !== 800 || imagePart.height !== 400) {
+    fail(name, 'request body should propagate intrinsic image dimensions', JSON.stringify(imagePart));
+    await cleanup();
+    return;
+  }
 
+  await cleanup();
+  pass(name);
+}
+
+async function testUnavailableImageDimensionsDoNotBlockAttachmentSend() {
+  const name = 'unavailable image dimensions are omitted without blocking attachment send';
+  class MockFileReader {
+    readAsDataURL(file) {
+      this.result = file.mockDataURL;
+      setTimeout(() => this.onload?.(), 0);
+    }
+  }
+  class FailingImage {
+    set src(_value) {
+      setTimeout(() => this.onerror?.(new Error('decode failed')), 0);
+    }
+  }
+  const harness = createHarness({ FileReader: MockFileReader, Image: FailingImage });
+  const { app, cleanup } = harness;
+  const parts = await app.buildAttachmentInputParts([{
+    name: 'unknown.png', type: 'image/png', previewURL: 'blob:unknown.png',
+    file: { name: 'unknown.png', mockDataURL: 'data:image/png;base64,bm90LWEtcG5n' },
+  }]);
+  const imagePart = parts[0];
+  if (!imagePart || imagePart.type !== 'input_image') {
+    fail(name, 'image attachment was not materialized', JSON.stringify(parts));
+    await cleanup();
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(imagePart, 'width') || Object.prototype.hasOwnProperty.call(imagePart, 'height')) {
+    fail(name, 'unavailable dimensions should be omitted', JSON.stringify(imagePart));
+    await cleanup();
+    return;
+  }
   await cleanup();
   pass(name);
 }
@@ -8321,6 +8404,7 @@ const runAppStreamTest = async (testCase) => {
   await runAppStreamTest(testSendMessageConsumesPostStreamWhenAvailable);
   await runAppStreamTest(testSendMessageRefreshesHeaderAfterCompletionUnlocksModelPicker);
   await runAppStreamTest(testSendMessageLazilyMaterializesAttachmentDataURLs);
+  await runAppStreamTest(testUnavailableImageDimensionsDoNotBlockAttachmentSend);
   await runAppStreamTest(testSendMessageKeepsComposerWhenAttachmentMaterializationFails);
   await runAppStreamTest(testWebSlashCommandsInvokeExistingControls);
   await runAppStreamTest(testUndoRedoCommandsUseOptimisticTranscriptAndRestoreComposer);

--- a/internal/session/file_upload_test.go
+++ b/internal/session/file_upload_test.go
@@ -57,7 +57,7 @@ func TestMessagePreservesImageBase64ByDefault(t *testing.T) {
 	msg := NewMessage("sess_test", llm.Message{Role: llm.RoleUser, Parts: []llm.Part{{
 		Type:      llm.PartImage,
 		ImagePath: "/tmp/upload.png",
-		ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: b64, Detail: "high"},
+		ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: b64, Detail: "high", Width: 1200, Height: 800},
 	}}}, 0)
 
 	partsJSON, err := msg.PartsJSON()
@@ -83,7 +83,7 @@ func TestMessageStripsImageBase64WhenStorageOptionEnabled(t *testing.T) {
 	msg := NewMessage("sess_test", llm.Message{Role: llm.RoleUser, Parts: []llm.Part{{
 		Type:      llm.PartImage,
 		ImagePath: uploadPath,
-		ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: b64, Detail: "high"},
+		ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: b64, Detail: "high", Width: 1200, Height: 800},
 	}}}, 0)
 
 	if msg.Parts[0].ImageData == nil || msg.Parts[0].ImageData.Base64 != b64 {
@@ -111,8 +111,8 @@ func TestMessageStripsImageBase64WhenStorageOptionEnabled(t *testing.T) {
 	if part.ImageData.Base64 != "" {
 		t.Fatalf("ImageData.Base64 = %q, want stripped", part.ImageData.Base64)
 	}
-	if part.ImageData.MediaType != "image/png" || part.ImageData.Detail != "high" {
-		t.Fatalf("ImageData metadata = %+v, want media type/detail preserved", part.ImageData)
+	if part.ImageData.MediaType != "image/png" || part.ImageData.Detail != "high" || part.ImageData.Width != 1200 || part.ImageData.Height != 800 {
+		t.Fatalf("ImageData metadata = %+v, want media type/detail/dimensions preserved", part.ImageData)
 	}
 }
 


### PR DESCRIPTION
## Summary

- measure uploaded image dimensions before building the optimistic user message
- carry intrinsic width/height through request parsing, session persistence, interjections, and restored session messages
- reserve the final responsive `360×270`-capped display geometry before image bytes finish loading
- honor JPEG EXIF orientation so phone photos keep the same geometry across optimistic and durable rendering
- recover dimensions safely for legacy stored images when metadata is absent

## Reproduction

I reproduced this in an ephemeral Web UI session with the uploaded image request delayed by 1.5 seconds.

Before the fix:

- pending image: `2×2` px (border only)
- loaded image: `270×270` px

After the fix:

- pending image: `270×270` px
- loaded image: `270×270` px

The browser now reserves the exact final box rather than collapsing the message and shifting it after decode.

## Tests

- `go test ./cmd -run 'Test(ParseUserMessageContent_(RejectsUntrustedImageDimensions|PersistsEXIFOrientedImageDimensions)|HandleSessionMessages_IncludesOrientationCorrectImageParts|SessionMessageImageDimensionsPrefersInlineBase64AndAppliesEXIF|InterjectionAttachments)' -count=1`
- `go test ./internal/session ./internal/serveui -count=1`
- `go build ./...`
- Playwright lifecycle suite with system Chromium: 5/5 passed
- `go vet ./...`
- `git diff --check`

`go test ./...` reaches all changed tests but currently fails in two unrelated existing skill-discovery tests because this environment's visible-skill budget omits their temporary fixture skill:

- `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir`
- `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`

## Review

Reviewed with Opus. The review found EXIF-oriented JPEG mismatch/cropping and several metadata/reconciliation test gaps; those findings are addressed in this revision.
