### PR TITLE
fix: Stalled voice transcription can exhaust every Telegram handler slot

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -43,6 +43,7 @@ const telegramMaxConcurrentHandlers = 8
 const telegramMaxPhotoDownloadBytes int64 = 25 << 20
 const telegramMaxVoiceDownloadBytes int64 = 25 << 20
 const telegramDownloadTimeout = 5 * time.Minute
+const telegramTranscriptionTimeout = 5 * time.Minute
 const telegramBotAPIRequestTimeout = 30 * time.Second
 const telegramUpdateLongPollSeconds = 60
 const telegramBotAPILongPollTimeout = (telegramUpdateLongPollSeconds * time.Second) + 10*time.Second
@@ -652,8 +653,9 @@ type telegramSessionMgr struct {
 	admissionMu       sync.Mutex
 	messageAdmissions map[int64]chan struct{}
 
-	tickerInterval time.Duration // 0 means use default (500ms); overridden in tests
-	editInterval   time.Duration // 0 means use minEditInterval; overridden in tests
+	tickerInterval       time.Duration // 0 means use default (500ms); overridden in tests
+	editInterval         time.Duration // 0 means use minEditInterval; overridden in tests
+	transcriptionTimeout time.Duration // 0 means use telegramTranscriptionTimeout; overridden in tests
 
 	// streamEventTimeout bounds how long the stream watchdog waits between events
 	// before declaring the stream dead. 0 means use defaultStreamEventTimeout.
@@ -1436,7 +1438,13 @@ func (m *telegramSessionMgr) handleMessageWithAdmission(ctx context.Context, bot
 		}
 		defer os.Remove(voicePath)
 
-		transcript, err := llm.TranscribeWithConfig(ctx, m.cfg, voicePath, "", "")
+		transcriptionTimeout := m.transcriptionTimeout
+		if transcriptionTimeout <= 0 {
+			transcriptionTimeout = telegramTranscriptionTimeout
+		}
+		transcriptionCtx, cancelTranscription := context.WithTimeout(ctx, transcriptionTimeout)
+		transcript, err := llm.TranscribeWithConfig(transcriptionCtx, m.cfg, voicePath, "", "")
+		cancelTranscription()
 		if err != nil {
 			log.Printf("telegram: transcribe error: %v", err)
 			// Check if it's a config/key issue vs a transient error

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -520,6 +520,136 @@ func TestTelegramSessionMgrAcquireMessageSlot_RespectsContextCancel(t *testing.T
 	}
 }
 
+func TestTelegramVoiceTranscriptionTimeoutReleasesHandlerChain(t *testing.T) {
+	const transcriptionTimeout = 500 * time.Millisecond
+
+	transcriptionStarted := make(chan struct{})
+	transcriptionCanceled := make(chan struct{})
+	releaseTranscription := make(chan struct{})
+	var startedOnce sync.Once
+	var canceledOnce sync.Once
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/voice.ogg":
+			_, _ = w.Write([]byte("voice"))
+		case "/audio/transcriptions":
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			startedOnce.Do(func() { close(transcriptionStarted) })
+			select {
+			case <-r.Context().Done():
+				canceledOnce.Do(func() { close(transcriptionCanceled) })
+			case <-releaseTranscription:
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+	defer close(releaseTranscription)
+
+	mgr := &telegramSessionMgr{
+		cfg: &config.Config{
+			Transcription: config.TranscriptionConfig{Provider: "openai"},
+			Providers: map[string]config.ProviderConfig{
+				"openai": {
+					Type:    config.ProviderTypeOpenAI,
+					APIKey:  "test-key",
+					BaseURL: ts.URL,
+				},
+			},
+		},
+		allowedUserIDs:       map[int64]struct{}{7: {}},
+		messageSlots:         make(chan struct{}, telegramMaxConcurrentHandlers),
+		transcriptionTimeout: transcriptionTimeout,
+	}
+	bot := &fakeBotSender{fileURL: ts.URL + "/voice.ogg"}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runHandler := func(msg *tgbotapi.Message) <-chan struct{} {
+		t.Helper()
+		if !mgr.acquireMessageSlot(ctx) {
+			t.Fatal("failed to acquire Telegram handler slot")
+		}
+		admission := mgr.admitMessage(msg)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			defer mgr.releaseMessageSlot()
+			mgr.handleMessageWithAdmission(ctx, bot, msg, admission)
+		}()
+		return done
+	}
+
+	voiceMessage := &tgbotapi.Message{
+		From:  &tgbotapi.User{ID: 7},
+		Chat:  &tgbotapi.Chat{ID: 1},
+		Voice: &tgbotapi.Voice{FileID: "voice"},
+	}
+	voiceDone := runHandler(voiceMessage)
+	select {
+	case <-transcriptionStarted:
+	case <-time.After(time.Second):
+		t.Fatal("transcription request did not start")
+	}
+
+	queuedDone := make([]<-chan struct{}, 0, telegramMaxConcurrentHandlers-1)
+	for range telegramMaxConcurrentHandlers - 1 {
+		queuedDone = append(queuedDone, runHandler(&tgbotapi.Message{
+			From: &tgbotapi.User{ID: 7},
+			Chat: &tgbotapi.Chat{ID: 1},
+		}))
+	}
+
+	differentChatAcquired := make(chan struct{})
+	differentChatDone := make(chan struct{})
+	go func() {
+		defer close(differentChatDone)
+		if !mgr.acquireMessageSlot(ctx) {
+			return
+		}
+		close(differentChatAcquired)
+		defer mgr.releaseMessageSlot()
+		msg := &tgbotapi.Message{From: &tgbotapi.User{ID: 7}, Chat: &tgbotapi.Chat{ID: 2}}
+		mgr.handleMessageWithAdmission(ctx, bot, msg, mgr.admitMessage(msg))
+	}()
+
+	select {
+	case <-differentChatAcquired:
+		t.Fatal("different chat acquired a slot while stalled transcription and its same-chat queue held every slot")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	waitForHandler := func(name string, done <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %s handler", name)
+		}
+	}
+	waitForHandler("voice", voiceDone)
+	for i, done := range queuedDone {
+		waitForHandler(fmt.Sprintf("queued same-chat %d", i+1), done)
+	}
+	waitForHandler("different-chat", differentChatDone)
+
+	select {
+	case <-transcriptionCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("transcription request context was not canceled")
+	}
+	if got := bot.lastText(); got != "Sorry, couldn't transcribe your voice message." {
+		t.Fatalf("transcription error reply = %q", got)
+	}
+	if got := len(mgr.messageSlots); got != 0 {
+		t.Fatalf("occupied Telegram handler slots = %d, want 0", got)
+	}
+}
+
 // --- TestBuildSegment ---
 
 func TestBuildSegment(t *testing.T) {


### PR DESCRIPTION
## What changed

- Bound Telegram voice transcription to a conservative five-minute context deadline.
- Keep `llm.TranscribeWithConfig` caller-controlled so other transcription callers retain their existing deadline policy.
- Added a per-manager timeout seam for tests.
- Added a regression test with a transcription endpoint that flushes a 200 response header and then stalls. The test fills all eight Telegram handler slots with one stalled voice request and its same-chat admission queue, then verifies the timeout cancels the provider request, releases the same-chat chain, frees every slot, and allows a different chat to execute.

## Why this is high-value

Telegram handlers retain both their global handler slot and same-chat admission ownership while voice transcription runs. The shared streaming HTTP client intentionally has no whole-request timeout, so a provider that returns headers and then stops producing its response body could previously block forever. Repeated messages from that chat could then occupy all eight global handler slots while waiting behind the first request, freezing Telegram processing for every chat until shutdown or restart.

A bounded transcription context turns that permanent bot-wide outage into the existing transcription-error reply and restores normal processing automatically.

## Validation

- `go test ./internal/serve -run 'TestTelegramVoiceTranscriptionTimeoutReleasesHandlerChain' -count=1`
- `go test -race ./internal/serve -run 'TestTelegramVoiceTranscriptionTimeoutReleasesHandlerChain' -count=1`
- `go test ./internal/serve`
- `go build ./...`
- `git diff --check`
- `go test ./...` was run; all packages except `cmd` passed. Two unrelated `cmd` tests fail because this host's 31 user skills exceed their configured visible-skill budgets, so the temporary request-directory skill is omitted: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`. Both failures reproduce when run individually and do not touch the Telegram changes.
