### PR TITLE
fix: Blocked Grok ACP handshake defeats both its timeout and server shutdown

### DIFF
--- a/internal/llm/grok_acp.go
+++ b/internal/llm/grok_acp.go
@@ -764,6 +764,23 @@ func (p *GrokBinProvider) startGrokACPProcess(ctx context.Context, req Request, 
 
 	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, grokACPHandshakeTimeout)
 	defer handshakeCancel()
+	stopHandshakeWatchdog := context.AfterFunc(handshakeCtx, func() {
+		// ACP writes do not observe their call context while blocked in Write.
+		// Close stdin directly so startup can unwind even while acpMu is held.
+		_ = process.stdin.Close()
+		process.cancel()
+	})
+	defer stopHandshakeWatchdog()
+	finishHandshake := func() error {
+		if stopHandshakeWatchdog() {
+			return nil
+		}
+		err := handshakeCtx.Err()
+		if err == nil {
+			err = context.Canceled
+		}
+		return fmt.Errorf("complete Grok ACP handshake: %w", err)
+	}
 	initialize, err := process.client.Initialize(handshakeCtx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersion1,
 		ClientCapabilities: acp.ClientCapabilities{
@@ -807,6 +824,9 @@ func (p *GrokBinProvider) startGrokACPProcess(ctx context.Context, req Request, 
 		process.handler.endTurn()
 		if err == nil {
 			process.sessionID = resumeID
+			if err := finishHandshake(); err != nil {
+				return nil, err
+			}
 			return process, nil
 		}
 	}
@@ -816,6 +836,9 @@ func (p *GrokBinProvider) startGrokACPProcess(ctx context.Context, req Request, 
 		process.handler.endTurn()
 		if err == nil {
 			process.sessionID = resumeID
+			if err := finishHandshake(); err != nil {
+				return nil, err
+			}
 			return process, nil
 		}
 	}
@@ -836,6 +859,9 @@ func (p *GrokBinProvider) startGrokACPProcess(ctx context.Context, req Request, 
 		return nil, fmt.Errorf("create Grok ACP session: empty session ID")
 	}
 	process.sessionID = strings.TrimSpace(newSession.SessionID)
+	if err := finishHandshake(); err != nil {
+		return nil, err
+	}
 	return process, nil
 }
 

--- a/internal/llm/grok_acp_test.go
+++ b/internal/llm/grok_acp_test.go
@@ -537,6 +537,121 @@ done
 	}
 }
 
+func TestGrokBinProviderACPCancellationUnblocksSessionWrite(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	binDir := t.TempDir()
+	firstPIDPath := filepath.Join(t.TempDir(), "first-pid")
+	blockedPath := filepath.Join(t.TempDir(), "blocked")
+	path := filepath.Join(binDir, "grok")
+	script := `#!/bin/sh
+if [ ! -f "$GROK_TEST_FIRST_PID" ]; then
+  echo $$ > "$GROK_TEST_FIRST_PID"
+  first=1
+else
+  first_pid=$(cat "$GROK_TEST_FIRST_PID")
+  if kill -0 "$first_pid" 2>/dev/null; then
+    exit 42
+  fi
+  first=0
+fi
+while IFS= read -r line; do
+  id=${line#*\"id\":}
+  id=${id%%,*}
+  case "$line" in
+    *'"method":"initialize"'*) printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":1,\"agentCapabilities\":{},\"authMethods\":[{\"id\":\"cached_token\",\"name\":\"Cached\"}]}}" ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{}}"
+      if [ "$first" = 1 ]; then
+        : > "$GROK_TEST_BLOCKED"
+        sleep 30
+      fi
+      ;;
+    *'"method":"session/new"'*) printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sessionId\":\"recovered-session\"}}" ;;
+    *'"method":"session/prompt"'*) printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"stopReason\":\"end_turn\"}}" ;;
+  esac
+done
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	p := NewGrokBinProvider("grok-4.5-low", map[string]string{
+		"GROK_TEST_FIRST_PID": firstPIDPath,
+		"GROK_TEST_BLOCKED":   blockedPath,
+	})
+	defer p.CleanupMCP()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	stream, err := p.Stream(ctx, Request{Messages: []Message{
+		SystemText(strings.Repeat("large system prompt ", 1<<18)),
+		UserText("wait"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(blockedPath); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("fake Grok process did not reach its blocked session write")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		p.CleanupMCP()
+		close(cleanupDone)
+	}()
+	<-ctx.Done()
+
+	streamDone := make(chan error, 1)
+	go func() { streamDone <- stream.Close() }()
+	select {
+	case err := <-streamDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream close remained blocked behind the Grok ACP session write")
+	}
+	select {
+	case <-cleanupDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Grok cleanup remained blocked behind the startup mutex")
+	}
+
+	next, err := p.Stream(context.Background(), Request{Messages: []Message{UserText("continue")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sawDone := false
+	for {
+		event, err := next.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if event.Type == EventError {
+			t.Fatal(event.Err)
+		}
+		if event.Type == EventDone {
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatal("subsequent Grok turn did not complete")
+	}
+}
+
 func TestGrokBinProviderACPCancellationStopsProcess(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 	binDir := t.TempDir()


### PR DESCRIPTION
## What changed

- Added a handshake-scoped watchdog that closes the Grok ACP process stdin and cancels its process context when startup is canceled or times out.
- Stop the watchdog before returning a successfully initialized, resumed, loaded, or newly created ACP session; if the callback already started, treat startup as failed and clean up the process.
- Added a regression test with a fake Grok process that completes initialize/authentication, then stops reading before a multi-megabyte `session/new` request. The test verifies the blocked stream, provider cleanup, and child process all unwind, then confirms a subsequent turn completes.

## Why this is high-value

ACP checks cancellation only after writing each request. A large durable-session handshake can therefore block forever in the stdin write when the Grok child remains alive but stops reading. Because durable startup holds `acpMu`, the existing deferred process stop cannot run and `CleanupMCP`/server shutdown cannot acquire the mutex to close stdin. This can permanently wedge a Jarvis conversation, leave its active-stream slot occupied, make `Stream.Close` hang, and block service shutdown. The watchdog breaks that cycle without taking the provider mutex while preserving successful handshake behavior.

## Validation

- `go test ./internal/llm -run 'TestGrokBinProviderACPCancellation(UnblocksSessionWrite|DuringInitialize|StopsProcess)$' -count=1`
- `go test ./internal/llm -run TestGrokBinProviderACPCancellationUnblocksSessionWrite -count=3`
- `go test -race ./internal/llm -run TestGrokBinProviderACPCancellationUnblocksSessionWrite -count=1`
- `go build ./...`
- `XDG_CONFIG_HOME=$(mktemp -d) go test ./...`
- `git diff --check`
