### PR TITLE
perf(web): unify DOM element construction

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -558,6 +558,9 @@ const setElementHidden = (element, hidden) => {
   else element.removeAttribute?.('hidden');
 };
 
+const createEl = (tag, className, text) => Object.assign(document.createElement(tag),
+  className ? { className } : {}, text !== undefined ? { textContent: text } : {});
+
 const nextFrame = (callback) => {
   const raf = window.requestAnimationFrame || globalThis.requestAnimationFrame;
   if (typeof raf === 'function') return raf.call(window, callback);
@@ -2562,6 +2565,7 @@ Object.assign(app, {
   syncTokenCookie,
   setAnimatedPanelOpen,
   setElementHidden,
+  createEl,
   panelSwipeSmoothedVelocity,
   panelSwipeProjectedDistance,
   panelSwipeReleaseDecision,

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -14,6 +14,7 @@ const {
   elements,
   STORAGE_KEYS,
   UI_PREFIX,
+  createEl,
   setAnimatedPanelOpen: setPanelOpen,
   setElementHidden: setPanelHidden,
   initPanelSwipeToClose
@@ -469,13 +470,6 @@ const fetchFileDiff = (sessionId, path) => {
 };
 
 // ===== Rendering =====
-
-const createEl = (tag, className, text) => {
-  const el = document.createElement(tag);
-  if (className) el.className = className;
-  if (text !== undefined) el.textContent = text;
-  return el;
-};
 
 const fileBaseName = (path) => {
   const idx = path.lastIndexOf('/');

--- a/internal/serveui/static/app-mcp.js
+++ b/internal/serveui/static/app-mcp.js
@@ -3,6 +3,7 @@
 (function initAppMCP() {
 
 const app = window.TermLLMApp;
+const createEl = app.createEl;
 const {
   UI_PREFIX, state, elements, saveSessions, getActiveSession, createSession, ensureActiveSession, sessionSlug,
   updateURL, persistAndRefreshShell, updateMCPStatusDisplay, setElementHidden, handleAuthFailure, renderMessages,
@@ -184,14 +185,10 @@ const renderMCPModal = (session, { loading = false } = {}) => {
   elements.mcpModalBody.innerHTML = '';
 
   if (loading) {
-    const row = document.createElement('div');
-    row.className = 'mcp-server-loading';
-    row.textContent = 'Loading configured MCP servers…';
+    const row = createEl('div', 'mcp-server-loading', 'Loading configured MCP servers…');
     elements.mcpModalBody.appendChild(row);
   } else if (!Array.isArray(session?.mcpServers) || session.mcpServers.length === 0) {
-    const row = document.createElement('div');
-    row.className = 'mcp-server-empty';
-    row.textContent = 'No MCP servers are configured yet. Add servers to ~/.config/term-llm/mcp.json, then reopen this panel.';
+    const row = createEl('div', 'mcp-server-empty', 'No MCP servers are configured yet. Add servers to ~/.config/term-llm/mcp.json, then reopen this panel.');
     elements.mcpModalBody.appendChild(row);
   } else {
     const enabledSet = new Set(
@@ -200,29 +197,20 @@ const renderMCPModal = (session, { loading = false } = {}) => {
         : normalizeMCPEnabledNames(session.mcpEnabled || [])
     );
     session.mcpServers.forEach((server) => {
-      const row = document.createElement('label');
-      row.className = 'mcp-server-row';
+      const row = createEl('label', 'mcp-server-row');
 
-      const icon = document.createElement('span');
-      icon.className = 'mcp-server-icon';
+      const icon = createEl('span', 'mcp-server-icon');
       icon.setAttribute('aria-hidden', 'true');
       icon.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="5" height="5" rx="1.2"/><rect x="14" y="14" width="5" height="5" rx="1.2"/><path d="M10 7.5h2.5a4 4 0 0 1 4 4V14"/><path d="M14 16.5h-2.5a4 4 0 0 1-4-4V10"/></svg>';
 
-      const copy = document.createElement('span');
-      copy.className = 'mcp-server-copy';
-      const titleRow = document.createElement('span');
-      titleRow.className = 'mcp-server-title-row';
-      const name = document.createElement('span');
-      name.className = 'mcp-server-name';
-      name.textContent = server.name;
-      const status = document.createElement('span');
-      status.className = `mcp-server-status ${String(server.status || '').toLowerCase()}`;
-      status.textContent = server.status || 'stopped';
+      const copy = createEl('span', 'mcp-server-copy');
+      const titleRow = createEl('span', 'mcp-server-title-row');
+      const name = createEl('span', 'mcp-server-name', server.name);
+      const status = createEl('span', `mcp-server-status ${String(server.status || '').toLowerCase()}`, server.status || 'stopped');
       titleRow.appendChild(name);
       titleRow.appendChild(status);
 
-      const subtitle = document.createElement('span');
-      subtitle.className = 'mcp-server-subtitle';
+      const subtitle = createEl('span', 'mcp-server-subtitle');
       const toolCount = Number(server.tools || 0);
       if (String(server.status || '').toLowerCase() === 'ready') {
         subtitle.textContent = `${toolCount} tool${toolCount === 1 ? '' : 's'} available`;
@@ -237,25 +225,19 @@ const renderMCPModal = (session, { loading = false } = {}) => {
       copy.appendChild(titleRow);
       copy.appendChild(subtitle);
       if (server.error) {
-        const error = document.createElement('span');
-        error.className = 'mcp-server-error';
-        error.textContent = server.error;
+        const error = createEl('span', 'mcp-server-error', server.error);
         copy.appendChild(error);
       }
 
-      const switchWrap = document.createElement('span');
-      switchWrap.className = 'mcp-switch';
-      const input = document.createElement('input');
-      input.className = 'mcp-switch-input';
+      const switchWrap = createEl('span', 'mcp-switch');
+      const input = createEl('input', 'mcp-switch-input');
       input.type = 'checkbox';
       input.value = server.name;
       input.checked = enabledSet.has(server.name) || Boolean(server.enabled);
       input.disabled = disabled;
       input.dataset.mcpServer = server.name;
-      const track = document.createElement('span');
-      track.className = 'mcp-switch-track';
-      const thumb = document.createElement('span');
-      thumb.className = 'mcp-switch-thumb';
+      const track = createEl('span', 'mcp-switch-track');
+      const thumb = createEl('span', 'mcp-switch-thumb');
       track.appendChild(thumb);
       switchWrap.appendChild(input);
       switchWrap.appendChild(track);

--- a/internal/serveui/static/app-modals.js
+++ b/internal/serveui/static/app-modals.js
@@ -1,6 +1,7 @@
 'use strict';
 (function initAppModals() {
 const app = window.TermLLMApp;
+const createEl = app.createEl;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, generateId, saveSessions,
   persistAndRefreshShell, setConnectionState, syncTokenCookie,
@@ -170,12 +171,10 @@ const renderAskUserModal = () => {
   elements.askUserError.textContent = '';
 
   if (total > 1) {
-    const steps = document.createElement('div');
-    steps.className = 'ask-user-steps';
+    const steps = createEl('div', 'ask-user-steps');
     for (let i = 0; i < total; i++) {
       if (i > 0) {
-        const line = document.createElement('div');
-        line.className = 'ask-user-step-line';
+        const line = createEl('div', 'ask-user-step-line');
         if (i <= activeTab) line.classList.add('done');
         steps.appendChild(line);
       }
@@ -192,47 +191,35 @@ const renderAskUserModal = () => {
   }
 
   prompt.questions.forEach((question, index) => {
-    const section = document.createElement('section');
-    section.className = 'ask-user-question';
+    const section = createEl('section', 'ask-user-question');
     section.dataset.questionIndex = index;
     if (index !== activeTab) section.style.display = 'none';
 
-    const headerEl = document.createElement('div');
-    headerEl.className = 'ask-user-question-header';
-    headerEl.textContent = question.header || `Question ${index + 1}`;
+    const headerEl = createEl('div', 'ask-user-question-header', question.header || `Question ${index + 1}`);
     section.appendChild(headerEl);
 
-    const textEl = document.createElement('p');
-    textEl.className = 'ask-user-question-text';
-    textEl.textContent = question.question || '';
+    const textEl = createEl('p', 'ask-user-question-text', question.question || '');
     section.appendChild(textEl);
 
-    const options = document.createElement('div');
-    options.className = 'ask-user-options';
+    const options = createEl('div', 'ask-user-options');
     const inputType = question.multi_select ? 'checkbox' : 'radio';
     const groupName = `ask_user_${index}`;
 
     (Array.isArray(question.options) ? question.options : []).forEach((option) => {
-      const label = document.createElement('label');
-      label.className = 'ask-user-option';
+      const label = createEl('label', 'ask-user-option');
 
       const input = document.createElement('input');
       input.type = inputType;
       input.name = groupName;
       input.value = option.label || '';
 
-      const copy = document.createElement('span');
-      copy.className = 'ask-user-option-copy';
+      const copy = createEl('span', 'ask-user-option-copy');
 
-      const titleEl = document.createElement('span');
-      titleEl.className = 'ask-user-option-title';
-      titleEl.textContent = option.label || 'Option';
+      const titleEl = createEl('span', 'ask-user-option-title', option.label || 'Option');
 
       copy.appendChild(titleEl);
       if (option.description) {
-        const desc = document.createElement('span');
-        desc.className = 'ask-user-option-desc';
-        desc.textContent = option.description;
+        const desc = createEl('span', 'ask-user-option-desc', option.description);
         copy.appendChild(desc);
       }
 
@@ -242,24 +229,18 @@ const renderAskUserModal = () => {
     });
 
     if (!question.multi_select) {
-      const customLabel = document.createElement('label');
-      customLabel.className = 'ask-user-option';
+      const customLabel = createEl('label', 'ask-user-option');
 
       const customRadio = document.createElement('input');
       customRadio.type = 'radio';
       customRadio.name = groupName;
       customRadio.value = '__custom__';
 
-      const customCopy = document.createElement('span');
-      customCopy.className = 'ask-user-option-copy';
+      const customCopy = createEl('span', 'ask-user-option-copy');
 
-      const customTitle = document.createElement('span');
-      customTitle.className = 'ask-user-option-title';
-      customTitle.textContent = 'Other';
+      const customTitle = createEl('span', 'ask-user-option-title', 'Other');
 
-      const customDesc = document.createElement('span');
-      customDesc.className = 'ask-user-option-desc';
-      customDesc.textContent = 'Type your own answer.';
+      const customDesc = createEl('span', 'ask-user-option-desc', 'Type your own answer.');
 
       customCopy.appendChild(customTitle);
       customCopy.appendChild(customDesc);
@@ -288,8 +269,7 @@ const renderAskUserModal = () => {
       section.appendChild(options);
     }
 
-    const note = document.createElement('div');
-    note.className = 'ask-user-note';
+    const note = createEl('div', 'ask-user-note');
     note.textContent = question.multi_select
       ? 'Choose one or more options to continue.'
       : 'Choose one option or provide a custom answer.';
@@ -454,11 +434,9 @@ const openApprovalModal = (sessionId, approvalId, path, isShell, isWorkspace, ti
   // Build radio options as a vertical list
   const body = elements.approvalBody;
   body.innerHTML = '';
-  const group = document.createElement('div');
-  group.className = 'approval-options';
+  const group = createEl('div', 'approval-options');
   options.forEach((opt, i) => {
-    const label = document.createElement('label');
-    label.className = 'approval-option';
+    const label = createEl('label', 'approval-option');
 
     const radio = document.createElement('input');
     radio.type = 'radio';
@@ -470,16 +448,11 @@ const openApprovalModal = (sessionId, approvalId, path, isShell, isWorkspace, ti
       elements.approvalApproveBtn.textContent = approvalPrimaryActionLabel(state.approval);
     });
 
-    const copy = document.createElement('div');
-    copy.className = 'approval-option-copy';
-    const titleEl = document.createElement('span');
-    titleEl.className = 'approval-option-title';
-    titleEl.textContent = opt.label || `Option ${i + 1}`;
+    const copy = createEl('div', 'approval-option-copy');
+    const titleEl = createEl('span', 'approval-option-title', opt.label || `Option ${i + 1}`);
     copy.appendChild(titleEl);
     if (opt.description) {
-      const desc = document.createElement('span');
-      desc.className = 'approval-option-desc';
-      desc.textContent = opt.description;
+      const desc = createEl('span', 'approval-option-desc', opt.description);
       copy.appendChild(desc);
     }
 
@@ -490,8 +463,7 @@ const openApprovalModal = (sessionId, approvalId, path, isShell, isWorkspace, ti
   body.appendChild(group);
 
   if (state.approval.resumeAutoAvailable) {
-    const resumeLabel = document.createElement('label');
-    resumeLabel.className = 'approval-option';
+    const resumeLabel = createEl('label', 'approval-option');
     const resumeCheckbox = document.createElement('input');
     resumeCheckbox.type = 'checkbox';
     resumeCheckbox.name = 'resume_auto';
@@ -499,14 +471,9 @@ const openApprovalModal = (sessionId, approvalId, path, isShell, isWorkspace, ti
     resumeCheckbox.addEventListener('change', () => {
       if (state.approval) state.approval.resumeAuto = Boolean(resumeCheckbox.checked);
     });
-    const resumeCopy = document.createElement('div');
-    resumeCopy.className = 'approval-option-copy';
-    const resumeTitle = document.createElement('span');
-    resumeTitle.className = 'approval-option-title';
-    resumeTitle.textContent = 'Resume Guardian auto after this decision';
-    const resumeDescription = document.createElement('span');
-    resumeDescription.className = 'approval-option-desc';
-    resumeDescription.textContent = 'Start a fresh automatic-review epoch. Leave unchecked to keep auto suspended.';
+    const resumeCopy = createEl('div', 'approval-option-copy');
+    const resumeTitle = createEl('span', 'approval-option-title', 'Resume Guardian auto after this decision');
+    const resumeDescription = createEl('span', 'approval-option-desc', 'Start a fresh automatic-review epoch. Leave unchecked to keep auto suspended.');
     resumeCopy.appendChild(resumeTitle);
     resumeCopy.appendChild(resumeDescription);
     resumeLabel.appendChild(resumeCheckbox);

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const app = window.TermLLMApp;
+const createEl = app.createEl;
 const {
   STORAGE_KEYS, state, elements, INTERRUPT_BADGE_META, sanitizeInterruptState, asTimestamp, relativeTime, fullDate,
   sessionBucket, toolIcon, formatUsage, saveSessions, findMessageElement, mountedConversationSessionId,
@@ -148,13 +149,10 @@ const createSessionMenuButton = (label, iconName, onClick) => {
   const button = document.createElement('button');
   button.type = 'button';
 
-  const icon = document.createElement('span');
-  icon.className = 'session-menu-icon';
+  const icon = createEl('span', 'session-menu-icon');
   icon.innerHTML = SESSION_MENU_ICONS[iconName] || '';
 
-  const text = document.createElement('span');
-  text.className = 'session-menu-label';
-  text.textContent = label;
+  const text = createEl('span', 'session-menu-label', label);
 
   button.appendChild(icon);
   button.appendChild(text);
@@ -227,10 +225,8 @@ const computeSidebarKey = (sorted) =>
 
 const getOrCreateGroupSection = (label) => {
   if (sidebarGroupCache.has(label)) return sidebarGroupCache.get(label);
-  const section = document.createElement('section');
-  section.className = 'session-group';
-  const h3 = document.createElement('h3');
-  h3.textContent = label;
+  const section = createEl('section', 'session-group');
+  const h3 = createEl('h3', '', label);
   section.appendChild(h3);
   sidebarGroupCache.set(label, section);
   return section;
@@ -253,28 +249,23 @@ const resolveSidebarSession = (sessionId) => state.sessions.find((s) => s.id ===
 
 const buildCachedSessionRow = (session) => {
   const sessionId = session.id;
-  const row = document.createElement('div');
-  row.className = 'session-row';
+  const row = createEl('div', 'session-row');
   row.dataset.sessionId = session.id;
   row.classList.toggle('is-active', sessionHasInProgressState(session));
   row.classList.toggle('is-refining-title', Boolean(session._refiningTitle));
   row.classList.toggle('is-branch', Boolean(session.branchParentSessionId));
   row.dataset.branchDepth = String(Math.max(0, Number(session.branchDepth) || 0));
 
-  const btn = document.createElement('button');
-  btn.className = 'session-btn';
+  const btn = createEl('button', 'session-btn');
   const tooltip = sidebarSessionTooltip(session);
   btn.title = tooltip;
   btn.setAttribute('aria-label', `Open session: ${sidebarSessionDisplayTitle(session)}`);
   if (session.id === state.activeSessionId) btn.classList.add('active');
 
-  const titleEl = document.createElement('div');
-  titleEl.className = 'session-title';
-  titleEl.textContent = sidebarSessionRowTitle(session);
+  const titleEl = createEl('div', 'session-title', sidebarSessionRowTitle(session));
   titleEl.title = tooltip;
 
-  const metaEl = document.createElement('div');
-  metaEl.className = 'session-meta';
+  const metaEl = createEl('div', 'session-meta');
   if (session.searchSnippet) {
     metaEl.textContent = session.searchSnippet;
     metaEl.title = session.searchSnippet;
@@ -301,11 +292,9 @@ const buildCachedSessionRow = (session) => {
     await app.switchToSession(sessionId);
   });
 
-  const menuWrap = document.createElement('div');
-  menuWrap.className = 'session-row-menu';
+  const menuWrap = createEl('div', 'session-row-menu');
 
-  const actionBtn = document.createElement('button');
-  actionBtn.className = 'session-menu-trigger';
+  const actionBtn = createEl('button', 'session-menu-trigger');
   actionBtn.type = 'button';
   actionBtn.textContent = '⋯';
   actionBtn.title = 'Session actions';
@@ -318,8 +307,7 @@ const buildCachedSessionRow = (session) => {
     row.classList.toggle('menu-open', willOpen);
   });
 
-  const menu = document.createElement('div');
-  menu.className = 'session-menu';
+  const menu = createEl('div', 'session-menu');
 
   const renameBtn = createSessionMenuButton('Rename', 'rename', async (event) => {
     event.preventDefault();
@@ -502,17 +490,14 @@ const createInterruptBadgeNode = (interruptState) => {
   const config = INTERRUPT_BADGE_META[stateName];
   if (!config) return null;
 
-  const badge = document.createElement('span');
-  badge.className = `interrupt-badge ${config.className}`;
+  const badge = createEl('span', `interrupt-badge ${config.className}`);
 
   if (stateName === 'evaluating') {
-    const spinner = document.createElement('span');
-    spinner.className = 'interrupt-spinner';
+    const spinner = createEl('span', 'interrupt-spinner');
     spinner.setAttribute('aria-hidden', 'true');
     badge.appendChild(spinner);
 
-    const text = document.createElement('span');
-    text.textContent = config.label;
+    const text = createEl('span', '', config.label);
     badge.appendChild(text);
   } else {
     badge.textContent = `${config.icon} ${config.label}`;
@@ -523,8 +508,7 @@ const createInterruptBadgeNode = (interruptState) => {
 
 const createMetaNode = (created, message = null) => {
   const timestamp = asTimestamp(created);
-  const meta = document.createElement('div');
-  meta.className = 'message-meta';
+  const meta = createEl('div', 'message-meta');
   if (message?.role === 'user') {
     const badge = createInterruptBadgeNode(message.interruptState);
     if (badge) {
@@ -542,8 +526,7 @@ const createMetaNode = (created, message = null) => {
 };
 
 const buildDeferredVideoNode = (video) => {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'deferred-video';
+  const wrapper = createEl('div', 'deferred-video');
 
   const button = document.createElement('button');
   button.type = 'button';
@@ -904,10 +887,8 @@ const STREAM_STABLE_HASH_B_OFFSET = 0x9747b28c;
 
 const createAssistantStreamContainers = (body) => {
   body.innerHTML = '';
-  const stableContainer = document.createElement('div');
-  stableContainer.className = 'markdown-stream-stable';
-  const tailContainer = document.createElement('div');
-  tailContainer.className = 'markdown-stream-tail';
+  const stableContainer = createEl('div', 'markdown-stream-stable');
+  const tailContainer = createEl('div', 'markdown-stream-tail');
   body.appendChild(stableContainer);
   body.appendChild(tailContainer);
   return { stableContainer, tailContainer };
@@ -1077,8 +1058,7 @@ const resetAssistantStableRender = (streamState) => {
 
 const appendAssistantStableMarkdown = (streamState, source) => {
   if (!streamState?.stableContainer || !source) return;
-  const piece = document.createElement('div');
-  piece.className = 'markdown-stream-piece';
+  const piece = createEl('div', 'markdown-stream-piece');
   renderAssistantMarkdown(piece, source, { streaming: true });
   streamState.stableContainer.appendChild(piece);
   streamState.stableLength = Math.max(0, Number(streamState.stableLength) || 0) + source.length;
@@ -1443,40 +1423,27 @@ const isSuccessfulPlanUpdate = (tool) => Boolean(
 );
 
 const createToolCard = (message) => {
-  const wrapper = document.createElement('article');
-  wrapper.className = 'message tool';
+  const wrapper = createEl('article', 'message tool');
   wrapper.dataset.messageId = message.id;
   wrapper.hidden = isSuccessfulPlanUpdate(message);
 
-  const card = document.createElement('div');
-  card.className = 'tool-card';
+  const card = createEl('div', 'tool-card');
 
-  const toggle = document.createElement('button');
-  toggle.className = 'tool-toggle';
+  const toggle = createEl('button', 'tool-toggle');
   toggle.type = 'button';
   toggle.setAttribute('aria-expanded', isToolExpanded(message) ? 'true' : 'false');
 
-  const arrow = document.createElement('span');
-  arrow.className = 'tool-arrow';
-  arrow.textContent = '▶';
+  const arrow = createEl('span', 'tool-arrow', '▶');
 
-  const name = document.createElement('span');
-  name.className = 'tool-name';
-  name.textContent = `${toolIcon(message.name)} ${message.name || 'tool'}`;
+  const name = createEl('span', 'tool-name', `${toolIcon(message.name)} ${message.name || 'tool'}`);
 
-  const status = document.createElement('span');
-  status.className = `tool-status${message.status === 'done' ? ' done' : ''}`;
-  status.textContent = message.status === 'done' ? '[done]' : '[running…]';
+  const status = createEl('span', `tool-status${message.status === 'done' ? ' done' : ''}`, message.status === 'done' ? '[done]' : '[running…]');
 
-  const details = document.createElement('div');
-  details.className = `tool-details${isToolExpanded(message) ? ' open' : ''}`;
+  const details = createEl('div', `tool-details${isToolExpanded(message) ? ' open' : ''}`);
 
-  const label = document.createElement('div');
-  label.className = 'tool-details-label';
-  label.textContent = 'Arguments:';
+  const label = createEl('div', 'tool-details-label', 'Arguments:');
 
-  const args = document.createElement('pre');
-  args.textContent = message.arguments || '(waiting for arguments…)';
+  const args = createEl('pre', '', message.arguments || '(waiting for arguments…)');
 
   details.appendChild(label);
   details.appendChild(args);
@@ -1502,13 +1469,10 @@ const createToolCard = (message) => {
 };
 
 const createModelSwapNode = (message) => {
-  const article = document.createElement('article');
-  article.className = 'message model-swap';
+  const article = createEl('article', 'message model-swap');
   article.dataset.messageId = message.id;
 
-  const body = document.createElement('div');
-  body.className = 'message-body model-swap-body';
-  body.textContent = message.content || '↔ Model switch';
+  const body = createEl('div', 'message-body model-swap-body', message.content || '↔ Model switch');
   article.appendChild(body);
   article.appendChild(createMetaNode(message.created, message));
   return article;
@@ -1549,33 +1513,24 @@ const compactionDetailText = (message) => {
 const appendCompactionRawPre = (body, message) => {
   const raw = String(message?.rawContent || '');
   if (!raw) return null;
-  const pre = document.createElement('pre');
-  pre.className = 'compaction-raw';
-  pre.textContent = raw;
+  const pre = createEl('pre', 'compaction-raw', raw);
   body.appendChild(pre);
   return pre;
 };
 
 const createCompactionNode = (message) => {
-  const article = document.createElement('article');
-  article.className = `message ${message.role}`;
+  const article = createEl('article', `message ${message.role}`);
   article.dataset.messageId = message.id;
 
-  const body = document.createElement('div');
-  body.className = 'message-body compaction-body';
+  const body = createEl('div', 'message-body compaction-body');
   if (message.activeBoundary) body.classList.add('active-boundary');
 
-  const row = document.createElement('div');
-  row.className = 'compaction-summary-row';
+  const row = createEl('div', 'compaction-summary-row');
 
-  const label = document.createElement('span');
-  label.className = 'compaction-label';
-  label.textContent = '↳ Context compacted';
+  const label = createEl('span', 'compaction-label', '↳ Context compacted');
   row.appendChild(label);
 
-  const detail = document.createElement('span');
-  detail.className = 'compaction-detail';
-  detail.textContent = compactionDetailText(message);
+  const detail = createEl('span', 'compaction-detail', compactionDetailText(message));
   row.appendChild(detail);
 
   if (message.role === 'compaction' && message.rawContent) {
@@ -1608,17 +1563,13 @@ const createCompactionNode = (message) => {
 };
 
 const createSkillRunNode = (message) => {
-  const article = document.createElement('article');
-  article.className = 'message skill-run';
+  const article = createEl('article', 'message skill-run');
   article.dataset.messageId = message.id;
   article.dataset.runId = message.runId || '';
 
-  const body = document.createElement('div');
-  body.className = 'message-body skill-run-body';
-  const header = document.createElement('div');
-  header.className = 'skill-run-header';
-  const title = document.createElement('strong');
-  title.textContent = `/${message.skill || 'skill'} · ${message.agent ? `@${message.agent} · ` : ''}${message.status || 'running'}`;
+  const body = createEl('div', 'message-body skill-run-body');
+  const header = createEl('div', 'skill-run-header');
+  const title = createEl('strong', '', `/${message.skill || 'skill'} · ${message.agent ? `@${message.agent} · ` : ''}${message.status || 'running'}`);
   header.appendChild(title);
 
   if (message.status === 'running' || message.status === 'cancelling') {
@@ -1632,8 +1583,7 @@ const createSkillRunNode = (message) => {
   }
   body.appendChild(header);
 
-  const detail = document.createElement('div');
-  detail.className = 'skill-run-detail';
+  const detail = createEl('div', 'skill-run-detail');
   const duration = Number(message.durationMs || 0);
   detail.textContent = [
     message.runId ? `run ${message.runId}` : '',
@@ -1643,20 +1593,15 @@ const createSkillRunNode = (message) => {
   if (detail.textContent) body.appendChild(detail);
 
   if (message.output) {
-    const output = document.createElement('pre');
-    output.className = 'skill-run-output';
-    output.textContent = message.output;
+    const output = createEl('pre', 'skill-run-output', message.output);
     body.appendChild(output);
   }
   if (message.error) {
-    const error = document.createElement('div');
-    error.className = 'skill-run-error';
-    error.textContent = message.error;
+    const error = createEl('div', 'skill-run-error', message.error);
     body.appendChild(error);
   }
   if (message.childSessionId) {
-    const link = document.createElement('a');
-    link.className = 'skill-run-action';
+    const link = createEl('a', 'skill-run-action');
     link.href = `${app.UI_PREFIX || '/ui'}/${encodeURIComponent(message.childSessionId)}`;
     link.textContent = 'Open child session';
     body.appendChild(link);
@@ -1728,8 +1673,7 @@ const observeTranscriptGap = (node, _message, sessionId) => {
 };
 
 const createTranscriptGapNode = (message) => {
-  const gap = document.createElement('div');
-  gap.className = 'transcript-gap';
+  const gap = createEl('div', 'transcript-gap');
   gap.dataset.messageId = message.id;
   gap.dataset.startOrdinal = String(message.startOrdinal);
   gap.dataset.endOrdinal = String(message.endOrdinal);
@@ -1739,8 +1683,7 @@ const createTranscriptGapNode = (message) => {
   gap.setAttribute('role', 'button');
   gap.setAttribute('tabindex', '0');
   gap.setAttribute('aria-label', `Load transcript rows ${Number(message.startOrdinal) + 1} through ${Number(message.endOrdinal) + 1}`);
-  const label = document.createElement('span');
-  label.textContent = 'Load earlier transcript';
+  const label = createEl('span', '', 'Load earlier transcript');
   gap.appendChild(label);
   return gap;
 };
@@ -1791,12 +1734,10 @@ const createMessageNode = (message) => {
   if (message.role === 'model-swap') return createModelSwapNode(message);
   if (message.role === 'path-note' && typeof app.createPathNoteNode === 'function') return app.createPathNoteNode(message);
   if (message.role === 'compaction' || message.role === 'compaction-boundary') return createCompactionNode(message);
-  const article = document.createElement('article');
-  article.className = `message ${message.role}`;
+  const article = createEl('article', `message ${message.role}`);
   article.dataset.messageId = message.id;
 
-  const body = document.createElement('div');
-  body.className = 'message-body';
+  const body = createEl('div', 'message-body');
   applyTextDirection(body, message.content || '');
 
   if (message.role === 'assistant') {
@@ -1807,8 +1748,7 @@ const createMessageNode = (message) => {
   } else {
     // User message: show attachments if present
     if (message.attachments && message.attachments.length > 0) {
-      const attDiv = document.createElement('div');
-      attDiv.className = 'message-attachments';
+      const attDiv = createEl('div', 'message-attachments');
       message.attachments.forEach(att => {
         const rawPreviewURL = att.previewURL || att.dataURL || '';
         const previewURL = rebaseAssetURL(rawPreviewURL);
@@ -1821,9 +1761,7 @@ const createMessageNode = (message) => {
           img.addEventListener('click', () => app.openLightbox(previewURL));
           attDiv.appendChild(img);
         } else {
-          const badge = document.createElement('span');
-          badge.className = 'att-file';
-          badge.textContent = att.name || 'file';
+          const badge = createEl('span', 'att-file', att.name || 'file');
           attDiv.appendChild(badge);
         }
       });
@@ -1838,9 +1776,7 @@ const createMessageNode = (message) => {
   article.appendChild(body);
 
   if (message.role === 'assistant' && message.usage) {
-    const usage = document.createElement('div');
-    usage.className = 'usage-line';
-    usage.textContent = formatUsage(message.usage);
+    const usage = createEl('div', 'usage-line', formatUsage(message.usage));
     article.appendChild(usage);
   }
 
@@ -1952,8 +1888,7 @@ const createToolArtifactsNode = (message) => {
   const artifacts = toolImageArtifacts(message);
   if (artifacts.length === 0) return null;
 
-  const wrapper = document.createElement('div');
-  wrapper.className = 'tool-artifacts';
+  const wrapper = createEl('div', 'tool-artifacts');
 
   artifacts.forEach((artifact, index) => {
     const img = document.createElement('img');
@@ -1993,29 +1928,21 @@ const syncToolArtifactsNode = (card, message) => {
 };
 
 const createToolGroupNode = (message) => {
-  const wrapper = document.createElement('article');
-  wrapper.className = 'message tool-group';
+  const wrapper = createEl('article', 'message tool-group');
   wrapper.dataset.messageId = message.id;
   wrapper.hidden = transcriptVisibleTools(message).length === 0;
 
-  const card = document.createElement('div');
-  card.className = 'tool-group-card';
+  const card = createEl('div', 'tool-group-card');
 
-  const toggle = document.createElement('button');
-  toggle.className = 'tool-group-toggle';
+  const toggle = createEl('button', 'tool-group-toggle');
   toggle.type = 'button';
   toggle.setAttribute('aria-expanded', isToolExpanded(message) ? 'true' : 'false');
 
-  const arrow = document.createElement('span');
-  arrow.className = 'tool-arrow';
-  arrow.textContent = '▶';
+  const arrow = createEl('span', 'tool-arrow', '▶');
 
-  const summary = document.createElement('span');
-  summary.className = 'tool-group-summary';
-  summary.textContent = toolGroupSummaryText(message);
+  const summary = createEl('span', 'tool-group-summary', toolGroupSummaryText(message));
 
-  const statusBadge = document.createElement('span');
-  statusBadge.className = 'tool-status';
+  const statusBadge = createEl('span', 'tool-status');
   if (isToolGroupFinished(message)) {
     statusBadge.style.display = 'none';
     statusBadge.textContent = '';
@@ -2142,20 +2069,14 @@ const buildArgsNode = (tool) => {
   const entries = formatToolArgs(tool);
   if (!entries || entries.length === 0) return null;
 
-  const argsDiv = document.createElement('div');
-  argsDiv.className = 'tool-entry-args';
+  const argsDiv = createEl('div', 'tool-entry-args');
 
   entries.forEach(([key, value]) => {
-    const line = document.createElement('div');
-    line.className = 'arg-line';
+    const line = createEl('div', 'arg-line');
 
-    const label = document.createElement('span');
-    label.className = 'arg-label';
-    label.textContent = key + ':';
+    const label = createEl('span', 'arg-label', key + ':');
 
-    const val = document.createElement('span');
-    val.className = 'arg-value';
-    val.textContent = typeof value === 'string' ? value : JSON.stringify(value);
+    const val = createEl('span', 'arg-value', typeof value === 'string' ? value : JSON.stringify(value));
 
     line.appendChild(label);
     line.appendChild(val);
@@ -2169,19 +2090,13 @@ const createToolEntryNode = (tool) => {
   const wrapper = document.createElement('div');
   wrapper.dataset.toolId = tool.id;
 
-  const entry = document.createElement('div');
-  entry.className = 'tool-group-entry';
+  const entry = createEl('div', 'tool-group-entry');
 
-  const icon = document.createElement('span');
-  icon.textContent = toolIcon(tool.name);
+  const icon = createEl('span', '', toolIcon(tool.name));
 
-  const name = document.createElement('span');
-  name.className = 'tool-entry-name';
-  name.textContent = tool.name || 'tool';
+  const name = createEl('span', 'tool-entry-name', tool.name || 'tool');
 
-  const status = document.createElement('span');
-  status.className = `tool-entry-status${tool.status === 'done' ? ' done' : (tool.status === 'error' ? ' error' : '')}`;
-  status.textContent = tool.status === 'done' ? '✓' : (tool.status === 'error' ? '×' : '…');
+  const status = createEl('span', `tool-entry-status${tool.status === 'done' ? ' done' : (tool.status === 'error' ? ' error' : '')}`, tool.status === 'done' ? '✓' : (tool.status === 'error' ? '×' : '…'));
 
   entry.appendChild(icon);
   entry.appendChild(name);
@@ -2374,8 +2289,7 @@ const getClipboardWriter = () => {
 };
 
 const createTurnActionPanel = (turn) => {
-  const panel = document.createElement('div');
-  panel.className = 'turn-action-panel';
+  const panel = createEl('div', 'turn-action-panel');
   panel.dataset.turnAssistantId = turn.lastAssistantId || '';
 
   const button = document.createElement('button');
@@ -2911,9 +2825,7 @@ const renderMessages = (forceScroll = false) => {
   if (!session || !messages.length) {
     elements.messages.innerHTML = '';
     if (!sessionHistoryLoading) {
-      const empty = document.createElement('div');
-      empty.className = 'empty-state';
-      empty.textContent = 'How can I help you today?';
+      const empty = createEl('div', 'empty-state', 'How can I help you today?');
       elements.messages.appendChild(empty);
     }
     _lastRenderedSessionId = sessionId;

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -724,32 +724,16 @@ const decorateMathCopyControls = (target) => {
     btn.title = 'Copy math as text';
     btn.setAttribute('aria-label', 'Copy math as text');
     btn.textContent = 'Copy TeX';
-    btn.addEventListener('click', async (event) => {
+    btn.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation?.();
-      const clipboard = getClipboardWriter();
-      if (!clipboard) return;
-      btn.disabled = true;
-      try {
-        await clipboard.writeText(text);
-        window.clearTimeout(btn._mathCopyResetTimer);
-        btn.classList.add('copied');
-        btn.textContent = 'Copied';
-        btn._mathCopyResetTimer = window.setTimeout(() => {
-          btn.classList.remove('copied');
-          btn.textContent = 'Copy TeX';
-          btn.disabled = !getClipboardWriter();
-        }, TURN_COPY_RESET_MS);
-      } catch (_err) {
-        btn.textContent = 'Failed';
-        window.setTimeout(() => {
-          btn.textContent = 'Copy TeX';
-          btn.disabled = !getClipboardWriter();
-        }, TURN_COPY_RESET_MS);
-      } finally {
-        if (!btn.classList.contains('copied')) btn.disabled = !getClipboardWriter();
-        else btn.disabled = false;
-      }
+      return copyTextWithFeedback(btn, text, {
+        timerKey: '_mathCopyResetTimer',
+        contentKey: 'textContent',
+        idleContent: 'Copy TeX',
+        copiedContent: 'Copied',
+        failedContent: 'Failed'
+      });
     });
     if (!getClipboardWriter()) btn.disabled = true;
     display.appendChild(btn);
@@ -800,34 +784,17 @@ const decorateAssistantFragment = (target, options = {}) => {
     btn.className = 'code-copy-btn';
     btn.title = 'Copy';
     btn.setAttribute('aria-label', 'Copy code');
-    btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
-    btn.addEventListener('click', async () => {
+    btn.innerHTML = TURN_COPY_ICON;
+    btn.addEventListener('click', () => {
       const code = pre.querySelector('code');
       const text = code ? code.textContent : pre.textContent;
-      const clipboard = getClipboardWriter();
-      if (!clipboard) return;
-      btn.disabled = true;
-      try {
-        await clipboard.writeText(text);
-        window.clearTimeout(btn._codeCopyResetTimer);
-        btn.classList.add('copied');
-        btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
-        btn._codeCopyResetTimer = window.setTimeout(() => {
-          btn.classList.remove('copied');
-          btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
-          btn.disabled = !getClipboardWriter();
-        }, 1500);
-      } catch (_err) {
-        window.clearTimeout(btn._codeCopyResetTimer);
-        btn.title = 'Copy failed';
-        btn._codeCopyResetTimer = window.setTimeout(() => {
-          btn.title = 'Copy';
-          btn.disabled = !getClipboardWriter();
-        }, 1500);
-      } finally {
-        if (!btn.classList.contains('copied')) btn.disabled = !getClipboardWriter();
-        else btn.disabled = false;
-      }
+      return copyTextWithFeedback(btn, text, {
+        timerKey: '_codeCopyResetTimer',
+        idleContent: TURN_COPY_ICON,
+        copiedContent: TURN_COPIED_ICON,
+        idleTitle: 'Copy',
+        failedTitle: 'Copy failed'
+      });
     });
     if (!getClipboardWriter()) btn.disabled = true;
     pre.style.position = 'relative';
@@ -1688,30 +1655,35 @@ const createTranscriptGapNode = (message) => {
   return gap;
 };
 
-const copyTextWithFeedback = async (button, text, idleLabel, timerKey) => {
+const applyCopyButtonState = (button, contentKey, content, title, ariaLabel) => {
+  if (content !== undefined) button[contentKey] = content;
+  if (title !== undefined) button.title = title;
+  if (ariaLabel !== undefined) button.setAttribute('aria-label', ariaLabel);
+};
+
+const copyTextWithFeedback = async (btn, text, options = {}) => {
   const clipboard = getClipboardWriter();
   if (!clipboard || !text) return;
-  button.disabled = true;
+  const {
+    timerKey, contentKey = 'innerHTML', idleContent, copiedContent, failedContent,
+    idleTitle, copiedTitle, failedTitle, idleAria, copiedAria
+  } = options;
+  btn.disabled = true;
   try {
     await clipboard.writeText(text);
-    window.clearTimeout(button[timerKey]);
-    button.classList.add('copied');
-    button.innerHTML = TURN_COPIED_ICON;
-    button.title = 'Copied';
-    button.setAttribute('aria-label', 'Copied');
-    button[timerKey] = window.setTimeout(() => {
-      button.classList.remove('copied');
-      button.innerHTML = TURN_COPY_ICON;
-      button.title = idleLabel;
-      button.setAttribute('aria-label', idleLabel);
-      button.disabled = !getClipboardWriter();
-    }, TURN_COPY_RESET_MS);
+    btn.classList.add('copied');
+    applyCopyButtonState(btn, contentKey, copiedContent, copiedTitle, copiedAria);
   } catch (_err) {
-    button.title = 'Copy failed';
-    window.setTimeout(() => { button.title = idleLabel; }, TURN_COPY_RESET_MS);
-  } finally {
-    button.disabled = button.classList.contains('copied') ? false : !getClipboardWriter();
+    btn.classList.remove('copied');
+    applyCopyButtonState(btn, contentKey, failedContent ?? idleContent, failedTitle, idleAria);
   }
+  window.clearTimeout(btn[timerKey]);
+  btn.disabled = false;
+  btn[timerKey] = window.setTimeout(() => {
+    btn.classList.remove('copied');
+    applyCopyButtonState(btn, contentKey, idleContent, idleTitle, idleAria);
+    btn.disabled = !getClipboardWriter();
+  }, TURN_COPY_RESET_MS);
 };
 
 const ATTACHMENT_IMAGE_MAX_WIDTH = 360, ATTACHMENT_IMAGE_MAX_HEIGHT = 270;
@@ -2310,7 +2282,16 @@ const createTurnActionPanel = (turn) => {
     const assistantId = button.dataset.turnAssistantId || '';
     const currentTurn = getAssistantTurns(ensureActiveSession())
       .find((candidate) => candidate.lastAssistantId === assistantId);
-    return copyTextWithFeedback(button, buildTurnClipboardText(currentTurn), 'Copy response', '_turnCopyResetTimer');
+    return copyTextWithFeedback(button, buildTurnClipboardText(currentTurn), {
+      timerKey: '_turnCopyResetTimer',
+      idleContent: TURN_COPY_ICON,
+      copiedContent: TURN_COPIED_ICON,
+      idleTitle: 'Copy response',
+      copiedTitle: 'Copied',
+      failedTitle: 'Copy failed',
+      idleAria: 'Copy response',
+      copiedAria: 'Copied'
+    });
   });
 
   panel.appendChild(button);

--- a/internal/serveui/static/app-runtime.js
+++ b/internal/serveui/static/app-runtime.js
@@ -3,6 +3,7 @@
 (function initAppRuntime() {
 
 const app = window.TermLLMApp;
+const createEl = app.createEl;
 const {
   UI_PREFIX, STORAGE_KEYS, state, elements, getActiveSession, updateSessionUsageDisplay, splitHeaderModelEffort,
   compactHeaderModelLabel, getDefaultProviderName, getDefaultModelForProvider
@@ -578,22 +579,17 @@ const openChipPopover = (selectEl, triggerEl) => {
 
   const currentValue = selectEl.value;
   options.forEach((opt) => {
-    const item = document.createElement('div');
-    item.className = 'chip-popover-item';
+    const item = createEl('div', 'chip-popover-item');
     item.setAttribute('role', 'option');
     item.tabIndex = -1;
     item.dataset.value = opt.value;
     const { primary, meta } = buildChipOptionLabel(opt);
     item.dataset.search = `${primary} ${meta} ${opt.value}`.toLowerCase();
     if (opt.value === currentValue) item.setAttribute('aria-selected', 'true');
-    const label = document.createElement('span');
-    label.className = 'chip-popover-item-label';
-    label.textContent = primary;
+    const label = createEl('span', 'chip-popover-item-label', primary);
     item.appendChild(label);
     if (meta) {
-      const metaEl = document.createElement('span');
-      metaEl.className = 'chip-popover-item-meta';
-      metaEl.textContent = meta;
+      const metaEl = createEl('span', 'chip-popover-item-meta', meta);
       item.appendChild(metaEl);
     }
     item.addEventListener('click', () => commitChipPopoverItem(item));
@@ -629,16 +625,12 @@ const copySelectOptions = (from, to, formatOption = null) => {
 };
 
 const runtimeField = ({ label, value, sourceSelect, onChange, formatOption = null }) => {
-  const field = document.createElement('label');
-  field.className = 'runtime-popover-field';
+  const field = createEl('label', 'runtime-popover-field');
 
-  const labelEl = document.createElement('span');
-  labelEl.className = 'runtime-popover-label';
-  labelEl.textContent = label;
+  const labelEl = createEl('span', 'runtime-popover-label', label);
   field.appendChild(labelEl);
 
-  const select = document.createElement('select');
-  select.className = 'runtime-popover-select';
+  const select = createEl('select', 'runtime-popover-select');
   copySelectOptions(sourceSelect, select, formatOption);
   select.value = value || '';
   select.addEventListener('change', async () => {
@@ -658,20 +650,14 @@ const renderRuntimePopoverContent = () => {
   if (!pop) return;
   pop.innerHTML = '';
 
-  const header = document.createElement('div');
-  header.className = 'runtime-popover-header';
-  const title = document.createElement('div');
-  title.className = 'runtime-popover-title';
-  title.textContent = 'Runtime';
-  const hint = document.createElement('div');
-  hint.className = 'runtime-popover-hint';
-  hint.textContent = 'Provider, model, and effort for the next reply';
+  const header = createEl('div', 'runtime-popover-header');
+  const title = createEl('div', 'runtime-popover-title', 'Runtime');
+  const hint = createEl('div', 'runtime-popover-hint', 'Provider, model, and effort for the next reply');
   header.appendChild(title);
   header.appendChild(hint);
   pop.appendChild(header);
 
-  const fields = document.createElement('div');
-  fields.className = 'runtime-popover-fields';
+  const fields = createEl('div', 'runtime-popover-fields');
   fields.appendChild(runtimeField({
     label: 'Provider',
     value: state.selectedProvider || '',

--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const app = window.TermLLMApp;
+const createEl = app.createEl;
 const { UI_PREFIX, state, elements } = app;
 
 const SEARCH_DEBOUNCE_MS = 180;
@@ -14,17 +15,13 @@ const widgetMount = (widget) => String(widget?.mount || widget?.id || '').replac
 
 const buildWidgetLink = (widget) => {
   const mount = widgetMount(widget);
-  const link = document.createElement('a');
-  link.className = 'widget-link';
+  const link = createEl('a', 'widget-link');
   link.href = `${UI_PREFIX}/widgets/${encodeURIComponent(mount)}/`;
   link.title = widget.description || widgetTitle(widget);
 
-  const titleRow = document.createElement('div');
-  titleRow.className = 'widget-title-row';
+  const titleRow = createEl('div', 'widget-title-row');
 
-  const title = document.createElement('span');
-  title.className = 'widget-title';
-  title.textContent = widgetTitle(widget);
+  const title = createEl('span', 'widget-title', widgetTitle(widget));
 
   const normalizedStatus = String(widget.state || 'stopped').toLowerCase();
   const statusClass = normalizedStatus.replace(/[^a-z0-9_-]/g, '');
@@ -33,21 +30,16 @@ const buildWidgetLink = (widget) => {
 
   titleRow.appendChild(title);
   if (showRunningIndicator) {
-    const stateBadge = document.createElement('span');
-    stateBadge.className = `widget-state ${statusClass}`;
+    const stateBadge = createEl('span', `widget-state ${statusClass}`);
     stateBadge.title = 'Running';
     stateBadge.setAttribute('aria-label', 'Running');
     titleRow.appendChild(stateBadge);
   } else if (showTextBadge) {
-    const stateBadge = document.createElement('span');
-    stateBadge.className = `widget-state ${statusClass}`;
-    stateBadge.textContent = normalizedStatus;
+    const stateBadge = createEl('span', `widget-state ${statusClass}`, normalizedStatus);
     titleRow.appendChild(stateBadge);
   }
   link.appendChild(titleRow);
-  const meta = document.createElement('div');
-  meta.className = 'widget-meta';
-  meta.textContent = widget.description || mount;
+  const meta = createEl('div', 'widget-meta', widget.description || mount);
   link.appendChild(meta);
 
   return link;

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -184,6 +184,21 @@ function loadAppCore() {
 
 const app = loadAppCore();
 
+(function testCreateElInitializesOptionalProperties() {
+  const name = 'createEl initializes only supplied class and text';
+  const complete = app.createEl('span', 'status', 'ready');
+  const bare = app.createEl('div');
+  if (complete.className !== 'status' || complete.textContent !== 'ready') {
+    fail(name, 'supplied properties were not assigned');
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(bare, 'className') || bare.textContent !== '') {
+    fail(name, 'omitted properties should retain element defaults');
+    return;
+  }
+  pass(name);
+})();
+
 (function testConversationMountGuardsAndScopedMessageLookup() {
   const name = 'conversation DOM helpers require mounted session ownership';
   const messages = makeNode();

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -183,6 +183,12 @@ function createHarness(options = {}) {
   };
 
   const app = {
+    createEl(tag, className, text) {
+      const element = document.createElement(tag);
+      if (className) element.className = className;
+      if (text !== undefined) element.textContent = text;
+      return element;
+    },
     UI_PREFIX: '/chat',
     STORAGE_KEYS: { diffSidebarWidth: 'term_llm_diff_sidebar_width' },
     state,

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -346,6 +346,12 @@ function createHarness(appOverrides = {}) {
   const parseCalls = [];
 
   const app = {
+    createEl(tag, className, text) {
+      const element = document.createElement(tag);
+      if (className) element.className = className;
+      if (text !== undefined) element.textContent = text;
+      return element;
+    },
     STORAGE_KEYS: { sidebarCollapsed: 'sidebar' },
     UI_PREFIX: '/chat',
     state,

--- a/internal/serveui/static/app_render_test.js
+++ b/internal/serveui/static/app_render_test.js
@@ -958,6 +958,26 @@ async function run(name, fn) {
     assertEqual(activeResets.length, 1, 'only latest reset timer remains active');
   });
 
+  await run('copy feedback resets failed code copies through the shared timer', async () => {
+    const { app, document, timers } = createHarness({
+      getClipboardWriter() {
+        return { async writeText() { throw new Error('denied'); } };
+      },
+    });
+    const target = new Element('div');
+    document.body.appendChild(target);
+    app.renderAssistantMarkdown(target, '```js\nthrow new Error();\n```');
+    const button = target.querySelector('.code-copy-btn');
+
+    await button.dispatchEvent({ type: 'click' });
+    assertEqual(button.title, 'Copy failed', 'failed state is visible');
+    assert(!button.classList.contains('copied'), 'failed copy does not retain copied state');
+    const reset = timers.find((timer) => timer.ms === 1500 && !timer.cleared);
+    assert(reset, 'failure uses the shared reset timer');
+    reset.callback();
+    assertEqual(button.title, 'Copy', 'idle title is restored');
+  });
+
   await run('math copy controls copy rendered TeX source as text', async () => {
     const { app, document, copied, timers } = createHarness();
     const root = document.createElement('div');

--- a/internal/serveui/static/app_sidebar_test.js
+++ b/internal/serveui/static/app_sidebar_test.js
@@ -125,6 +125,12 @@ function createHarness(options = {}) {
   };
   let renderSidebarCount = 0;
   const app = {
+    createEl(tag, className, text) {
+      const element = document.createElement(tag);
+      if (className) element.className = className;
+      if (text !== undefined) element.textContent = text;
+      return element;
+    },
     UI_PREFIX: '/chat',
     state,
     elements,

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -390,6 +390,12 @@ function createHarness(options = {}) {
   let providerRetryStatus = null;
   let modelSwapUpdateCount = 0;
   const app = {
+    createEl(tag, className, text) {
+      const element = document.createElement(tag);
+      if (className) element.className = className;
+      if (text !== undefined) element.textContent = text;
+      return element;
+    },
     UI_PREFIX: '/ui',
     STORAGE_KEYS: {
       selectedProvider: 'selectedProvider',


### PR DESCRIPTION
## Summary

- promote the existing DOM element factory into `app-core.js`
- replace repeated `createElement` + `className` + `textContent` boilerplate across render, modal, MCP, runtime, sidebar, and diff code
- route math, code-block, and turn-copy feedback through one shared state/reset helper and reuse the same SVG icons
- exercise both shared helpers directly and update isolated JS harnesses to provide the production dependencies

## Bundle arithmetic

The failing CI ratchet requires legacy first-party production JavaScript to stay below **20,570 lines**. Main had grown to **20,579**.

This PR reduces that surface by **182 lines**, from **20,579 to 20,397**, without changing the threshold. It also removes **6,859 source bytes**. `app-render.js`, the tightest individual budget, drops from **3,142 to 3,035 lines**.

The clipboard follow-up accounts for **19 production lines** and **1,511 bytes** of that reduction while replacing three independent feedback/timer implementations with one.

## Verification

- `go test ./internal/serveui -run '^TestConversationLifecycleSizeAndPurityBudgets$' -count=1`
- `go test ./internal/serveui -count=1`
- `go build ./...`
- `git diff --check`

`go test ./...` passed all changed and relevant packages, including `internal/serveui`, but the overall command remains red in two unrelated `cmd` tests because this machine injects 31 user skills and the tests cap rendered skill metadata before their temporary fixture skill is reached:

- `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir`
- `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`
