### PR TITLE
perf: make steering immediate and boundary-safe

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1904,8 +1904,12 @@ func (s *serveServer) handleSessionInterrupt(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	displayText := strings.TrimSpace(req.Message)
+	delivery, err := normalizeInterruptDelivery(req.Delivery)
+	if err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
 	var msg llm.Message
-	var err error
 	if len(req.Content) > 0 && strings.TrimSpace(string(req.Content)) != "" && strings.TrimSpace(string(req.Content)) != "null" {
 		msg, err = parseUserMessageContent(req.Content)
 		if err != nil {
@@ -1938,15 +1942,19 @@ func (s *serveServer) handleSessionInterrupt(w http.ResponseWriter, r *http.Requ
 	s.augmentMessagesWithMentions(r.Context(), rt, sessionID, "", mentionMessages)
 	msg = mentionMessages[0]
 
-	fastProvider, fastErr := llm.NewFastProvider(s.cfgRef, rt.providerKey)
-	if fastErr != nil {
-		log.Printf("[serve] fast provider unavailable for interrupt: %v", fastErr)
+	var fastProvider llm.Provider
+	if delivery == interruptDeliveryAuto {
+		var fastErr error
+		fastProvider, fastErr = llm.NewFastProvider(s.cfgRef, rt.providerKey)
+		if fastErr != nil {
+			log.Printf("[serve] fast provider unavailable for interrupt: %v", fastErr)
+		}
 	}
 	clientMessageID := strings.TrimSpace(req.ClientMessageID)
 	if clientMessageID == "" {
 		clientMessageID = strings.TrimSpace(req.InterjectionID)
 	}
-	action, replayed, interruptErr := rt.InterruptMessage(r.Context(), msg, displayText, clientMessageID, fastProvider, false)
+	action, replayed, interruptErr := rt.InterruptMessage(r.Context(), msg, displayText, clientMessageID, fastProvider, delivery)
 	if interruptErr != nil {
 		writeOpenAIError(w, http.StatusConflict, "conflict_error", interruptErr.Error())
 		return

--- a/cmd/serve_jobs_v2_notify.go
+++ b/cmd/serve_jobs_v2_notify.go
@@ -173,7 +173,7 @@ func (s *serveServer) notifyQueuedAgentWeb(ctx context.Context, runID, sessionID
 				// originating session is already generating. Pass no classifier
 				// provider so this best-effort notice cannot be upgraded into a
 				// cancel/interrupt decision for the user's active run.
-				if _, _, err := rt.InterruptMessage(ctx, llm.UserText(message), message, "job_notify_"+strings.TrimSpace(runID), nil, true); err == nil {
+				if _, _, err := rt.InterruptMessage(ctx, llm.UserText(message), message, "job_notify_"+strings.TrimSpace(runID), nil, interruptDeliverySteer); err == nil {
 					return nil
 				}
 			}

--- a/cmd/serve_jobs_v2_notify_test.go
+++ b/cmd/serve_jobs_v2_notify_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -277,6 +278,138 @@ func TestJobsV2NotifyWhenDoneContinuesLoadedIdleWebSession(t *testing.T) {
 	}
 	if provider.CurrentTurn() != 1 {
 		t.Fatalf("provider turns = %d, want 1", provider.CurrentTurn())
+	}
+}
+
+func TestNotifyQueuedAgentWeb_ActiveRunOwnsNotificationExactlyOnce(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	if err := store.Create(context.Background(), &session.Session{ID: "sess-active", Origin: session.OriginWeb, Status: session.StatusActive}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	provider := llm.NewMockProvider("active").
+		AddTurn(llm.MockTurn{Text: "working", Delay: 100 * time.Millisecond}).
+		AddTextResponse("notification acknowledged")
+	engine := llm.NewEngine(provider, nil)
+	stream, err := engine.Stream(context.Background(), llm.Request{
+		Messages: []llm.Message{llm.UserText("work")},
+		Tools:    []llm.ToolSpec{{Name: "dummy", Schema: map[string]any{"type": "object"}}},
+		MaxTurns: 2,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	rt := &serveRuntime{engine: engine, provider: provider, providerKey: "active", store: store}
+	state := &runtimeInterruptState{done: make(chan struct{}), cancel: func() {}}
+	rt.setActiveInterrupt(state)
+	mgr := newServeSessionManager(time.Minute, 10, nil)
+	putTestSession(mgr, "sess-active", rt)
+	srv := &serveServer{store: store, sessionMgr: mgr}
+	defer func() {
+		rt.clearActiveInterrupt(state)
+		_ = stream.Close()
+		mgr.Close()
+	}()
+
+	message := "Queued job job_123 (developer) succeeded: hello world"
+	if err := srv.notifyQueuedAgentWeb(context.Background(), "run-active", "sess-active", message); err != nil {
+		t.Fatalf("notifyQueuedAgentWeb: %v", err)
+	}
+	interjectionEvents := 0
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv: %v", recvErr)
+		}
+		if event.Type == llm.EventInterjection && event.InterjectionID == "job_notify_run-active" {
+			interjectionEvents++
+		}
+	}
+	if interjectionEvents != 1 {
+		t.Fatalf("job notification interjection events = %d, want exactly one", interjectionEvents)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("active run retained consumed notification: %#v", pending)
+	}
+	requests := provider.RecordedRequests()
+	if len(requests) != 2 {
+		t.Fatalf("provider requests = %d, want initial plus notification continuation", len(requests))
+	}
+	notificationMessages := 0
+	for _, request := range requests {
+		for _, requestMessage := range request.Messages {
+			if requestMessage.ClientMessageID == "job_notify_run-active" && llm.MessageText(requestMessage) == message {
+				notificationMessages++
+			}
+		}
+	}
+	if notificationMessages != 1 {
+		t.Fatalf("provider notification messages = %d, want exactly one", notificationMessages)
+	}
+	store.mu.Lock()
+	persisted := append([]session.Message(nil), store.messages["sess-active"]...)
+	store.mu.Unlock()
+	if len(persisted) != 0 || len(rt.history) != 0 {
+		t.Fatalf("active-run notification also fell back: persisted=%#v history=%#v", persisted, rt.history)
+	}
+}
+
+func TestNotifyQueuedAgentWeb_RunFinishedTeardownFallsBackWithoutPhantom(t *testing.T) {
+	store := newServeRuntimeTestStore()
+	if err := store.Create(context.Background(), &session.Session{ID: "sess-teardown", Origin: session.OriginWeb, Status: session.StatusActive}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	provider := llm.NewMockProvider("teardown").AddTextResponse("finished")
+	engine := llm.NewEngine(provider, nil)
+	stream, err := engine.Stream(context.Background(), llm.Request{
+		Messages: []llm.Message{llm.UserText("work")},
+		Tools:    []llm.ToolSpec{{Name: "dummy", Schema: map[string]any{"type": "object"}}},
+		MaxTurns: 2,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for {
+		_, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv: %v", recvErr)
+		}
+	}
+
+	rt := &serveRuntime{engine: engine, provider: provider, providerKey: "teardown", store: store}
+	// Retain activeInterrupt to model the window after the engine closes its final
+	// boundary but before response-run teardown clears runtime ownership.
+	state := &runtimeInterruptState{done: make(chan struct{}), cancel: func() {}}
+	rt.setActiveInterrupt(state)
+	mgr := newServeSessionManager(time.Minute, 10, nil)
+	putTestSession(mgr, "sess-teardown", rt)
+	srv := &serveServer{store: store, sessionMgr: mgr}
+	defer func() {
+		rt.clearActiveInterrupt(state)
+		mgr.Close()
+	}()
+
+	message := "Queued job job_456 (developer) succeeded: complete"
+	if err := srv.notifyQueuedAgentWeb(context.Background(), "run-finished", "sess-teardown", message); err != nil {
+		t.Fatalf("notifyQueuedAgentWeb: %v", err)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("run-finished fallback retained phantom interjection: %#v", pending)
+	}
+	store.mu.Lock()
+	persisted := append([]session.Message(nil), store.messages["sess-teardown"]...)
+	store.mu.Unlock()
+	if len(persisted) != 1 || persisted[0].Role != llm.RoleAssistant || persisted[0].TextContent != message {
+		t.Fatalf("fallback notifications = %#v, want exactly one assistant notice", persisted)
+	}
+	if len(rt.history) != 1 || rt.history[0].Role != llm.RoleAssistant || llm.MessageText(rt.history[0]) != message {
+		t.Fatalf("runtime history = %#v, want one assistant notice", rt.history)
 	}
 }
 

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -28,6 +28,7 @@ type sessionInterruptRequest struct {
 	Content         json.RawMessage `json:"content"`
 	InterjectionID  string          `json:"interjection_id"`
 	ClientMessageID string          `json:"client_message_id,omitempty"`
+	Delivery        string          `json:"delivery,omitempty"`
 }
 
 type sessionRuntimeEffortRequest struct {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -388,8 +388,28 @@ func (rt *serveRuntime) updateInterruptFromEvent(ev llm.Event) {
 	}
 }
 
+type interruptDelivery string
+
+// Rush is intentionally absent: it requires negotiated provider capability and
+// per-tool interruptibility rather than another unconditional delivery value.
+const (
+	interruptDeliveryAuto  interruptDelivery = "auto"
+	interruptDeliverySteer interruptDelivery = "steer"
+)
+
+func normalizeInterruptDelivery(delivery string) (interruptDelivery, error) {
+	switch strings.ToLower(strings.TrimSpace(delivery)) {
+	case "", string(interruptDeliveryAuto):
+		return interruptDeliveryAuto, nil
+	case string(interruptDeliverySteer):
+		return interruptDeliverySteer, nil
+	default:
+		return "", fmt.Errorf("unsupported interrupt delivery %q (supported values: auto, steer)", delivery)
+	}
+}
+
 func (rt *serveRuntime) Interrupt(ctx context.Context, msg string, fastProvider llm.Provider) (llm.InterruptAction, error) {
-	action, _, err := rt.InterruptMessage(ctx, llm.UserText(msg), msg, "", fastProvider, false)
+	action, _, err := rt.InterruptMessage(ctx, llm.UserText(msg), msg, "", fastProvider, interruptDeliveryAuto)
 	return action, err
 }
 
@@ -418,7 +438,7 @@ func (rt *serveRuntime) QueueActiveRunRuntimeSwitch(model, reasoningEffort strin
 	return nil
 }
 
-func interjectionFingerprint(msg llm.Message, displayText string, autoContinue bool) (string, error) {
+func interjectionFingerprint(msg llm.Message, displayText string, delivery interruptDelivery) (string, error) {
 	parts := append([]llm.Part(nil), msg.Parts...)
 	for i := range parts {
 		// Parsing inline attachments can materialize them at a fresh temporary path
@@ -427,10 +447,12 @@ func interjectionFingerprint(msg llm.Message, displayText string, autoContinue b
 		parts[i].FilePath = ""
 	}
 	payload, err := json.Marshal(struct {
-		Parts        []llm.Part `json:"parts"`
-		DisplayText  string     `json:"display_text"`
-		AutoContinue bool       `json:"auto_continue"`
-	}{parts, displayText, autoContinue})
+		Parts       []llm.Part `json:"parts"`
+		DisplayText string     `json:"display_text"`
+		// Delivery is part of idempotency semantics: retrying the same ID with a
+		// different ownership policy is a conflicting mutation, not a replay.
+		Delivery interruptDelivery `json:"delivery"`
+	}{parts, displayText, delivery})
 	if err != nil {
 		return "", fmt.Errorf("encode interjection idempotency payload: %w", err)
 	}
@@ -438,15 +460,21 @@ func interjectionFingerprint(msg llm.Message, displayText string, autoContinue b
 	return fmt.Sprintf("%x", sum), nil
 }
 
-func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, displayText string, interjectionID string, fastProvider llm.Provider, autoContinue bool) (llm.InterruptAction, bool, error) {
+func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, displayText string, interjectionID string, fastProvider llm.Provider, delivery interruptDelivery) (llm.InterruptAction, bool, error) {
 	interjectionID = strings.TrimSpace(interjectionID)
+	if delivery == "" {
+		delivery = interruptDeliveryAuto
+	}
+	if delivery != interruptDeliveryAuto && delivery != interruptDeliverySteer {
+		return llm.InterruptInterject, false, fmt.Errorf("unsupported interrupt delivery %q", delivery)
+	}
 	if interjectionID != "" && msg.Role == llm.RoleUser {
 		msg.ClientMessageID = interjectionID
 	}
 	fingerprint := ""
 	if interjectionID != "" {
 		var err error
-		fingerprint, err = interjectionFingerprint(msg, displayText, autoContinue)
+		fingerprint, err = interjectionFingerprint(msg, displayText, delivery)
 		if err != nil {
 			return llm.InterruptInterject, false, err
 		}
@@ -507,15 +535,18 @@ func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, d
 		}
 		classifyText += summary
 	}
-	classifyCtx := ctx
-	classifyCancel := func() {}
-	if interjectionID != "" {
-		// Stay below the web client's 5-second mutation first-frame timeout so a
-		// healthy classifier normally responds before transport fallback begins.
-		classifyCtx, classifyCancel = context.WithTimeout(context.WithoutCancel(ctx), 4*time.Second)
+	action := llm.InterruptInterject
+	if delivery == interruptDeliveryAuto {
+		classifyCtx := ctx
+		classifyCancel := func() {}
+		if interjectionID != "" {
+			// Stay below the web client's 5-second mutation first-frame timeout so a
+			// healthy classifier normally responds before transport fallback begins.
+			classifyCtx, classifyCancel = context.WithTimeout(context.WithoutCancel(ctx), 4*time.Second)
+		}
+		action = llm.ClassifyInterrupt(classifyCtx, fastProvider, classifyText, activity)
+		classifyCancel()
 	}
-	action := llm.ClassifyInterrupt(classifyCtx, fastProvider, classifyText, activity)
-	classifyCancel()
 	var resultErr error
 	switch action {
 	case llm.InterruptCancel:
@@ -528,9 +559,12 @@ func (rt *serveRuntime) InterruptMessage(ctx context.Context, msg llm.Message, d
 			cancel()
 		}
 	case llm.InterruptInterject:
-		_, queueStatus := rt.engine.QueueInterjectionWithStatus(llm.QueuedInterjection{ID: interjectionID, Message: msg, DisplayText: displayText, AutoContinue: autoContinue})
-		if queueStatus == llm.InterjectionQueueFollowUpOwned || queueStatus == llm.InterjectionQueueCommitted {
+		_, queueStatus := rt.engine.QueueInterjectionWithStatus(llm.QueuedInterjection{ID: interjectionID, Message: msg, DisplayText: displayText})
+		switch queueStatus {
+		case llm.InterjectionQueueFollowUpOwned, llm.InterjectionQueueCommitted:
 			resultErr = fmt.Errorf("interjection %q is already %s", interjectionID, queueStatus)
+		case llm.InterjectionQueueRunFinished:
+			resultErr = fmt.Errorf("active run finished before interjection %q could be consumed", interjectionID)
 		}
 	}
 	if call != nil {

--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -1115,7 +1115,7 @@ func TestServeRuntimeInterruptCancelMarksResponseRunCancellationRequested(t *tes
 	}
 
 	rt.engine.QueueInterjection(llm.QueuedInterjection{ID: "msg-earlier-queued", Message: llm.UserText("earlier queued")})
-	action, _, err := rt.InterruptMessage(context.Background(), llm.UserText("stop right away"), "stop right away", "msg-stop", nil, false)
+	action, _, err := rt.InterruptMessage(context.Background(), llm.UserText("/stop"), "/stop", "msg-stop", nil, interruptDeliveryAuto)
 	if err != nil {
 		t.Fatalf("InterruptMessage: %v", err)
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2867,9 +2867,131 @@ func TestHandleSessionInterrupt_DeduplicatesRetriedImageInterjection(t *testing.
 		t.Fatalf("mismatched idempotency payload status = %d, want 409; body=%s", rr.Code, rr.Body.String())
 	}
 
+	deliveryMismatch := `{"message":"please inspect this image","interjection_id":"web-1","delivery":"steer","content":[{"type":"input_image","image_url":"data:image/png;base64,aGVsbG8=","filename":"img.png"}]}`
+	req = httptest.NewRequest(http.MethodPost, "/v1/sessions/sess-merge/interrupt", strings.NewReader(deliveryMismatch))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("mismatched idempotency delivery status = %d, want 409; body=%s", rr.Code, rr.Body.String())
+	}
+
 	parts := entries[0].Message.Parts
 	if len(parts) != 2 || parts[0].Type != llm.PartImage || parts[1].Type != llm.PartText || parts[1].Text != "please inspect this image" {
 		t.Fatalf("queued parts = %#v, want image plus message text", parts)
+	}
+}
+
+func TestHandleSessionInterrupt_DeliveryDispatch(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	tests := []struct {
+		name       string
+		delivery   string
+		wantStatus int
+		wantAction string
+		wantCancel int
+		wantQueued int
+	}{
+		{name: "omitted auto dispatches explicit command", wantStatus: http.StatusOK, wantAction: "cancel", wantCancel: 1},
+		{name: "auto dispatches explicit command", delivery: `,"delivery":"auto"`, wantStatus: http.StatusOK, wantAction: "cancel", wantCancel: 1},
+		{name: "steer bypasses auto dispatch", delivery: `,"delivery":"steer"`, wantStatus: http.StatusOK, wantAction: "interject", wantQueued: 1},
+		{name: "unknown rejected", delivery: `,"delivery":"rush"`, wantStatus: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := newServeSessionManager(time.Minute, 10, nil)
+			defer mgr.Close()
+			engine := llm.NewEngine(llm.NewMockProvider("mock"), nil)
+			cancelCalls := 0
+			rt := &serveRuntime{engine: engine, providerKey: "mock"}
+			state := &runtimeInterruptState{cancel: func() { cancelCalls++ }, done: make(chan struct{})}
+			rt.setActiveInterrupt(state)
+			defer rt.clearActiveInterrupt(state)
+			putTestSession(mgr, "sess-delivery", rt)
+
+			srv := &serveServer{sessionMgr: mgr}
+			body := fmt.Sprintf(`{"message":"/stop","interjection_id":"delivery-1"%s}`, tt.delivery)
+			req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess-delivery/interrupt", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			srv.handleSessionByID(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+			if tt.wantAction != "" && !strings.Contains(rr.Body.String(), `"action":"`+tt.wantAction+`"`) {
+				t.Fatalf("body = %s, want action %q", rr.Body.String(), tt.wantAction)
+			}
+			if cancelCalls != tt.wantCancel {
+				t.Fatalf("cancel calls = %d, want %d", cancelCalls, tt.wantCancel)
+			}
+			if pending := engine.ListPendingInterjections(); len(pending) != tt.wantQueued {
+				t.Fatalf("pending = %#v, want %d entries", pending, tt.wantQueued)
+			}
+		})
+	}
+}
+
+func TestHandleSessionInterrupt_ValidatesDeliveryBeforeContentIO(t *testing.T) {
+	srv := &serveServer{}
+	body := `{"delivery":"rush","interjection_id":"delivery-early","content":[{"type":"input_file","filename":"bad.pdf","file_data":"%%%"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess-delivery/interrupt", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.handleSessionInterrupt(rr, req, "sess-delivery")
+
+	if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "unsupported interrupt delivery") {
+		t.Fatalf("status/body = %d %s, want delivery validation before content parsing", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "bad.pdf") {
+		t.Fatalf("content parsing ran before delivery validation: %s", rr.Body.String())
+	}
+}
+
+func TestInterruptMessage_DeliveryControlsFastClassifier(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		delivery      interruptDelivery
+		wantAction    llm.InterruptAction
+		wantFastTurns int
+		wantQueued    int
+	}{
+		{name: "auto invokes fast classifier", delivery: interruptDeliveryAuto, wantAction: llm.InterruptCancel, wantFastTurns: 1},
+		{name: "steer bypasses fast classifier", delivery: interruptDeliverySteer, wantAction: llm.InterruptInterject, wantQueued: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := llm.NewEngine(llm.NewMockProvider("engine"), nil)
+			fastProvider := llm.NewMockProvider("classifier").AddTextResponse("cancel")
+			rt := &serveRuntime{engine: engine}
+			state := &runtimeInterruptState{done: make(chan struct{}), cancel: func() {}}
+			rt.setActiveInterrupt(state)
+			defer rt.clearActiveInterrupt(state)
+
+			action, replayed, err := rt.InterruptMessage(
+				context.Background(),
+				llm.UserText("change course"),
+				"change course",
+				"delivery-direct-"+string(tt.delivery),
+				fastProvider,
+				tt.delivery,
+			)
+			if err != nil {
+				t.Fatalf("InterruptMessage: %v", err)
+			}
+			if replayed {
+				t.Fatal("first dispatch unexpectedly replayed")
+			}
+			if action != tt.wantAction {
+				t.Fatalf("action = %v, want %v", action, tt.wantAction)
+			}
+			if got := fastProvider.CurrentTurn(); got != tt.wantFastTurns {
+				t.Fatalf("fast provider turns = %d, want %d", got, tt.wantFastTurns)
+			}
+			if pending := engine.ListPendingInterjections(); len(pending) != tt.wantQueued {
+				t.Fatalf("pending = %#v, want %d", pending, tt.wantQueued)
+			}
+		})
 	}
 }
 
@@ -2895,7 +3017,7 @@ func TestInterruptMessage_DeduplicatesConcurrentRetry(t *testing.T) {
 			"please incorporate this",
 			"web-concurrent-1",
 			fastProvider,
-			false,
+			interruptDeliveryAuto,
 		)
 		results <- result{action: action, replayed: replayed, err: err}
 	}
@@ -3286,7 +3408,7 @@ func TestServeRuntimeRunClearsUnappliedRuntimeSwitch(t *testing.T) {
 	}
 }
 
-func TestServeRuntimeRun_LeavesPendingInterjectionAtEndOfSimpleStream(t *testing.T) {
+func TestServeRuntimeRun_RejectsInterjectionDuringSimpleStream(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "sessions.db")
 	store, err := session.NewStore(session.Config{Enabled: true, Path: dbPath})
 	if err != nil {
@@ -3320,11 +3442,14 @@ func TestServeRuntimeRun_LeavesPendingInterjectionAtEndOfSimpleStream(t *testing
 	}
 
 	action, err := rt.Interrupt(context.Background(), "also remember this", nil)
-	if err != nil {
-		t.Fatalf("Interrupt failed: %v", err)
-	}
 	if action != llm.InterruptInterject {
 		t.Fatalf("Interrupt action = %v, want %v", action, llm.InterruptInterject)
+	}
+	if err == nil || !strings.Contains(err.Error(), "active run finished") {
+		t.Fatalf("Interrupt error = %v, want non-consuming simple-stream error", err)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("simple stream retained phantom interjection: %#v", pending)
 	}
 
 	close(provider.releaseSecond)
@@ -3341,11 +3466,8 @@ func TestServeRuntimeRun_LeavesPendingInterjectionAtEndOfSimpleStream(t *testing
 	if len(rt.history) != 2 {
 		t.Fatalf("history len = %d, want 2", len(rt.history))
 	}
-	if got := engine.PeekInterjection(); got != "also remember this" {
-		t.Fatalf("pending interjection = %q, want %q", got, "also remember this")
-	}
-	if !engine.CancelInterjection(engine.ListPendingInterjections()[0].ID) {
-		t.Fatal("expected residual interjection to remain cancellable")
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("pending interjections = %#v, want none", pending)
 	}
 
 	msgs, err := store.GetMessages(context.Background(), "serve-interject-persist", 0, 0)
@@ -3857,8 +3979,14 @@ func TestHandleResponses_UIFollowUpRunFailureReleasesClaim(t *testing.T) {
 	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), "event: response.failed") {
 		t.Fatalf("run failure response status=%d body=%s", rr.Code, rr.Body.String())
 	}
-	if _, status := engine.QueueInterjectionWithStatus(entry); status != llm.InterjectionQueueQueued {
+	if status := engine.ClaimInterjection(messageID); status != llm.InterjectionClaimNotFound {
 		t.Fatalf("claim was not released after run failure: %q", status)
+	}
+	if _, status := engine.QueueInterjectionWithStatus(entry); status != llm.InterjectionQueueRunFinished {
+		t.Fatalf("finished run unexpectedly reclaimed retry ownership: %q", status)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("finished run retained retry as phantom interjection: %#v", pending)
 	}
 }
 
@@ -10222,7 +10350,7 @@ func TestClassifiedCancelPreservesCompletedToolContextForFollowUp(t *testing.T) 
 		t.Fatal("provider did not reach the post-tool turn")
 	}
 
-	action, _, err := runtime.InterruptMessage(context.Background(), llm.UserText("stop right away"), "stop right away", "msg-stop-now", nil, false)
+	action, _, err := runtime.InterruptMessage(context.Background(), llm.UserText("/stop"), "/stop", "msg-stop-now", nil, interruptDeliveryAuto)
 	if err != nil {
 		t.Fatalf("InterruptMessage: %v", err)
 	}

--- a/internal/llm/classify.go
+++ b/internal/llm/classify.go
@@ -80,14 +80,12 @@ func classifyInterruptHeuristic(msg string) (InterruptAction, bool) {
 		return InterruptInterject, true
 	}
 
-	overrides := []string{"/stop", "/cancel", "/takeover", "stop", "cancel", "abort", "never mind", "nevermind", "forget it"}
-	for _, w := range overrides {
-		if normalized == w || strings.HasPrefix(normalized, w+" ") {
-			return InterruptCancel, true
-		}
+	switch normalized {
+	case "/stop", "/cancel":
+		return InterruptCancel, true
+	default:
+		return InterruptInterject, false
 	}
-
-	return InterruptInterject, false
 }
 
 // ClassifyInterrupt decides how to handle a new user message while a stream is active.

--- a/internal/llm/classify_test.go
+++ b/internal/llm/classify_test.go
@@ -32,8 +32,24 @@ func TestClassifyTimeout(t *testing.T) {
 func TestClassifyInterruptExplicitCancel(t *testing.T) {
 	t.Parallel()
 
-	if got := ClassifyInterrupt(context.Background(), nil, "/cancel now", InterruptActivity{}); got != InterruptCancel {
-		t.Fatalf("ClassifyInterrupt(cancel) = %v, want InterruptCancel", got)
+	for _, command := range []string{"/stop", "/cancel"} {
+		if got := ClassifyInterrupt(context.Background(), nil, command, InterruptActivity{}); got != InterruptCancel {
+			t.Fatalf("ClassifyInterrupt(%q) = %v, want InterruptCancel", command, got)
+		}
+	}
+}
+
+func TestClassifyInterruptCancellationProseIsNotImmediate(t *testing.T) {
+	t.Parallel()
+
+	for _, prose := range []string{"stop changing direction", "cancel that assumption", "abort only the upload", "/stop after this step"} {
+		action, immediate := ClassifyInterruptImmediate(prose)
+		if immediate || action != InterruptInterject {
+			t.Fatalf("ClassifyInterruptImmediate(%q) = (%v, %v), want non-immediate interject", prose, action, immediate)
+		}
+		if got := ClassifyInterrupt(context.Background(), nil, prose, InterruptActivity{}); got != InterruptInterject {
+			t.Fatalf("ClassifyInterrupt(%q) = %v, want fallback interject", prose, got)
+		}
 	}
 }
 

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -148,6 +148,7 @@ type Engine struct {
 	claimedInterjectionOrder   []string
 	committedInterjectionIDs   map[string]struct{}
 	committedInterjectionOrder []string
+	interjectionRunState       interjectionRunState
 
 	// pendingRequestRuntime is a same-provider model/effort override requested
 	// while an agentic loop is active. It is drained at the next provider-turn
@@ -200,6 +201,15 @@ const (
 	InterjectionQueueAlreadyQueued InterjectionQueueStatus = "already_queued"
 	InterjectionQueueFollowUpOwned InterjectionQueueStatus = "follow_up_owned"
 	InterjectionQueueCommitted     InterjectionQueueStatus = "committed"
+	InterjectionQueueRunFinished   InterjectionQueueStatus = "run_finished"
+)
+
+type interjectionRunState uint8
+
+const (
+	interjectionRunIdle interjectionRunState = iota
+	interjectionRunAccepting
+	interjectionRunNonConsuming
 )
 
 type InterjectionClaimStatus string
@@ -214,11 +224,10 @@ const (
 // QueuedInterjection is a structured user message submitted while a run is active.
 // Queued entries are cancellable until the engine drains them into a provider turn.
 type QueuedInterjection struct {
-	ID           string
-	Message      Message
-	DisplayText  string
-	Status       InterjectionStatus
-	AutoContinue bool // If true, drain at a text-only turn boundary and continue the run.
+	ID          string
+	Message     Message
+	DisplayText string
+	Status      InterjectionStatus
 }
 
 type queuedInterjection = QueuedInterjection
@@ -350,6 +359,7 @@ func (e *Engine) ResetConversation() {
 	e.claimedInterjectionOrder = nil
 	e.committedInterjectionIDs = nil
 	e.committedInterjectionOrder = nil
+	e.interjectionRunState = interjectionRunIdle
 	e.contextNoticeEmitted.Store(false)
 	e.callbackMu.Unlock()
 
@@ -815,7 +825,8 @@ func (e *Engine) QueueInterjection(entry QueuedInterjection) string {
 }
 
 // QueueInterjectionWithStatus reports whether the stable identity was newly
-// queued, already queued, transferred to a follow-up, or already committed.
+// queued for an accepting agentic run, rejected because the current/latest run
+// cannot consume it, already queued, transferred to a follow-up, or committed.
 func (e *Engine) QueueInterjectionWithStatus(entry QueuedInterjection) (string, InterjectionQueueStatus) {
 	e.callbackMu.Lock()
 	defer e.callbackMu.Unlock()
@@ -834,6 +845,9 @@ func (e *Engine) QueueInterjectionWithStatus(entry QueuedInterjection) (string, 
 		if e.pendingInterjections[i].ID == entry.ID {
 			return entry.ID, InterjectionQueueAlreadyQueued
 		}
+	}
+	if e.interjectionRunState == interjectionRunNonConsuming {
+		return entry.ID, InterjectionQueueRunFinished
 	}
 	entry.Message.Role = RoleUser
 	if strings.TrimSpace(entry.Message.ClientMessageID) == "" {
@@ -1094,7 +1108,20 @@ func (e *Engine) markInterjectionsCommittedLocked(entries []queuedInterjection) 
 func (e *Engine) drainInterjections() []queuedInterjection {
 	e.callbackMu.Lock()
 	defer e.callbackMu.Unlock()
+	return e.drainInterjectionsLocked()
+}
 
+func (e *Engine) drainInterjectionsForNextTurn(canAcceptMore bool) []queuedInterjection {
+	e.callbackMu.Lock()
+	defer e.callbackMu.Unlock()
+	out := e.drainInterjectionsLocked()
+	if !canAcceptMore {
+		e.interjectionRunState = interjectionRunNonConsuming
+	}
+	return out
+}
+
+func (e *Engine) drainInterjectionsLocked() []queuedInterjection {
 	if len(e.pendingInterjections) == 0 {
 		return nil
 	}
@@ -1105,34 +1132,42 @@ func (e *Engine) drainInterjections() []queuedInterjection {
 	return out
 }
 
-// drainAutoContinueInterjections atomically commits the queued interjection
-// prefix marked AutoContinue. It intentionally preserves FIFO order: a normal
-// pending user interjection blocks later auto-continue notifications from being
-// injected ahead of it.
-func (e *Engine) drainAutoContinueInterjections() []queuedInterjection {
+func (e *Engine) beginInterjectionRun(canConsume bool) {
+	e.callbackMu.Lock()
+	if canConsume {
+		e.interjectionRunState = interjectionRunAccepting
+	} else {
+		e.interjectionRunState = interjectionRunNonConsuming
+	}
+	e.callbackMu.Unlock()
+}
+
+func (e *Engine) markInterjectionRunNonConsuming() {
+	e.callbackMu.Lock()
+	e.interjectionRunState = interjectionRunNonConsuming
+	e.callbackMu.Unlock()
+}
+
+// drainBoundaryInterjections atomically either commits every pending steer for
+// another provider turn or closes this run's final agentic boundary. Explicit
+// error and cancellation exits are closed by runLoop's deferred teardown.
+func (e *Engine) drainBoundaryInterjections(canContinue, canAcceptMore bool) []queuedInterjection {
 	e.callbackMu.Lock()
 	defer e.callbackMu.Unlock()
 
-	if len(e.pendingInterjections) == 0 || !e.pendingInterjections[0].AutoContinue {
+	if !canContinue || len(e.pendingInterjections) == 0 {
+		e.interjectionRunState = interjectionRunNonConsuming
 		return nil
 	}
-	n := 0
-	for n < len(e.pendingInterjections) && e.pendingInterjections[n].AutoContinue {
-		n++
+	out := e.drainInterjectionsLocked()
+	if !canAcceptMore {
+		e.interjectionRunState = interjectionRunNonConsuming
 	}
-	out := make([]queuedInterjection, n)
-	copy(out, e.pendingInterjections[:n])
-	e.markInterjectionsCommittedLocked(out)
-	copy(e.pendingInterjections, e.pendingInterjections[n:])
-	for i := len(e.pendingInterjections) - n; i < len(e.pendingInterjections); i++ {
-		e.pendingInterjections[i] = queuedInterjection{}
-	}
-	e.pendingInterjections = e.pendingInterjections[:len(e.pendingInterjections)-n]
 	return out
 }
 
-func (e *Engine) continueWithAutoInterjections(ctx context.Context, send eventSender, req *Request, turnCallback TurnCompletedCallback, attempt int, finalMsg Message) (bool, error) {
-	interjections := e.drainAutoContinueInterjections()
+func (e *Engine) continueWithInterjections(ctx context.Context, send eventSender, req *Request, turnCallback TurnCompletedCallback, attempt int, finalMsg Message, canContinue, canAcceptMore bool) (bool, error) {
+	interjections := e.drainBoundaryInterjections(canContinue, canAcceptMore)
 	if len(interjections) == 0 {
 		return false, nil
 	}
@@ -1547,6 +1582,9 @@ func (e *Engine) prepareRequestContext(ctx context.Context, req *Request) {
 
 // Stream returns a stream, applying external tools when needed.
 func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
+	// Until this request is proven agentic, it has no boundary at which it can
+	// consume steering. This also clears accepting state left by a prior run.
+	e.markInterjectionRunNonConsuming()
 	req.Messages = FilterConversationMessages(req.Messages)
 
 	caps := e.provider.Capabilities()
@@ -1614,6 +1652,7 @@ func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 	useLoop := len(req.Tools) > 0 && caps.ToolCalls
 
 	if useLoop {
+		e.beginInterjectionRun(getMaxTurns(req) > 1)
 		if req.SessionID != "" {
 			// Tools read this for session-scoped concerns like file-change tracking.
 			ctx = ContextWithSessionID(ctx, req.SessionID)
@@ -2082,6 +2121,11 @@ func cloneProviderReplayParts(parts []Part) []Part {
 }
 
 func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) error {
+	defer e.markInterjectionRunNonConsuming()
+	sendDone := func() error {
+		e.markInterjectionRunNonConsuming()
+		return send.Send(Event{Type: EventDone})
+	}
 	maxTurns := getMaxTurns(req)
 	originalToolChoice := req.ToolChoice
 	originalTools := append([]ToolSpec(nil), req.Tools...)
@@ -2305,6 +2349,9 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 	}
 turnLoop:
 	for attempt := 0; attempt < maxTurns; attempt++ {
+		// The final provider turn has no later agentic boundary. Reject arrivals
+		// throughout that stream instead of accepting steering it cannot consume.
+		e.beginInterjectionRun(attempt < maxTurns-1)
 		// A model-activated skill can tighten the filter between turns. Remove
 		// now-disallowed definitions before the next provider request.
 		req.Tools = e.FilterAllowedToolSpecs(req.Tools)
@@ -2732,7 +2779,7 @@ turnLoop:
 				return false, err
 			}
 			if finishingToolExecuted {
-				if err := send.Send(Event{Type: EventDone}); err != nil {
+				if err := sendDone(); err != nil {
 					return false, err
 				}
 				recoveryCompleted = true
@@ -3205,23 +3252,17 @@ turnLoop:
 				attempt--
 				continue
 			}
-			// Auto-continue interjections are completion notices from background work.
-			// Unlike ordinary user interjections during prose, they should be handed to
-			// the provider immediately so the active web run can acknowledge them rather
-			// than leaving the session stopped with a pending notice.
-			if attempt < maxTurns-1 {
-				continued, err := e.continueWithAutoInterjections(ctx, send, &req, turnCallback, attempt, finalMsg)
-				if err != nil {
+			continued, err := e.continueWithInterjections(ctx, send, &req, turnCallback, attempt, finalMsg, attempt < maxTurns-1, attempt < maxTurns-2)
+			if err != nil {
+				return err
+			}
+			if continued {
+				if err := applyPendingRequestModelSwitch(attempt + 1); err != nil {
 					return err
 				}
-				if continued {
-					if err := applyPendingRequestModelSwitch(attempt + 1); err != nil {
-						return err
-					}
-					continue
-				}
+				continue
 			}
-			if err := send.Send(Event{Type: EventDone}); err != nil {
+			if err := sendDone(); err != nil {
 				return err
 			}
 			return nil
@@ -3270,8 +3311,24 @@ turnLoop:
 				cancel()
 			}
 
+			// These terminal paths cannot consume another steer. Close ownership before
+			// inspecting the queue so arrivals at or after the decision are rejected.
+			if finishingToolExecuted || inlineToolLoop {
+				if err := sendDone(); err != nil {
+					return err
+				}
+				return nil
+			}
+			if attempt == maxTurns-1 {
+				e.markInterjectionRunNonConsuming()
+				if err := send.Send(Event{Type: EventPhase, Text: MaxTurnsExceededWarning(maxTurns)}); err != nil {
+					return err
+				}
+				return &MaxTurnsExceededError{MaxTurns: maxTurns}
+			}
+
 			// Check for user interjections (MCP sync path)
-			if interjections := e.drainInterjections(); len(interjections) > 0 {
+			if interjections := e.drainInterjectionsForNextTurn(attempt < maxTurns-2); len(interjections) > 0 {
 				interjectionMsgs := make([]Message, 0, len(interjections))
 				for _, interjection := range interjections {
 					interjectionMsg := interjection.Message
@@ -3298,24 +3355,6 @@ turnLoop:
 						return err
 					}
 				}
-			}
-
-			// If a finishing tool was executed, we're done (agent completed its task)
-			if finishingToolExecuted {
-				if err := send.Send(Event{Type: EventDone}); err != nil {
-					return err
-				}
-				return nil
-			}
-
-			// Inline-loop providers have already consumed tool results and streamed
-			// their final answer in this invocation. Persisted interjections are
-			// intentionally delivered on the next user turn.
-			if inlineToolLoop {
-				if err := send.Send(Event{Type: EventDone}); err != nil {
-					return err
-				}
-				return nil
 			}
 
 			// Continue the loop - provider will receive updated messages on next turn
@@ -3373,17 +3412,24 @@ turnLoop:
 					cancel()
 				}
 			}
-			// Auto-continue interjections are completion notices from background work.
-			// Unlike ordinary user interjections during prose, they should be handed to
-			// the provider immediately so the active web run can acknowledge them rather
-			// than leaving the session stopped with a pending notice.
-			if err := send.Send(Event{Type: EventDone}); err != nil {
+			continued, err := e.continueWithInterjections(ctx, send, &req, turnCallback, attempt, finalMsg, attempt < maxTurns-1, attempt < maxTurns-2)
+			if err != nil {
+				return err
+			}
+			if continued {
+				if err := applyPendingRequestModelSwitch(attempt + 1); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := sendDone(); err != nil {
 				return err
 			}
 			return nil
 		}
 
 		if attempt == maxTurns-1 {
+			e.markInterjectionRunNonConsuming()
 			if err := send.Send(Event{Type: EventPhase, Text: MaxTurnsExceededWarning(maxTurns)}); err != nil {
 				return err
 			}
@@ -3491,7 +3537,7 @@ turnLoop:
 		}
 
 		if finishingToolExecuted {
-			if err := send.Send(Event{Type: EventDone}); err != nil {
+			if err := sendDone(); err != nil {
 				return err
 			}
 			return nil
@@ -3499,7 +3545,7 @@ turnLoop:
 
 		// Check for user interjections queued during this turn.
 		// If present, inject them as FIFO user messages so the LLM sees them on the next turn.
-		if interjections := e.drainInterjections(); len(interjections) > 0 {
+		if interjections := e.drainInterjectionsForNextTurn(attempt < maxTurns-2); len(interjections) > 0 {
 			interjectionMsgs := make([]Message, 0, len(interjections))
 			for _, interjection := range interjections {
 				interjectionMsg := interjection.Message

--- a/internal/llm/engine_orchestration_test.go
+++ b/internal/llm/engine_orchestration_test.go
@@ -304,7 +304,7 @@ func TestEngineOrchestration_InlineSyncToolLoopWithoutOrderedEventsKeepsLegacyPe
 	}
 }
 
-func TestEngineOrchestration_InlineSyncToolLoopDrainsInterjectionsBeforeDone(t *testing.T) {
+func TestEngineOrchestration_InlineSyncToolLoopLeavesInterjectionsForFollowUp(t *testing.T) {
 	registry := NewToolRegistry()
 	registry.Register(&mockTool{name: "test_tool", result: "tool output"})
 	provider := &inlineSyncToolProvider{inline: true}
@@ -325,6 +325,7 @@ func TestEngineOrchestration_InlineSyncToolLoopDrainsInterjectionsBeforeDone(t *
 	}
 	defer stream.Close()
 	interjectionIndex, doneIndex, index := -1, -1, 0
+	var lateStatus InterjectionQueueStatus
 	for {
 		event, err := stream.Recv()
 		if err == io.EOF {
@@ -338,14 +339,22 @@ func TestEngineOrchestration_InlineSyncToolLoopDrainsInterjectionsBeforeDone(t *
 		}
 		if event.Type == EventDone {
 			doneIndex = index
+			_, lateStatus = engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "late-inline", Message: UserText("too late")})
 		}
 		index++
 	}
-	if interjectionIndex < 0 || doneIndex < 0 || interjectionIndex >= doneIndex {
-		t.Fatalf("interjection/done indexes = %d/%d", interjectionIndex, doneIndex)
+	if interjectionIndex != -1 || doneIndex < 0 {
+		t.Fatalf("interjection/done indexes = %d/%d, want no committed interjection before done", interjectionIndex, doneIndex)
 	}
-	if len(persisted) == 0 || persisted[len(persisted)-1].Role != RoleUser || MessageText(persisted[len(persisted)-1]) != "follow-up instruction" {
-		t.Fatalf("persisted messages did not end with interjection: %+v", persisted)
+	if lateStatus != InterjectionQueueRunFinished {
+		t.Fatalf("late inline status = %q, want %q", lateStatus, InterjectionQueueRunFinished)
+	}
+	if len(persisted) == 0 || persisted[len(persisted)-1].Role == RoleUser {
+		t.Fatalf("inline terminal path persisted interjection: %+v", persisted)
+	}
+	pending := engine.ListPendingInterjections()
+	if len(pending) != 1 || MessageText(pending[0].Message) != "follow-up instruction" {
+		t.Fatalf("pending interjections = %+v, want only pre-boundary follow-up", pending)
 	}
 	if provider.calls != 1 {
 		t.Fatalf("provider calls = %d, want 1", provider.calls)

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1770,14 +1770,27 @@ func TestEngineStopsAfterAsyncFinishingTool(t *testing.T) {
 	}
 	defer stream.Close()
 
+	var boundaryChecked bool
 	for {
-		_, err := stream.Recv()
+		event, err := stream.Recv()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
 			t.Fatalf("recv error: %v", err)
 		}
+		if event.Type == EventDone {
+			boundaryChecked = true
+			if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "after-finish", Message: UserText("too late")}); status != InterjectionQueueRunFinished {
+				t.Fatalf("finishing-tool boundary status = %q, want %q", status, InterjectionQueueRunFinished)
+			}
+			if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+				t.Fatalf("finishing-tool boundary retained phantom steer: %#v", pending)
+			}
+		}
+	}
+	if !boundaryChecked {
+		t.Fatal("finishing tool did not emit done boundary")
 	}
 
 	if len(provider.calls) != 1 {
@@ -4145,7 +4158,7 @@ func TestEngineInterjection_NoToolCalls(t *testing.T) {
 	}
 }
 
-func TestEngineInterjection_AutoContinueNoToolCalls(t *testing.T) {
+func TestEngineInterjection_OrdinarySteerContinuesNoToolCalls(t *testing.T) {
 	t.Parallel()
 
 	provider := &fakeProvider{
@@ -4181,7 +4194,7 @@ func TestEngineInterjection_AutoContinueNoToolCalls(t *testing.T) {
 	tool := &delayingTool{}
 	registry.Register(tool)
 	engine := NewEngine(provider, registry)
-	engine.QueueInterjection(QueuedInterjection{ID: "job-notify", Message: UserText("job done"), DisplayText: "job done", AutoContinue: true})
+	engine.QueueInterjection(QueuedInterjection{ID: "job-notify", Message: UserText("job done"), DisplayText: "job done"})
 	stream, err := engine.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}, Tools: []ToolSpec{tool.Spec()}, MaxTurns: 3})
 	if err != nil {
 		t.Fatalf("stream error: %v", err)
@@ -4222,12 +4235,29 @@ func TestEngineInterjection_AutoContinueNoToolCalls(t *testing.T) {
 	}
 }
 
-func TestEngineInterjection_AutoContinuePreservesFIFOBehindUserInterjection(t *testing.T) {
+func TestEngineInterjection_OrdinarySteersPreserveFIFOAtTextBoundary(t *testing.T) {
 	t.Parallel()
 
 	provider := &fakeProvider{
 		script: func(call int, req Request) []Event {
-			return []Event{{Type: EventTextDelta, Text: "just text"}, {Type: EventDone}}
+			switch call {
+			case 0:
+				return []Event{{Type: EventTextDelta, Text: "first response"}, {Type: EventDone}}
+			case 1:
+				if len(req.Messages) < 4 {
+					t.Fatalf("second call messages = %#v, want original, assistant, then two steers", req.Messages)
+				}
+				got := req.Messages[len(req.Messages)-3:]
+				if got[0].Role != RoleAssistant || MessageText(got[0]) != "first response" ||
+					got[1].Role != RoleUser || MessageText(got[1]) != "user note" || got[1].ClientMessageID != "user-note" ||
+					got[2].Role != RoleUser || MessageText(got[2]) != "job done" || got[2].ClientMessageID != "job-notify" {
+					t.Fatalf("second call tail = %#v, want assistant then FIFO steers with stable IDs", got)
+				}
+				return []Event{{Type: EventTextDelta, Text: "follow up"}, {Type: EventDone}}
+			default:
+				t.Fatalf("unexpected provider call %d", call)
+				return nil
+			}
 		},
 	}
 	registry := NewToolRegistry()
@@ -4235,13 +4265,14 @@ func TestEngineInterjection_AutoContinuePreservesFIFOBehindUserInterjection(t *t
 	registry.Register(tool)
 	engine := NewEngine(provider, registry)
 	engine.QueueInterjection(QueuedInterjection{ID: "user-note", Message: UserText("user note"), DisplayText: "user note"})
-	engine.QueueInterjection(QueuedInterjection{ID: "job-notify", Message: UserText("job done"), DisplayText: "job done", AutoContinue: true})
+	engine.QueueInterjection(QueuedInterjection{ID: "job-notify", Message: UserText("job done"), DisplayText: "job done"})
 
 	stream, err := engine.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}, Tools: []ToolSpec{tool.Spec()}, MaxTurns: 3})
 	if err != nil {
 		t.Fatalf("stream error: %v", err)
 	}
 	defer stream.Close()
+	var interjectionIDs []string
 	for {
 		event, err := stream.Recv()
 		if err == io.EOF {
@@ -4251,15 +4282,366 @@ func TestEngineInterjection_AutoContinuePreservesFIFOBehindUserInterjection(t *t
 			t.Fatalf("recv error: %v", err)
 		}
 		if event.Type == EventInterjection {
-			t.Fatalf("unexpected interjection event: %#v", event)
+			interjectionIDs = append(interjectionIDs, event.InterjectionID)
+			if event.InterjectionStatus != InterjectionCommitted {
+				t.Fatalf("interjection status = %q, want committed", event.InterjectionStatus)
+			}
 		}
 	}
-	if len(provider.calls) != 1 {
-		t.Fatalf("provider calls = %d, want 1", len(provider.calls))
+	if want := []string{"user-note", "job-notify"}; !reflect.DeepEqual(interjectionIDs, want) {
+		t.Fatalf("interjection event IDs = %#v, want %#v", interjectionIDs, want)
+	}
+	if len(provider.calls) != 2 {
+		t.Fatalf("provider calls = %d, want 2", len(provider.calls))
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("pending interjections = %#v, want none", pending)
+	}
+}
+
+func TestEngineInterjection_TextBoundaryPreservesStructuredParts(t *testing.T) {
+	t.Parallel()
+
+	structured := Message{
+		Role: RoleUser,
+		Parts: []Part{
+			{Type: PartImage, ImageData: &ToolImageData{MediaType: "image/png", Base64: "aW1n"}},
+			{Type: PartFile, FileData: &ToolFileData{MediaType: "text/plain", Base64: "ZmlsZQ==", Filename: "notes.txt", SizeBytes: 4}},
+			{Type: PartAgentMention, Text: "@reviewer inspect the attachment"},
+		},
+	}
+	provider := &fakeProvider{script: func(call int, req Request) []Event {
+		if call == 1 {
+			last := req.Messages[len(req.Messages)-1]
+			if last.Role != RoleUser || last.ClientMessageID != "structured-steer" || len(last.Parts) != 3 {
+				t.Fatalf("provider steer = %#v, want stable structured user message", last)
+			}
+			if last.Parts[0].Type != PartImage || last.Parts[1].Type != PartFile || last.Parts[2].Type != PartText || last.Parts[2].Text != structured.Parts[2].Text {
+				t.Fatalf("provider-safe steer parts = %#v, want image, file, mention text", last.Parts)
+			}
+		}
+		return []Event{{Type: EventTextDelta, Text: fmt.Sprintf("response %d", call+1)}, {Type: EventDone}}
+	}}
+	registry := NewToolRegistry()
+	tool := &delayingTool{}
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+	var persisted []Message
+	engine.SetTurnCompletedCallback(func(_ context.Context, _ int, messages []Message, _ TurnMetrics) error {
+		persisted = append(persisted, messages...)
+		return nil
+	})
+	engine.QueueInterjection(QueuedInterjection{ID: "structured-steer", Message: structured, DisplayText: "inspect attachments"})
+
+	stream, err := engine.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}, Tools: []ToolSpec{tool.Spec()}, MaxTurns: 3})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var committed *Event
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv: %v", recvErr)
+		}
+		if event.Type == EventInterjection {
+			copy := event
+			committed = &copy
+		}
+	}
+	if committed == nil || committed.InterjectionID != "structured-steer" || committed.InterjectionStatus != InterjectionCommitted {
+		t.Fatalf("committed event = %#v", committed)
+	}
+	if !reflect.DeepEqual(committed.Message.Parts, structured.Parts) {
+		t.Fatalf("event parts = %#v, want %#v", committed.Message.Parts, structured.Parts)
+	}
+	var persistedSteer *Message
+	for i := range persisted {
+		if persisted[i].ClientMessageID == "structured-steer" {
+			persistedSteer = &persisted[i]
+			break
+		}
+	}
+	if persistedSteer == nil || !reflect.DeepEqual(persistedSteer.Parts, structured.Parts) {
+		t.Fatalf("persisted steer = %#v, want structured parts", persistedSteer)
+	}
+}
+
+func TestEngineInterjection_SimpleStreamRejectsFirstRunSteeringWhileActive(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	provider := &fakeProvider{
+		hasCapabilities: true,
+		capabilities:    Capabilities{ToolCalls: false},
+		script: func(_ int, _ Request) []Event {
+			close(started)
+			<-release
+			return []Event{{Type: EventTextDelta, Text: "simple"}, {Type: EventDone}}
+		},
+	}
+	engine := NewEngine(provider, nil)
+	stream, err := engine.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+	<-started
+
+	if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "during-simple", Message: UserText("steer")}); status != InterjectionQueueRunFinished {
+		t.Fatalf("simple-stream status = %q, want %q", status, InterjectionQueueRunFinished)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("simple stream retained unconsumable steer: %#v", pending)
+	}
+	close(release)
+	drainStream(t, stream)
+}
+
+func TestEngineInterjection_SimpleStreamClearsPriorAgenticOwnership(t *testing.T) {
+	t.Parallel()
+
+	simpleStarted := make(chan struct{})
+	simpleRelease := make(chan struct{})
+	provider := &fakeProvider{script: func(call int, _ Request) []Event {
+		if call == 1 {
+			close(simpleStarted)
+			<-simpleRelease
+		}
+		return []Event{{Type: EventTextDelta, Text: fmt.Sprintf("response %d", call+1)}, {Type: EventDone}}
+	}}
+	registry := NewToolRegistry()
+	tool := &delayingTool{}
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+
+	agentic, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("agentic")},
+		Tools:    []ToolSpec{tool.Spec()},
+		MaxTurns: 2,
+	})
+	if err != nil {
+		t.Fatalf("agentic Stream: %v", err)
+	}
+	drainStream(t, agentic)
+
+	simple, err := engine.Stream(context.Background(), Request{Messages: []Message{UserText("simple")}})
+	if err != nil {
+		t.Fatalf("simple Stream: %v", err)
+	}
+	defer simple.Close()
+	<-simpleStarted
+	if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "after-agentic", Message: UserText("steer")}); status != InterjectionQueueRunFinished {
+		t.Fatalf("simple stream after agentic status = %q, want %q", status, InterjectionQueueRunFinished)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("simple stream retained stale-owned steer: %#v", pending)
+	}
+	close(simpleRelease)
+	drainStream(t, simple)
+}
+
+func TestEngineInterjection_FinalAgenticTurnRejectsSteeringWhileStreaming(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	provider := &fakeProvider{script: func(_ int, _ Request) []Event {
+		close(started)
+		<-release
+		return []Event{{Type: EventTextDelta, Text: "final"}, {Type: EventDone}}
+	}}
+	registry := NewToolRegistry()
+	tool := &delayingTool{}
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("hello")},
+		Tools:    []ToolSpec{tool.Spec()},
+		MaxTurns: 1,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+	<-started
+
+	if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "during-final", Message: UserText("too late")}); status != InterjectionQueueRunFinished {
+		t.Fatalf("final-turn status = %q, want %q", status, InterjectionQueueRunFinished)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("final provider turn retained phantom steer: %#v", pending)
+	}
+	close(release)
+	drainStream(t, stream)
+}
+
+func TestEngineInterjection_MaxTurnsLeavesSteersPending(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{script: func(_ int, _ Request) []Event {
+		return []Event{{Type: EventTextDelta, Text: "final"}, {Type: EventDone}}
+	}}
+	registry := NewToolRegistry()
+	tool := &delayingTool{}
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+	engine.QueueInterjection(QueuedInterjection{ID: "before-final", Message: UserText("recover me")})
+
+	stream, err := engine.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}, Tools: []ToolSpec{tool.Spec()}, MaxTurns: 1})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv: %v", recvErr)
+		}
+		if event.Type == EventInterjection {
+			t.Fatalf("max-turn steer was committed: %#v", event)
+		}
+	}
+	if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "after-final", Message: UserText("follow up")}); status != InterjectionQueueRunFinished {
+		t.Fatalf("post-boundary queue status = %q, want %q", status, InterjectionQueueRunFinished)
 	}
 	pending := engine.ListPendingInterjections()
-	if len(pending) != 2 || pending[0].ID != "user-note" || pending[1].ID != "job-notify" {
-		t.Fatalf("pending interjections = %#v, want FIFO user-note then job-notify", pending)
+	if len(pending) != 1 || pending[0].ID != "before-final" {
+		t.Fatalf("pending = %#v, want only the pre-boundary steer", pending)
+	}
+	if !engine.CancelInterjection("before-final") {
+		t.Fatal("pre-boundary max-turn steer should remain cancellable")
+	}
+	if engine.CancelInterjection("after-final") {
+		t.Fatal("run_finished steer must not leave a phantom queue entry")
+	}
+}
+
+func TestEngineInterjection_MaxTurnToolBoundaryRejectsLateSteer(t *testing.T) {
+	t.Parallel()
+
+	tool := &delayingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	provider := &fakeProvider{script: func(_ int, _ Request) []Event {
+		return []Event{
+			{Type: EventToolCall, Tool: &ToolCall{ID: "call-max", Name: tool.Spec().Name, Arguments: json.RawMessage(`{}`)}},
+			{Type: EventDone},
+		}
+	}}
+	engine := NewEngine(provider, registry)
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("use the tool")},
+		Tools:    []ToolSpec{tool.Spec()},
+		MaxTurns: 1,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+
+	var sawBoundary bool
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("Recv: %v", recvErr)
+		}
+		if event.Type == EventError {
+			var maxErr *MaxTurnsExceededError
+			if !errors.As(event.Err, &maxErr) {
+				t.Fatalf("stream error: %v", event.Err)
+			}
+			break
+		}
+		if event.Type != EventPhase || event.Text != MaxTurnsExceededWarning(1) {
+			continue
+		}
+		sawBoundary = true
+		if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "after-max-tool", Message: UserText("too late")}); status != InterjectionQueueRunFinished {
+			t.Fatalf("max-turn tool boundary status = %q, want %q", status, InterjectionQueueRunFinished)
+		}
+		if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+			t.Fatalf("max-turn tool boundary retained phantom steer: %#v", pending)
+		}
+	}
+	if !sawBoundary {
+		t.Fatal("max-turn tool path did not emit boundary warning")
+	}
+}
+
+func TestEngineInterjection_RunFinishedStateResetsForNextRun(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{script: func(call int, _ Request) []Event {
+		return []Event{{Type: EventTextDelta, Text: fmt.Sprintf("response %d", call+1)}, {Type: EventDone}}
+	}}
+	registry := NewToolRegistry()
+	tool := &delayingTool{}
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+	request := Request{Messages: []Message{UserText("hello")}, Tools: []ToolSpec{tool.Spec()}, MaxTurns: 2}
+
+	first, err := engine.Stream(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first Stream: %v", err)
+	}
+	for {
+		_, recvErr := first.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("first Recv: %v", recvErr)
+		}
+	}
+	if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "too-late", Message: UserText("late")}); status != InterjectionQueueRunFinished {
+		t.Fatalf("late status = %q, want run_finished", status)
+	}
+	if pending := engine.ListPendingInterjections(); len(pending) != 0 {
+		t.Fatalf("late steer was retained after run_finished: %#v", pending)
+	}
+
+	secondStarted := make(chan struct{})
+	secondRelease := make(chan struct{})
+	provider.script = func(call int, _ Request) []Event {
+		if call == 1 {
+			close(secondStarted)
+			<-secondRelease
+		}
+		return []Event{{Type: EventTextDelta, Text: fmt.Sprintf("response %d", call+1)}, {Type: EventDone}}
+	}
+	second, err := engine.Stream(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second Stream: %v", err)
+	}
+	<-secondStarted
+	if _, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "next-run", Message: UserText("steer next")}); status != InterjectionQueueQueued {
+		t.Fatalf("new-run status = %q, want queued", status)
+	}
+	close(secondRelease)
+	var committed bool
+	for {
+		event, recvErr := second.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("second Recv: %v", recvErr)
+		}
+		if event.Type == EventInterjection && event.InterjectionID == "next-run" {
+			committed = true
+		}
+	}
+	if !committed {
+		t.Fatal("new run did not consume queued steer")
 	}
 }
 

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -658,9 +658,14 @@ type telegramSessionMgr struct {
 	// streamEventTimeout bounds how long the stream watchdog waits between events
 	// before declaring the stream dead. 0 means use defaultStreamEventTimeout.
 	streamEventTimeout time.Duration
+
+	fastProviderFactory func() llm.Provider // test seam; nil uses configured fast provider
 }
 
 func (m *telegramSessionMgr) newFastProvider() llm.Provider {
+	if m != nil && m.fastProviderFactory != nil {
+		return m.fastProviderFactory()
+	}
 	if m == nil || m.cfg == nil {
 		return nil
 	}
@@ -670,6 +675,10 @@ func (m *telegramSessionMgr) newFastProvider() llm.Provider {
 		return nil
 	}
 	return fastProvider
+}
+
+func (m *telegramSessionMgr) classifyInterrupt(ctx context.Context, text string, activity llm.InterruptActivity) llm.InterruptAction {
+	return llm.ClassifyInterrupt(ctx, m.newFastProvider(), text, activity)
 }
 
 func (m *telegramSessionMgr) isAllowed(userID int64, username string) bool {
@@ -1517,8 +1526,7 @@ func (m *telegramSessionMgr) handleMessageWithAdmission(ctx context.Context, bot
 			// turns so the structured message remains available to the provider.
 			action := llm.InterruptCancel
 			if tempImagePath == "" {
-				fastProvider := m.newFastProvider()
-				action = llm.ClassifyInterrupt(ctx, fastProvider, newMsgText, activity)
+				action = m.classifyInterrupt(ctx, newMsgText, activity)
 			}
 			switch action {
 			case llm.InterruptCancel:
@@ -1550,28 +1558,23 @@ func (m *telegramSessionMgr) handleMessageWithAdmission(ctx context.Context, bot
 					cancelFn()
 					return
 				}
-				select {
-				case <-doneCh:
-					log.Printf("[telegram] stream for chat %d finished before interjection could be queued; handling message as a new turn", chatID)
-					break activeWait
-				default:
-				}
-				interjectionID := activeEngine.QueueInterjection(llm.QueuedInterjection{
+				interjectionID, queueStatus := activeEngine.QueueInterjectionWithStatus(llm.QueuedInterjection{
 					Message:     llm.UserText(newMsgText),
 					DisplayText: newMsgText,
 				})
-				select {
-				case <-doneCh:
-					if activeEngine.CancelInterjection(interjectionID) {
-						log.Printf("[telegram] stream for chat %d finished before interjection %s was accepted; handling message as a new turn", chatID, interjectionID)
-						break activeWait
-					}
+				switch queueStatus {
+				case llm.InterjectionQueueQueued, llm.InterjectionQueueAlreadyQueued:
+					_, _ = bot.Send(tgbotapi.NewMessage(chatID, "📝 Noted. I will incorporate that while I continue."))
+					// Do not persist here: the engine persists the interjection exactly once
+					// when it drains it into the conversation via TurnCompletedCallback.
+					return
+				case llm.InterjectionQueueRunFinished:
+					log.Printf("[telegram] stream for chat %d reached its final boundary before interjection %s; handling message as a new turn", chatID, interjectionID)
+					break activeWait
 				default:
+					log.Printf("[telegram] interjection %s for chat %d is already %s; not resubmitting it", interjectionID, chatID, queueStatus)
+					return
 				}
-				_, _ = bot.Send(tgbotapi.NewMessage(chatID, "📝 Noted. I will incorporate that while I continue."))
-				// Do not persist here: the engine persists the interjection exactly once
-				// when it drains it into the conversation via TurnCompletedCallback.
-				return
 			}
 		case <-ctx.Done():
 			return

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -400,6 +400,39 @@ func TestSendStreamDone_OnlyFirstCompletionSends(t *testing.T) {
 	}
 }
 
+func TestTelegramInterruptClassificationPolicy(t *testing.T) {
+	t.Run("explicit commands bypass fast classifier", func(t *testing.T) {
+		fast := llm.NewMockProvider("fast").AddTextResponse("interject")
+		mgr := &telegramSessionMgr{fastProviderFactory: func() llm.Provider { return fast }}
+		for _, command := range []string{"/stop", "/cancel"} {
+			if got := mgr.classifyInterrupt(context.Background(), command, llm.InterruptActivity{}); got != llm.InterruptCancel {
+				t.Fatalf("classifyInterrupt(%q) = %v, want cancel", command, got)
+			}
+		}
+		if got := fast.CurrentTurn(); got != 0 {
+			t.Fatalf("fast classifier turns = %d, want zero for explicit commands", got)
+		}
+	})
+
+	t.Run("natural prose uses fast classifier", func(t *testing.T) {
+		fast := llm.NewMockProvider("fast").AddTextResponse("cancel")
+		mgr := &telegramSessionMgr{fastProviderFactory: func() llm.Provider { return fast }}
+		if got := mgr.classifyInterrupt(context.Background(), "stop changing the schema and inspect it", llm.InterruptActivity{}); got != llm.InterruptCancel {
+			t.Fatalf("classifyInterrupt(natural prose) = %v, want classifier cancel", got)
+		}
+		if got := fast.CurrentTurn(); got != 1 {
+			t.Fatalf("fast classifier turns = %d, want one", got)
+		}
+	})
+
+	t.Run("natural prose defaults to steering without fast classifier", func(t *testing.T) {
+		mgr := &telegramSessionMgr{}
+		if got := mgr.classifyInterrupt(context.Background(), "stop changing the schema and inspect it", llm.InterruptActivity{}); got != llm.InterruptInterject {
+			t.Fatalf("classifyInterrupt(natural prose) = %v, want fallback interject", got)
+		}
+	})
+}
+
 func TestTelegramSessionMgrNewFastProvider_ReturnsFreshProviderEachTime(t *testing.T) {
 	mgr := &telegramSessionMgr{
 		cfg: &config.Config{
@@ -3562,7 +3595,7 @@ func TestHandleMessage_PreservesArrivalOrderAcrossPhotoDownload(t *testing.T) {
 		MessageID: 2,
 		From:      &tgbotapi.User{ID: 7, UserName: "sam"},
 		Chat:      &tgbotapi.Chat{ID: 42},
-		Text:      "stop and use this clarification",
+		Text:      "/stop",
 	}
 	photoAdmission := mgr.admitMessage(photoMessage)
 	textAdmission := mgr.admitMessage(textMessage)
@@ -3699,7 +3732,7 @@ func TestHandleMessage_CancelInterruptIsNotBlockedBySessionMutex(t *testing.T) {
 
 	secondDone := make(chan struct{})
 	go func() {
-		mgr.handleMessage(context.Background(), bot, message("stop and switch to this"))
+		mgr.handleMessage(context.Background(), bot, message("/stop"))
 		close(secondDone)
 	}()
 	select {

--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -265,13 +265,13 @@ const removePendingInterjectionById = (messageId, options = {}) => {
 
 const cancelPendingInterjection = async (entry) => {
   if (!entry?.sessionId || !entry?.messageId) return;
-  if (entry.action === 'deciding') {
-    if (!entry.transportStarted) {
-      removePendingInterjectionById(entry.messageId);
-      discardPendingInterruptCommit(entry.messageId);
-      state.queuedInterrupts = state.queuedInterrupts.filter((queued) => queued.messageId !== entry.messageId);
-      return;
-    }
+  if (!entry.transportStarted) {
+    removePendingInterjectionById(entry.messageId);
+    discardPendingInterruptCommit(entry.messageId);
+    state.queuedInterrupts = state.queuedInterrupts.filter((queued) => queued.messageId !== entry.messageId);
+    return;
+  }
+  if (entry.deliveryPending || entry.action === 'deciding') {
     entry.cancelRequested = true;
     entry.action = 'cancel';
     discardPendingInterruptCommit(entry.messageId);
@@ -318,8 +318,8 @@ const requeuePendingInterjections = (session) => {
 
 const interruptActiveRunNow = async (session, prompt, messageId, contentParts = null, attachments = []) => {
   const body = Array.isArray(contentParts) && contentParts.length > 0
-    ? { message: prompt, content: prompt ? [...contentParts, { type: 'input_text', text: prompt }] : contentParts, interjection_id: messageId, client_message_id: messageId }
-    : { message: prompt, interjection_id: messageId, client_message_id: messageId };
+    ? { message: prompt, content: prompt ? [...contentParts, { type: 'input_text', text: prompt }] : contentParts, interjection_id: messageId, client_message_id: messageId, delivery: 'steer' }
+    : { message: prompt, interjection_id: messageId, client_message_id: messageId, delivery: 'steer' };
   const headers = requestHeaders(session.id);
   headers['Idempotency-Key'] = `interrupt_${messageId}`;
   const response = await app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(session.id)}/interrupt`, {
@@ -374,9 +374,9 @@ const interruptActiveRunNow = async (session, prompt, messageId, contentParts = 
 
 const interruptMutationTails = new Map();
 
-// Serialize interrupt classification per session. The stack is updated
-// immediately, but server queue ownership follows the same FIFO order the user
-// sees above the composer.
+// Serialize interrupt delivery per session. The stack is updated immediately,
+// but server queue ownership follows the same FIFO order the user sees above
+// the composer.
 const interruptActiveRun = (session, prompt, messageId, contentParts = null, attachments = []) => {
   const sessionId = String(session?.id || '').trim();
   const previous = interruptMutationTails.get(sessionId) || Promise.resolve();
@@ -388,8 +388,13 @@ const interruptActiveRun = (session, prompt, messageId, contentParts = null, att
       state.queuedInterrupts = state.queuedInterrupts.filter((item) => item.messageId !== messageId);
       return 'discarded';
     }
-    if (entry) entry.transportStarted = true;
-    return interruptActiveRunNow(session, prompt, messageId, contentParts, attachments);
+    if (entry) {
+      entry.transportStarted = true;
+      entry.deliveryPending = true;
+    }
+    return interruptActiveRunNow(session, prompt, messageId, contentParts, attachments).finally(() => {
+      if (entry) entry.deliveryPending = false;
+    });
   });
   const tail = request.then(() => undefined, () => undefined).finally(() => {
     if (interruptMutationTails.get(sessionId) === tail) interruptMutationTails.delete(sessionId);

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -354,7 +354,7 @@ const sendMessage = async (options = {}) => {
     }
     stageDraftMessage(prompt, session.id);
     app.trackPendingInterruptCommit(session.id, prompt, pendingMessageId, pendingAttachments);
-    app.trackPendingInterjection(session.id, prompt || pendingAttachments[0]?.name || 'Attachment', pendingMessageId, 'deciding', pendingAttachments);
+    app.trackPendingInterjection(session.id, prompt || pendingAttachments[0]?.name || 'Attachment', pendingMessageId, 'interject', pendingAttachments);
     persistAndRefreshShell();
     elements.promptInput.value = '';
     state.attachments = [];

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -5725,14 +5725,65 @@ async function testPendingInterjectionsRenderAsCancellableStack() {
   pass(name);
 }
 
-async function testInterjectionClassificationPreservesStackOrder() {
-  const name = 'interjection classification is serialized in composer stack order';
+async function testFirstPartySteerSkipsDecidingPhaseAndSendsDelivery() {
+  const name = 'first-party steering sends delivery steer without a deciding phase';
+  let releaseInterrupt;
+  let markInterruptStarted;
+  let requestBody = null;
+  const interruptStarted = new Promise((resolve) => { markInterruptStarted = resolve; });
+  const interruptResponse = new Promise((resolve) => { releaseInterrupt = resolve; });
+  const harness = createHarness({
+    fetchImpl: async (url, requestOptions, { Response }) => {
+      if (!url.endsWith('/interrupt')) throw new Error(`unexpected fetch: ${url}`);
+      requestBody = JSON.parse(requestOptions.body || '{}');
+      markInterruptStarted();
+      await interruptResponse;
+      return new Response(JSON.stringify({ action: 'interject' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  });
+  const { app, state, elements, cleanup } = harness;
+  const session = { id: 'session_immediate_steer', title: 'Immediate steer', messages: [], activeResponseId: 'resp_active' };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  elements.promptInput.value = 'stop changing the schema; inspect it first';
+
+  const sending = app.sendMessage();
+  await interruptStarted;
+  const pending = state.pendingInterjections[0];
+  if (requestBody?.delivery !== 'steer' || !pending || pending.action !== 'interject') {
+    fail(name, 'steer used classifier-shaped request or UI state', JSON.stringify({ requestBody, pending }));
+    releaseInterrupt();
+    await Promise.allSettled([sending]);
+    await cleanup();
+    return;
+  }
+  if (state.pendingInterjections.some((entry) => entry.action === 'deciding')) {
+    fail(name, 'first-party steer entered deciding phase', JSON.stringify(state.pendingInterjections));
+    releaseInterrupt();
+    await Promise.allSettled([sending]);
+    await cleanup();
+    return;
+  }
+
+  releaseInterrupt();
+  await sending;
+  await cleanup();
+  pass(name);
+}
+
+async function testInterjectionDeliveryPreservesStackOrder() {
+  const name = 'interjection delivery is serialized in composer stack order';
   let releaseFirst;
   let interruptCalls = 0;
+  const requestBodies = [];
   const firstResponse = new Promise((resolve) => { releaseFirst = resolve; });
   const harness = createHarness({
-    fetchImpl: async (url, _requestOptions, { Response }) => {
+    fetchImpl: async (url, requestOptions, { Response }) => {
       if (!url.endsWith('/interrupt')) throw new Error(`unexpected fetch: ${url}`);
+      requestBodies.push(JSON.parse(requestOptions.body || '{}'));
       interruptCalls += 1;
       if (interruptCalls === 1) await firstResponse;
       return new Response(JSON.stringify({ action: 'interject' }), {
@@ -5761,8 +5812,8 @@ async function testInterjectionClassificationPreservesStackOrder() {
   }
   releaseFirst();
   await Promise.all([first, second]);
-  if (interruptCalls !== 2) {
-    fail(name, `interrupt request count = ${interruptCalls}, want 2`);
+  if (interruptCalls !== 2 || requestBodies.some((body) => body.delivery !== 'steer')) {
+    fail(name, `interrupt requests = ${interruptCalls}, want 2 steer deliveries`, JSON.stringify(requestBodies));
     await cleanup();
     return;
   }
@@ -8397,7 +8448,8 @@ const runAppStreamTest = async (testCase) => {
   await runAppStreamTest(testReplayedInterjectionUsesExactClientIdentity);
   await runAppStreamTest(testCommittedFollowUpConflictRefreshesWithoutRestoringPrompt);
   await runAppStreamTest(testPendingInterjectionsRenderAsCancellableStack);
-  await runAppStreamTest(testInterjectionClassificationPreservesStackOrder);
+  await runAppStreamTest(testFirstPartySteerSkipsDecidingPhaseAndSendsDelivery);
+  await runAppStreamTest(testInterjectionDeliveryPreservesStackOrder);
   await runAppStreamTest(testHistoricalReplayCommitsExactInterjectionBeforeFreshEvents);
   await runAppStreamTest(testHeartbeatTakeoverRetiresQueuedHistoricalReplay);
   await runAppStreamTest(testPendingInterjectionCanCancelWhileClassifying);

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -41,9 +41,8 @@ import (
 
 // Model is the main chat TUI model
 type pendingInterjectionUI struct {
-	ID      string
-	Text    string
-	UIState string
+	ID   string
+	Text string
 }
 
 type pendingStreamModelSwitch struct {
@@ -314,9 +313,6 @@ type Model struct {
 	pendingInterjections    []pendingInterjectionUI
 	selectedInterjection    int       // Selected pending interjection; -1 means none
 	interjectionSeq         uint64    // Monotonic sequence for locally generated interjection IDs
-	interruptRequestSeq     uint64    // Monotonic sequence for async interrupt classification
-	activeInterruptSeq      uint64    // Currently active async interrupt classification request
-	pendingInterruptUI      string    // UI state of latest pending interjection: "", "deciding", "interject"
 	interruptNotice         string    // One-line UI notice for recent interrupt actions
 	ctrlCExitArmedUntil     time.Time // Second Ctrl+C before this time exits the TUI
 	promptHistory           promptHistoryState
@@ -597,13 +593,6 @@ type (
 	streamRenderTickMsg   struct{}
 	footerMessageClearMsg struct {
 		Seq uint64
-	}
-	interruptClassifiedMsg struct {
-		RequestID      uint64
-		InterjectionID string
-		Content        string
-		Parts          []llm.Part
-		Action         llm.InterruptAction
 	}
 	compactStartedMsg struct{}
 	compactDoneMsg    struct {
@@ -1947,7 +1936,6 @@ func isParentChatMessage(msg tea.Msg) bool {
 		footerMessageClearMsg,
 		copyResultMsg,
 		copyStatusClearMsg,
-		interruptClassifiedMsg,
 		compactStartedMsg,
 		compactDoneMsg,
 		handoverDoneMsg,
@@ -2311,9 +2299,6 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		if cmd != nil {
 			cmds = append(cmds, cmd)
 		}
-
-	case interruptClassifiedMsg:
-		return m.handleInterruptClassified(msg)
 
 	case compactDoneMsg:
 		m.streaming = false
@@ -2692,7 +2677,9 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 				// If the engine queue is already empty but we never rendered the
 				// interjection inline, fall back to the visible pending draft.
 				m.restorePendingInterjectionDraft()
-				m.clearPendingInterjectionState()
+				if m.engine == nil || len(m.engine.ListPendingInterjections()) == 0 {
+					m.clearPendingInterjection()
+				}
 
 				titleCmd := m.terminalTitleCmd()
 				if m.altScreen {
@@ -2988,7 +2975,7 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 				}
 				if !matchedPending && m.pendingInterjectionID == "" && strings.TrimSpace(ev.Text) == strings.TrimSpace(m.pendingInterjection) {
 					matchedPending = true
-					m.clearPendingInterjectionState()
+					m.clearPendingInterjection()
 				}
 			}
 			_ = matchedPending
@@ -3237,7 +3224,7 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			// engine queue is already empty but the UI still shows a pending
 			// interjection, restore that draft rather than letting it vanish.
 			m.restorePendingInterjectionDraft()
-			if m.activeInterruptSeq == 0 {
+			if m.engine == nil || len(m.engine.ListPendingInterjections()) == 0 {
 				m.clearPendingInterjection()
 			}
 		}

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -352,7 +352,7 @@ func (m *Model) cancelActiveForInterrupt() (bool, tea.Cmd) {
 		if m.engine != nil {
 			_ = m.engine.DrainInterjection()
 		}
-		m.clearPendingInterjectionState()
+		m.clearPendingInterjection()
 		cmds = append(cmds, m.streamCancelTimeoutCmd())
 		cancelled = true
 	}
@@ -538,10 +538,10 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	// While streaming, pending interjections form a cancellable stack. With an
-	// empty composer, up/down selects and delete/backspace cancels the selected
-	// not-yet-incorporated interjection.
-	if m.streaming && len(m.pendingInterjections) > 0 && strings.TrimSpace(m.textarea.Value()) == "" {
+	// Pending interjections form a cancellable stack. With an empty composer,
+	// up/down selects and delete/backspace cancels the selected not-yet-consumed
+	// entry, including one preserved after its run reached the final boundary.
+	if len(m.pendingInterjections) > 0 && strings.TrimSpace(m.textarea.Value()) == "" {
 		switch msg.String() {
 		case "up":
 			if m.selectedInterjection < 0 {
@@ -921,7 +921,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			if residual := m.engine.DrainInterjection(); residual != "" {
 				m.setTextareaValue(residual)
 			}
-			m.clearPendingInterjectionState()
+			m.clearPendingInterjection()
 
 			m.textarea.Focus()
 			return m, tea.Batch(m.applyPendingStreamModelSwitch(), m.streamCancelTimeoutCmd())
@@ -1086,6 +1086,10 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.setTextareaValue(strings.TrimSuffix(raw, "\\") + "\n")
 				return m, nil
 			}
+			if action, ok := llm.ClassifyInterruptImmediate(raw); ok && action == llm.InterruptCancel {
+				m.applyInterruptActionWithParts(m.nextPendingInterjectionID(), raw, m.imagePartList(), action)
+				return m, nil
+			}
 			if strings.HasPrefix(raw, "/") {
 				if updated, cmd, handled := m.queueMainSkillDuringStream(raw); handled {
 					m.invalidateAltScreenStreamingViewportCache()
@@ -1110,7 +1114,6 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			content := m.expandedPastePlaceholders(raw)
 			parts := m.imagePartList()
-			hasImages := len(parts) > 0
 			if delegationContext != "" {
 				parts = append(parts, llm.Part{Type: llm.PartAgentMention, Text: delegationContext})
 			}
@@ -1124,16 +1127,8 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.pasteChunks = nil
 
 			interjectionID := m.nextPendingInterjectionID()
-			if action, ok := llm.ClassifyInterruptImmediate(content); ok && !hasImages {
-				m.applyInterruptActionWithParts(interjectionID, content, parts, action)
-				return m, nil
-			}
-			if m.fastProvider == nil {
-				m.applyInterruptActionWithParts(interjectionID, content, parts, llm.InterruptInterject)
-				return m, nil
-			}
-
-			return m, m.queueInterruptClassification(interjectionID, content, parts)
+			m.applyInterruptActionWithParts(interjectionID, content, parts, llm.InterruptInterject)
+			return m, nil
 		}
 		// Allow textarea to receive input
 		old := m.textarea.Value()
@@ -1662,7 +1657,6 @@ func (m *Model) syncLatestPendingInterjection() {
 	if len(m.pendingInterjections) == 0 {
 		m.pendingInterjectionID = ""
 		m.pendingInterjection = ""
-		m.pendingInterruptUI = ""
 		m.selectedInterjection = -1
 		return
 	}
@@ -1672,14 +1666,12 @@ func (m *Model) syncLatestPendingInterjection() {
 	latest := m.pendingInterjections[len(m.pendingInterjections)-1]
 	m.pendingInterjectionID = latest.ID
 	m.pendingInterjection = latest.Text
-	m.pendingInterruptUI = latest.UIState
 }
 
-func (m *Model) setPendingInterjection(interjectionID, content, uiState string) {
+func (m *Model) setPendingInterjection(interjectionID, content string) {
 	for i := range m.pendingInterjections {
 		if m.pendingInterjections[i].ID == interjectionID {
 			m.pendingInterjections[i].Text = content
-			m.pendingInterjections[i].UIState = uiState
 			if m.selectedInterjection < 0 {
 				m.selectedInterjection = i
 			}
@@ -1687,7 +1679,7 @@ func (m *Model) setPendingInterjection(interjectionID, content, uiState string) 
 			return
 		}
 	}
-	m.pendingInterjections = append(m.pendingInterjections, pendingInterjectionUI{ID: interjectionID, Text: content, UIState: uiState})
+	m.pendingInterjections = append(m.pendingInterjections, pendingInterjectionUI{ID: interjectionID, Text: content})
 	m.selectedInterjection = len(m.pendingInterjections) - 1
 	m.syncLatestPendingInterjection()
 }
@@ -1711,13 +1703,7 @@ func (m *Model) clearPendingInterjection() {
 	m.pendingInterjections = nil
 	m.pendingInterjectionID = ""
 	m.pendingInterjection = ""
-	m.pendingInterruptUI = ""
 	m.selectedInterjection = -1
-}
-
-func (m *Model) clearPendingInterjectionState() {
-	m.activeInterruptSeq = 0
-	m.clearPendingInterjection()
 }
 
 func (m *Model) cancelSelectedPendingInterjection() bool {
@@ -1729,12 +1715,8 @@ func (m *Model) cancelSelectedPendingInterjection() bool {
 		idx = len(m.pendingInterjections) - 1
 	}
 	entry := m.pendingInterjections[idx]
-	if entry.UIState == "interject" {
-		if !m.engine.CancelInterjection(entry.ID) {
-			return false
-		}
-	} else if entry.UIState == "deciding" && entry.ID == m.pendingInterjectionID {
-		m.activeInterruptSeq = 0
+	if !m.engine.CancelInterjection(entry.ID) {
+		return false
 	}
 	copy(m.pendingInterjections[idx:], m.pendingInterjections[idx+1:])
 	m.pendingInterjections = m.pendingInterjections[:len(m.pendingInterjections)-1]
@@ -1743,39 +1725,11 @@ func (m *Model) cancelSelectedPendingInterjection() bool {
 	return true
 }
 
-func (m *Model) queueInterruptClassification(interjectionID, content string, parts []llm.Part) tea.Cmd {
-	m.interruptRequestSeq++
-	requestID := m.interruptRequestSeq
-	activity := m.currentInterruptActivity()
-
-	m.activeInterruptSeq = requestID
-	m.setPendingInterjection(interjectionID, content, "deciding")
-	m.interruptNotice = ""
-	m.setTextareaValue("")
-
-	provider := m.fastProvider
-	classifyText := content
-	if classifyText == "" && len(parts) > 0 {
-		classifyText = llm.MessageAttachmentSummary(llm.Message{Role: llm.RoleUser, Parts: parts})
-	}
-	return func() tea.Msg {
-		action := llm.ClassifyInterrupt(context.Background(), provider, classifyText, activity)
-		return interruptClassifiedMsg{
-			RequestID:      requestID,
-			InterjectionID: interjectionID,
-			Content:        content,
-			Parts:          parts,
-			Action:         action,
-		}
-	}
-}
-
 func (m *Model) applyInterruptAction(interjectionID, content string, action llm.InterruptAction) {
 	m.applyInterruptActionWithParts(interjectionID, content, nil, action)
 }
 
 func (m *Model) applyInterruptActionWithParts(interjectionID, content string, parts []llm.Part, action llm.InterruptAction) {
-	m.activeInterruptSeq = 0
 	m.setTextareaValue("")
 
 	summary := content
@@ -1785,12 +1739,20 @@ func (m *Model) applyInterruptActionWithParts(interjectionID, content string, pa
 
 	switch action {
 	case llm.InterruptCancel:
+		if m.engine != nil {
+			m.engine.DiscardPendingInterjections()
+		}
 		m.clearPendingInterjection()
-		m.interruptNotice = "✕ cancelled current response — draft restored below"
 		m.phase = "Stopping..."
-		m.setTextareaValue(content)
-		// Restore image attachments when classification chose to cancel the run.
-		// The normal text draft is restored above; queued-interjection cancellation does not restore drafts.
+		if immediate, ok := llm.ClassifyInterruptImmediate(content); ok && immediate == llm.InterruptCancel {
+			m.interruptNotice = "✕ cancelled current response"
+			m.setTextareaValue("")
+		} else {
+			m.interruptNotice = "✕ cancelled current response — draft restored below"
+			m.setTextareaValue(content)
+		}
+		// Image attachments remain in the composer; explicit /stop and /cancel
+		// consume only their command text.
 		if len(parts) > 0 {
 			// Parts already came from current composer images, so leave m.images as-is if still present.
 		}
@@ -1799,7 +1761,6 @@ func (m *Model) applyInterruptActionWithParts(interjectionID, content string, pa
 			m.streamCancelFunc()
 		}
 	case llm.InterruptInterject:
-		m.setPendingInterjection(interjectionID, summary, "interject")
 		leadingImages := 0
 		for leadingImages < len(parts) && parts[leadingImages].Type == llm.PartImage {
 			leadingImages++
@@ -1813,26 +1774,20 @@ func (m *Model) applyInterruptActionWithParts(interjectionID, content string, pa
 		if len(msg.Parts) == 0 {
 			msg = llm.UserText(content)
 		}
-		m.engine.QueueInterjection(llm.QueuedInterjection{ID: interjectionID, Message: msg, DisplayText: summary})
-		m.images = nil
-		m.selectedImage = -1
-	}
-}
-
-func (m *Model) handleInterruptClassified(msg interruptClassifiedMsg) (tea.Model, tea.Cmd) {
-	if msg.RequestID == 0 || msg.RequestID != m.activeInterruptSeq {
-		return m, nil
-	}
-	if !m.streaming {
-		m.clearPendingInterjectionState()
-		if strings.TrimSpace(m.textarea.Value()) == "" {
-			m.setTextareaValue(msg.Content)
+		_, queueStatus := m.engine.QueueInterjectionWithStatus(llm.QueuedInterjection{ID: interjectionID, Message: msg, DisplayText: summary})
+		switch queueStatus {
+		case llm.InterjectionQueueQueued, llm.InterjectionQueueAlreadyQueued:
+			m.setPendingInterjection(interjectionID, summary)
+			m.images = nil
+			m.selectedImage = -1
+		case llm.InterjectionQueueRunFinished:
+			m.interruptNotice = "response cannot consume steering — draft kept below"
+			m.setTextareaValue(content)
+		default:
+			m.interruptNotice = "steering was already handled — draft kept below"
+			m.setTextareaValue(content)
 		}
-		return m, nil
 	}
-
-	m.applyInterruptActionWithParts(msg.InterjectionID, msg.Content, msg.Parts, msg.Action)
-	return m, nil
 }
 
 func (m *Model) restorePendingInterjectionDraft() {
@@ -1873,7 +1828,7 @@ func (m *Model) restorePendingInterjectionDraft() {
 		m.setTextareaValue(strings.Join(textParts, "\n"))
 		return
 	}
-	if m.pendingInterjection != "" && (m.pendingInterruptUI == "interject" || m.pendingInterruptUI == "deciding") {
+	if m.pendingInterjection != "" {
 		m.setTextareaValue(m.pendingInterjection)
 	}
 }

--- a/internal/tui/chat/handlers_test.go
+++ b/internal/tui/chat/handlers_test.go
@@ -993,12 +993,12 @@ func TestResumeBrowserCloseReturnsToChatWithoutLosingDraft(t *testing.T) {
 	}
 }
 
-func TestHandleKeyMsg_StreamingCancelInterjectionRestoresComposerAndShowsStopping(t *testing.T) {
+func TestHandleKeyMsg_StreamingStopCommandCancelsAndShowsStopping(t *testing.T) {
 	m := newTestChatModel(false)
 	m.streaming = true
 	m.phase = "Running shell sleep"
 	m.pendingInterjection = "old"
-	m.setTextareaValue("stop sleeping")
+	m.setTextareaValue("/stop")
 
 	cancelCalls := 0
 	m.streamCancelFunc = func() {
@@ -1010,8 +1010,8 @@ func TestHandleKeyMsg_StreamingCancelInterjectionRestoresComposerAndShowsStoppin
 	if cancelCalls != 1 {
 		t.Fatalf("expected stream cancel to be called once, got %d", cancelCalls)
 	}
-	if got := m.textarea.Value(); got != "stop sleeping" {
-		t.Fatalf("expected textarea draft restored after cancel interjection, got %q", got)
+	if got := m.textarea.Value(); got != "" {
+		t.Fatalf("expected explicit stop command to be consumed, got %q", got)
 	}
 	if m.pendingInterjection != "" {
 		t.Fatalf("expected pendingInterjection to be cleared, got %q", m.pendingInterjection)
@@ -1067,89 +1067,70 @@ func TestHandleKeyMsg_CancelsSelectedPendingInterjection(t *testing.T) {
 	}
 }
 
-func TestHandleKeyMsg_StreamingAsyncClassificationFeelsImmediate(t *testing.T) {
+func TestHandleKeyMsg_StreamingEnterSteersImmediatelyWithoutFastProvider(t *testing.T) {
 	m := newTestChatModel(false)
 	m.streaming = true
 	m.phase = "Thinking"
-	m.fastProvider = llm.NewMockProvider("fast").AddTextResponse("interject")
-	m.setTextareaValue("also check the schema")
+	fastProvider := llm.NewMockProvider("fast").AddTextResponse("cancel")
+	m.fastProvider = fastProvider
+	m.setTextareaValue("stop changing the schema; inspect it first")
 
 	_, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if cmd == nil {
-		t.Fatal("expected async classification command")
+	if cmd != nil {
+		t.Fatal("normal streaming Enter should queue synchronously")
 	}
 	if got := m.textarea.Value(); got != "" {
 		t.Fatalf("expected textarea to clear immediately, got %q", got)
 	}
-	if got := m.pendingInterjection; got != "also check the schema" {
+	if got := m.pendingInterjection; got != "stop changing the schema; inspect it first" {
 		t.Fatalf("expected pending interjection to render immediately, got %q", got)
 	}
-	if got := m.pendingInterruptUI; got != "deciding" {
-		t.Fatalf("expected deciding state immediately, got %q", got)
+	if got := fastProvider.CurrentTurn(); got != 0 {
+		t.Fatalf("fast provider calls = %d, want zero", got)
 	}
-
-	msg := cmd()
-	if _, ok := msg.(interruptClassifiedMsg); !ok {
-		t.Fatalf("expected interruptClassifiedMsg, got %T", msg)
-	}
-	_, _ = m.handleInterruptClassified(msg.(interruptClassifiedMsg))
-
-	if got := m.pendingInterruptUI; got != "interject" {
-		t.Fatalf("expected interject state after classification, got %q", got)
-	}
-	if got := m.engine.DrainInterjection(); got != "also check the schema" {
+	if got := m.engine.DrainInterjection(); got != "stop changing the schema; inspect it first" {
 		t.Fatalf("expected engine interjection to be queued, got %q", got)
 	}
 }
 
-func TestHandleInterruptClassified_StreamAlreadyFinishedRestoresDraft(t *testing.T) {
+func TestHandleKeyMsg_SimpleStreamKeepsUnconsumableSteerAsDraft(t *testing.T) {
 	m := newTestChatModel(false)
-	m.activeInterruptSeq = 7
-	m.pendingInterjection = "keep sleeping"
-	m.pendingInterruptUI = "deciding"
+	provider := llm.NewMockProvider("simple").
+		WithCapabilities(llm.Capabilities{ToolCalls: false}).
+		AddTurn(llm.MockTurn{Text: "simple response", Delay: time.Second})
+	m.engine = llm.NewEngine(provider, nil)
+	stream, err := m.engine.Stream(context.Background(), llm.Request{Messages: []llm.Message{llm.UserText("hello")}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+	m.streaming = true
+	m.setTextareaValue("also inspect the schema")
 
-	_, cmd := m.handleInterruptClassified(interruptClassifiedMsg{
-		RequestID: 7,
-		Content:   "keep sleeping",
-		Action:    llm.InterruptInterject,
-	})
+	_, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if cmd != nil {
-		t.Fatal("expected no follow-up command when restoring draft")
+		t.Fatal("simple-stream steering should resolve synchronously")
 	}
-	if got := m.textarea.Value(); got != "keep sleeping" {
-		t.Fatalf("expected interjection text restored to composer, got %q", got)
+	if got := m.textarea.Value(); got != "also inspect the schema" {
+		t.Fatalf("composer = %q, want rejected steer kept as draft", got)
 	}
-	if m.streaming {
-		t.Fatal("expected stream to remain finished")
+	if len(m.pendingInterjections) != 0 || len(m.engine.ListPendingInterjections()) != 0 {
+		t.Fatalf("simple stream retained phantom steer: ui=%#v engine=%#v", m.pendingInterjections, m.engine.ListPendingInterjections())
 	}
-	if got := m.pendingInterjection; got != "" {
-		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
-	}
-	if got := m.pendingInterruptUI; got != "" {
-		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
-	}
-	if got := len(m.messages); got != 0 {
-		t.Fatalf("expected restored draft not to auto-send, got %d messages", got)
+	if !strings.Contains(m.interruptNotice, "cannot consume steering") {
+		t.Fatalf("interrupt notice = %q, want non-consuming explanation", m.interruptNotice)
 	}
 }
 
-func TestStreamEventInterjection_DoesNotDiscardNewerPendingClassification(t *testing.T) {
+func TestStreamEventInterjection_DoesNotDiscardNewerPendingSteer(t *testing.T) {
 	m := newTestChatModel(false)
 	m.streaming = true
 	m.phase = "Thinking"
-	m.fastProvider = llm.NewMockProvider("fast").AddTextResponse("interject")
 
 	firstID := m.nextPendingInterjectionID()
 	m.applyInterruptAction(firstID, "first note", llm.InterruptInterject)
 	secondID := m.nextPendingInterjectionID()
-	cmd := m.queueInterruptClassification(secondID, "second note", nil)
-	if cmd == nil {
-		t.Fatal("expected async interrupt classification command")
-	}
-	requestID := m.activeInterruptSeq
-	if requestID == 0 {
-		t.Fatal("expected active interrupt request id")
-	}
+	m.applyInterruptAction(secondID, "second note", llm.InterruptInterject)
 
 	_, _ = m.Update(streamEventMsg{event: ui.InterjectionEvent("first note", firstID)})
 
@@ -1159,28 +1140,8 @@ func TestStreamEventInterjection_DoesNotDiscardNewerPendingClassification(t *tes
 	if got := m.pendingInterjectionID; got != secondID {
 		t.Fatalf("pendingInterjectionID after first event = %q, want %q", got, secondID)
 	}
-	if got := m.pendingInterruptUI; got != "deciding" {
-		t.Fatalf("pendingInterruptUI after first event = %q, want deciding", got)
-	}
-	if got := m.activeInterruptSeq; got != requestID {
-		t.Fatalf("activeInterruptSeq after first event = %d, want %d", got, requestID)
-	}
 	if len(m.pendingInterjections) != 1 || m.pendingInterjections[0].ID != secondID {
 		t.Fatalf("pending stack after first event = %#v, want only second", m.pendingInterjections)
-	}
-
-	msg := cmd()
-	classified, ok := msg.(interruptClassifiedMsg)
-	if !ok {
-		t.Fatalf("expected interruptClassifiedMsg, got %T", msg)
-	}
-	if classified.InterjectionID != secondID {
-		t.Fatalf("classified interjection id = %q, want %q", classified.InterjectionID, secondID)
-	}
-	_, _ = m.handleInterruptClassified(classified)
-
-	if got := m.pendingInterruptUI; got != "interject" {
-		t.Fatalf("pendingInterruptUI after classification = %q, want interject", got)
 	}
 	if got := m.engine.DrainInterjection(); got != "first note\nsecond note" {
 		t.Fatalf("expected both FIFO interjections to remain queued, got %q", got)
@@ -1203,9 +1164,6 @@ func TestStreamEventInterjection_MatchesByIDNotText(t *testing.T) {
 	}
 	if got := m.pendingInterjection; got != "same text" {
 		t.Fatalf("pendingInterjection after stale event = %q, want same text", got)
-	}
-	if got := m.pendingInterruptUI; got != "interject" {
-		t.Fatalf("pendingInterruptUI after stale event = %q, want interject", got)
 	}
 	if len(m.pendingInterjections) != 1 || m.pendingInterjections[0].ID != secondID {
 		t.Fatalf("pending stack after stale event = %#v, want only second", m.pendingInterjections)
@@ -1236,7 +1194,6 @@ func TestStreamDone_PendingInterjectRestoresDraftWithoutEngineResidual(t *testin
 	m := newTestChatModel(false)
 	m.streaming = true
 	m.pendingInterjection = "keep sleeping"
-	m.pendingInterruptUI = "interject"
 
 	_, cmd := m.Update(streamEventMsg{event: ui.DoneEvent(0)})
 	if cmd == nil {
@@ -1251,8 +1208,31 @@ func TestStreamDone_PendingInterjectRestoresDraftWithoutEngineResidual(t *testin
 	if got := m.pendingInterjection; got != "" {
 		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
 	}
-	if got := m.pendingInterruptUI; got != "" {
-		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
+}
+
+func TestStreamDone_OccupiedComposerKeepsQueuedSteerVisibleAndCancellable(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.setTextareaValue("unrelated draft")
+	m.engine.QueueInterjection(llm.QueuedInterjection{ID: "late-steer", Message: llm.UserText("keep sleeping"), DisplayText: "keep sleeping"})
+	m.setPendingInterjection("late-steer", "keep sleeping")
+
+	_, _ = m.Update(streamEventMsg{event: ui.DoneEvent(0)})
+
+	if got := m.textarea.Value(); got != "unrelated draft" {
+		t.Fatalf("composer = %q, want existing draft preserved", got)
+	}
+	if len(m.pendingInterjections) != 1 || m.pendingInterjections[0].ID != "late-steer" {
+		t.Fatalf("pending UI = %#v, want late steer still visible", m.pendingInterjections)
+	}
+	if pending := m.engine.ListPendingInterjections(); len(pending) != 1 || pending[0].ID != "late-steer" {
+		t.Fatalf("engine pending = %#v, want late steer cancellable", pending)
+	}
+
+	m.setTextareaValue("")
+	_, _ = m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if len(m.pendingInterjections) != 0 || len(m.engine.ListPendingInterjections()) != 0 {
+		t.Fatalf("late steer was not cancellable after completion: ui=%#v engine=%#v", m.pendingInterjections, m.engine.ListPendingInterjections())
 	}
 }
 
@@ -1260,7 +1240,6 @@ func TestStreamError_PendingInterjectRestoresDraftWithoutEngineResidual(t *testi
 	m := newTestChatModel(false)
 	m.streaming = true
 	m.pendingInterjection = "keep sleeping"
-	m.pendingInterruptUI = "interject"
 
 	_, cmd := m.Update(streamEventMsg{event: ui.ErrorEvent(context.Canceled)})
 	if cmd != nil {
@@ -1274,9 +1253,6 @@ func TestStreamError_PendingInterjectRestoresDraftWithoutEngineResidual(t *testi
 	}
 	if got := m.pendingInterjection; got != "" {
 		t.Fatalf("expected pending interjection cleared after restore, got %q", got)
-	}
-	if got := m.pendingInterruptUI; got != "" {
-		t.Fatalf("expected pending interrupt UI cleared after restore, got %q", got)
 	}
 }
 
@@ -1576,29 +1552,27 @@ func TestPasteCollapse_StreamingInterjectionExpandsPlaceholderOnSend(t *testing.
 	}
 }
 
-func TestPasteCollapse_StreamingInterruptClassificationUsesExpandedPlaceholder(t *testing.T) {
+func TestPasteCollapse_StreamingSteerBypassesClassifierWithExpandedContent(t *testing.T) {
 	stubClipboard(t)
 	m := newTestChatModel(false)
 	m.streaming = true
-	m.fastProvider = llm.NewMockProvider("fast").AddTextResponse("interject")
+	fastProvider := llm.NewMockProvider("fast").AddTextResponse("cancel")
+	m.fastProvider = fastProvider
 	pasteText := strings.Repeat("async alpha ", 12) + "\n" + strings.Repeat("async beta ", 12)
 
 	_, _ = m.handlePasteMsg(tea.PasteMsg{Content: pasteText})
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if cmd == nil {
-		t.Fatal("expected interrupt classification command")
+	if cmd != nil {
+		t.Fatal("streaming steer should queue synchronously")
 	}
 	if len(m.pasteChunks) != 0 {
-		t.Fatalf("expected paste chunks cleared after queueing classification, got %d", len(m.pasteChunks))
+		t.Fatalf("expected paste chunks cleared after queueing steer, got %d", len(m.pasteChunks))
 	}
-
-	gotMsg := cmd()
-	msg, ok := gotMsg.(interruptClassifiedMsg)
-	if !ok {
-		t.Fatalf("expected interruptClassifiedMsg, got %T", gotMsg)
+	if got := fastProvider.CurrentTurn(); got != 0 {
+		t.Fatalf("fast provider calls = %d, want zero", got)
 	}
-	if msg.Content != pasteText {
-		t.Fatalf("classification content = %q, want expanded paste %q", msg.Content, pasteText)
+	if got := m.engine.DrainInterjection(); got != pasteText {
+		t.Fatalf("queued content = %q, want expanded paste %q", got, pasteText)
 	}
 }
 

--- a/internal/tui/chat/mentions_test.go
+++ b/internal/tui/chat/mentions_test.go
@@ -944,8 +944,8 @@ func TestInvalidStreamingAgentMentionPreservesDraftBeforeQueueMutation(t *testin
 	if m.textarea.Value() != content || len(m.images) != 1 || len(m.files) != 1 || len(m.pasteChunks) != 1 {
 		t.Fatalf("invalid interjection lost draft state: text=%q images=%d files=%d pastes=%d", m.textarea.Value(), len(m.images), len(m.files), len(m.pasteChunks))
 	}
-	if len(m.engine.ListPendingInterjections()) != 0 || len(m.pendingInterjections) != 0 || m.activeInterruptSeq != 0 {
-		t.Fatalf("invalid interjection mutated queue state: engine=%#v ui=%#v seq=%d", m.engine.ListPendingInterjections(), m.pendingInterjections, m.activeInterruptSeq)
+	if len(m.engine.ListPendingInterjections()) != 0 || len(m.pendingInterjections) != 0 {
+		t.Fatalf("invalid interjection mutated queue state: engine=%#v ui=%#v", m.engine.ListPendingInterjections(), m.pendingInterjections)
 	}
 	if !strings.Contains(m.footerMessage, "depth exhausted") {
 		t.Fatalf("footer = %q", m.footerMessage)

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -705,13 +705,6 @@ func (m *Model) buildFooterLayout() footerLayout {
 		selectedStyle := lipgloss.NewStyle().Foreground(theme.Primary).Bold(true)
 		for i, pending := range m.pendingInterjections {
 			pendingText := pending.Text
-			label := "will incorporate"
-			switch pending.UIState {
-			case "deciding":
-				label = "deciding…"
-			case "interject":
-				label = "will incorporate"
-			}
 			// Truncate long messages before wrapping so very narrow widths remain stable.
 			maxLen := m.width - 26 // account for prefix/suffix
 			if maxLen > 0 && len(pendingText) > maxLen {
@@ -721,7 +714,7 @@ func (m *Model) buildFooterLayout() footerLayout {
 			if i == m.selectedInterjection {
 				prefix = "  ▸ "
 			}
-			line := prefix + pendingText + " (" + label + ")"
+			line := prefix + pendingText + " (will incorporate)"
 			if i == m.selectedInterjection {
 				line += "  [del cancels]"
 				appendMetaRow(selectedStyle.Render(line))
@@ -732,19 +725,12 @@ func (m *Model) buildFooterLayout() footerLayout {
 	} else if m.pendingInterjection != "" {
 		pendingStyle := lipgloss.NewStyle().Foreground(theme.Muted).Italic(true)
 		pendingText := m.pendingInterjection
-		label := "will incorporate"
-		switch m.pendingInterruptUI {
-		case "deciding":
-			label = "deciding…"
-		case "interject":
-			label = "will incorporate"
-		}
 		// Truncate long messages before wrapping so very narrow widths remain stable.
 		maxLen := m.width - 20 // account for prefix/suffix
 		if maxLen > 0 && len(pendingText) > maxLen {
 			pendingText = pendingText[:maxLen] + "…"
 		}
-		appendMetaRow(pendingStyle.Render("  ⏳ " + pendingText + " (" + label + ")"))
+		appendMetaRow(pendingStyle.Render("  ⏳ " + pendingText + " (will incorporate)"))
 	}
 
 	if len(m.files) > 0 {

--- a/internal/tui/chat/render_test.go
+++ b/internal/tui/chat/render_test.go
@@ -1767,8 +1767,8 @@ func TestRenderInputInline_ShowsPendingInterjection(t *testing.T) {
 
 func TestRenderInputInline_ShowsPendingInterjectionStack(t *testing.T) {
 	m := newTestChatModel(false)
-	m.setPendingInterjection("one", "first", "interject")
-	m.setPendingInterjection("two", "second", "deciding")
+	m.setPendingInterjection("one", "first")
+	m.setPendingInterjection("two", "second")
 	m.width = 80
 
 	output := m.renderInputInline()
@@ -1777,8 +1777,8 @@ func TestRenderInputInline_ShowsPendingInterjectionStack(t *testing.T) {
 	if !strings.Contains(stripped, "first") || !strings.Contains(stripped, "second") {
 		t.Fatalf("expected both pending interjections in output, got %q", stripped)
 	}
-	if !strings.Contains(stripped, "will incorporate") || !strings.Contains(stripped, "deciding") {
-		t.Fatalf("expected stack labels in output, got %q", stripped)
+	if strings.Count(stripped, "will incorporate") != 2 {
+		t.Fatalf("expected both pending labels in output, got %q", stripped)
 	}
 	if !strings.Contains(stripped, "[del cancels]") {
 		t.Fatalf("expected cancel affordance in output, got %q", stripped)


### PR DESCRIPTION
## Summary

Make first-party steering immediate, deterministic at run boundaries, and useful after prose-only responses.

- queue TUI and web steering synchronously instead of waiting on the fast cancel-vs-interject classifier
- reserve explicit `/stop`, `/cancel`, Esc, Ctrl-C, and the web Stop control for cancellation
- continue ordinary user steers after text-only model responses, preserving FIFO order, structured parts, stable IDs, persistence, and model/effort switches
- expose `delivery: "steer" | "auto"` on the interrupt endpoint while keeping omitted/`auto` backward compatible
- track whether the current engine run can still consume steering, so late arrivals are rejected for deterministic follow-up rather than silently stranded
- remove dead TUI classification/"deciding" state and keep post-boundary steers visible or recoverable
- preserve Telegram's explicit-stop and natural-language classifier behavior while using atomic queue status instead of a done-channel race
- keep jobs-v2 notifications exactly once across the final-boundary teardown window

## Why

Codex, OpenCode, Pi, and Claude Code all admit ordinary steering immediately as user input. Claude additionally cancels only tools that declare safe interruption; Pi waits for the current tool and skips remaining calls. term-llm previously put a fast-model classification request before queue admission, which could add latency and miss the nearest legal boundary. It also left ordinary steers pending when a response ended without tool calls.

Steering remains the exact raw `RoleUser` message. This PR deliberately does not add a developer-role prelude: most non-OpenAI adapters fold developer text into user content, while persistence and compaction treat it inconsistently.

## Delivery semantics

- `delivery: "steer"`: enqueue immediately; never classify as cancellation
- `delivery: "auto"` or omitted: preserve the existing classifier behavior for compatible API clients
- unsupported values return `400`

Delivery participates in interjection idempotency. Reusing one interjection ID with different delivery semantics is a conflict.

## Rush

This does **not** add a `rush` mode. Other harnesses do not expose a clean universal equivalent:

- Claude cancels only when currently executing tools declare themselves interruptible
- Codex interrupts and resubmits pending steering
- Pi applies steering after the current tool boundary
- OpenCode uses explicit interrupt/resume

A safe rush mode requires capability negotiation, per-tool interrupt behavior, partial assistant/tool-result repair, and a policy for side effects already in progress. Adding an unconditional enum value now would be a foot-gun, not responsiveness.

## Verification

Passed with isolated HOME/XDG state where applicable:

- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go test -race ./internal/llm ./internal/serve ./internal/tui/chat -count=1`
- focused `go test -race ./cmd` covering jobs notifications, delivery/idempotency, simple streams, final boundaries, and claim/release paths
- Node-backed serve UI tests through `go test ./internal/serveui`
- `gofmt` and `git diff --check`

A full `go test -race ./cmd` still encounters the existing in-memory SQLite teardown failure (`TestRunnerActiveGoalCancelPausesGoal`: `no such table: sessions`); all changed cmd paths pass under focused race runs.

## Review

- pre-implementation plan reviewed with Claude Opus
- implementation completed by a developer agent
- full diff reviewed with Claude Opus
- addressed the review's jobs-notification duplication, tool-less stale state, terminal-boundary consistency, dead TUI path, Telegram TOCTOU, validation-order, and test-quality findings
