### PR TITLE
fix: Worktree diff generation launches one Git process per untracked file with no cancellation or output bound

### DIFF
--- a/cmd/serve_worktrees.go
+++ b/cmd/serve_worktrees.go
@@ -214,12 +214,13 @@ func (s *serveServer) handleWorktreeDiff(w http.ResponseWriter, r *http.Request)
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}
-	diff, err := worktree.Diff(wt.Dir)
+	result, err := worktree.DiffContext(r.Context(), wt.Dir)
 	if err != nil {
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"diff": diff})
+	result.Diff = result.DisplayDiff()
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (s *serveServer) handleWorktreeMerge(w http.ResponseWriter, r *http.Request) {

--- a/internal/tui/worktrees/browse.go
+++ b/internal/tui/worktrees/browse.go
@@ -43,7 +43,7 @@ type listResultMsg struct {
 type diffResultMsg struct {
 	dir        string
 	generation uint64
-	diff       string
+	result     worktree.DiffResult
 	err        error
 }
 type inUseResultMsg struct {
@@ -87,6 +87,7 @@ type Model struct {
 	detailBusy       int
 	detailScroll     int
 	detailGeneration uint64
+	detailCancel     context.CancelFunc
 	deleteTarget     *worktree.Worktree
 	forceRisks       []string
 }
@@ -229,7 +230,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case diffResultMsg:
 		if m.detail != nil && msg.generation == m.detailGeneration && samePath(m.detail.Dir, msg.dir) {
-			m.detailDiff, m.diffErr = msg.diff, msg.err
+			m.detailDiff, m.diffErr = msg.result.DisplayDiff(), msg.err
+			m.detailCancel = nil
 			m.detailBusy--
 		}
 		return m, nil
@@ -265,6 +267,10 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case modeDetails:
 		switch key {
 		case "esc", "q":
+			if m.detailCancel != nil {
+				m.detailCancel()
+				m.detailCancel = nil
+			}
 			m.mode, m.detail = modeBrowse, nil
 		case "up", "k":
 			if m.detailScroll > 0 {
@@ -404,6 +410,11 @@ func (m *Model) openDetails() (tea.Model, tea.Cmd) {
 	if wt == nil {
 		return m, nil
 	}
+	if m.detailCancel != nil {
+		m.detailCancel()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	m.detailCancel = cancel
 	target := *wt
 	m.mode, m.detail, m.detailScroll = modeDetails, &target, 0
 	m.detailGeneration++
@@ -413,8 +424,9 @@ func (m *Model) openDetails() (tea.Model, tea.Cmd) {
 	dir, store := target.Dir, m.store
 	return m, tea.Batch(
 		func() tea.Msg {
-			diff, err := worktree.Diff(dir)
-			return diffResultMsg{dir: dir, generation: generation, diff: diff, err: err}
+			defer cancel()
+			result, err := worktree.DiffContext(ctx, dir)
+			return diffResultMsg{dir: dir, generation: generation, result: result, err: err}
 		},
 		func() tea.Msg {
 			users, err := worktree.InUse(context.Background(), store, dir)

--- a/internal/tui/worktrees/browse_test.go
+++ b/internal/tui/worktrees/browse_test.go
@@ -135,7 +135,7 @@ func TestDetailsRendersMetadataSessionsAndDiffStates(t *testing.T) {
 	m := testModel()
 	_, _ = m.openDetails()
 	m.Update(inUseResultMsg{dir: "/repo/wt-2", generation: m.detailGeneration, sessions: []worktree.InUseSession{{Number: 7, Name: "chat", Status: "active"}}})
-	m.Update(diffResultMsg{dir: "/repo/wt-2", generation: m.detailGeneration, diff: "+changed"})
+	m.Update(diffResultMsg{dir: "/repo/wt-2", generation: m.detailGeneration, result: worktree.DiffResult{Diff: "+changed"}})
 	out := m.View().Content
 	for _, want := range []string{"Worktree Details", "Name: two", "#7 chat [active]", "+changed"} {
 		if !strings.Contains(out, want) {
@@ -143,13 +143,29 @@ func TestDetailsRendersMetadataSessionsAndDiffStates(t *testing.T) {
 		}
 	}
 
-	m.Update(diffResultMsg{dir: "/repo/wt-2", generation: m.detailGeneration, diff: ""})
+	m.Update(diffResultMsg{dir: "/repo/wt-2", generation: m.detailGeneration, result: worktree.DiffResult{}})
 	if !strings.Contains(m.View().Content, "Clean (no changes)") {
 		t.Fatal("clean detail state not rendered")
 	}
 	m.Update(diffResultMsg{dir: "/repo/wt-2", generation: m.detailGeneration, err: errors.New("diff failed")})
 	if !strings.Contains(m.View().Content, "diff failed") {
 		t.Fatal("diff error not rendered")
+	}
+}
+
+func TestLeavingDetailsCancelsDiff(t *testing.T) {
+	m := testModel()
+	m.mode = modeDetails
+	m.detail = &worktree.Worktree{Dir: "/repo/wt-2"}
+	canceled := false
+	m.detailCancel = func() { canceled = true }
+
+	press(m, 'q', "q")
+	if !canceled {
+		t.Fatal("leaving details did not cancel diff generation")
+	}
+	if m.detailCancel != nil || m.detail != nil || m.mode != modeBrowse {
+		t.Fatalf("details remained active after cancellation: mode=%v detail=%v cancel=%v", m.mode, m.detail, m.detailCancel != nil)
 	}
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -2,6 +2,7 @@
 package worktree
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/rand"
@@ -21,6 +22,7 @@ import (
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/appdata"
+	"github.com/samsaffron/term-llm/internal/procutil"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/textmatch"
 )
@@ -53,6 +55,56 @@ type Worktree struct {
 // Progress is emitted by long-running worktree operations.
 type Progress struct {
 	Message string `json:"message"`
+}
+
+const (
+	maxDiffBytes          = 2 << 20
+	maxDiffUntrackedFiles = 100
+	diffDiagnosticBytes   = 64 << 10
+
+	diffOutputLimitReason          = "output_limit"
+	diffUntrackedFileLimitReason   = "untracked_file_limit"
+	diffUntrackedUnavailableReason = "untracked_unavailable"
+)
+
+// DiffResult contains bounded worktree diff output and any truncation metadata.
+type DiffResult struct {
+	Diff              string   `json:"diff"`
+	Truncated         bool     `json:"truncated"`
+	TruncationReasons []string `json:"truncation_reasons,omitempty"`
+}
+
+// DisplayDiff returns the diff with a human-readable truncation notice.
+func (r DiffResult) DisplayDiff() string {
+	if !r.Truncated {
+		return r.Diff
+	}
+	labels := make([]string, 0, len(r.TruncationReasons))
+	for _, reason := range r.TruncationReasons {
+		switch reason {
+		case diffOutputLimitReason:
+			labels = append(labels, fmt.Sprintf("output exceeded %d MiB", maxDiffBytes>>20))
+		case diffUntrackedFileLimitReason:
+			labels = append(labels, fmt.Sprintf("more than %d untracked files", maxDiffUntrackedFiles))
+		case diffUntrackedUnavailableReason:
+			labels = append(labels, "some untracked files could not be included")
+		default:
+			labels = append(labels, reason)
+		}
+	}
+	notice := "[Diff truncated"
+	if len(labels) > 0 {
+		notice += ": " + strings.Join(labels, "; ")
+	}
+	notice += "]"
+	if r.Diff == "" {
+		return notice
+	}
+	separator := "\n"
+	if strings.HasSuffix(r.Diff, "\n") {
+		separator = ""
+	}
+	return r.Diff + separator + notice + "\n"
 }
 
 // CreateOptions configures Create.
@@ -808,11 +860,70 @@ func TouchLastBound(dir string) error {
 	return writeMetadata(root, m)
 }
 
-// Diff returns a unified diff from the recorded base and includes untracked files.
+var errDiffOutputLimit = errors.New("worktree diff output limit reached")
+
+type boundedDiffWriter struct {
+	builder   strings.Builder
+	limit     int
+	truncated bool
+}
+
+func (w *boundedDiffWriter) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	remaining := w.limit - w.builder.Len()
+	if remaining >= len(p) {
+		_, _ = w.builder.Write(p)
+		return originalLen, nil
+	}
+	if remaining > 0 {
+		_, _ = w.builder.Write(p[:remaining])
+	}
+	w.truncated = true
+	return originalLen, errDiffOutputLimit
+}
+
+func (w *boundedDiffWriter) String() string { return w.builder.String() }
+
+func (w *boundedDiffWriter) endsInNewline() bool {
+	value := w.builder.String()
+	return len(value) > 0 && value[len(value)-1] == '\n'
+}
+
+// Diff returns a bounded unified diff from the recorded base, including
+// untracked files. Callers that can be abandoned should use DiffContext.
 func Diff(dir string) (string, error) {
+	result, err := DiffContext(context.Background(), dir)
+	return result.DisplayDiff(), err
+}
+
+// DiffContext returns a bounded unified diff and stops active Git commands when
+// ctx is canceled. At most maxDiffUntrackedFiles are included.
+func DiffContext(ctx context.Context, dir string) (DiffResult, error) {
+	var result DiffResult
+	addTruncation := func(reason string) {
+		result.Truncated = true
+		for _, existing := range result.TruncationReasons {
+			if existing == reason {
+				return
+			}
+		}
+		result.TruncationReasons = append(result.TruncationReasons, reason)
+	}
+	output := &boundedDiffWriter{limit: maxDiffBytes}
+	finish := func() DiffResult {
+		result.Diff = strings.ReplaceAll(output.String(), "--- "+os.DevNull, "--- /dev/null")
+		if output.truncated {
+			addTruncation(diffOutputLimitReason)
+		}
+		return result
+	}
+
+	if err := ctx.Err(); err != nil {
+		return finish(), err
+	}
 	wt, err := getWorktreeForOperation(dir)
 	if err != nil {
-		return "", err
+		return finish(), err
 	}
 	base := strings.TrimSpace(wt.Base)
 	if base == "" {
@@ -821,35 +932,170 @@ func Diff(dir string) (string, error) {
 	if base == "" {
 		base = "HEAD"
 	}
-	var b strings.Builder
-	out, err := runGit(dir, "diff", "--binary", base, "--")
+
+	stderr, err := runGitInto(ctx, dir, nil, nil, output, "diff", "--binary", base, "--")
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return finish(), ctxErr
+	}
+	if output.truncated {
+		return finish(), nil
+	}
 	if err != nil {
-		// git diff returns 0 for differences; any error is real but include output.
-		if strings.TrimSpace(out) != "" {
-			b.WriteString(out)
-		}
-		return b.String(), err
+		return finish(), fmt.Errorf("worktree: diff tracked files: %w: %s", err, strings.TrimSpace(stderr))
 	}
-	b.WriteString(out)
-	untracked, err := runGit(dir, "ls-files", "--others", "--exclude-standard", "-z")
+
+	untracked, untrackedTruncated, err := listUntracked(ctx, dir, maxDiffUntrackedFiles)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return finish(), ctxErr
+	}
 	if err != nil {
-		return b.String(), nil
+		// Preserve the previous best-effort behavior for untracked-file discovery.
+		return finish(), nil
 	}
-	for _, rel := range strings.Split(untracked, "\x00") {
-		if rel == "" {
-			continue
-		}
-		if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
-			b.WriteByte('\n')
-		}
-		noIndexOut, _ := runGitAllowExit(dir, []string{"diff", "--no-index", "--", os.DevNull, rel}, map[int]bool{0: true, 1: true})
-		noIndexOut = strings.ReplaceAll(noIndexOut, "--- "+os.DevNull, "--- /dev/null")
-		b.WriteString(noIndexOut)
-		if !strings.HasSuffix(noIndexOut, "\n") {
-			b.WriteByte('\n')
+	if untrackedTruncated {
+		addTruncation(diffUntrackedFileLimitReason)
+	}
+	if len(untracked) == 0 {
+		return finish(), nil
+	}
+	if output.builder.Len() > 0 && !output.endsInNewline() {
+		_, _ = output.Write([]byte{'\n'})
+		if output.truncated {
+			return finish(), nil
 		}
 	}
-	return b.String(), nil
+
+	index, err := os.CreateTemp("", "term-llm-diff-index-*")
+	if err != nil {
+		addTruncation(diffUntrackedUnavailableReason)
+		return finish(), nil
+	}
+	indexPath := index.Name()
+	if err := index.Close(); err != nil {
+		_ = os.Remove(indexPath)
+		addTruncation(diffUntrackedUnavailableReason)
+		return finish(), nil
+	}
+	if err := os.Remove(indexPath); err != nil {
+		addTruncation(diffUntrackedUnavailableReason)
+		return finish(), nil
+	}
+	defer os.Remove(indexPath)
+
+	env := []string{"GIT_INDEX_FILE=" + indexPath, "GIT_LITERAL_PATHSPECS=1"}
+	if err := runGitDiscard(ctx, dir, env, nil, "read-tree", "--empty"); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return finish(), ctxErr
+		}
+		addTruncation(diffUntrackedUnavailableReason)
+		return finish(), nil
+	}
+	var paths bytes.Buffer
+	for _, rel := range untracked {
+		paths.WriteString(rel)
+		paths.WriteByte(0)
+	}
+	if err := runGitDiscard(ctx, dir, env, &paths, "add", "-N", "--pathspec-from-file=-", "--pathspec-file-nul"); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return finish(), ctxErr
+		}
+		addTruncation(diffUntrackedUnavailableReason)
+		return finish(), nil
+	}
+	_, err = runGitInto(ctx, dir, env, nil, output, "diff", "--binary", "--")
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return finish(), ctxErr
+	}
+	if output.truncated {
+		return finish(), nil
+	}
+	if err != nil {
+		addTruncation(diffUntrackedUnavailableReason)
+		return finish(), nil
+	}
+	return finish(), nil
+}
+
+func listUntracked(ctx context.Context, dir string, limit int) ([]string, bool, error) {
+	cmdCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	args := []string{"ls-files", "--others", "--exclude-standard", "-z"}
+	if runGitTestHook != nil {
+		runGitTestHook(dir, append([]string(nil), args...))
+	}
+	cmd := exec.CommandContext(cmdCtx, "git", args...)
+	cmd.Dir = dir
+	stderr := procutil.NewLimitedBuffer(diffDiagnosticBytes)
+	cmd.Stderr = stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, false, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, false, err
+	}
+
+	paths := make([]string, 0, limit)
+	truncated := false
+	reader := bufio.NewReader(stdout)
+	var readErr error
+	for {
+		path, err := reader.ReadString(0)
+		if len(path) > 0 {
+			path = strings.TrimSuffix(path, "\x00")
+			if path != "" {
+				if len(paths) == limit {
+					truncated = true
+					cancel()
+					break
+				}
+				paths = append(paths, path)
+			}
+		}
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				readErr = err
+			}
+			break
+		}
+	}
+	waitErr := cmd.Wait()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return paths, truncated, ctxErr
+	}
+	if readErr != nil {
+		return paths, truncated, readErr
+	}
+	if waitErr != nil && !truncated {
+		return paths, false, fmt.Errorf("%w: %s", waitErr, strings.TrimSpace(stderr.String()))
+	}
+	return paths, truncated, nil
+}
+
+func runGitDiscard(ctx context.Context, dir string, env []string, stdin io.Reader, args ...string) error {
+	output := procutil.NewLimitedBuffer(diffDiagnosticBytes)
+	_, err := runGitInto(ctx, dir, env, stdin, output, args...)
+	return err
+}
+
+func runGitInto(ctx context.Context, dir string, env []string, stdin io.Reader, stdout io.Writer, args ...string) (string, error) {
+	if runGitTestHook != nil {
+		runGitTestHook(dir, append([]string(nil), args...))
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	stderr := procutil.NewLimitedBuffer(diffDiagnosticBytes)
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return stderr.String(), ctxErr
+	}
+	return stderr.String(), err
 }
 
 // Promote creates a branch at the worktree HEAD and checks it out.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 var worktreeTestRepoTemplate string
@@ -437,6 +440,147 @@ func TestDiffIncludesUntrackedFiles(t *testing.T) {
 	}
 	if !strings.Contains(diff, "new.txt") || !strings.Contains(diff, "+hello from untracked") {
 		t.Fatalf("diff = %q, want untracked file diff", diff)
+	}
+}
+
+func TestDiffUsesConstantGitProcessesAndCapsUntrackedFiles(t *testing.T) {
+	repo := newGitRepoForWorktreeTest(t)
+	wt, err := Create(context.Background(), repo, CreateOptions{Name: "diff-process-bound"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cleanupWorktreeTest(t, wt.Dir)
+	t.Cleanup(func() { runGitTestHook = nil })
+
+	created := 0
+	for _, count := range []int{1, 100, 1000} {
+		for created < count {
+			name := fmt.Sprintf("generated-%04d.txt", created)
+			if err := os.WriteFile(filepath.Join(wt.Dir, name), []byte("generated\n"), 0o644); err != nil {
+				t.Fatalf("WriteFile %s: %v", name, err)
+			}
+			created++
+		}
+
+		var calls [][]string
+		runGitTestHook = func(_ string, args []string) {
+			calls = append(calls, append([]string(nil), args...))
+		}
+		result, err := DiffContext(context.Background(), wt.Dir)
+		runGitTestHook = nil
+		if err != nil {
+			t.Fatalf("DiffContext with %d untracked files: %v", count, err)
+		}
+
+		diffCalls := 0
+		for _, args := range calls {
+			if len(args) > 0 && args[0] == "diff" {
+				diffCalls++
+			}
+			if strings.Contains(strings.Join(args, " "), "--no-index") {
+				t.Fatalf("DiffContext with %d files launched per-file git diff: %v", count, args)
+			}
+		}
+		if diffCalls != 2 {
+			t.Fatalf("DiffContext with %d files launched %d diff processes, want 2; calls=%v", count, diffCalls, calls)
+		}
+		wantTruncated := count > maxDiffUntrackedFiles
+		if result.Truncated != wantTruncated {
+			t.Fatalf("DiffContext with %d files truncated=%t, want %t; reasons=%v", count, result.Truncated, wantTruncated, result.TruncationReasons)
+		}
+		if wantTruncated && !slices.Contains(result.TruncationReasons, diffUntrackedFileLimitReason) {
+			t.Fatalf("DiffContext with %d files reasons=%v, want %q", count, result.TruncationReasons, diffUntrackedFileLimitReason)
+		}
+	}
+}
+
+func TestDiffBoundsLargeOutput(t *testing.T) {
+	t.Parallel()
+
+	repo := newGitRepoForWorktreeTest(t)
+	wt, err := Create(context.Background(), repo, CreateOptions{Name: "diff-output-bound"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cleanupWorktreeTest(t, wt.Dir)
+
+	large := strings.Repeat("a changed line that cannot fit in the diff limit\n", maxDiffBytes/20)
+	if err := os.WriteFile(filepath.Join(wt.Dir, "file.txt"), []byte(large), 0o644); err != nil {
+		t.Fatalf("WriteFile file.txt: %v", err)
+	}
+	result, err := DiffContext(context.Background(), wt.Dir)
+	if err != nil {
+		t.Fatalf("DiffContext: %v", err)
+	}
+	if !result.Truncated || !slices.Contains(result.TruncationReasons, diffOutputLimitReason) {
+		t.Fatalf("result truncated=%t reasons=%v, want output truncation", result.Truncated, result.TruncationReasons)
+	}
+	if len(result.Diff) > maxDiffBytes {
+		t.Fatalf("diff length = %d, want at most %d", len(result.Diff), maxDiffBytes)
+	}
+}
+
+func TestDiffContextCancelsActiveGitProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX git shim")
+	}
+	repo := newGitRepoForWorktreeTest(t)
+	wt, err := Create(context.Background(), repo, CreateOptions{Name: "diff-cancel"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cleanupWorktreeTest(t, wt.Dir)
+	if err := os.WriteFile(filepath.Join(wt.Dir, "file.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile file.txt: %v", err)
+	}
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath git: %v", err)
+	}
+	shimDir := t.TempDir()
+	ready := filepath.Join(shimDir, "ready")
+	shim := filepath.Join(shimDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "diff" ]; then
+  : > "$DIFF_READY"
+  while :; do :; done
+fi
+exec "$REAL_GIT" "$@"
+`
+	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile git shim: %v", err)
+	}
+	t.Setenv("REAL_GIT", realGit)
+	t.Setenv("DIFF_READY", ready)
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := DiffContext(ctx, wt.Dir)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("git shim did not start")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("DiffContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("DiffContext did not terminate the canceled git process")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a context-aware worktree diff path that streams Git output into a shared 2 MiB limiter, terminates active Git commands on cancellation, and reports explicit truncation metadata.
- Capped untracked-file inclusion at 100 files and replaced one `git diff --no-index` launch per file with a temporary-index pipeline that uses a constant number of Git processes.
- Passed HTTP request cancellation through `/v1/worktrees/diff` and cancel superseded/closed TUI worktree-detail loads.
- Added regression coverage for 1, 100, and 1,000 untracked files, large output truncation, blocking-child cancellation, and TUI detail cancellation.

## Why this is high-value

Worktree details are opened directly in Sam/Jarvis's normal managed-worktree workflow, and generated repositories routinely contain large sets of untracked files. Previously the diff path launched `N+2` Git processes for `N` untracked files and retained unbounded tracked/binary output. For 1,000 files, this change reduces the diff pipeline from 1,002 Git launches to a fixed 5 (about a 99.5% reduction), stops listing after detecting the 101st untracked file, and caps retained diff output at 2 MiB. Abandoned HTTP and TUI requests now stop their active child process instead of continuing CPU and file I/O work.

## Validation

- `go test ./internal/worktree ./internal/tui/worktrees ./cmd -run 'TestDiff|TestLeavingDetailsCancelsDiff|TestDetailsRendersMetadataSessionsAndDiffStates|TestServeWorktreeHandlersCreateListDiffDelete' -count=1`
- `go test -race ./internal/worktree -run '^TestDiff' -count=1`
- `go test ./internal/tui/worktrees -run 'TestDetails|TestLeavingDetails' -count=20`
- `go build ./...`
- `HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/config" XDG_DATA_HOME="$TEST_HOME/data" XDG_CACHE_HOME="$TEST_HOME/cache" go test ./...` (temporary isolated home, per repository guidance)
- `go vet ./...`
- `git diff --check`

An initial ambient-home `go test ./...` run hit two unrelated skill-discovery tests because the user's configured skill metadata budget omitted the fixtures; the repository-recommended isolated-home run passed in full.
