### PR TITLE
fix: treat clean Git materialization as tracking baseline

### DIFF
--- a/internal/tools/file_track_test.go
+++ b/internal/tools/file_track_test.go
@@ -727,25 +727,28 @@ func TestShellToolRecordsSessionTrackedGitIgnoredPath(t *testing.T) {
 func TestShellSnapshotBudgets(t *testing.T) {
 	snap := &shellSnapshot{maxFileBytes: 1024}
 
-	if !snap.canReadContent(512) {
-		t.Fatal("small file within all budgets must be readable")
+	if !snap.canCapturePreContent(512) {
+		t.Fatal("small file within all pre-snapshot budgets must be readable")
 	}
-	if snap.canReadContent(2048) {
+	if snap.canCapturePreContent(2048) {
 		t.Fatal("file above the per-file cap must be refused")
 	}
 
-	snap.contentBytes = maxShellSnapshotBytes - 100
-	if snap.canReadContent(512) {
-		t.Fatal("read exceeding the total-bytes budget must be refused")
+	snap.preContentBytes = maxShellSnapshotBytes - 100
+	if snap.canCapturePreContent(512) {
+		t.Fatal("read exceeding the pre-snapshot bytes budget must be refused")
 	}
-	if !snap.canReadContent(100) {
-		t.Fatal("read exactly filling the total-bytes budget is allowed")
+	if !snap.canCapturePreContent(100) {
+		t.Fatal("read exactly filling the pre-snapshot bytes budget is allowed")
 	}
 
-	snap.contentBytes = 0
-	snap.contentReads = maxShellContentReads
-	if snap.canReadContent(10) {
-		t.Fatal("read beyond the read-count cap must be refused")
+	snap.preContentBytes = 0
+	snap.preContentReads = maxShellContentReads
+	if snap.canCapturePreContent(10) {
+		t.Fatal("read beyond the pre-snapshot count cap must be refused")
+	}
+	if !snap.canReadPostContent(10) {
+		t.Fatal("exhausted pre-snapshot budget must not consume the post-comparison budget")
 	}
 }
 

--- a/internal/tools/shell_track.go
+++ b/internal/tools/shell_track.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -9,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,17 +25,31 @@ import (
 // detected via stat and recorded metadata-only (truncated).
 const (
 	maxShellGlobMatches   = 1000             // candidate paths per glob expansion
-	maxShellContentReads  = 200              // full-content snapshots per shell call
-	maxShellSnapshotBytes = 64 * 1024 * 1024 // total content bytes held per shell call (pre + post)
+	maxShellContentReads  = 200              // full-content snapshots per phase and shell call
+	maxShellSnapshotBytes = 64 * 1024 * 1024 // total content bytes read per phase and shell call
+	maxShellGitRepos      = 64               // distinct candidate repositories inspected post-command
 	gitCommandTimeout     = 5 * time.Second
 )
+
+type shellCandidateSource uint8
+
+const (
+	shellSourceLiteral shellCandidateSource = 1 << iota
+	shellSourceGlob
+	shellSourceSession
+	shellSourceGit
+)
+
+func (source shellCandidateSource) preservesCleanGitState() bool {
+	return source&(shellSourceLiteral|shellSourceSession) != 0
+}
 
 // shellSnapshotEntry captures one file's pre-exec state.
 type shellSnapshotEntry struct {
 	existed bool
 	size    int64
 	modTime time.Time
-	content []byte // nil when not read (oversized or beyond read budget)
+	content []byte // nil when not read (oversized or beyond the pre-snapshot budget)
 }
 
 // shellSnapshot holds the pre-exec state used to detect file changes made by
@@ -40,32 +57,44 @@ type shellSnapshotEntry struct {
 // scope. Without them, previously tracked session paths and Git status provide
 // broader best-effort fallback tracking.
 type shellSnapshot struct {
-	sessionID    string
-	workDir      string
-	patterns     []string
-	files        map[string]*shellSnapshotEntry
-	gitRoot      string
-	gitStatus    map[string]string // absolute path -> porcelain XY status
-	contentReads int
-	contentBytes int64
-	maxFileBytes int
+	sessionID string
+	workDir   string
+	patterns  []string
+	files     map[string]*shellSnapshotEntry
+	sources   map[string]shellCandidateSource
+	gitRoot   string
+	gitStatus map[string]string // absolute path -> pre-command porcelain XY status
+
+	preContentReads  int
+	preContentBytes  int64
+	postContentReads int
+	postContentBytes int64
+	maxFileBytes     int
 }
 
-// canReadContent reports whether a file of the given size may have its
-// content captured under the per-file cap, the read-count cap, and the
-// total-bytes budget. Pathological calls (many large files) degrade to
-// stat-only entries and truncated metadata records instead of holding
-// hundreds of megabytes in memory.
-func (snap *shellSnapshot) canReadContent(size int64) bool {
+// canCapturePreContent reports whether a file may be retained in the bounded
+// pre-command snapshot. Post-command comparison uses separate accounting so a
+// full pre snapshot cannot prevent deterministic comparison of captured files.
+func (snap *shellSnapshot) canCapturePreContent(size int64) bool {
 	return size <= int64(snap.maxFileBytes) &&
-		snap.contentReads < maxShellContentReads &&
-		snap.contentBytes+size <= maxShellSnapshotBytes
+		snap.preContentReads < maxShellContentReads &&
+		snap.preContentBytes+size <= maxShellSnapshotBytes
 }
 
-// noteContentRead accounts one captured content buffer against the budgets.
-func (snap *shellSnapshot) noteContentRead(content []byte) {
-	snap.contentReads++
-	snap.contentBytes += int64(len(content))
+func (snap *shellSnapshot) notePreContentRead(content []byte) {
+	snap.preContentReads++
+	snap.preContentBytes += int64(len(content))
+}
+
+func (snap *shellSnapshot) canReadPostContent(size int64) bool {
+	return size <= int64(snap.maxFileBytes) &&
+		snap.postContentReads < maxShellContentReads &&
+		snap.postContentBytes+size <= maxShellSnapshotBytes
+}
+
+func (snap *shellSnapshot) notePostContentRead(content []byte) {
+	snap.postContentReads++
+	snap.postContentBytes += int64(len(content))
 }
 
 // preShellSnapshot records the relevant filesystem state before a shell
@@ -85,12 +114,12 @@ func preShellSnapshot(ctx context.Context, recorder FileChangeRecorder, workDir 
 		workDir:      workDir,
 		patterns:     patterns,
 		files:        make(map[string]*shellSnapshotEntry),
+		sources:      make(map[string]shellCandidateSource),
 		maxFileBytes: recorder.MaxFileBytes(),
 	}
 
-	if repo := DetectGitRepo(workDir); repo.IsRepo {
-		snap.gitRoot = repo.Root
-	}
+	resolver := newShellRepoResolver()
+	snap.gitRoot = resolver.owningRepo(workDir)
 
 	var sessionPaths []string
 	if len(patterns) == 0 {
@@ -104,34 +133,51 @@ func preShellSnapshot(ctx context.Context, recorder FileChangeRecorder, workDir 
 		snap.gitStatus = gitStatusPorcelain(ctx, snap.gitRoot)
 	}
 
-	candidates := expandShellPatterns(workDir, patterns)
-	if snap.gitRoot != "" {
-		// Affected-path entries can be intentionally broad (for example "**/*"),
-		// and literal entries can still name generated files. In a git repository,
-		// keep these hints aligned with Git's notion of source files: ignored
-		// build/cache artifacts should not enter the tracked file-change set just
-		// because an affected_paths entry happened to match them. When hints are
-		// omitted, session-tracked paths are appended below and intentionally
-		// bypass this filter as a per-session escape hatch.
-		candidates = filterGitIgnoredCandidates(ctx, snap.gitRoot, candidates)
+	for _, candidate := range expandShellPatterns(workDir, patterns) {
+		snap.sources[candidate.path] |= candidate.source
 	}
 	if snap.gitStatus != nil {
 		// Snapshot paths that were already dirty before the command. Otherwise a
 		// command that edits a dirty tracked file, or an existing untracked file,
 		// can leave porcelain status unchanged (e.g. " M" -> " M", "??" ->
-		// "??") and would be invisible in postShellChanges.
+		// "??") and would be invisible after the command.
 		for path := range snap.gitStatus {
-			candidates = append(candidates, path)
+			if !hasGitAdminComponent(path) {
+				snap.sources[path] |= shellSourceGit
+			}
 		}
 	}
-	candidates = append(candidates, sessionPaths...)
-	for _, path := range candidates {
-		if _, seen := snap.files[path]; seen {
-			continue
+	for _, path := range sessionPaths {
+		path = filepath.Clean(path)
+		if !hasGitAdminComponent(path) {
+			snap.sources[path] |= shellSourceSession
 		}
+	}
+
+	paths := make([]string, 0, len(snap.sources))
+	for path := range snap.sources {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
 		snap.files[path] = snap.statAndMaybeRead(path)
 	}
 	return snap
+}
+
+type shellPostCandidate struct {
+	entry           *shellSnapshotEntry
+	source          shellCandidateSource
+	postOnlyPattern bool
+	repoRoot        string
+	postStatus      string
+	gitBefore       []byte
+	gitBeforeOK     bool
+}
+
+type shellRepoStatus struct {
+	paths     map[string]string
+	available bool
 }
 
 // postShellChanges diffs the filesystem against a pre-exec snapshot and
@@ -147,42 +193,144 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), fileRecordTimeout)
 	defer cancel()
 
-	type candidate struct {
-		entry        *shellSnapshotEntry // nil when not statted pre-exec (git-derived)
-		fromReexpand bool
-	}
-	candidates := make(map[string]candidate)
-
+	candidates := make(map[string]*shellPostCandidate, len(snap.files))
 	for path, entry := range snap.files {
-		candidates[path] = candidate{entry: entry}
+		candidates[path] = &shellPostCandidate{entry: entry, source: snap.sources[path]}
 	}
-	// Re-expanding the same patterns catches files created by the command.
-	// A path matched now but not pre-exec did not exist then.
-	reexpanded := expandShellPatterns(snap.workDir, snap.patterns)
-	if snap.gitRoot != "" {
-		reexpanded = filterGitIgnoredCandidates(ctx, snap.gitRoot, reexpanded)
+
+	// Re-expanding the same patterns catches files created by the command. A
+	// glob match seen only post-command is treated as a creation; exact literals
+	// were included in the pre snapshot even when missing.
+	for _, expanded := range expandShellPatterns(snap.workDir, snap.patterns) {
+		candidate, seen := candidates[expanded.path]
+		if !seen {
+			candidate = &shellPostCandidate{}
+			candidates[expanded.path] = candidate
+			candidate.postOnlyPattern = expanded.source&shellSourceGlob != 0
+		}
+		candidate.source |= expanded.source
 	}
-	for _, path := range reexpanded {
-		if _, seen := candidates[path]; !seen {
-			candidates[path] = candidate{fromReexpand: true}
+
+	// For the no-hints Git fallback, one post-command status supplies both the
+	// discovery set and the clean/dirty baseline for the owning repository.
+	repoStatuses := make(map[string]shellRepoStatus)
+	if snap.gitRoot != "" && snap.gitStatus != nil {
+		postStatus := gitStatusPorcelain(ctx, snap.gitRoot)
+		repoStatuses[snap.gitRoot] = shellRepoStatus{paths: postStatus, available: postStatus != nil}
+		for path := range postStatus {
+			if hasGitAdminComponent(path) {
+				continue
+			}
+			candidate := candidates[path]
+			if candidate == nil {
+				candidate = &shellPostCandidate{}
+				candidates[path] = candidate
+			}
+			candidate.source |= shellSourceGit
 		}
 	}
 
-	// Only diff post-status against Git when a pre-status snapshot was captured;
-	// otherwise every dirty path would look newly changed.
-	var postStatus map[string]string
-	if snap.gitRoot != "" && snap.gitStatus != nil {
-		postStatus = gitStatusPorcelain(ctx, snap.gitRoot)
-		for path := range gitChangedPaths(snap.gitStatus, postStatus) {
-			if _, seen := candidates[path]; !seen {
-				candidates[path] = candidate{}
+	paths := make([]string, 0, len(candidates))
+	for path := range candidates {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	// Resolve the deepest owning repository from post-command filesystem state.
+	// This catches repositories cloned or created by the command and handles
+	// nested repos/worktrees without invoking Git once per candidate.
+	resolver := newShellRepoResolver()
+	reposNeedingStatus := make(map[string]struct{})
+	literalPathsByRepo := make(map[string][]string)
+	for _, path := range paths {
+		candidate := candidates[path]
+		if hasGitAdminComponent(path) {
+			delete(candidates, path)
+			continue
+		}
+		candidate.repoRoot = resolver.owningRepo(path)
+		if candidate.repoRoot == "" {
+			continue
+		}
+		if candidate.source&shellSourceLiteral != 0 && candidate.source&shellSourceSession == 0 {
+			literalPathsByRepo[candidate.repoRoot] = append(literalPathsByRepo[candidate.repoRoot], path)
+		}
+		if !candidate.source.preservesCleanGitState() {
+			if _, loaded := repoStatuses[candidate.repoRoot]; !loaded {
+				reposNeedingStatus[candidate.repoRoot] = struct{}{}
 			}
 		}
 	}
 
+	statusRoots := sortedMapKeys(reposNeedingStatus)
+	for i, root := range statusRoots {
+		if i >= maxShellGitRepos {
+			break // safely degrade to before/after comparison for excess repos
+		}
+		status := gitStatusPorcelain(ctx, root)
+		repoStatuses[root] = shellRepoStatus{paths: status, available: status != nil}
+	}
+
+	// Exact literal affected_paths are deliberate snapshots even when the
+	// command leaves Git clean, but ignored literals are still excluded. Batch
+	// check-ignore once per owning repo rather than shelling out per path.
+	ignoredLiterals := make(map[string]bool)
+	literalRoots := sortedMapKeys(literalPathsByRepo)
+	for i, root := range literalRoots {
+		if i >= maxShellGitRepos {
+			break
+		}
+		for path := range gitIgnoredCandidates(ctx, root, literalPathsByRepo[root]) {
+			ignoredLiterals[path] = true
+		}
+	}
+
+	filteredPaths := paths[:0]
+	for _, path := range paths {
+		candidate := candidates[path]
+		if candidate == nil || ignoredLiterals[filepath.Clean(path)] {
+			continue
+		}
+		if candidate.repoRoot != "" {
+			if state, ok := repoStatuses[candidate.repoRoot]; ok && state.available {
+				candidate.postStatus = state.paths[path]
+				if !candidate.source.preservesCleanGitState() && candidate.postStatus == "" {
+					// Broad globs are discovery scopes. Inside Git, post-command clean
+					// materialization is the baseline, so only dirty tracked and
+					// untracked non-ignored paths survive.
+					continue
+				}
+			}
+		}
+		filteredPaths = append(filteredPaths, path)
+	}
+	paths = filteredPaths
+
+	// Clean tracked paths discovered only by the Git fallback were not statted
+	// pre-command. Recover their index content in one bounded Git process rather
+	// than invoking git show once per candidate.
+	var indexPaths []string
+	for _, path := range paths {
+		candidate := candidates[path]
+		_, wasDirty := snap.gitStatus[path]
+		indexUnchanged := len(candidate.postStatus) == 2 && candidate.postStatus[0] == ' '
+		if candidate.entry == nil && candidate.source&shellSourceGit != 0 &&
+			candidate.repoRoot == snap.gitRoot && !wasDirty && indexUnchanged {
+			indexPaths = append(indexPaths, path)
+		}
+	}
+	indexContent := gitShowIndexBatch(ctx, snap.gitRoot, indexPaths, snap.maxFileBytes,
+		maxShellContentReads-snap.postContentReads, maxShellSnapshotBytes-snap.postContentBytes)
+	for path, content := range indexContent {
+		candidate := candidates[path]
+		candidate.gitBefore = content
+		candidate.gitBeforeOK = true
+		snap.notePostContentRead(content)
+	}
+
 	var changes []llm.FileChange
-	for path, cand := range candidates {
-		rec := snap.buildChangeRecord(ctx, path, cand.entry, cand.fromReexpand)
+	for _, path := range paths {
+		rec := snap.buildChangeRecord(path, candidates[path])
 		if rec == nil {
 			continue
 		}
@@ -198,11 +346,19 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 // buildChangeRecord compares one path's current state with its pre-exec state
 // and returns the change to record, or nil when nothing changed (or change
 // detection is impossible).
-func (snap *shellSnapshot) buildChangeRecord(ctx context.Context, path string, prev *shellSnapshotEntry, fromReexpand bool) *filetrack.ChangeRecord {
+func (snap *shellSnapshot) buildChangeRecord(path string, candidate *shellPostCandidate) *filetrack.ChangeRecord {
+	prev := candidate.entry
 	info, statErr := os.Stat(path)
 	existsNow := statErr == nil && info.Mode().IsRegular()
 	if statErr == nil && !info.Mode().IsRegular() {
 		return nil // directories, sockets, etc.
+	}
+
+	// Stat is the universal unchanged fast path for every pre-existing file,
+	// including files whose content was captured. This prevents historical
+	// session paths beyond the content cap from becoming false modifications.
+	if prev != nil && prev.existed && existsNow && info.Size() == prev.size && info.ModTime().Equal(prev.modTime) {
+		return nil
 	}
 
 	rec := &filetrack.ChangeRecord{SessionID: snap.sessionID, Path: path}
@@ -214,41 +370,16 @@ func (snap *shellSnapshot) buildChangeRecord(ctx context.Context, path string, p
 	case prev != nil && prev.content != nil:
 		rec.Before = prev.content
 	case prev != nil:
-		// Statted pre-exec but content not read (oversized / beyond budget):
-		// change detection falls back to size+mtime.
-		if existsNow && info.Size() == prev.size && info.ModTime().Equal(prev.modTime) {
-			return nil
-		}
 		rec.BeforeUnknown = true
 		rec.BeforeSizeHint = prev.size
-	case fromReexpand:
-		// Newly matched by the same pre-exec glob set → did not exist before.
+	case candidate.postOnlyPattern:
+		rec.BeforeMissing = true
+	case candidate.gitBeforeOK:
+		rec.Before = candidate.gitBefore
+	case candidate.source&shellSourceGit != 0 && (candidate.postStatus == "??" || strings.HasPrefix(candidate.postStatus, "A")):
 		rec.BeforeMissing = true
 	default:
-		// Git-derived candidate never statted pre-exec; classify via status.
-		preLine, wasDirty := snap.gitStatus[path]
-		switch {
-		case !wasDirty:
-			// Clean and tracked pre-exec: the index still holds the pre-exec
-			// content. Recovered content counts against the snapshot budget
-			// like any other read.
-			if snap.contentBytes < maxShellSnapshotBytes && snap.contentReads < maxShellContentReads {
-				if content, ok := gitShowIndex(ctx, snap.gitRoot, path, snap.maxFileBytes); ok {
-					snap.noteContentRead(content)
-					rec.Before = content
-				} else {
-					rec.BeforeUnknown = true
-				}
-			} else {
-				rec.BeforeUnknown = true
-			}
-		case strings.HasPrefix(preLine, "??"):
-			// Untracked pre-exec; content unrecoverable.
-			rec.BeforeUnknown = true
-		default:
-			// Dirty tracked file pre-exec; worktree content unrecoverable.
-			rec.BeforeUnknown = true
-		}
+		rec.BeforeUnknown = true
 	}
 
 	// Establish the "after" side.
@@ -259,22 +390,27 @@ func (snap *shellSnapshot) buildChangeRecord(ctx context.Context, path string, p
 		}
 		return rec
 	}
-	if !snap.canReadContent(info.Size()) {
+
+	// A captured pre buffer always gets a post read when the file remains under
+	// the per-file cap. These reads are transient and deliberately independent
+	// of the bounded pre-snapshot and discretionary post-read budgets.
+	mustCompareCaptured := prev != nil && prev.content != nil
+	if info.Size() > int64(snap.maxFileBytes) || (!mustCompareCaptured && !snap.canReadPostContent(info.Size())) {
 		rec.AfterUnknown = true
 		rec.AfterSizeHint = info.Size()
 		return rec
 	}
-	content, err := os.ReadFile(path)
-	if err != nil {
+	content, ok := readFileBounded(path, snap.maxFileBytes)
+	if !ok {
 		rec.AfterUnknown = true
 		rec.AfterSizeHint = info.Size()
 		return rec
 	}
-	snap.noteContentRead(content)
+	if !mustCompareCaptured {
+		snap.notePostContentRead(content)
+	}
 	rec.After = content
 
-	// Skip unchanged files (store would also drop them, but avoiding the
-	// round trip keeps the common no-op case cheap).
 	if rec.Before != nil && bytes.Equal(rec.Before, rec.After) {
 		return nil
 	}
@@ -282,21 +418,34 @@ func (snap *shellSnapshot) buildChangeRecord(ctx context.Context, path string, p
 }
 
 // statAndMaybeRead captures one file's current state, reading content when it
-// fits the per-file cap and the read budget.
+// fits the per-file cap and the bounded pre-snapshot budget.
 func (snap *shellSnapshot) statAndMaybeRead(path string) *shellSnapshotEntry {
 	info, err := os.Stat(path)
 	if err != nil || !info.Mode().IsRegular() {
 		return &shellSnapshotEntry{existed: false}
 	}
 	entry := &shellSnapshotEntry{existed: true, size: info.Size(), modTime: info.ModTime()}
-	if !snap.canReadContent(info.Size()) {
+	if !snap.canCapturePreContent(info.Size()) {
 		return entry
 	}
-	if content, err := os.ReadFile(path); err == nil {
-		snap.noteContentRead(content)
+	if content, ok := readFileBounded(path, snap.maxFileBytes); ok {
+		snap.notePreContentRead(content)
 		entry.content = content
 	}
 	return entry
+}
+
+func readFileBounded(path string, maxBytes int) ([]byte, bool) {
+	if maxBytes < 0 {
+		return nil, false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer file.Close()
+	content, err := io.ReadAll(io.LimitReader(file, int64(maxBytes)+1))
+	return content, err == nil && len(content) <= maxBytes
 }
 
 // errShellGlobLimit terminates a glob walk once enough candidates are found.
@@ -312,13 +461,20 @@ func normalizeShellPatterns(patterns []string) []string {
 	return normalized
 }
 
+type shellExpandedCandidate struct {
+	path   string
+	source shellCandidateSource
+}
+
 // expandShellPatterns resolves affected_paths entries (files or globs,
 // relative to workDir or absolute) into absolute paths. Literal paths are
 // included even when missing so creations can be detected. GlobWalk (rather
-// than FilepathGlob) lets the walk stop at the match cap instead of
-// collecting every match from a pathological pattern like "**" first.
-func expandShellPatterns(workDir string, patterns []string) []string {
-	var paths []string
+// than FilepathGlob) lets the walk stop at the match cap instead of collecting
+// every match from a pathological pattern like "**" first. Its filesystem
+// wrapper hides .git directories from traversal so administrative files cannot
+// consume the candidate cap.
+func expandShellPatterns(workDir string, patterns []string) []shellExpandedCandidate {
+	var candidates []shellExpandedCandidate
 	for _, pattern := range patterns {
 		pattern = strings.TrimSpace(pattern)
 		if pattern == "" {
@@ -328,26 +484,135 @@ func expandShellPatterns(workDir string, patterns []string) []string {
 			pattern = filepath.Join(workDir, pattern)
 		}
 		if !strings.ContainsAny(pattern, "*?[{") {
-			paths = append(paths, filepath.Clean(pattern))
+			path := filepath.Clean(pattern)
+			if !hasGitAdminComponent(path) {
+				candidates = append(candidates, shellExpandedCandidate{path: path, source: shellSourceLiteral})
+			}
 			continue
 		}
-		if len(paths) >= maxShellGlobMatches {
-			return paths
+		if len(candidates) >= maxShellGlobMatches {
+			return candidates
 		}
 
 		base, rel := doublestar.SplitPattern(filepath.ToSlash(pattern))
-		baseDir := filepath.FromSlash(base)
-		_ = doublestar.GlobWalk(os.DirFS(baseDir), rel, func(matchPath string, d fs.DirEntry) error {
-			if !d.IsDir() || matchPath == "." {
-				paths = append(paths, filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(matchPath))))
+		baseDir := filepath.Clean(filepath.FromSlash(base))
+		if hasGitAdminComponent(baseDir) {
+			continue
+		}
+		fsys := shellGlobFS{FS: os.DirFS(baseDir)}
+		_ = doublestar.GlobWalk(fsys, rel, func(matchPath string, d fs.DirEntry) error {
+			if d.IsDir() {
+				if d.Name() == ".git" {
+					return fs.SkipDir
+				}
+				return nil
 			}
-			if len(paths) >= maxShellGlobMatches {
+			path := filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(matchPath)))
+			if !hasGitAdminComponent(path) {
+				candidates = append(candidates, shellExpandedCandidate{path: path, source: shellSourceGlob})
+			}
+			if len(candidates) >= maxShellGlobMatches {
 				return errShellGlobLimit
 			}
 			return nil
 		}, doublestar.WithNoFollow())
 	}
-	return paths
+	return candidates
+}
+
+type shellGlobFS struct {
+	fs.FS
+}
+
+func (fsys shellGlobFS) Open(name string) (fs.File, error) {
+	if hasGitAdminComponent(filepath.FromSlash(name)) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return fsys.FS.Open(name)
+}
+
+func (fsys shellGlobFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if hasGitAdminComponent(filepath.FromSlash(name)) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+	entries, err := fs.ReadDir(fsys.FS, name)
+	if err != nil {
+		return nil, err
+	}
+	filtered := entries[:0]
+	for _, entry := range entries {
+		if entry.Name() != ".git" {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered, nil
+}
+
+func hasGitAdminComponent(path string) bool {
+	path = filepath.Clean(path)
+	volume := filepath.VolumeName(path)
+	path = strings.TrimPrefix(path, volume)
+	for _, component := range strings.Split(path, string(filepath.Separator)) {
+		if component == ".git" {
+			return true
+		}
+	}
+	return false
+}
+
+type shellRepoResolver struct {
+	byDir map[string]string
+}
+
+func newShellRepoResolver() *shellRepoResolver {
+	return &shellRepoResolver{byDir: make(map[string]string)}
+}
+
+// owningRepo discovers the deepest repository containing path using only
+// filesystem markers. Both .git directories and worktree/submodule .git files
+// establish ownership.
+func (resolver *shellRepoResolver) owningRepo(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = filepath.Clean(path)
+	}
+	start := abs
+	if info, err := os.Stat(start); err != nil || !info.IsDir() {
+		start = filepath.Dir(start)
+	}
+
+	var visited []string
+	for dir := filepath.Clean(start); ; dir = filepath.Dir(dir) {
+		if root, ok := resolver.byDir[dir]; ok {
+			for _, item := range visited {
+				resolver.byDir[item] = root
+			}
+			return root
+		}
+		visited = append(visited, dir)
+		if _, err := os.Lstat(filepath.Join(dir, ".git")); err == nil {
+			for _, item := range visited {
+				resolver.byDir[item] = dir
+			}
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			for _, item := range visited {
+				resolver.byDir[item] = ""
+			}
+			return ""
+		}
+	}
+}
+
+func sortedMapKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // gitIgnoredCandidates returns the subset of paths ignored by Git. It uses
@@ -437,21 +702,6 @@ func canonicalPathForGitRel(path string) string {
 	}
 }
 
-func filterGitIgnoredCandidates(ctx context.Context, root string, paths []string) []string {
-	ignored := gitIgnoredCandidates(ctx, root, paths)
-	if len(ignored) == 0 {
-		return paths
-	}
-	filtered := make([]string, 0, len(paths))
-	for _, path := range paths {
-		if ignored[filepath.Clean(path)] {
-			continue
-		}
-		filtered = append(filtered, path)
-	}
-	return filtered
-}
-
 // gitStatusPorcelain returns the repo's dirty paths (absolute) mapped to their
 // porcelain XY status. Returns nil on any failure — git tracking is optional.
 func gitStatusPorcelain(ctx context.Context, root string) map[string]string {
@@ -473,70 +723,102 @@ func gitStatusPorcelain(ctx context.Context, root string) map[string]string {
 		}
 		xy := entry[:2]
 		rel := entry[3:]
-		// Renames/copies carry the original path in the next token.
-		if xy[0] == 'R' || xy[0] == 'C' {
-			i++
+		abs := filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))
+		if !hasGitAdminComponent(abs) {
+			status[abs] = xy
 		}
-		abs := filepath.Join(root, filepath.FromSlash(rel))
-		status[abs] = xy
+		// Renames/copies carry the original path in the next token. Include
+		// both sides so broad discovery can retain the dirty deletion as well as
+		// the destination.
+		if (xy[0] == 'R' || xy[0] == 'C') && i+1 < len(tokens) {
+			i++
+			original := filepath.Clean(filepath.Join(root, filepath.FromSlash(tokens[i])))
+			if !hasGitAdminComponent(original) {
+				status[original] = xy
+			}
+		}
 	}
 	return status
 }
 
-// gitChangedPaths returns paths whose porcelain status differs between two
-// snapshots (including paths present in only one of them).
-func gitChangedPaths(pre, post map[string]string) map[string]struct{} {
-	changed := make(map[string]struct{})
-	for path, line := range post {
-		if pre[path] != line {
-			changed[path] = struct{}{}
-		}
+// gitShowIndexBatch returns bounded index content for paths inside one repo.
+// One cat-file process serves the whole batch; failures or oversized blobs
+// safely degrade the remaining paths to unknown before-content.
+func gitShowIndexBatch(ctx context.Context, root string, absPaths []string, maxFileBytes, maxReads int, maxTotalBytes int64) map[string][]byte {
+	contentByPath := make(map[string][]byte)
+	if root == "" || maxFileBytes < 0 || maxReads <= 0 || maxTotalBytes < 0 || len(absPaths) == 0 {
+		return contentByPath
 	}
-	for path := range pre {
-		if _, ok := post[path]; !ok {
-			changed[path] = struct{}{}
-		}
-	}
-	return changed
-}
 
-// gitShowIndex returns the index content for a path inside a repo. Used to
-// recover the before-content of files that were clean when the shell command
-// started. Returns ok=false when the file is untracked, too large, or git fails.
-func gitShowIndex(ctx context.Context, root, absPath string, maxBytes int) ([]byte, bool) {
-	if maxBytes < 0 {
-		return nil, false
+	type query struct {
+		path string
+		spec string
 	}
-	rel := GetRelativePath(absPath, root)
-	if rel == absPath || strings.HasPrefix(rel, "..") {
-		return nil, false
+	queries := make([]query, 0, len(absPaths))
+	for _, absPath := range absPaths {
+		rel := GetRelativePath(absPath, root)
+		if rel == absPath || strings.HasPrefix(rel, "..") || strings.ContainsAny(rel, "\r\n") {
+			continue
+		}
+		queries = append(queries, query{path: absPath, spec: ":" + filepath.ToSlash(rel)})
+	}
+	if len(queries) == 0 {
+		return contentByPath
 	}
 
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitCommandTimeout)
 	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "git", "-C", root, "show", ":"+filepath.ToSlash(rel))
+	var input strings.Builder
+	for _, query := range queries {
+		input.WriteString(query.spec)
+		input.WriteByte('\n')
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", root, "cat-file", "--batch")
+	cmd.Stdin = strings.NewReader(input.String())
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, false
+		return contentByPath
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, false
+		return contentByPath
 	}
 
-	out, readErr := io.ReadAll(io.LimitReader(stdout, int64(maxBytes)+1))
-	if readErr != nil {
-		cancel()
-		_ = cmd.Wait()
-		return nil, false
+	reader := bufio.NewReader(stdout)
+	var totalBytes int64
+	for _, query := range queries {
+		header, err := reader.ReadString('\n')
+		if err != nil {
+			cancel()
+			break
+		}
+		header = strings.TrimSuffix(header, "\n")
+		if strings.HasSuffix(header, " missing") {
+			continue
+		}
+		fields := strings.Fields(header)
+		if len(fields) != 3 || fields[1] != "blob" {
+			cancel()
+			break
+		}
+		size, err := strconv.ParseInt(fields[2], 10, 64)
+		if err != nil || size < 0 || size > int64(maxFileBytes) || len(contentByPath) >= maxReads || totalBytes+size > maxTotalBytes {
+			// Continuing would require draining an arbitrarily large blob. Stop
+			// this best-effort batch instead and preserve the per-file I/O bound.
+			cancel()
+			break
+		}
+		content := make([]byte, size)
+		if _, err := io.ReadFull(reader, content); err != nil {
+			cancel()
+			break
+		}
+		if _, err := reader.ReadByte(); err != nil { // cat-file separator newline
+			cancel()
+			break
+		}
+		contentByPath[query.path] = content
+		totalBytes += size
 	}
-	if len(out) > maxBytes {
-		cancel()
-		_ = cmd.Wait()
-		return nil, false
-	}
-	if err := cmd.Wait(); err != nil {
-		return nil, false
-	}
-	return out, true
+	_ = cmd.Wait()
+	return contentByPath
 }

--- a/internal/tools/shell_track.go
+++ b/internal/tools/shell_track.go
@@ -24,11 +24,14 @@ import (
 // call, not correctness: files beyond the content-read budgets are still
 // detected via stat and recorded metadata-only (truncated).
 const (
-	maxShellGlobMatches   = 1000             // candidate paths per glob expansion
-	maxShellContentReads  = 200              // full-content snapshots per phase and shell call
-	maxShellSnapshotBytes = 64 * 1024 * 1024 // total content bytes read per phase and shell call
-	maxShellGitRepos      = 64               // distinct candidate repositories inspected post-command
-	gitCommandTimeout     = 5 * time.Second
+	maxShellGlobMatches    = 1000             // candidate paths per glob expansion
+	maxShellContentReads   = 200              // full-content snapshots per phase and shell call
+	maxShellSnapshotBytes  = 64 * 1024 * 1024 // total content bytes read per phase and shell call
+	maxShellGitRepos       = 64               // distinct candidate repositories inspected post-command
+	maxGitBatchHeaderBytes = 64 * 1024        // malformed cat-file headers abort without unbounded buffering
+	maxGitBatchDrainBytes  = 64 * 1024 * 1024 // total skipped object bytes drained per cat-file batch
+	gitCommandTimeout      = 5 * time.Second
+	gitCommandWaitDelay    = 100 * time.Millisecond
 )
 
 type shellCandidateSource uint8
@@ -248,7 +251,7 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 			delete(candidates, path)
 			continue
 		}
-		candidate.repoRoot = resolver.owningRepo(path)
+		candidate.repoRoot = resolver.owningRepoForCandidate(path, snap.workDir, snap.gitRoot)
 		if candidate.repoRoot == "" {
 			continue
 		}
@@ -264,8 +267,11 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 
 	statusRoots := sortedMapKeys(reposNeedingStatus)
 	for i, root := range statusRoots {
+		if ctx.Err() != nil {
+			break
+		}
 		if i >= maxShellGitRepos {
-			break // safely degrade to before/after comparison for excess repos
+			break // unavailable status suppresses broad candidates in excess repos below
 		}
 		status := gitStatusPorcelain(ctx, root)
 		repoStatuses[root] = shellRepoStatus{paths: status, available: status != nil}
@@ -277,6 +283,9 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 	ignoredLiterals := make(map[string]bool)
 	literalRoots := sortedMapKeys(literalPathsByRepo)
 	for i, root := range literalRoots {
+		if ctx.Err() != nil {
+			break
+		}
 		if i >= maxShellGitRepos {
 			break
 		}
@@ -292,12 +301,23 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 			continue
 		}
 		if candidate.repoRoot != "" {
-			if state, ok := repoStatuses[candidate.repoRoot]; ok && state.available {
+			state, statusLoaded := repoStatuses[candidate.repoRoot]
+			if statusLoaded && state.available {
 				candidate.postStatus = state.paths[path]
-				if !candidate.source.preservesCleanGitState() && candidate.postStatus == "" {
-					// Broad globs are discovery scopes. Inside Git, post-command clean
-					// materialization is the baseline, so only dirty tracked and
-					// untracked non-ignored paths survive.
+			}
+			_, wasDirty := snap.gitStatus[path]
+			knownDirtyBaseline := wasDirty && candidate.entry != nil && candidate.entry.existed
+			if !candidate.source.preservesCleanGitState() && !knownDirtyBaseline {
+				if !statusLoaded || !state.available {
+					// Repo caps and status failures fail closed for broad discovery:
+					// emitting every changed glob match would turn a clean clone or
+					// checkout into materialization noise. Exact literals, session
+					// paths, and captured pre-dirty baselines remain preserved.
+					continue
+				}
+				if candidate.postStatus == "" {
+					// Globs are discovery scopes, so a Git-clean path at return is
+					// intentionally omitted. Exact literals preserve edit+commit.
 					continue
 				}
 			}
@@ -330,6 +350,9 @@ func postShellChanges(ctx context.Context, recorder FileChangeRecorder, snap *sh
 
 	var changes []llm.FileChange
 	for _, path := range paths {
+		if ctx.Err() != nil {
+			break
+		}
 		rec := snap.buildChangeRecord(path, candidates[path])
 		if rec == nil {
 			continue
@@ -354,10 +377,10 @@ func (snap *shellSnapshot) buildChangeRecord(path string, candidate *shellPostCa
 		return nil // directories, sockets, etc.
 	}
 
-	// Stat is the universal unchanged fast path for every pre-existing file,
-	// including files whose content was captured. This prevents historical
-	// session paths beyond the content cap from becoming false modifications.
-	if prev != nil && prev.existed && existsNow && info.Size() == prev.size && info.ModTime().Equal(prev.modTime) {
+	// For metadata-only snapshots, equal size and mtime are the only bounded
+	// unchanged signal available. Captured content must still be byte-compared:
+	// callers can preserve mtime while replacing same-size bytes.
+	if prev != nil && prev.existed && prev.content == nil && existsNow && info.Size() == prev.size && info.ModTime().Equal(prev.modTime) {
 		return nil
 	}
 
@@ -502,7 +525,7 @@ func expandShellPatterns(workDir string, patterns []string) []shellExpandedCandi
 		fsys := shellGlobFS{FS: os.DirFS(baseDir)}
 		_ = doublestar.GlobWalk(fsys, rel, func(matchPath string, d fs.DirEntry) error {
 			if d.IsDir() {
-				if d.Name() == ".git" {
+				if isGitAdminName(d.Name()) {
 					return fs.SkipDir
 				}
 				return nil
@@ -531,6 +554,13 @@ func (fsys shellGlobFS) Open(name string) (fs.File, error) {
 	return fsys.FS.Open(name)
 }
 
+func (fsys shellGlobFS) Stat(name string) (fs.FileInfo, error) {
+	if hasGitAdminComponent(filepath.FromSlash(name)) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+	}
+	return fs.Stat(fsys.FS, name)
+}
+
 func (fsys shellGlobFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	if hasGitAdminComponent(filepath.FromSlash(name)) {
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
@@ -541,11 +571,17 @@ func (fsys shellGlobFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	filtered := entries[:0]
 	for _, entry := range entries {
-		if entry.Name() != ".git" {
+		if !isGitAdminName(entry.Name()) {
 			filtered = append(filtered, entry)
 		}
 	}
 	return filtered, nil
+}
+
+func isGitAdminName(name string) bool {
+	// EqualFold is deliberately limited to the complete component, so .github
+	// remains visible while case-insensitive filesystems cannot expose .GIT.
+	return strings.EqualFold(name, ".git")
 }
 
 func hasGitAdminComponent(path string) bool {
@@ -553,7 +589,7 @@ func hasGitAdminComponent(path string) bool {
 	volume := filepath.VolumeName(path)
 	path = strings.TrimPrefix(path, volume)
 	for _, component := range strings.Split(path, string(filepath.Separator)) {
-		if component == ".git" {
+		if isGitAdminName(component) {
 			return true
 		}
 	}
@@ -561,46 +597,100 @@ func hasGitAdminComponent(path string) bool {
 }
 
 type shellRepoResolver struct {
-	byDir map[string]string
+	markers map[string]bool
 }
 
 func newShellRepoResolver() *shellRepoResolver {
-	return &shellRepoResolver{byDir: make(map[string]string)}
+	return &shellRepoResolver{markers: make(map[string]bool)}
 }
 
-// owningRepo discovers the deepest repository containing path using only
-// filesystem markers. Both .git directories and worktree/submodule .git files
-// establish ownership.
+// owningRepo discovers the deepest repository containing path. The unbounded
+// form is used only for the shell working directory itself.
 func (resolver *shellRepoResolver) owningRepo(path string) string {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		abs = filepath.Clean(path)
+	return resolver.owningRepoWithin(path, "", true)
+}
+
+// owningRepoForCandidate bounds ancestor discovery to the command's relevant
+// filesystem scope. Paths under workDir may inherit its owning repository and
+// still discover deeper nested repos. Explicit absolute paths outside workDir
+// may discover their own repo before the common ancestor, but are not assigned
+// to an unrelated .git marker at that arbitrary common ancestor.
+func (resolver *shellRepoResolver) owningRepoForCandidate(path, workDir, workRepo string) string {
+	absPath := absoluteCleanPath(path)
+	absWorkDir := absoluteCleanPath(workDir)
+	if pathWithinRoot(absPath, absWorkDir) {
+		boundary := absWorkDir
+		if workRepo != "" {
+			boundary = absoluteCleanPath(workRepo)
+		}
+		return resolver.owningRepoWithin(absPath, boundary, true)
+	}
+	boundary := commonPathAncestor(absWorkDir, absPath)
+	return resolver.owningRepoWithin(absPath, boundary, false)
+}
+
+// owningRepoWithin discovers repositories from path up to boundary. Both .git
+// directories and worktree/submodule .git files establish ownership.
+func (resolver *shellRepoResolver) owningRepoWithin(path, boundary string, includeBoundary bool) string {
+	abs := absoluteCleanPath(path)
+	if boundary != "" {
+		boundary = absoluteCleanPath(boundary)
+		if !pathWithinRoot(abs, boundary) {
+			return ""
+		}
 	}
 	start := abs
 	if info, err := os.Stat(start); err != nil || !info.IsDir() {
 		start = filepath.Dir(start)
 	}
 
-	var visited []string
 	for dir := filepath.Clean(start); ; dir = filepath.Dir(dir) {
-		if root, ok := resolver.byDir[dir]; ok {
-			for _, item := range visited {
-				resolver.byDir[item] = root
-			}
-			return root
+		atBoundary := boundary != "" && dir == boundary
+		if atBoundary && !includeBoundary {
+			return ""
 		}
-		visited = append(visited, dir)
-		if _, err := os.Lstat(filepath.Join(dir, ".git")); err == nil {
-			for _, item := range visited {
-				resolver.byDir[item] = dir
-			}
+		marker, checked := resolver.markers[dir]
+		if !checked {
+			_, err := os.Lstat(filepath.Join(dir, ".git"))
+			marker = err == nil
+			resolver.markers[dir] = marker
+		}
+		if marker {
+			return dir
+		}
+		if atBoundary {
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+	}
+}
+
+func absoluteCleanPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(abs)
+}
+
+func pathWithinRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || filepath.IsAbs(rel) {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func commonPathAncestor(first, second string) string {
+	for dir := filepath.Clean(first); ; dir = filepath.Dir(dir) {
+		if pathWithinRoot(second, dir) {
 			return dir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			for _, item := range visited {
-				resolver.byDir[item] = ""
-			}
 			return ""
 		}
 	}
@@ -613,6 +703,16 @@ func sortedMapKeys[T any](values map[string]T) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// boundedGitCommand applies gitCommandTimeout without detaching from a shorter
+// parent deadline. WaitDelay prevents descendants that inherited stdout/stderr
+// pipes from keeping a canceled best-effort Git probe alive indefinitely.
+func boundedGitCommand(ctx context.Context, root string, args ...string) (*exec.Cmd, context.CancelFunc) {
+	commandCtx, cancel := context.WithTimeout(ctx, gitCommandTimeout)
+	cmd := exec.CommandContext(commandCtx, "git", append([]string{"-C", root}, args...)...)
+	cmd.WaitDelay = gitCommandWaitDelay
+	return cmd, cancel
 }
 
 // gitIgnoredCandidates returns the subset of paths ignored by Git. It uses
@@ -650,10 +750,8 @@ func gitIgnoredCandidates(ctx context.Context, root string, paths []string) map[
 		return ignored
 	}
 
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitCommandTimeout)
+	cmd, cancel := boundedGitCommand(ctx, root, "check-ignore", "-z", "--stdin")
 	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "git", "-C", root, "check-ignore", "-z", "--stdin")
 	cmd.Stdin = strings.NewReader(input.String())
 	out, err := cmd.Output()
 	if err != nil {
@@ -705,10 +803,8 @@ func canonicalPathForGitRel(path string) string {
 // gitStatusPorcelain returns the repo's dirty paths (absolute) mapped to their
 // porcelain XY status. Returns nil on any failure — git tracking is optional.
 func gitStatusPorcelain(ctx context.Context, root string) map[string]string {
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitCommandTimeout)
+	cmd, cancel := boundedGitCommand(ctx, root, "status", "--porcelain", "-z", "--untracked-files=all")
 	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "git", "-C", root, "status", "--porcelain", "-z", "--untracked-files=all")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil
@@ -742,8 +838,9 @@ func gitStatusPorcelain(ctx context.Context, root string) map[string]string {
 }
 
 // gitShowIndexBatch returns bounded index content for paths inside one repo.
-// One cat-file process serves the whole batch; failures or oversized blobs
-// safely degrade the remaining paths to unknown before-content.
+// One cat-file process serves the whole batch. Bounded oversized and non-blob
+// objects are drained and skipped so later blobs remain recoverable; malformed
+// or unreasonable responses abort the remaining best-effort batch.
 func gitShowIndexBatch(ctx context.Context, root string, absPaths []string, maxFileBytes, maxReads int, maxTotalBytes int64) map[string][]byte {
 	contentByPath := make(map[string][]byte)
 	if root == "" || maxFileBytes < 0 || maxReads <= 0 || maxTotalBytes < 0 || len(absPaths) == 0 {
@@ -766,14 +863,13 @@ func gitShowIndexBatch(ctx context.Context, root string, absPaths []string, maxF
 		return contentByPath
 	}
 
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitCommandTimeout)
+	cmd, cancel := boundedGitCommand(ctx, root, "cat-file", "--batch")
 	defer cancel()
 	var input strings.Builder
 	for _, query := range queries {
 		input.WriteString(query.spec)
 		input.WriteByte('\n')
 	}
-	cmd := exec.CommandContext(ctx, "git", "-C", root, "cat-file", "--batch")
 	cmd.Stdin = strings.NewReader(input.String())
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -783,36 +879,58 @@ func gitShowIndexBatch(ctx context.Context, root string, absPaths []string, maxF
 		return contentByPath
 	}
 
-	reader := bufio.NewReader(stdout)
-	var totalBytes int64
+	reader := bufio.NewReaderSize(stdout, maxGitBatchHeaderBytes)
+	var totalBytes, drainedBytes int64
 	for _, query := range queries {
-		header, err := reader.ReadString('\n')
-		if err != nil {
+		if len(contentByPath) >= maxReads {
 			cancel()
 			break
 		}
-		header = strings.TrimSuffix(header, "\n")
+		headerBytes, err := reader.ReadSlice('\n')
+		if err != nil {
+			cancel() // includes ErrBufferFull for an unreasonably long header
+			break
+		}
+		header := strings.TrimSuffix(string(headerBytes), "\n")
 		if strings.HasSuffix(header, " missing") {
 			continue
 		}
 		fields := strings.Fields(header)
-		if len(fields) != 3 || fields[1] != "blob" {
+		if len(fields) != 3 {
 			cancel()
 			break
 		}
 		size, err := strconv.ParseInt(fields[2], 10, 64)
-		if err != nil || size < 0 || size > int64(maxFileBytes) || len(contentByPath) >= maxReads || totalBytes+size > maxTotalBytes {
-			// Continuing would require draining an arbitrarily large blob. Stop
-			// this best-effort batch instead and preserve the per-file I/O bound.
+		if err != nil || size < 0 {
 			cancel()
 			break
 		}
+
+		retain := fields[1] == "blob" &&
+			size <= int64(maxFileBytes) &&
+			size <= maxTotalBytes-totalBytes
+		if !retain {
+			if size > maxGitBatchDrainBytes-drainedBytes {
+				// A malformed or unreasonably large object cannot be drained
+				// within the batch's bounded I/O policy, so abort the remainder.
+				cancel()
+				break
+			}
+			if !drainGitBatchObject(reader, size) {
+				cancel()
+				break
+			}
+			drainedBytes += size
+			continue
+		}
+
 		content := make([]byte, size)
 		if _, err := io.ReadFull(reader, content); err != nil {
 			cancel()
 			break
 		}
-		if _, err := reader.ReadByte(); err != nil { // cat-file separator newline
+		separator, err := reader.ReadByte()
+		if err != nil || separator != '\n' {
 			cancel()
 			break
 		}
@@ -821,4 +939,12 @@ func gitShowIndexBatch(ctx context.Context, root string, absPaths []string, maxF
 	}
 	_ = cmd.Wait()
 	return contentByPath
+}
+
+func drainGitBatchObject(reader *bufio.Reader, size int64) bool {
+	if _, err := io.CopyN(io.Discard, reader, size); err != nil {
+		return false
+	}
+	separator, err := reader.ReadByte()
+	return err == nil && separator == '\n'
 }

--- a/internal/tools/shell_track_regression_test.go
+++ b/internal/tools/shell_track_regression_test.go
@@ -1,0 +1,286 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func executeTrackedShell(t *testing.T, recorder *fakeFileRecorder, dir, command string, affectedPaths ...string) {
+	t.Helper()
+	tool := NewShellTool(nil, nil, DefaultOutputLimits())
+	tool.recorder = recorder
+	args, err := json.Marshal(ShellArgs{
+		Command:       command,
+		WorkingDir:    dir,
+		AffectedPaths: affectedPaths,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := tool.Execute(trackingContext(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.IsError {
+		t.Fatalf("shell command failed: %s", output.Content)
+	}
+}
+
+func requireTestGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+func runTestGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	requireTestGit(t)
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v (%s)", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func initCommittedTestRepo(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	runTestGit(t, dir, "init", "-q")
+	for path, content := range files {
+		writeTestFile(t, filepath.Join(dir, path), content)
+	}
+	runTestGit(t, dir, "add", ".")
+	runTestGit(t, dir, "commit", "-qm", "initial")
+}
+
+func TestShellToolReadOnlyCommandWithLargeSessionHistoryRecordsNothing(t *testing.T) {
+	dir := t.TempDir()
+	paths := make([]string, maxShellContentReads+25)
+	for i := range paths {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("historical-%03d.txt", i))
+		writeTestFile(t, paths[i], "unchanged\n")
+	}
+
+	recorder := &fakeFileRecorder{sessionPaths: paths}
+	executeTrackedShell(t, recorder, dir, "cat historical-000.txt >/dev/null")
+	if records := recorder.recorded(); len(records) != 0 {
+		t.Fatalf("read-only command recorded %d historical paths, want zero", len(records))
+	}
+}
+
+func TestShellSnapshotChangesAroundContentReadCap(t *testing.T) {
+	dir := t.TempDir()
+	paths := make([]string, maxShellContentReads+2)
+	for i := range paths {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("path-%03d.txt", i))
+		writeTestFile(t, paths[i], "before\n")
+	}
+	recorder := &fakeFileRecorder{sessionPaths: paths}
+	ctx := trackingContext()
+	snap := preShellSnapshot(ctx, recorder, dir, nil)
+
+	captured := paths[maxShellContentReads-1]
+	beyondCap := paths[maxShellContentReads]
+	writeTestFile(t, captured, "captured changed\n")
+	writeTestFile(t, beyondCap, "beyond cap changed\n")
+	changes := postShellChanges(ctx, recorder, snap)
+	if len(changes) != 2 {
+		t.Fatalf("changes = %+v, want two changed paths around cap", changes)
+	}
+
+	capturedRecord := recorder.findRecord(t, captured)
+	if string(capturedRecord.Before) != "before\n" || string(capturedRecord.After) != "captured changed\n" {
+		t.Fatalf("captured record = %q -> %q", capturedRecord.Before, capturedRecord.After)
+	}
+	beyondRecord := recorder.findRecord(t, beyondCap)
+	if !beyondRecord.BeforeUnknown || string(beyondRecord.After) != "beyond cap changed\n" {
+		t.Fatalf("beyond-cap record = %+v", beyondRecord)
+	}
+}
+
+func TestShellGlobPrunesGitAdminAndPreservesSimilarNames(t *testing.T) {
+	dir := t.TempDir()
+	runTestGit(t, dir, "init", "-q")
+	for i := 0; i < maxShellGlobMatches+25; i++ {
+		writeTestFile(t, filepath.Join(dir, ".git", "tracking-fixtures", fmt.Sprintf("entry-%04d", i)), "admin\n")
+	}
+
+	source := filepath.Join(dir, "zz-source.txt")
+	github := filepath.Join(dir, ".github", "workflows", "ci.yml")
+	suffix := filepath.Join(dir, "archive.git")
+	marker := filepath.Join(dir, "submodule", ".git")
+	writeTestFile(t, source, "before\n")
+	writeTestFile(t, github, "before\n")
+	writeTestFile(t, suffix, "before\n")
+	writeTestFile(t, marker, "gitdir: elsewhere\n")
+
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir,
+		"printf 'after source\\n' > zz-source.txt && printf 'after github\\n' > .github/workflows/ci.yml && printf 'after suffix\\n' > archive.git && printf 'gitdir: changed\\n' > submodule/.git",
+		"**/*")
+
+	if records := recorder.recorded(); len(records) != 3 {
+		t.Fatalf("records = %+v, want source, .github, and archive.git only", records)
+	}
+	recorder.findRecord(t, source)
+	recorder.findRecord(t, github)
+	recorder.findRecord(t, suffix)
+	for _, record := range recorder.recorded() {
+		if hasGitAdminComponent(record.Path) {
+			t.Fatalf("recorded Git administrative path: %+v", record)
+		}
+	}
+}
+
+func TestShellBroadScopeNewCleanRepoIsMaterializationBaseline(t *testing.T) {
+	dir := t.TempDir()
+	requireTestGit(t)
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir,
+		"mkdir cloned && git -C cloned init -q && printf 'clean\\n' > cloned/source.txt && git -C cloned add . && git -C cloned -c user.name=t -c user.email=t@t commit -qm initial",
+		"cloned/**/*")
+	if records := recorder.recorded(); len(records) != 0 {
+		t.Fatalf("new clean repository recorded materialized files: %+v", records)
+	}
+}
+
+func setupBranchMaterializationRepo(t *testing.T) (dir, originalBranch string) {
+	t.Helper()
+	dir = t.TempDir()
+	initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "base\n"})
+	originalBranch = runTestGit(t, dir, "branch", "--show-current")
+	runTestGit(t, dir, "checkout", "-qb", "other")
+	writeTestFile(t, filepath.Join(dir, "tracked.txt"), "other\n")
+	runTestGit(t, dir, "add", "tracked.txt")
+	runTestGit(t, dir, "commit", "-qm", "other")
+	runTestGit(t, dir, "checkout", "-q", originalBranch)
+	return dir, originalBranch
+}
+
+func TestShellBroadScopeCleanBranchCheckoutRecordsNothing(t *testing.T) {
+	dir, _ := setupBranchMaterializationRepo(t)
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir, "git checkout -q other", "**/*.txt")
+	if records := recorder.recorded(); len(records) != 0 {
+		t.Fatalf("clean checkout recorded materialized files: %+v", records)
+	}
+}
+
+func TestShellBroadScopeRetainsDirtyTrackedFileAfterMaterialization(t *testing.T) {
+	dir, _ := setupBranchMaterializationRepo(t)
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir, "git checkout -q other && printf 'dirty after checkout\\n' > tracked.txt", "**/*.txt")
+	record := recorder.findRecord(t, filepath.Join(dir, "tracked.txt"))
+	if string(record.Before) != "base\n" || string(record.After) != "dirty after checkout\n" {
+		t.Fatalf("dirty materialization record = %q -> %q", record.Before, record.After)
+	}
+}
+
+func TestShellGitFallbackRetainsNewStagedFile(t *testing.T) {
+	dir := t.TempDir()
+	initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "base\n"})
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir, "printf 'staged\\n' > new.txt && git add new.txt")
+	record := recorder.findRecord(t, filepath.Join(dir, "new.txt"))
+	if !record.BeforeMissing || string(record.After) != "staged\n" {
+		t.Fatalf("new staged record = %+v", record)
+	}
+}
+
+func TestShellExactLiteralTracksPythonStyleEdit(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skipf("python3 unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "before\n"})
+	recorder := &fakeFileRecorder{}
+	command := fmt.Sprintf("%s -c 'open(\"tracked.txt\", \"w\").write(\"after\\n\")'", python)
+	executeTrackedShell(t, recorder, dir, command, "tracked.txt")
+	record := recorder.findRecord(t, filepath.Join(dir, "tracked.txt"))
+	if string(record.Before) != "before\n" || string(record.After) != "after\n" {
+		t.Fatalf("literal Python edit = %q -> %q", record.Before, record.After)
+	}
+}
+
+func TestShellExactLiteralTracksEditCommittedBeforeReturn(t *testing.T) {
+	dir := t.TempDir()
+	initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "before\n"})
+	runTestGit(t, dir, "config", "user.name", "t")
+	runTestGit(t, dir, "config", "user.email", "t@t")
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir,
+		"printf 'committed\\n' > tracked.txt && git add tracked.txt && git commit -qm edit",
+		"tracked.txt")
+	record := recorder.findRecord(t, filepath.Join(dir, "tracked.txt"))
+	if string(record.Before) != "before\n" || string(record.After) != "committed\n" {
+		t.Fatalf("literal edit+commit = %q -> %q", record.Before, record.After)
+	}
+}
+
+func TestShellBroadScopeExcludesIgnoredBuildOutput(t *testing.T) {
+	dir := t.TempDir()
+	initCommittedTestRepo(t, dir, map[string]string{".gitignore": "build/\n"})
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir, "mkdir -p build && printf 'artifact\\n' > build/output.txt", "**/*")
+	if records := recorder.recorded(); len(records) != 0 {
+		t.Fatalf("ignored build output was recorded: %+v", records)
+	}
+}
+
+func TestShellSessionTrackedRevertToCleanIsRecorded(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tracked.txt")
+	initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "base\n"})
+	writeTestFile(t, path, "session edit\n")
+	recorder := &fakeFileRecorder{sessionPaths: []string{path}}
+	executeTrackedShell(t, recorder, dir, "git checkout -- tracked.txt")
+	record := recorder.findRecord(t, path)
+	if string(record.Before) != "session edit\n" || string(record.After) != "base\n" {
+		t.Fatalf("session revert record = %q -> %q", record.Before, record.After)
+	}
+}
+
+func TestShellBroadScopeUsesDeepestNestedRepoOwnership(t *testing.T) {
+	outer := t.TempDir()
+	initCommittedTestRepo(t, outer, map[string]string{"outer.txt": "outer\n"})
+	nested := filepath.Join(outer, "nested")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initCommittedTestRepo(t, nested, map[string]string{"clean.txt": "clean\n", "dirty.txt": "base\n"})
+
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, outer,
+		"printf 'temporary\\n' > nested/clean.txt && git -C nested checkout -- clean.txt && printf 'dirty\\n' > nested/dirty.txt",
+		"nested/**/*.txt")
+	if records := recorder.recorded(); len(records) != 1 {
+		t.Fatalf("nested repo records = %+v, want only dirty.txt", records)
+	}
+	record := recorder.findRecord(t, filepath.Join(nested, "dirty.txt"))
+	if string(record.Before) != "base\n" || string(record.After) != "dirty\n" {
+		t.Fatalf("nested dirty record = %q -> %q", record.Before, record.After)
+	}
+}

--- a/internal/tools/shell_track_regression_test.go
+++ b/internal/tools/shell_track_regression_test.go
@@ -1,13 +1,16 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func executeTrackedShell(t *testing.T, recorder *fakeFileRecorder, dir, command string, affectedPaths ...string) {
@@ -117,6 +120,41 @@ func TestShellSnapshotChangesAroundContentReadCap(t *testing.T) {
 	beyondRecord := recorder.findRecord(t, beyondCap)
 	if !beyondRecord.BeforeUnknown || string(beyondRecord.After) != "beyond cap changed\n" {
 		t.Fatalf("beyond-cap record = %+v", beyondRecord)
+	}
+}
+
+func TestShellSnapshotByteComparesCapturedContentWithUnchangedStat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tracked.txt")
+	writeTestFile(t, path, "before\n")
+
+	recorder := &fakeFileRecorder{}
+	ctx := trackingContext()
+	snap := preShellSnapshot(ctx, recorder, dir, []string{"tracked.txt"})
+	entry := snap.files[path]
+	if entry == nil || entry.content == nil {
+		t.Fatalf("pre snapshot did not capture content: %+v", entry)
+	}
+
+	writeTestFile(t, path, "after!\n") // same byte length as "before\n"
+	if err := os.Chtimes(path, entry.modTime, entry.modTime); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != entry.size || !info.ModTime().Equal(entry.modTime) {
+		t.Fatalf("failed to emulate unchanged stat: size=%d/%d mtime=%v/%v", info.Size(), entry.size, info.ModTime(), entry.modTime)
+	}
+
+	changes := postShellChanges(ctx, recorder, snap)
+	if len(changes) != 1 {
+		t.Fatalf("changes = %+v, want captured same-stat edit", changes)
+	}
+	record := recorder.findRecord(t, path)
+	if string(record.Before) != "before\n" || string(record.After) != "after!\n" {
+		t.Fatalf("same-stat record = %q -> %q", record.Before, record.After)
 	}
 }
 
@@ -282,5 +320,303 @@ func TestShellBroadScopeUsesDeepestNestedRepoOwnership(t *testing.T) {
 	record := recorder.findRecord(t, filepath.Join(nested, "dirty.txt"))
 	if string(record.Before) != "base\n" || string(record.After) != "dirty\n" {
 		t.Fatalf("nested dirty record = %q -> %q", record.Before, record.After)
+	}
+}
+
+func TestShellGitFallbackRecordsDirtyToCleanRevertsWithoutSessionHistory(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{name: "checkout", command: "git checkout -- tracked.txt"},
+		{name: "reset hard", command: "git reset --hard -q HEAD"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "tracked.txt")
+			initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "base\n"})
+			writeTestFile(t, path, "user dirty\n")
+
+			recorder := &fakeFileRecorder{}
+			executeTrackedShell(t, recorder, dir, tt.command)
+			record := recorder.findRecord(t, path)
+			if string(record.Before) != "user dirty\n" || string(record.After) != "base\n" {
+				t.Fatalf("dirty-to-clean record = %q -> %q", record.Before, record.After)
+			}
+		})
+	}
+}
+
+func TestShellGitCleanAtReturnDependsOnAffectedPathSpecificity(t *testing.T) {
+	tests := []struct {
+		name       string
+		affected   string
+		wantRecord bool
+	}{
+		{name: "glob discovery omitted", affected: "*.txt"},
+		{name: "exact literal preserved", affected: "tracked.txt", wantRecord: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "tracked.txt")
+			initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "before\n"})
+			runTestGit(t, dir, "config", "user.name", "t")
+			runTestGit(t, dir, "config", "user.email", "t@t")
+
+			recorder := &fakeFileRecorder{}
+			executeTrackedShell(t, recorder, dir,
+				"printf 'committed\\n' > tracked.txt && git add tracked.txt && git commit -qm edit",
+				tt.affected)
+			if !tt.wantRecord {
+				if records := recorder.recorded(); len(records) != 0 {
+					t.Fatalf("Git-clean glob discovery recorded edit+commit: %+v", records)
+				}
+				return
+			}
+			record := recorder.findRecord(t, path)
+			if string(record.Before) != "before\n" || string(record.After) != "committed\n" {
+				t.Fatalf("literal edit+commit = %q -> %q", record.Before, record.After)
+			}
+		})
+	}
+}
+
+func TestGitShowIndexBatchSkipsOversizedBlobAndContinues(t *testing.T) {
+	dir := t.TempDir()
+	initCommittedTestRepo(t, dir, map[string]string{
+		"big.txt":   strings.Repeat("x", 256),
+		"small.txt": "recoverable\n",
+	})
+	big := filepath.Join(dir, "big.txt")
+	small := filepath.Join(dir, "small.txt")
+
+	got := gitShowIndexBatch(context.Background(), dir, []string{big, small}, 64, 2, 1024)
+	if _, ok := got[big]; ok {
+		t.Fatal("oversized blob was retained")
+	}
+	if string(got[small]) != "recoverable\n" {
+		t.Fatalf("later blob = %q, want recoverable content", got[small])
+	}
+}
+
+func TestGitShowIndexBatchSkipsGitlinkAndContinues(t *testing.T) {
+	dir := t.TempDir()
+	initCommittedTestRepo(t, dir, map[string]string{"normal.txt": "recoverable\n"})
+	head := runTestGit(t, dir, "rev-parse", "HEAD")
+	runTestGit(t, dir, "update-index", "--add", "--cacheinfo", "160000,"+head+",gitlink")
+	gitlink := filepath.Join(dir, "gitlink")
+	normal := filepath.Join(dir, "normal.txt")
+
+	got := gitShowIndexBatch(context.Background(), dir, []string{gitlink, normal}, 1024, 2, 2048)
+	if _, ok := got[gitlink]; ok {
+		t.Fatal("non-blob gitlink was retained")
+	}
+	if string(got[normal]) != "recoverable\n" {
+		t.Fatalf("later blob = %q, want recoverable content", got[normal])
+	}
+}
+
+func TestShellGitStatusFailureSuppressesBroadCandidatesButPreservesLiterals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX git wrapper")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		affected   string
+		wantRecord bool
+	}{
+		{name: "broad candidate suppressed", affected: "*.txt"},
+		{name: "literal baseline preserved", affected: "tracked.txt", wantRecord: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "tracked.txt")
+			initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "before\n"})
+
+			wrapperDir := t.TempDir()
+			wrapperPath := filepath.Join(wrapperDir, "git")
+			wrapper := fmt.Sprintf(`#!/bin/sh
+cmd="$1"
+if [ "$1" = "-C" ]; then
+	cmd="$3"
+fi
+if [ "$cmd" = "status" ]; then
+	exit 2
+fi
+exec %q "$@"
+`, realGit)
+			if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			recorder := &fakeFileRecorder{}
+			executeTrackedShell(t, recorder, dir, "printf 'after\\n' > tracked.txt", tt.affected)
+			if !tt.wantRecord {
+				if records := recorder.recorded(); len(records) != 0 {
+					t.Fatalf("status failure emitted broad candidates: %+v", records)
+				}
+				return
+			}
+			record := recorder.findRecord(t, path)
+			if string(record.Before) != "before\n" || string(record.After) != "after\n" {
+				t.Fatalf("literal record = %q -> %q", record.Before, record.After)
+			}
+		})
+	}
+}
+
+func TestShellGitStatusFailurePreservesCapturedDirtyBaseline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX git wrapper")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tracked.txt")
+	initCommittedTestRepo(t, dir, map[string]string{"tracked.txt": "base\n"})
+	writeTestFile(t, path, "user dirty\n")
+
+	wrapperDir := t.TempDir()
+	marker := filepath.Join(wrapperDir, "first-status")
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	wrapper := fmt.Sprintf(`#!/bin/sh
+cmd="$1"
+if [ "$1" = "-C" ]; then
+	cmd="$3"
+fi
+if [ "$cmd" = "status" ]; then
+	if [ -e %q ]; then
+		exit 2
+	fi
+	: > %q
+fi
+exec %q "$@"
+`, marker, marker, realGit)
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	recorder := &fakeFileRecorder{}
+	executeTrackedShell(t, recorder, dir, "git checkout -- tracked.txt")
+	record := recorder.findRecord(t, path)
+	if string(record.Before) != "user dirty\n" || string(record.After) != "base\n" {
+		t.Fatalf("dirty baseline after status failure = %q -> %q", record.Before, record.After)
+	}
+}
+
+func TestGitStatusHonorsParentDeadlineAndPipeWaitBound(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX git wrapper")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	runTestGit(t, dir, "init", "-q")
+
+	wrapperDir := t.TempDir()
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	wrapper := fmt.Sprintf(`#!/bin/sh
+cmd="$1"
+if [ "$1" = "-C" ]; then
+	cmd="$3"
+fi
+if [ "$cmd" = "status" ]; then
+	sleep 3 &
+	sleep 3
+fi
+exec %q "$@"
+`, realGit)
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if status := gitStatusPorcelain(ctx, dir); status != nil {
+		t.Fatalf("status = %#v, want timeout failure", status)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("git status ignored parent deadline or waited on inherited pipes: %v", elapsed)
+	}
+}
+
+func TestShellRepoResolverBoundsCandidateAncestorsToCommandScope(t *testing.T) {
+	scope := t.TempDir()
+	initCommittedTestRepo(t, scope, map[string]string{"root.txt": "root\n"})
+	workDir := filepath.Join(scope, "work")
+	unrelated := filepath.Join(scope, "unrelated", "file.txt")
+	writeTestFile(t, filepath.Join(workDir, "work.txt"), "work\n")
+	writeTestFile(t, unrelated, "unrelated\n")
+
+	resolver := newShellRepoResolver()
+	workRepo := resolver.owningRepo(workDir)
+	if canonicalTestPath(workRepo) != canonicalTestPath(scope) {
+		t.Fatalf("working repo = %q, want %q", workRepo, scope)
+	}
+	if got := resolver.owningRepoForCandidate(unrelated, workDir, workRepo); got != "" {
+		t.Fatalf("unrelated sibling inherited arbitrary ancestor repo %q", got)
+	}
+	if got := resolver.owningRepoForCandidate(filepath.Join(workDir, "work.txt"), workDir, workRepo); canonicalTestPath(got) != canonicalTestPath(scope) {
+		t.Fatalf("working-scope candidate repo = %q, want %q", got, scope)
+	}
+
+	nested := filepath.Join(scope, "unrelated", "nested")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initCommittedTestRepo(t, nested, map[string]string{"nested.txt": "nested\n"})
+	if got := resolver.owningRepoForCandidate(filepath.Join(nested, "nested.txt"), workDir, workRepo); canonicalTestPath(got) != canonicalTestPath(nested) {
+		t.Fatalf("absolute nested candidate repo = %q, want %q", got, nested)
+	}
+}
+
+func TestShellAbsoluteGlobDiscoversExternalNestedRepo(t *testing.T) {
+	scope := t.TempDir()
+	initCommittedTestRepo(t, scope, map[string]string{"root.txt": "root\n"})
+	workDir := filepath.Join(scope, "work")
+	writeTestFile(t, filepath.Join(workDir, "work.txt"), "work\n")
+	nested := filepath.Join(scope, "external", "nested")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initCommittedTestRepo(t, nested, map[string]string{"tracked.txt": "before\n"})
+	runTestGit(t, nested, "config", "user.name", "t")
+	runTestGit(t, nested, "config", "user.email", "t@t")
+
+	recorder := &fakeFileRecorder{}
+	command := fmt.Sprintf("printf 'after\\n' > %q && git -C %q add tracked.txt && git -C %q commit -qm edit", filepath.Join(nested, "tracked.txt"), nested, nested)
+	executeTrackedShell(t, recorder, workDir, command, filepath.Join(nested, "*.txt"))
+	if records := recorder.recorded(); len(records) != 0 {
+		t.Fatalf("absolute glob failed to treat external nested Git-clean edit as materialization: %+v", records)
+	}
+}
+
+func TestGitAdminComponentIsCaseFoldedButComponentExact(t *testing.T) {
+	if !hasGitAdminComponent(filepath.Join("root", ".GIT", "config")) {
+		t.Fatal("case-folded .GIT component was not excluded")
+	}
+	for _, path := range []string{
+		filepath.Join("root", ".github", "workflows", "ci.yml"),
+		filepath.Join("root", "archive.git"),
+	} {
+		if hasGitAdminComponent(path) {
+			t.Fatalf("non-administrative path %q was excluded", path)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- stop shell tracking from emitting 200 false truncated modifications after the pre-snapshot read budget is exhausted
- treat clean Git clone, worktree, and checkout materialization as a baseline rather than authored file changes
- preserve deliberate exact-path snapshots, dirty/untracked files, and destructive dirty-to-clean reverts
- prune Git administrative state before recursive glob limits are consumed
- bound batched Git status/index recovery by the outer recording deadline and degrade safely on repository or object limits

## Production evidence

The 30 sessions with the most tracked paths showed:

- 28/30 sessions had at least one shell call tracking 900 or more paths
- 43 calls tracked at least 900 paths, dominated by checkout helpers, clones, and worktree creation
- 914 later calls each emitted exactly 200 rows
- `914 * 200 = 182,800` repeated rows; 182,799 were truncated
- those repeated 200-row events were 73% of the 249,515 tracking rows in the sample

The exact 200-row shape came from one shared read counter: pre-snapshotting consumed the 200-read cap, then post-comparison could not read those same files and recorded their after sides as unknown.

## Behavior

- pre-snapshot memory and post-comparison work now use separate bounded accounting
- captured before-content remains eligible for deterministic byte comparison; stat-only snapshots retain the size/mtime fast path
- `.git` components are pruned during glob traversal and rejected at every candidate entry point without excluding `.github` or ordinary names ending in `.git`
- broad candidates inside a post-command Git repository are retained only when dirty or untracked/non-ignored
- newly cloned repositories and linked worktrees are discovered after the command, including nested repositories
- exact literal `affected_paths` remain authoritative, including edit-and-commit commands that return Git-clean
- pre-existing dirty files reverted to clean are still recorded so destructive shell actions remain attributable
- batched index recovery skips bounded oversized/non-blob objects without losing later recoverable files
- per-repository Git commands honor the outer file-recording deadline and use `WaitDelay` to prevent descendant-held pipes from extending cancellation

## Tests

Passed:

- `go test ./internal/tools ./internal/filetrack -count=1`
- `go test -race ./internal/tools -run 'Shell|GitShowIndexBatch|GitStatus|GitAdmin|RepoResolver' -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

The isolated broad `go test ./... -count=1` has one unrelated existing failure in `internal/serveui`: the production JavaScript line-budget assertion reports 20,579 lines against a 20,570 ceiling. This PR changes no serve UI files.

## Review

The implementation plan and completed patch were each reviewed independently with Claude Opus. The patch review found four blocking regressions around same-mtime edits, dirty-to-clean reverts, batched index recovery, and timeout propagation; all were addressed in the follow-up commit with regression coverage.
