### PR TITLE
feat: add provider inference benchmark command

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -1,0 +1,707 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/benchmark"
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/terminalpolicy"
+	"github.com/spf13/cobra"
+)
+
+type benchmarkFlags struct {
+	provider               string
+	mode                   string
+	cache                  string
+	allowUnknownCache      bool
+	inputTokens            string
+	assumeContextLimit     string
+	outputTokens           int
+	runs                   int
+	warmups                int
+	concurrency            int
+	seed                   int64
+	reasoningEffort        string
+	temperature            float32
+	timeout                time.Duration
+	cacheTolerance         float64
+	targetTolerance        float64
+	json                   bool
+	jsonl                  string
+	dryRun                 bool
+	yes                    bool
+	includeManagedProvider bool
+}
+
+type benchmarkTargetPlan struct {
+	target    benchmark.Target
+	scenarios []benchmark.Scenario
+}
+
+func init() {
+	rootCmd.AddCommand(newBenchmarkCommand())
+}
+
+func newBenchmarkCommand() *cobra.Command {
+	flags := benchmarkFlags{}
+	cmd := &cobra.Command{
+		Use:   "benchmark",
+		Short: "Measure client-observed LLM streaming and input-processing performance",
+		Long: `Benchmark provider inference without the agent engine, tools, sessions, or search.
+
+Timings are measured at the llm.Provider/llm.Stream boundary. They include client,
+network, queueing, tokenization, and transport overhead and are not server telemetry.
+Cold-prefix token fits use provider-reported counts; unsupported cache or decode
+metrics remain explicitly unavailable rather than being inferred from stream chunks.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runBenchmark(cmd, flags)
+		},
+	}
+	cmd.Flags().StringVarP(&flags.provider, "provider", "p", "", "Provider, optionally with model; Ollama without a model benchmarks all configured models")
+	if err := cmd.RegisterFlagCompletionFunc("provider", ProviderFlagCompletion); err != nil {
+		panic("failed to register benchmark provider completion: " + err.Error())
+	}
+	cmd.Flags().StringVar(&flags.mode, "mode", "balanced", "Workload mode: balanced, quick, decode, prefill, or long-context")
+	cmd.Flags().StringVar(&flags.cache, "cache", "cold", "Cache workload: cold (warm is reserved for a future separate workload)")
+	cmd.Flags().BoolVar(&flags.allowUnknownCache, "allow-unknown-cache", false, "Allow token fits when the adapter cannot report cache reads (results stay labeled unknown)")
+	cmd.Flags().StringVar(&flags.inputTokens, "input-tokens", "", "Comma-separated input-token targets (supports K/M suffixes)")
+	cmd.Flags().StringVar(&flags.assumeContextLimit, "assume-context-limit", "", "Expert safety override for an unknown local Ollama context limit (supports K/M suffixes; does not configure num_ctx)")
+	cmd.Flags().IntVar(&flags.outputTokens, "output-tokens", 0, "Requested output-token ceiling (0 uses the mode profile)")
+	cmd.Flags().IntVar(&flags.runs, "runs", -1, "Measured runs per scenario (-1 uses the mode profile)")
+	cmd.Flags().IntVar(&flags.warmups, "warmup", -1, "Warmup runs per scenario (-1 uses the mode profile)")
+	cmd.Flags().IntVar(&flags.concurrency, "concurrency", 1, "Concurrent requests (schema version 1 supports only 1)")
+	cmd.Flags().Int64Var(&flags.seed, "seed", 42, "Deterministic workload seed")
+	cmd.Flags().StringVar(&flags.reasoningEffort, "reasoning-effort", "", "Explicit provider reasoning effort")
+	cmd.Flags().Float32Var(&flags.temperature, "temperature", 0, "Explicit sampling temperature (only sent when the adapter supports it)")
+	cmd.Flags().DurationVar(&flags.timeout, "timeout", 10*time.Minute, "Hard timeout per request")
+	cmd.Flags().Float64Var(&flags.cacheTolerance, "cache-tolerance", 0.01, "Maximum cache-read ratio accepted as cold")
+	cmd.Flags().Float64Var(&flags.targetTolerance, "target-tolerance", 0.15, "Maximum relative provider-token deviation from an input target")
+	cmd.Flags().BoolVar(&flags.json, "json", false, "Emit one complete JSON report")
+	cmd.Flags().StringVar(&flags.jsonl, "jsonl", "", "Append each raw request record to this JSONL file as it completes")
+	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", false, "Resolve and list every benchmark target without dispatching inference requests")
+	cmd.Flags().BoolVarP(&flags.yes, "yes", "y", false, "Approve expensive token budgets without prompting")
+	cmd.Flags().BoolVar(&flags.includeManagedProvider, "include-managed-provider", false, "Allow subprocess/CLI providers and label timing subprocess-inclusive")
+	return cmd
+}
+
+func runBenchmark(cmd *cobra.Command, flags benchmarkFlags) error {
+	if flags.cache != "cold" {
+		return fmt.Errorf("benchmark cache mode %q is not implemented; schema version 1 keeps warm-cache workloads separate", flags.cache)
+	}
+	if flags.concurrency != 1 {
+		return fmt.Errorf("benchmark concurrency %d is not implemented; schema version 1 supports only sequential concurrency=1", flags.concurrency)
+	}
+	if flags.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	if flags.cacheTolerance < 0 || flags.cacheTolerance >= 1 {
+		return fmt.Errorf("--cache-tolerance must be in [0, 1)")
+	}
+	if flags.targetTolerance <= 0 || flags.targetTolerance >= 1 {
+		return fmt.Errorf("--target-tolerance must be in (0, 1)")
+	}
+
+	scenarios, profileRuns, profileWarmups, err := benchmark.DefaultProfile(flags.mode)
+	if err != nil {
+		return err
+	}
+	if flags.runs < -1 || flags.warmups < -1 {
+		return fmt.Errorf("--runs and --warmup must be non-negative or -1 for profile defaults")
+	}
+	if flags.runs == -1 {
+		flags.runs = profileRuns
+	}
+	if flags.warmups == -1 {
+		flags.warmups = profileWarmups
+	}
+	if flags.runs < 1 {
+		return fmt.Errorf("--runs must be at least 1")
+	}
+	if flags.inputTokens != "" {
+		inputs, err := parseBenchmarkTokenList(flags.inputTokens)
+		if err != nil {
+			return fmt.Errorf("--input-tokens: %w", err)
+		}
+		output := flags.outputTokens
+		if output == 0 {
+			output = defaultBenchmarkOutput(flags.mode)
+		}
+		scenarios = benchmark.ScenariosForOverride(flags.mode, inputs, output)
+	} else if flags.outputTokens > 0 {
+		for i := range scenarios {
+			scenarios[i].OutputTokens = flags.outputTokens
+		}
+	}
+	if flags.outputTokens < 0 {
+		return fmt.Errorf("--output-tokens must be non-negative")
+	}
+	assumedContextLimit := 0
+	if strings.TrimSpace(flags.assumeContextLimit) != "" {
+		assumedContextLimit, err = parseBenchmarkContextLimit(flags.assumeContextLimit)
+		if err != nil {
+			return fmt.Errorf("--assume-context-limit: %w", err)
+		}
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	plans, skipped, err := resolveBenchmarkTargets(cmd.Context(), cfg, flags.provider, scenarios, flags.mode, flags.inputTokens != "", flags.includeManagedProvider, assumedContextLimit)
+	if err != nil {
+		return err
+	}
+	for _, warning := range skipped {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", warning)
+	}
+	for i := range plans {
+		plan := &plans[i]
+		if plan.target.Error != "" {
+			continue
+		}
+		if flags.reasoningEffort != "" && !plan.target.Capabilities.SupportsReasoningEffort {
+			plan.target.Error = fmt.Sprintf("does not support --reasoning-effort through its benchmark adapter")
+			continue
+		}
+		if cmd.Flags().Changed("temperature") && !plan.target.Capabilities.SupportsTemperature {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s:%s does not support benchmark temperature control; --temperature will not be sent and is null in results\n", plan.target.ProviderKey, plan.target.RequestedModel)
+		}
+	}
+
+	outputNotGuaranteed := false
+	budget := benchmark.Budget{}
+	for _, plan := range plans {
+		if plan.target.Error != "" {
+			continue
+		}
+		if !plan.target.Capabilities.SupportsOutputLimit {
+			outputNotGuaranteed = true
+		}
+		part := benchmark.ComputeBudgetForTarget(plan.target, flags.mode, plan.scenarios, flags.runs, flags.warmups, !plan.target.Capabilities.SupportsOutputLimit)
+		addBenchmarkBudget(&budget, part)
+	}
+	budget.OutputBudgetIsRequested = outputNotGuaranteed
+	budget.CacheWriteBillingRisk = true
+	budget.Notes = []string{
+		"Input totals are maximum requested provider tokens, not billed-token predictions.",
+		"Cache-write tokens count as computed input and may have provider-specific billing.",
+	}
+	budgetWriter := cmd.OutOrStdout()
+	if flags.json {
+		budgetWriter = cmd.ErrOrStderr()
+	}
+	benchmark.WriteBudget(budgetWriter, flags.mode, budget)
+	if flags.dryRun {
+		return writeBenchmarkDryRun(cmd.OutOrStdout(), flags.json, plans, budget)
+	}
+	if benchmarkNeedsApproval(flags.mode, budget) {
+		if err := approveBenchmark(cmd, flags.yes, flags.json); err != nil {
+			return err
+		}
+	}
+
+	var jsonlFile *os.File
+	var jsonlEncoder *json.Encoder
+	if flags.jsonl != "" {
+		jsonlFile, err = openBenchmarkJSONL(flags.jsonl)
+		if err != nil {
+			return err
+		}
+		defer jsonlFile.Close()
+		jsonlEncoder = json.NewEncoder(jsonlFile)
+	}
+
+	opts := benchmark.Options{
+		Mode:                flags.mode,
+		Cache:               flags.cache,
+		Runs:                flags.runs,
+		Warmups:             flags.warmups,
+		Concurrency:         flags.concurrency,
+		Seed:                flags.seed,
+		ReasoningEffort:     flags.reasoningEffort,
+		Temperature:         flags.temperature,
+		TemperatureSet:      cmd.Flags().Changed("temperature"),
+		Timeout:             flags.timeout,
+		CacheTolerance:      flags.cacheTolerance,
+		TargetTolerance:     flags.targetTolerance,
+		AllowUnknownCache:   flags.allowUnknownCache,
+		AssumedContextLimit: assumedContextLimit,
+		TermLLMVersion:      versionString(),
+	}
+	if jsonlEncoder != nil {
+		opts.OnRecord = func(record benchmark.RunRecord) error {
+			return jsonlEncoder.Encode(record)
+		}
+	}
+
+	targets, allRecords, err := executeBenchmarkPlans(cmd.Context(), cfg, plans, opts, flags.includeManagedProvider)
+	if err != nil {
+		return err
+	}
+
+	report := benchmark.NewReport(opts, budget, targets, allRecords)
+	if flags.json {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	}
+	benchmark.WriteHuman(cmd.OutOrStdout(), report)
+	return nil
+}
+
+func openBenchmarkJSONL(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open benchmark JSONL for append: %w", err)
+	}
+	return file, nil
+}
+
+var newBenchmarkProvider = llm.NewProviderByNameNoRetry
+
+func executeBenchmarkPlans(ctx context.Context, cfg *config.Config, plans []benchmarkTargetPlan, opts benchmark.Options, includeManaged bool) ([]benchmark.Target, []benchmark.RunRecord, error) {
+	allRecords := make([]benchmark.RunRecord, 0)
+	targets := make([]benchmark.Target, 0, len(plans))
+	runner := benchmark.Runner{}
+	for _, plan := range plans {
+		target := plan.target
+		if target.Error != "" {
+			targets = append(targets, target)
+			continue
+		}
+
+		provider, err := newBenchmarkProvider(cfg, target.ProviderKey, target.RequestedModel)
+		if err != nil {
+			target.Error = fmt.Sprintf("create provider: %v", err)
+			targets = append(targets, target)
+			continue
+		}
+		target.Provider = provider
+		cleanup := func() {
+			if cleaner, ok := provider.(interface{ CleanupMCP() }); ok {
+				cleaner.CleanupMCP()
+			}
+		}
+		if provider.Capabilities().ManagesOwnContext && !includeManaged {
+			target.Error = "provider manages its own context; use --include-managed-provider for subprocess-inclusive timing"
+			cleanup()
+			targets = append(targets, target)
+			continue
+		}
+
+		targetOpts := opts
+		targetOpts.Scenarios = plan.scenarios
+		records, runErr := runner.RunTarget(ctx, target, targetOpts)
+		allRecords = append(allRecords, records...)
+		cleanup()
+		if runErr != nil {
+			var callbackErr *benchmark.RecordCallbackError
+			if errors.As(runErr, &callbackErr) || ctx.Err() != nil {
+				return targets, allRecords, runErr
+			}
+			target.Error = runErr.Error()
+		}
+		targets = append(targets, target)
+	}
+	return targets, allRecords, nil
+}
+
+func resolveBenchmarkTargets(ctx context.Context, cfg *config.Config, providerFlag string, scenarios []benchmark.Scenario, mode string, explicitInputs, includeManaged bool, assumedContextLimit int) ([]benchmarkTargetPlan, []string, error) {
+	providerKey := cfg.DefaultProvider
+	model := ""
+	if providerFlag != "" {
+		var err error
+		providerKey, model, err = llm.ParseProviderModel(providerFlag, cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	providerCfg, configured := cfg.Providers[providerKey]
+	providerType := config.InferProviderType(providerKey, providerCfg.Type)
+	localOllama := benchmarkUsesLocalOllama(providerKey, providerType)
+	if assumedContextLimit > 0 && !localOllama {
+		return nil, nil, fmt.Errorf("--assume-context-limit is only supported for local Ollama providers (native or OpenAI-compatible Ollama)")
+	}
+	capabilities, ok := benchmarkAdapterCapabilities(providerType, localOllama)
+	if !ok {
+		return nil, nil, fmt.Errorf("provider %q (type %s) is not supported by benchmark schema version 1; supported adapters: local Ollama (native or OpenAI-compatible), chatgpt, claude-bin", providerKey, providerType)
+	}
+	if capabilities.ManagedContext && !includeManaged {
+		return nil, nil, fmt.Errorf("provider %q manages its own context; use --include-managed-provider to opt into subprocess-inclusive timing", providerKey)
+	}
+	if providerType == config.ProviderTypeChatGPT && strings.EqualFold(model, "luna") {
+		model = "gpt-5.6-luna"
+	}
+
+	models := []string{model}
+	modelInfoByID := make(map[string]llm.ModelInfo)
+	if model == "" && localOllama {
+		listed, err := listBenchmarkModels(ctx, cfg, providerKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list local Ollama models for %q: %w", providerKey, err)
+		}
+		models = models[:0]
+		for _, info := range listed {
+			id := strings.TrimSpace(info.ID)
+			if id == "" {
+				continue
+			}
+			models = append(models, id)
+			modelInfoByID[id] = info
+		}
+		if len(models) == 0 {
+			return nil, nil, fmt.Errorf("local Ollama provider %q returned no installed models", providerKey)
+		}
+	}
+	if len(models) == 0 || (len(models) == 1 && strings.TrimSpace(models[0]) == "") {
+		fallback := strings.TrimSpace(providerCfg.Model)
+		if fallback == "" {
+			fallback = config.DefaultProviderModel(string(providerType))
+		}
+		models = []string{fallback}
+	}
+	models = uniqueNonEmpty(models)
+	if len(models) == 0 {
+		if configured {
+			return nil, nil, fmt.Errorf("provider %q has no configured model", providerKey)
+		}
+		return nil, nil, fmt.Errorf("provider %q requires an explicit model", providerKey)
+	}
+
+	var plans []benchmarkTargetPlan
+	var skipped []string
+	if assumedContextLimit > 0 {
+		skipped = append(skipped, benchmark.AssumedContextLimitLimitation(assumedContextLimit))
+	}
+	for _, selectedModel := range models {
+		selectedModel = config.UpstreamModelForProviderModel(cfg, providerKey, selectedModel)
+		inputLimit := llm.InputLimitForProviderModel(providerKey, selectedModel)
+		if info := modelInfoByID[selectedModel]; info.InputLimit > 0 {
+			inputLimit = info.InputLimit
+		}
+		configuredContext := providerCfg.ContextWindow
+		if modelConfig, ok := config.ModelConfigForProviderModel(cfg, providerKey, selectedModel); ok && modelConfig.ContextWindow > 0 {
+			configuredContext = modelConfig.ContextWindow
+			inputLimit = modelConfig.ContextWindow
+			if modelConfig.MaxOutputTokens > 0 && modelConfig.MaxOutputTokens < modelConfig.ContextWindow {
+				inputLimit = modelConfig.ContextWindow - modelConfig.MaxOutputTokens
+			}
+		}
+		if providerCfg.NumCtx != nil && *providerCfg.NumCtx > 0 {
+			configuredContext = *providerCfg.NumCtx
+		}
+		effectiveOllamaContext := configuredContext
+		contextLimitSource := "configured Ollama context"
+		if assumedContextLimit > 0 && (effectiveOllamaContext == 0 || assumedContextLimit < effectiveOllamaContext) {
+			effectiveOllamaContext = assumedContextLimit
+			contextLimitSource = "assumed Ollama context limit"
+		}
+		filtered := make([]benchmark.Scenario, 0, len(scenarios))
+		for _, scenario := range scenarios {
+			if capabilities.MinimumOutputTokens > 0 && scenario.OutputTokens < capabilities.MinimumOutputTokens {
+				skipped = append(skipped, fmt.Sprintf("raising %s:%s output ceiling from %d to provider-safe minimum %d", providerKey, selectedModel, scenario.OutputTokens, capabilities.MinimumOutputTokens))
+				scenario.OutputTokens = capabilities.MinimumOutputTokens
+			}
+			if inputLimit > 0 && scenario.InputTokens+512 > inputLimit {
+				skipped = append(skipped, fmt.Sprintf("skipping %s:%s target %d above conservative effective input limit %d", providerKey, selectedModel, scenario.InputTokens, inputLimit))
+				continue
+			}
+			if localOllama && effectiveOllamaContext > 0 && scenario.InputTokens+scenario.OutputTokens+512 > effectiveOllamaContext {
+				skipped = append(skipped, fmt.Sprintf("skipping %s:%s target %d because input + output/template headroom exceeds %s %d", providerKey, selectedModel, scenario.InputTokens, contextLimitSource, effectiveOllamaContext))
+				continue
+			}
+			if localOllama && effectiveOllamaContext == 0 && scenario.InputTokens+scenario.OutputTokens+512 > 4_096 {
+				skipped = append(skipped, fmt.Sprintf("skipping %s:%s target %d because Ollama context is not configured; only requests fitting the conservative 4096-token floor are safe", providerKey, selectedModel, scenario.InputTokens))
+				continue
+			}
+			filtered = append(filtered, scenario)
+		}
+		targetCapabilities := capabilities
+		reasoningExpected := providerType == config.ProviderTypeChatGPT || strings.HasSuffix(strings.ToLower(selectedModel), "-think")
+		if providerType == config.ProviderTypeClaudeBin {
+			_, modelEffort := llm.BaseModelAndEffortForProvider(string(providerType), selectedModel)
+			reasoningExpected = modelEffort != ""
+			targetCapabilities.SupportsReasoningEffort = len(llm.ReasoningEffortsForProviderModel(string(providerType), selectedModel)) > 0
+		}
+		if providerCfg.Think != nil && *providerCfg.Think {
+			reasoningExpected = true
+		}
+		reportedNumCtx := 0
+		if localOllama {
+			reportedNumCtx = configuredContext
+		}
+		target := benchmark.Target{
+			ProviderKey:         providerKey,
+			ProviderType:        string(providerType),
+			RequestedModel:      selectedModel,
+			Capabilities:        targetCapabilities,
+			InputLimit:          inputLimit,
+			ConfiguredNumCtx:    reportedNumCtx,
+			AssumedContextLimit: assumedContextLimit,
+			ServiceTier:         providerCfg.ServiceTier,
+			ReasoningExpected:   reasoningExpected,
+		}
+		if len(filtered) == 0 {
+			target.Error = "no benchmark input targets fit the model/context limits"
+		}
+		if target.Error == "" && mode == "long-context" && inputLimit == 0 && effectiveOllamaContext == 0 && !explicitInputs {
+			target.Error = "long-context benchmark requires a known input limit or explicit --input-tokens"
+		}
+		plans = append(plans, benchmarkTargetPlan{target: target, scenarios: filtered})
+	}
+	return plans, skipped, nil
+}
+
+func benchmarkUsesLocalOllama(providerKey string, providerType config.ProviderType) bool {
+	return providerType == config.ProviderTypeOllama ||
+		(strings.EqualFold(strings.TrimSpace(providerKey), "ollama") &&
+			(providerType == config.ProviderTypeOpenAICompat || providerType == config.ProviderTypeVLLM))
+}
+
+func listBenchmarkModels(ctx context.Context, cfg *config.Config, providerKey string) ([]llm.ModelInfo, error) {
+	provider, err := newBenchmarkProvider(cfg, providerKey, "")
+	if err != nil {
+		return nil, err
+	}
+	if cleaner, ok := provider.(interface{ CleanupMCP() }); ok {
+		defer cleaner.CleanupMCP()
+	}
+	lister, ok := provider.(interface {
+		ListModels(context.Context) ([]llm.ModelInfo, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("adapter %T cannot list models", provider)
+	}
+	return lister.ListModels(ctx)
+}
+
+func writeBenchmarkDryRun(w io.Writer, jsonOutput bool, plans []benchmarkTargetPlan, budget benchmark.Budget) error {
+	type dryRunTarget struct {
+		Provider            string               `json:"provider"`
+		Model               string               `json:"model"`
+		AssumedContextLimit int                  `json:"assumed_context_limit,omitempty"`
+		Scenarios           []benchmark.Scenario `json:"scenarios,omitempty"`
+		Error               string               `json:"error,omitempty"`
+	}
+	targets := make([]dryRunTarget, 0, len(plans))
+	assumedContextLimit := 0
+	for _, plan := range plans {
+		targets = append(targets, dryRunTarget{
+			Provider:            plan.target.ProviderKey,
+			Model:               plan.target.RequestedModel,
+			AssumedContextLimit: plan.target.AssumedContextLimit,
+			Scenarios:           plan.scenarios,
+			Error:               plan.target.Error,
+		})
+		if plan.target.AssumedContextLimit > 0 {
+			assumedContextLimit = plan.target.AssumedContextLimit
+		}
+	}
+	limitations := []string(nil)
+	if assumedContextLimit > 0 {
+		limitations = append(limitations, benchmark.AssumedContextLimitLimitation(assumedContextLimit))
+	}
+	if jsonOutput {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(struct {
+			DryRun              bool             `json:"dry_run"`
+			AssumedContextLimit int              `json:"assumed_context_limit,omitempty"`
+			Budget              benchmark.Budget `json:"budget"`
+			Targets             []dryRunTarget   `json:"targets"`
+			Limitations         []string         `json:"limitations,omitempty"`
+		}{DryRun: true, AssumedContextLimit: assumedContextLimit, Budget: budget, Targets: targets, Limitations: limitations})
+	}
+	if assumedContextLimit > 0 {
+		fmt.Fprintf(w, "\nWARNING: %s\n", benchmark.AssumedContextLimitLimitation(assumedContextLimit))
+	}
+	fmt.Fprintf(w, "\nResolved benchmark targets (%d; no inference dispatched):\n", len(targets))
+	for _, target := range targets {
+		if target.Error != "" {
+			fmt.Fprintf(w, "  %s:%s — unavailable: %s\n", target.Provider, target.Model, target.Error)
+			continue
+		}
+		fmt.Fprintf(w, "  %s:%s (%d scenarios)\n", target.Provider, target.Model, len(target.Scenarios))
+	}
+	return nil
+}
+
+func benchmarkAdapterCapabilities(providerType config.ProviderType, localOllama bool) (benchmark.AdapterCapabilities, bool) {
+	if localOllama {
+		return benchmark.AdapterCapabilities{
+			ReportsCacheReads:       false,
+			ReportsCacheWrites:      false,
+			ReportsReasoningTokens:  false,
+			SupportsOutputLimit:     true,
+			SupportsTemperature:     true,
+			SupportsReasoningEffort: false,
+			MinimumOutputTokens:     1,
+			IncrementalStream:       true,
+			MeasurementScope:        "direct_http",
+			CacheTelemetryNote:      "Ollama prompt token counts do not distinguish cache reads; state remains unknown",
+			OutputLimitSupportNote:  "Ollama num_predict or OpenAI-compatible max_tokens",
+		}, true
+	}
+	switch providerType {
+	case config.ProviderTypeChatGPT:
+		return benchmark.AdapterCapabilities{
+			ReportsCacheReads:       true,
+			ReportsCacheWrites:      true,
+			ReportsReasoningTokens:  true,
+			SupportsOutputLimit:     false,
+			SupportsTemperature:     false,
+			SupportsReasoningEffort: true,
+			MinimumOutputTokens:     1,
+			IncrementalStream:       true,
+			MeasurementScope:        "direct_api",
+			CacheTelemetryNote:      "Responses input_tokens_details.cached_tokens",
+			OutputLimitSupportNote:  "ChatGPT backend route rejects max_output_tokens; benchmark requests one bounded natural completion with an explicit end marker",
+		}, true
+	case config.ProviderTypeClaudeBin:
+		return benchmark.AdapterCapabilities{
+			ReportsCacheReads:       false,
+			ReportsCacheWrites:      true,
+			ReportsReasoningTokens:  false,
+			SupportsOutputLimit:     false,
+			SupportsTemperature:     false,
+			SupportsReasoningEffort: true,
+			MinimumOutputTokens:     16,
+			IncrementalStream:       false,
+			ManagedContext:          true,
+			MeasurementScope:        "subprocess_inclusive",
+			CacheTelemetryNote:      "CLI-backed usage is not treated as trustworthy cache-state telemetry",
+			OutputLimitSupportNote:  "claude-bin does not map Request.MaxOutputTokens to the CLI; benchmark requests one bounded natural completion with an explicit end marker",
+		}, true
+	default:
+		return benchmark.AdapterCapabilities{}, false
+	}
+}
+
+func parseBenchmarkContextLimit(value string) (int, error) {
+	if strings.Contains(value, ",") {
+		return 0, fmt.Errorf("must be one token count")
+	}
+	values, err := parseBenchmarkTokenList(value)
+	if err != nil {
+		return 0, err
+	}
+	if len(values) != 1 {
+		return 0, fmt.Errorf("must be one token count")
+	}
+	return values[0], nil
+}
+
+func parseBenchmarkTokenList(value string) ([]int, error) {
+	seen := make(map[int]bool)
+	var result []int
+	for _, raw := range strings.Split(value, ",") {
+		raw = strings.TrimSpace(strings.ReplaceAll(raw, "_", ""))
+		if raw == "" {
+			return nil, fmt.Errorf("empty token target")
+		}
+		multiplier := float64(1)
+		suffix := raw[len(raw)-1]
+		if suffix == 'k' || suffix == 'K' {
+			multiplier = 1_000
+			raw = raw[:len(raw)-1]
+		} else if suffix == 'm' || suffix == 'M' {
+			multiplier = 1_000_000
+			raw = raw[:len(raw)-1]
+		}
+		number, err := strconv.ParseFloat(raw, 64)
+		if err != nil || number <= 0 {
+			return nil, fmt.Errorf("invalid token target %q", raw)
+		}
+		tokens := int(number * multiplier)
+		if tokens < 32 {
+			return nil, fmt.Errorf("token target %d is too small (minimum 32)", tokens)
+		}
+		if !seen[tokens] {
+			seen[tokens] = true
+			result = append(result, tokens)
+		}
+	}
+	sort.Ints(result)
+	return result, nil
+}
+
+func defaultBenchmarkOutput(mode string) int {
+	switch mode {
+	case "quick":
+		return 128
+	case "decode":
+		return 256
+	default:
+		return 16
+	}
+}
+
+func uniqueNonEmpty(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func addBenchmarkBudget(total *benchmark.Budget, part benchmark.Budget) {
+	total.MaximumRequests += part.MaximumRequests
+	total.MaximumTotalInput += part.MaximumTotalInput
+	total.MaximumTotalOutput += part.MaximumTotalOutput
+	total.MaximumRequestInput = max(total.MaximumRequestInput, part.MaximumRequestInput)
+	total.MaximumRequestOutput = max(total.MaximumRequestOutput, part.MaximumRequestOutput)
+	total.IncludesCalibration = total.IncludesCalibration || part.IncludesCalibration
+	total.IncludesWarmups = total.IncludesWarmups || part.IncludesWarmups
+	total.IncludesRetryAllowance = total.IncludesRetryAllowance || part.IncludesRetryAllowance
+	total.CacheWriteBillingRisk = total.CacheWriteBillingRisk || part.CacheWriteBillingRisk
+}
+
+func benchmarkNeedsApproval(mode string, budget benchmark.Budget) bool {
+	return mode == "balanced" || mode == "prefill" || mode == "long-context" || budget.MaximumTotalInput > 250_000
+}
+
+func benchmarkInteractive(in io.Reader, out io.Writer) bool {
+	input, inputOK := in.(*os.File)
+	output, outputOK := out.(*os.File)
+	return inputOK && outputOK && terminalpolicy.Interactive(input, output)
+}
+
+func approveBenchmark(cmd *cobra.Command, yes, jsonOutput bool) error {
+	if yes {
+		return nil
+	}
+	out := cmd.OutOrStdout()
+	if jsonOutput {
+		out = cmd.ErrOrStderr()
+	}
+	if !benchmarkInteractive(cmd.InOrStdin(), out) {
+		return fmt.Errorf("benchmark token budget requires explicit approval in non-interactive mode; use --yes")
+	}
+	fmt.Fprint(out, "Run this benchmark token budget? Type 'yes' to continue: ")
+	response, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("read benchmark approval: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(response), "yes") {
+		return fmt.Errorf("benchmark cancelled")
+	}
+	return nil
+}

--- a/cmd/benchmark_test.go
+++ b/cmd/benchmark_test.go
@@ -1,0 +1,356 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/benchmark"
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func TestResolveBenchmarkTargetsAllActualOllamaModelsFromOpenAICompatibleConfig(t *testing.T) {
+	actualModels := []string{"qwen:7b", "gemma:latest", "local/third:Q4"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		models := make([]map[string]string, 0, len(actualModels))
+		for _, model := range actualModels {
+			models = append(models, map[string]string{"id": model})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": models})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		DefaultProvider: "ollama",
+		Providers: map[string]config.ProviderConfig{
+			"ollama": {
+				Type:    config.ProviderTypeOpenAICompat,
+				BaseURL: server.URL + "/v1",
+				Model:   "configured-but-not-exclusive",
+			},
+		},
+	}
+	scenarios := []benchmark.Scenario{{InputTokens: 2_000, OutputTokens: 128, Workload: "decode"}}
+	plans, skipped, err := resolveBenchmarkTargets(context.Background(), cfg, "ollama", scenarios, "quick", false, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 0 || len(plans) != len(actualModels) {
+		t.Fatalf("plans=%#v skipped=%v", plans, skipped)
+	}
+	for i, model := range actualModels {
+		if plans[i].target.RequestedModel != model {
+			t.Fatalf("model %d = %q, want %q", i, plans[i].target.RequestedModel, model)
+		}
+		if plans[i].target.ProviderType != string(config.ProviderTypeOpenAICompat) || plans[i].target.Capabilities.ReportsCacheReads || plans[i].target.Capabilities.MeasurementScope != "direct_http" {
+			t.Fatalf("Ollama target = %#v", plans[i].target)
+		}
+	}
+}
+
+func TestResolveBenchmarkTargetsAliasesAndManagedOptIn(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
+	scenarios := []benchmark.Scenario{{InputTokens: 2_000, OutputTokens: 128, Workload: "decode"}}
+	plans, _, err := resolveBenchmarkTargets(context.Background(), cfg, "chatgpt:luna", scenarios, "quick", false, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].target.RequestedModel != "gpt-5.6-luna" || !plans[0].target.Capabilities.ReportsCacheReads || plans[0].target.Capabilities.SupportsOutputLimit {
+		t.Fatalf("ChatGPT plans = %#v", plans)
+	}
+	if _, _, err := resolveBenchmarkTargets(context.Background(), cfg, "claude-bin:haiku", scenarios, "quick", false, false, 0); err == nil || !strings.Contains(err.Error(), "--include-managed-provider") {
+		t.Fatalf("managed provider error = %v", err)
+	}
+	plans, _, err = resolveBenchmarkTargets(context.Background(), cfg, "claude-bin:haiku", scenarios, "quick", false, true, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plans[0].target.Capabilities.ManagedContext || plans[0].target.Capabilities.IncrementalStream || plans[0].target.Capabilities.SupportsOutputLimit || plans[0].target.Capabilities.SupportsReasoningEffort || plans[0].target.ReasoningExpected {
+		t.Fatalf("Claude Haiku target = %#v", plans[0].target)
+	}
+	plans, _, err = resolveBenchmarkTargets(context.Background(), cfg, "claude-bin:sonnet-high", scenarios, "quick", false, true, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || !plans[0].target.Capabilities.SupportsReasoningEffort || !plans[0].target.ReasoningExpected {
+		t.Fatalf("Claude reasoning-effort target = %#v", plans)
+	}
+}
+
+func TestResolveBenchmarkTargetsRequiresOllamaLongContextNumCtx(t *testing.T) {
+	numCtx := 64_000
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"ollama": {Type: config.ProviderTypeOllama, Model: "local-model", NumCtx: &numCtx},
+	}}
+	scenarios := []benchmark.Scenario{{InputTokens: 96_000, OutputTokens: 16, Workload: "prefill"}}
+	plans, _, err := resolveBenchmarkTargets(context.Background(), cfg, "ollama:local-model", scenarios, "long-context", true, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].target.Error == "" || !strings.Contains(plans[0].target.Error, "context") {
+		t.Fatalf("long-context plans = %#v", plans)
+	}
+}
+
+func TestResolveBenchmarkTargetsUsesAssumedOllamaContextLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		providerKey  string
+		providerType config.ProviderType
+	}{
+		{name: "native", providerKey: "local", providerType: config.ProviderTypeOllama},
+		{name: "openai compatible", providerKey: "ollama", providerType: config.ProviderTypeOpenAICompat},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+				tc.providerKey: {Type: tc.providerType, Model: "local-model"},
+			}}
+			const assumedLimit = 64_528
+			scenarios := []benchmark.Scenario{
+				{InputTokens: 16_000, OutputTokens: 16, Workload: "prefill"},
+				{InputTokens: 64_000, OutputTokens: 16, Workload: "prefill"},
+				{InputTokens: 64_001, OutputTokens: 16, Workload: "prefill"},
+			}
+			plans, warnings, err := resolveBenchmarkTargets(context.Background(), cfg, tc.providerKey+":local-model", scenarios, "long-context", false, false, assumedLimit)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(plans) != 1 || plans[0].target.Error != "" || len(plans[0].scenarios) != 2 {
+				t.Fatalf("plans = %#v", plans)
+			}
+			if plans[0].scenarios[1].InputTokens != 64_000 {
+				t.Fatalf("boundary scenario was not retained: %#v", plans[0].scenarios)
+			}
+			if plans[0].target.AssumedContextLimit != assumedLimit || plans[0].target.ConfiguredNumCtx != 0 {
+				t.Fatalf("target context metadata = %#v", plans[0].target)
+			}
+			warningText := strings.Join(warnings, " ")
+			if !strings.Contains(warningText, "EXPERT OVERRIDE") || !strings.Contains(warningText, "num_ctx") || !strings.Contains(warningText, "64001") {
+				t.Fatalf("warnings = %v", warnings)
+			}
+		})
+	}
+}
+
+func TestResolveBenchmarkTargetsRejectsAssumedLimitForNonOllama(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
+	scenarios := []benchmark.Scenario{{InputTokens: 2_000, OutputTokens: 16, Workload: "prefill"}}
+	_, _, err := resolveBenchmarkTargets(context.Background(), cfg, "chatgpt:luna", scenarios, "prefill", true, false, 64_000)
+	if err == nil || !strings.Contains(err.Error(), "only supported for local Ollama") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestParseBenchmarkTokenList(t *testing.T) {
+	got, err := parseBenchmarkTokenList("1K, 4_000, 0.096M, 4K")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []int{1_000, 4_000, 96_000}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestParseBenchmarkContextLimit(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  int
+	}{
+		{value: "64K", want: 64_000},
+		{value: "0.5M", want: 500_000},
+		{value: "1_000_000", want: 1_000_000},
+	} {
+		got, err := parseBenchmarkContextLimit(tc.value)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.value, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parse %q = %d, want %d", tc.value, got, tc.want)
+		}
+	}
+	for _, value := range []string{"", "0", "64G", "64K,128K"} {
+		if _, err := parseBenchmarkContextLimit(value); err == nil {
+			t.Fatalf("parse %q unexpectedly succeeded", value)
+		}
+	}
+}
+
+func TestApproveBenchmarkRequiresYesNonInteractive(t *testing.T) {
+	cmd := newBenchmarkCommand()
+	cmd.SetIn(bytes.NewBufferString("yes\n"))
+	cmd.SetOut(&bytes.Buffer{})
+	if err := approveBenchmark(cmd, false, false); err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("approval error = %v", err)
+	}
+	if err := approveBenchmark(cmd, true, false); err != nil {
+		t.Fatalf("--yes approval = %v", err)
+	}
+}
+
+func TestBenchmarkBudgetDisclosesCalibrationValidationWarmupAndRetry(t *testing.T) {
+	budget := benchmark.ComputeBudget(2, []benchmark.Scenario{{InputTokens: 2_000, OutputTokens: 128}}, 3, 1, false)
+	// Per target: 2 calibration/validation + 1 warmup + (3 measured * 2 attempts) = 9.
+	if budget.MaximumRequests != 18 || budget.MaximumTotalInput != 36_000 || budget.MaximumTotalOutput != 2_304 {
+		t.Fatalf("budget = %#v", budget)
+	}
+}
+
+func TestResolveBenchmarkTargetsMarksChatGPTOutputLimitUnsupported(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
+	scenarios := []benchmark.Scenario{{InputTokens: 2_000, OutputTokens: 16, Workload: "prefill"}}
+	plans, warnings, err := resolveBenchmarkTargets(context.Background(), cfg, "chatgpt:luna", scenarios, "prefill", true, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].scenarios[0].OutputTokens != 16 || plans[0].target.Capabilities.SupportsOutputLimit {
+		t.Fatalf("plans = %#v", plans)
+	}
+	if strings.Contains(strings.Join(warnings, " "), "provider-safe minimum") {
+		t.Fatalf("unsupported output limit unexpectedly raised the requested output: %v", warnings)
+	}
+}
+
+func TestResolveBenchmarkTargetsUsesConfiguredUpstreamModelAlias(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"custom": {
+			Type:  config.ProviderTypeOllama,
+			Model: "friendly-high",
+			ModelConfigs: []config.ProviderModelConfig{{
+				ID: "upstream/model", Alias: "friendly", ReasoningEfforts: []string{"high"},
+			}},
+		},
+	}}
+	scenarios := []benchmark.Scenario{{InputTokens: 1_000, OutputTokens: 16, Workload: "prefill"}}
+	plans, _, err := resolveBenchmarkTargets(context.Background(), cfg, "custom:friendly-high", scenarios, "prefill", true, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].target.RequestedModel != "upstream/model-high" {
+		t.Fatalf("plans = %#v", plans)
+	}
+}
+
+func TestExecuteBenchmarkPlansContinuesAndRendersPerModelFailure(t *testing.T) {
+	originalFactory := newBenchmarkProvider
+	defer func() { newBenchmarkProvider = originalFactory }()
+	newBenchmarkProvider = func(_ *config.Config, _ string, model string) (llm.Provider, error) {
+		return &benchmarkCommandProvider{model: model, fail: model == "broken"}, nil
+	}
+	capabilities := benchmark.AdapterCapabilities{ReportsCacheReads: true, SupportsOutputLimit: true}
+	plans := []benchmarkTargetPlan{
+		{target: benchmark.Target{ProviderKey: "p", ProviderType: "test", RequestedModel: "broken", Capabilities: capabilities}, scenarios: []benchmark.Scenario{{InputTokens: 100, OutputTokens: 1, Workload: "prefill"}}},
+		{target: benchmark.Target{ProviderKey: "p", ProviderType: "test", RequestedModel: "working", Capabilities: capabilities}, scenarios: []benchmark.Scenario{{InputTokens: 100, OutputTokens: 1, Workload: "prefill"}}},
+	}
+	opts := benchmark.Options{Mode: "prefill", Cache: "cold", Runs: 1, Timeout: time.Second, CacheTolerance: 0.01, TargetTolerance: 0.15}
+	targets, records, err := executeBenchmarkPlans(context.Background(), &config.Config{}, plans, opts, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 2 || targets[0].Error == "" || targets[1].Error != "" {
+		t.Fatalf("targets = %#v", targets)
+	}
+	if len(records) != 4 {
+		t.Fatalf("records = %#v", records)
+	}
+	report := benchmark.NewReport(opts, benchmark.Budget{}, targets, records)
+	var out bytes.Buffer
+	benchmark.WriteHuman(&out, report)
+	if !strings.Contains(out.String(), "Status: failed") || !strings.Contains(out.String(), "working") || !strings.Contains(out.String(), "Workload") || !strings.Contains(out.String(), "prefill") {
+		t.Fatalf("human report = %s", out.String())
+	}
+}
+
+func TestWriteBenchmarkDryRunJSONIsSingleCleanDocument(t *testing.T) {
+	plans := []benchmarkTargetPlan{{target: benchmark.Target{ProviderKey: "ollama", RequestedModel: "model", AssumedContextLimit: 64_000}, scenarios: []benchmark.Scenario{{InputTokens: 100, OutputTokens: 1}}}}
+	var out bytes.Buffer
+	if err := writeBenchmarkDryRun(&out, true, plans, benchmark.Budget{MaximumRequests: 3}); err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not one JSON document: %v\n%s", err, out.String())
+	}
+	if decoded["dry_run"] != true || decoded["assumed_context_limit"] != float64(64_000) {
+		t.Fatalf("decoded = %#v", decoded)
+	}
+	limitations, ok := decoded["limitations"].([]any)
+	if !ok || len(limitations) != 1 || !strings.Contains(limitations[0].(string), "num_ctx") {
+		t.Fatalf("limitations = %#v", decoded["limitations"])
+	}
+}
+
+func TestOpenBenchmarkJSONLAppends(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runs.jsonl")
+	if err := os.WriteFile(path, []byte("first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := openBenchmarkJSONL(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(file, "second\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "first\nsecond\n" {
+		t.Fatalf("JSONL = %q", got)
+	}
+}
+
+type benchmarkCommandProvider struct {
+	model string
+	fail  bool
+}
+
+func (p *benchmarkCommandProvider) Name() string                   { return p.model }
+func (p *benchmarkCommandProvider) Credential() string             { return "mock" }
+func (p *benchmarkCommandProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+func (p *benchmarkCommandProvider) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	if p.fail {
+		return nil, fmt.Errorf("model unavailable")
+	}
+	return &benchmarkCommandStream{events: []llm.Event{
+		{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 1}},
+		{Type: llm.EventDone},
+	}}, nil
+}
+
+type benchmarkCommandStream struct {
+	events []llm.Event
+	next   int
+}
+
+func (s *benchmarkCommandStream) Recv() (llm.Event, error) {
+	if s.next >= len(s.events) {
+		return llm.Event{}, io.EOF
+	}
+	event := s.events[s.next]
+	s.next++
+	return event, nil
+}
+func (*benchmarkCommandStream) Close() error { return nil }

--- a/internal/benchmark/aggregate.go
+++ b/internal/benchmark/aggregate.go
@@ -1,0 +1,323 @@
+package benchmark
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+type aggregateKey struct {
+	provider string
+	model    string
+	workload string
+	input    int
+	output   int
+}
+
+type runKey struct {
+	aggregateKey
+	run int
+}
+
+func AggregateRuns(records []RunRecord) []Aggregate {
+	latest := latestMeasuredAttempts(records)
+	groups := make(map[aggregateKey][]RunRecord)
+	for _, record := range latest {
+		key := aggregateKey{record.Provider, record.RequestedModel, record.Workload, record.RequestedInput, record.RequestedOutput}
+		groups[key] = append(groups[key], record)
+	}
+
+	out := make([]Aggregate, 0, len(groups))
+	for key, runs := range groups {
+		aggregate := Aggregate{
+			Provider:        key.provider,
+			RequestedModel:  key.model,
+			Workload:        key.workload,
+			RequestedInput:  key.input,
+			RequestedOutput: key.output,
+			MeasuredRuns:    len(runs),
+			CacheState:      aggregateCacheState(runs),
+		}
+		var (
+			total, computed, cached, writes, outputs []float64
+			activity, visible, e2e                   []float64
+			decode, visibleDecode, tpot, rate        []float64
+		)
+		for _, run := range runs {
+			if run.Success {
+				aggregate.SuccessfulRuns++
+			} else {
+				aggregate.ErrorRuns++
+			}
+			if run.LatencyEligible {
+				aggregate.LatencyValidRuns++
+				if run.UsageReceived {
+					total = append(total, float64(run.Usage.TotalInputTokens))
+					outputs = append(outputs, float64(run.Usage.OutputTokens))
+				}
+				appendMetric(&activity, run.Timing.ActivityTTFTMS)
+				appendMetric(&visible, run.Timing.VisibleTTFTMS)
+				appendMetric(&e2e, run.Timing.EndToEndMS)
+				if run.Timing.DecodeTokensPerSec != nil || run.Timing.VisibleTokensPerSec != nil {
+					aggregate.DecodeValidRuns++
+				}
+				appendMetric(&decode, run.Timing.DecodeTokensPerSec)
+				appendMetric(&visibleDecode, run.Timing.VisibleTokensPerSec)
+				appendMetric(&tpot, run.Timing.TPOTMS)
+			}
+			if run.FitEligible {
+				aggregate.FitValidRuns++
+				computed = append(computed, float64(run.Usage.ComputedInputTokens))
+				if run.Usage.CachedInputTokens != nil {
+					cached = append(cached, float64(*run.Usage.CachedInputTokens))
+				}
+				if run.Usage.CacheWriteTokens != nil {
+					writes = append(writes, float64(*run.Usage.CacheWriteTokens))
+				}
+				if run.Timing.ActivityTTFTMS != nil && *run.Timing.ActivityTTFTMS > 0 {
+					rate = append(rate, float64(run.Usage.ComputedInputTokens)/(*run.Timing.ActivityTTFTMS/1000))
+				}
+			}
+		}
+		aggregate.TotalInputTokens = medianPtr(total)
+		aggregate.ComputedInputTokens = medianPtr(computed)
+		aggregate.CachedInputTokens = medianPtr(cached)
+		aggregate.CacheWriteTokens = medianPtr(writes)
+		aggregate.OutputTokens = medianPtr(outputs)
+		aggregate.ActivityTTFTMS = summarize(activity)
+		aggregate.VisibleTTFTMS = summarize(visible)
+		aggregate.EndToEndMS = summarize(e2e)
+		aggregate.DecodeTokensPerSecond = summarize(decode)
+		aggregate.VisibleTokensPerSecond = summarize(visibleDecode)
+		aggregate.TPOTMS = summarize(tpot)
+		aggregate.EffectiveInputTokensRate = summarize(rate)
+		out = append(out, aggregate)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		if out[i].RequestedModel != out[j].RequestedModel {
+			return out[i].RequestedModel < out[j].RequestedModel
+		}
+		if out[i].RequestedInput != out[j].RequestedInput {
+			return out[i].RequestedInput < out[j].RequestedInput
+		}
+		return out[i].Workload < out[j].Workload
+	})
+	return out
+}
+
+func latestMeasuredAttempts(records []RunRecord) []RunRecord {
+	latest := make(map[runKey]RunRecord)
+	for _, record := range records {
+		if record.Phase != "measured" {
+			continue
+		}
+		key := runKey{
+			aggregateKey: aggregateKey{record.Provider, record.RequestedModel, record.Workload, record.RequestedInput, record.RequestedOutput},
+			run:          record.Run,
+		}
+		if previous, ok := latest[key]; !ok || record.Attempt > previous.Attempt || (record.Attempt == previous.Attempt && record.Order > previous.Order) {
+			latest[key] = record
+		}
+	}
+	out := make([]RunRecord, 0, len(latest))
+	for _, record := range latest {
+		out = append(out, record)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		if out[i].RequestedModel != out[j].RequestedModel {
+			return out[i].RequestedModel < out[j].RequestedModel
+		}
+		if out[i].RequestedInput != out[j].RequestedInput {
+			return out[i].RequestedInput < out[j].RequestedInput
+		}
+		if out[i].Workload != out[j].Workload {
+			return out[i].Workload < out[j].Workload
+		}
+		return out[i].Run < out[j].Run
+	})
+	return out
+}
+
+func ComputeFits(records []RunRecord) []Fit {
+	type point struct {
+		input     float64
+		ttftSecs  float64
+		validRuns int
+	}
+	type modelKey struct{ provider, model string }
+	byTarget := make(map[aggregateKey][]RunRecord)
+	for _, record := range latestMeasuredAttempts(records) {
+		if record.Workload != "prefill" || !record.FitEligible || record.Timing.ActivityTTFTMS == nil {
+			continue
+		}
+		key := aggregateKey{record.Provider, record.RequestedModel, record.Workload, record.RequestedInput, record.RequestedOutput}
+		byTarget[key] = append(byTarget[key], record)
+	}
+	models := make(map[modelKey][]point)
+	for key, runs := range byTarget {
+		var inputs, ttfts []float64
+		for _, run := range runs {
+			inputs = append(inputs, float64(run.Usage.ComputedInputTokens))
+			ttfts = append(ttfts, *run.Timing.ActivityTTFTMS/1000)
+		}
+		models[modelKey{key.provider, key.model}] = append(models[modelKey{key.provider, key.model}], point{
+			input:     median(inputs),
+			ttftSecs:  median(ttfts),
+			validRuns: len(runs),
+		})
+	}
+
+	ranges := []struct {
+		label    string
+		min, max int
+	}{
+		{"1K-16K", 1_000, 16_000},
+		{"16K-64K", 16_000, 64_000},
+		{"64K-128K", 64_000, 128_000},
+		{"128K-512K", 128_000, 512_000},
+		{"512K-max", 512_000, math.MaxInt},
+	}
+
+	var fits []Fit
+	for model, points := range models {
+		for rangeIndex, fitRange := range ranges {
+			var selected []point
+			for _, candidate := range points {
+				inRange := candidate.input >= float64(fitRange.min)
+				if rangeIndex == len(ranges)-1 {
+					inRange = inRange && candidate.input <= float64(fitRange.max)
+				} else {
+					inRange = inRange && candidate.input < float64(fitRange.max)
+				}
+				if inRange {
+					selected = append(selected, candidate)
+				}
+			}
+			if len(selected) < 3 {
+				continue
+			}
+			sort.Slice(selected, func(i, j int) bool { return selected[i].input < selected[j].input })
+			var slopes []float64
+			validRuns := 0
+			for i := range selected {
+				validRuns += selected[i].validRuns
+				for j := i + 1; j < len(selected); j++ {
+					dx := selected[j].input - selected[i].input
+					if dx > 0 {
+						slopes = append(slopes, (selected[j].ttftSecs-selected[i].ttftSecs)/dx)
+					}
+				}
+			}
+			if len(slopes) == 0 {
+				continue
+			}
+			slope := median(slopes)
+			if slope <= 0 {
+				continue
+			}
+			intercepts := make([]float64, 0, len(selected))
+			for _, candidate := range selected {
+				intercepts = append(intercepts, candidate.ttftSecs-slope*candidate.input)
+			}
+			intercept := median(intercepts)
+			residuals := make([]float64, 0, len(selected))
+			for _, candidate := range selected {
+				predicted := intercept + slope*candidate.input
+				residuals = append(residuals, math.Abs(candidate.ttftSecs-predicted))
+			}
+			fits = append(fits, Fit{
+				Provider:                model.provider,
+				RequestedModel:          model.model,
+				Range:                   fitRange.label,
+				MinimumInputTokens:      int(math.Round(selected[0].input)),
+				MaximumInputTokens:      int(math.Round(selected[len(selected)-1].input)),
+				DistinctLengths:         len(selected),
+				ValidRuns:               validRuns,
+				SlopeSecondsPerToken:    slope,
+				EffectiveTokensPerSec:   1 / slope,
+				InterceptSeconds:        intercept,
+				MedianAbsoluteErrorSecs: median(residuals),
+				Method:                  "median_pairwise_slopes",
+			})
+		}
+	}
+	sort.Slice(fits, func(i, j int) bool {
+		left := fmt.Sprintf("%s\x00%s\x00%09d", fits[i].Provider, fits[i].RequestedModel, fits[i].MinimumInputTokens)
+		right := fmt.Sprintf("%s\x00%s\x00%09d", fits[j].Provider, fits[j].RequestedModel, fits[j].MinimumInputTokens)
+		return left < right
+	})
+	return fits
+}
+
+func summarize(values []float64) Distribution {
+	result := Distribution{Count: len(values), Label: "unavailable"}
+	if len(values) == 0 {
+		return result
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	result.Label = "min_median_max"
+	result.Min = floatPtr(sorted[0])
+	result.Median = floatPtr(medianSorted(sorted))
+	result.Max = floatPtr(sorted[len(sorted)-1])
+	if len(sorted) >= 10 {
+		result.Label = "min_median_max_p95"
+		index := int(math.Ceil(0.95*float64(len(sorted)))) - 1
+		result.P95 = floatPtr(sorted[index])
+	}
+	return result
+}
+
+func medianPtr(values []float64) *float64 {
+	if len(values) == 0 {
+		return nil
+	}
+	return floatPtr(median(values))
+}
+
+func median(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	return medianSorted(sorted)
+}
+
+func medianSorted(sorted []float64) float64 {
+	middle := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[middle]
+	}
+	return (sorted[middle-1] + sorted[middle]) / 2
+}
+
+func appendMetric(values *[]float64, value *float64) {
+	if value != nil {
+		*values = append(*values, *value)
+	}
+}
+
+func aggregateCacheState(runs []RunRecord) string {
+	state := ""
+	for _, run := range runs {
+		if run.CacheState == "unknown" {
+			return "unknown"
+		}
+		if state == "" {
+			state = run.CacheState
+		} else if state != run.CacheState {
+			return "mixed"
+		}
+	}
+	if state == "" {
+		return "unknown"
+	}
+	return state
+}

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -1,0 +1,654 @@
+package benchmark
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(duration time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(duration)
+	c.mu.Unlock()
+}
+
+type timedEvent struct {
+	after time.Duration
+	event llm.Event
+}
+
+type scriptedTurn struct {
+	streamAfter time.Duration
+	events      []timedEvent
+	err         error
+}
+
+type scriptedProvider struct {
+	clock    *fakeClock
+	turns    []scriptedTurn
+	next     int
+	requests []llm.Request
+	resets   int
+}
+
+func (p *scriptedProvider) Name() string                   { return "scripted" }
+func (p *scriptedProvider) Credential() string             { return "mock" }
+func (p *scriptedProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+func (p *scriptedProvider) ResetConversation()             { p.resets++ }
+func (p *scriptedProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	p.requests = append(p.requests, req)
+	if p.next >= len(p.turns) {
+		return nil, errors.New("no scripted turn")
+	}
+	turn := p.turns[p.next]
+	p.next++
+	p.clock.advance(turn.streamAfter)
+	if turn.err != nil {
+		return nil, turn.err
+	}
+	return &scriptedStream{clock: p.clock, events: turn.events}, nil
+}
+
+type scriptedStream struct {
+	clock  *fakeClock
+	events []timedEvent
+	next   int
+}
+
+func (s *scriptedStream) Recv() (llm.Event, error) {
+	if s.next >= len(s.events) {
+		return llm.Event{}, io.EOF
+	}
+	event := s.events[s.next]
+	s.next++
+	s.clock.advance(event.after)
+	return event.event, nil
+}
+func (s *scriptedStream) Close() error { return nil }
+
+func baseOptions() Options {
+	return Options{
+		Mode:            "quick",
+		Cache:           "cold",
+		Runs:            1,
+		Concurrency:     1,
+		Seed:            42,
+		Timeout:         time.Second,
+		CacheTolerance:  0.01,
+		TargetTolerance: 0.15,
+	}
+}
+
+func targetFor(provider llm.Provider, reportsCache bool) Target {
+	return Target{
+		ProviderKey:    "test",
+		ProviderType:   "test",
+		RequestedModel: "model",
+		Provider:       provider,
+		Capabilities: AdapterCapabilities{
+			ReportsCacheReads:      reportsCache,
+			ReportsCacheWrites:     reportsCache,
+			ReportsReasoningTokens: reportsCache,
+			SupportsOutputLimit:    true,
+			IncrementalStream:      true,
+		},
+	}
+}
+
+func TestGeneratePayloadDeterministicDistinctAndEarlyUnique(t *testing.T) {
+	seedA := DeriveSeed(42, 2_000, "measured", 1, 0)
+	seedB := DeriveSeed(42, 2_000, "measured", 2, 0)
+	first := GeneratePayload(seedA, 256, "prefill", 16, true)
+	repeated := GeneratePayload(seedA, 256, "prefill", 16, true)
+	second := GeneratePayload(seedB, 256, "prefill", 16, true)
+	if first.Text != repeated.Text || first.SHA256 != repeated.SHA256 {
+		t.Fatal("same seed did not reproduce payload")
+	}
+	if first.SHA256 == second.SHA256 {
+		t.Fatal("different scenario dimensions reused payload")
+	}
+	prefixA := first.Text[:min(64, len(first.Text))]
+	prefixB := second.Text[:min(64, len(second.Text))]
+	if prefixA == prefixB {
+		t.Fatalf("payload uniqueness was not early: prefix %q", prefixA)
+	}
+	if strings.Contains(first.Text, "http://") || strings.Contains(first.Text, "https://") {
+		t.Fatal("payload unexpectedly contains URL")
+	}
+}
+
+func TestGeneratePayloadUnsupportedOutputLimitUsesBoundedNaturalInstruction(t *testing.T) {
+	for _, workload := range []string{"decode", "prefill"} {
+		payload := GeneratePayload(0x1234, 256, workload, 128, false)
+		other := GeneratePayload(0x5678, 256, workload, 128, false)
+		marker := "BENCHMARK-END-0000000000001234"
+		otherMarker := "BENCHMARK-END-0000000000005678"
+
+		for _, phrase := range []string{
+			"one concise paragraph",
+			"approximately 128 words",
+			"End the paragraph with the exact marker " + marker,
+			"Do not repeat words or phrases mechanically",
+			"do not repeat the marker",
+			"do not write or continue anything after it",
+		} {
+			if !strings.Contains(payload.Text, phrase) {
+				t.Errorf("%s fallback prompt missing %q: %q", workload, phrase, payload.Text)
+			}
+		}
+		if strings.Count(payload.Text, marker) != 1 || strings.Contains(payload.Text, otherMarker) || !strings.Contains(other.Text, otherMarker) {
+			t.Errorf("%s fallback markers are not unique: first=%q second=%q", workload, payload.Text, other.Text)
+		}
+		lower := strings.ToLower(payload.Text)
+		for _, repetitive := range []string{"occurrences of", "separated by single spaces", "exactly 128"} {
+			if strings.Contains(lower, repetitive) {
+				t.Errorf("%s fallback prompt demands a repetitive exact run via %q: %q", workload, repetitive, payload.Text)
+			}
+		}
+	}
+}
+
+func TestNormalizeUsageIncludesCacheWritesAsComputedInput(t *testing.T) {
+	usage := normalizeUsage(llm.Usage{InputTokens: 12, CacheWriteTokens: 127_000, CachedInputTokens: 0, OutputTokens: 3}, AdapterCapabilities{ReportsCacheReads: true, ReportsCacheWrites: true})
+	if usage.TotalInputTokens != 127_012 || usage.ComputedInputTokens != 127_012 {
+		t.Fatalf("normalized usage = total %d computed %d, want 127012/127012", usage.TotalInputTokens, usage.ComputedInputTokens)
+	}
+	if usage.TokenCountSource != "normalized_components" {
+		t.Fatalf("source = %q", usage.TokenCountSource)
+	}
+	if usage.CacheWriteTokens == nil || *usage.CacheWriteTokens != 127_000 {
+		t.Fatalf("cache-write metric = %v, want 127000", usage.CacheWriteTokens)
+	}
+	unsupported := normalizeUsage(llm.Usage{InputTokens: 12, CachedInputTokens: 99, CacheWriteTokens: 88, ReasoningTokens: 7}, AdapterCapabilities{})
+	if unsupported.CachedInputTokens != nil || unsupported.CacheWriteTokens != nil || unsupported.ReasoningTokens != nil {
+		t.Fatalf("unsupported provider metrics must be null: %#v", unsupported)
+	}
+}
+
+func TestMeasureActivityVisibleTTFTAndReasoningDecode(t *testing.T) {
+	clock := newFakeClock()
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{{
+		streamAfter: 10 * time.Millisecond,
+		events: []timedEvent{
+			{after: 20 * time.Millisecond, event: llm.Event{Type: llm.EventReasoningDelta, Text: "thinking"}},
+			{after: 30 * time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "a"}},
+			{after: 40 * time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "b"}},
+			{after: 5 * time.Millisecond, event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 8, ReasoningTokens: 2}}},
+			{after: 5 * time.Millisecond, event: llm.Event{Type: llm.EventDone}},
+		},
+	}}}
+	record := (Runner{Clock: clock}).measure(context.Background(), targetFor(provider, true), baseOptions(), measureSpec{
+		phase: "measured", workload: "decode", run: 1, attempt: 1, inputTarget: 100, outputTarget: 8, estimateTarget: 100,
+	})
+	assertFloat(t, record.Timing.ActivityTTFTMS, 30)
+	assertFloat(t, record.Timing.VisibleTTFTMS, 60)
+	assertFloat(t, record.Timing.ObservedDecodeMS, 70)
+	assertFloat(t, record.Timing.DecodeTokensPerSec, 100)
+	assertFloat(t, record.Timing.TPOTMS, 10)
+	assertFloat(t, record.Timing.EndToEndMS, 110)
+	if record.DecodeStatus != "observed_incremental" || !record.ReasoningObserved || !record.Success {
+		t.Fatalf("record status = %#v", record)
+	}
+}
+
+func TestMeasureHiddenReasoningUsesVisibleWindowOnly(t *testing.T) {
+	clock := newFakeClock()
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{{events: []timedEvent{
+		{after: 10 * time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "a"}},
+		{after: 100 * time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "b"}},
+		{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 10, ReasoningTokens: 6}}},
+		{event: llm.Event{Type: llm.EventDone}},
+	}}}}
+	record := (Runner{Clock: clock}).measure(context.Background(), targetFor(provider, true), baseOptions(), measureSpec{
+		phase: "measured", workload: "decode", inputTarget: 100, outputTarget: 10, estimateTarget: 100,
+	})
+	if record.Timing.DecodeTokensPerSec != nil {
+		t.Fatalf("hidden reasoning produced all-output decode rate %v", *record.Timing.DecodeTokensPerSec)
+	}
+	assertFloat(t, record.Timing.VisibleTokensPerSec, 30)
+	if record.DecodeStatus != "visible_only_hidden_reasoning_excluded" {
+		t.Fatalf("decode status = %q", record.DecodeStatus)
+	}
+}
+
+func TestMeasureLateReasoningDoesNotSpanObservedWindow(t *testing.T) {
+	clock := newFakeClock()
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{{events: []timedEvent{
+		{after: 10 * time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "a"}},
+		{after: 20 * time.Millisecond, event: llm.Event{Type: llm.EventReasoningDelta, Text: "late summary"}},
+		{after: 30 * time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "b"}},
+		{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 10, ReasoningTokens: 6}}},
+		{event: llm.Event{Type: llm.EventDone}},
+	}}}}
+	record := (Runner{Clock: clock}).measure(context.Background(), targetFor(provider, true), baseOptions(), measureSpec{
+		phase: "measured", workload: "decode", inputTarget: 100, outputTarget: 10, estimateTarget: 100,
+	})
+	if !record.ReasoningObserved || record.ObservableReasoningWindow || record.Timing.DecodeTokensPerSec != nil {
+		t.Fatalf("late reasoning treated as full observable window: %#v", record)
+	}
+	assertFloat(t, record.Timing.VisibleTokensPerSec, 60)
+}
+
+func TestMeasureNonIncrementalStreamLeavesDecodeNull(t *testing.T) {
+	clock := newFakeClock()
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{{events: []timedEvent{
+		{after: time.Second, event: llm.Event{Type: llm.EventTextDelta, Text: "whole response"}},
+		{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 100}}},
+		{event: llm.Event{Type: llm.EventDone}},
+	}}}}
+	record := (Runner{Clock: clock}).measure(context.Background(), targetFor(provider, true), baseOptions(), measureSpec{
+		phase: "measured", workload: "decode", inputTarget: 100, outputTarget: 100, estimateTarget: 100,
+	})
+	if record.DecodeStatus != "non_incremental" || record.Timing.DecodeTokensPerSec != nil || record.Timing.TPOTMS != nil {
+		t.Fatalf("non-incremental decode metrics were not null: %#v", record.Timing)
+	}
+}
+
+func TestMeasureAcceptsIntentionalResponsesOutputLimitWithValidUsage(t *testing.T) {
+	clock := newFakeClock()
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{{events: []timedEvent{
+		{after: time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "a"}},
+		{after: time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "b"}},
+		{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 8}}},
+		{event: llm.Event{Type: llm.EventError, Err: &llm.ResponsesIncompleteError{Reason: "max_output_tokens"}}},
+	}}}}
+	record := (Runner{Clock: clock}).measure(context.Background(), targetFor(provider, true), baseOptions(), measureSpec{
+		phase: "measured", workload: "decode", inputTarget: 100, outputTarget: 8, estimateTarget: 100,
+	})
+	if !record.Success || !record.TerminalReceived || !record.OutputLimitReached || record.Error != "" {
+		t.Fatalf("intentional output stop = %#v", record)
+	}
+
+	provider.turns = append(provider.turns, scriptedTurn{events: []timedEvent{
+		{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 7}}},
+		{event: llm.Event{Type: llm.EventError, Err: &llm.ResponsesIncompleteError{Reason: "max_output_tokens"}}},
+	}})
+	record = (Runner{Clock: clock}).measure(context.Background(), targetFor(provider, true), baseOptions(), measureSpec{
+		phase: "measured", workload: "decode", inputTarget: 100, outputTarget: 8, estimateTarget: 100,
+	})
+	if record.Success || record.Error == "" {
+		t.Fatalf("mismatched incomplete usage was accepted: %#v", record)
+	}
+}
+
+func TestMeasureUnsupportedOutputLimitUsesBoundedPromptAndProviderUsage(t *testing.T) {
+	clock := newFakeClock()
+	events := make([]timedEvent, 0, 12)
+	for range 10 {
+		events = append(events, timedEvent{after: time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "natural output "}})
+	}
+	events = append(events,
+		timedEvent{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 13}}},
+		timedEvent{event: llm.Event{Type: llm.EventDone}},
+	)
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{{events: events}}}
+	target := targetFor(provider, true)
+	target.Capabilities.SupportsOutputLimit = false
+	record := (Runner{Clock: clock}).measure(context.Background(), target, baseOptions(), measureSpec{
+		phase: "measured", workload: "decode", inputTarget: 100, outputTarget: 8, estimateTarget: 100, seed: 0x1234,
+	})
+	if !record.Success || !record.TerminalReceived || record.OutputLimitStatus != "unsupported_not_enforced" {
+		t.Fatalf("record = %#v", record)
+	}
+	if record.ActivityEvents != 10 {
+		t.Fatalf("stream stopped after %d events, want all 10 events consumed through provider completion", record.ActivityEvents)
+	}
+	if got := provider.requests[0].MaxOutputTokens; got != 0 {
+		t.Fatalf("unsupported MaxOutputTokens sent to adapter: %d", got)
+	}
+	if record.Usage.OutputTokens != 13 {
+		t.Fatalf("provider output usage = %d, want authoritative actual usage 13", record.Usage.OutputTokens)
+	}
+	assertFloat(t, record.Timing.DecodeTokensPerSec, float64(13-1)/(9*time.Millisecond).Seconds())
+	prompt := provider.requests[0].Messages[0].Parts[0].Text
+	if !strings.Contains(prompt, "one concise paragraph") || !strings.Contains(prompt, "approximately 8 words") || !strings.Contains(prompt, "BENCHMARK-END-0000000000001234") {
+		t.Fatalf("bounded natural output instruction missing: %q", prompt)
+	}
+	if strings.Contains(prompt, "occurrences of") || strings.Contains(prompt, "separated by single spaces") {
+		t.Fatalf("unsupported output instruction demands a repetitive run: %q", prompt)
+	}
+	report := NewReport(baseOptions(), Budget{}, []Target{target}, []RunRecord{record})
+	if len(report.Targets) != 1 || report.Targets[0].OutputLimitMeaning != "requested_but_adapter_does_not_enforce" {
+		t.Fatalf("output-limit metadata = %#v", report.Targets)
+	}
+}
+
+func TestRunnerManagedQuickTargetsGeneratedPayloadNotProviderTotal(t *testing.T) {
+	clock := newFakeClock()
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{{events: []timedEvent{
+		{after: time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "amber"}},
+		{after: time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: " amber"}},
+		{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{
+			InputTokens: 12_000, CachedInputTokens: 500, CacheWriteTokens: 8_000,
+			ProviderRawInputTokens: 20_500, OutputTokens: 8,
+		}}},
+		{event: llm.Event{Type: llm.EventDone}},
+	}}}}
+	target := Target{
+		ProviderKey: "claude-bin", ProviderType: "claude-bin", RequestedModel: "haiku", Provider: provider,
+		Capabilities: AdapterCapabilities{
+			ReportsCacheWrites: true, IncrementalStream: false, ManagedContext: true,
+			MeasurementScope: "subprocess_inclusive",
+		},
+	}
+	opts := baseOptions()
+	opts.Scenarios = []Scenario{{InputTokens: 2_000, OutputTokens: 8, Workload: "decode"}}
+	records, err := (Runner{Clock: clock}).RunTarget(context.Background(), target, opts)
+	if err != nil {
+		t.Fatalf("managed quick benchmark failed on provider overhead: %v", err)
+	}
+	if len(records) != 1 || len(provider.requests) != 1 {
+		t.Fatalf("managed quick performed calibration requests: records=%d requests=%d", len(records), len(provider.requests))
+	}
+	record := records[0]
+	if record.Phase != "measured" || record.InputTargetMeaning != "generated_user_payload" || math.Abs(float64(record.LocalEstimate-2_000)) > 2 {
+		t.Fatalf("payload target record = %#v", record)
+	}
+	if record.Usage.TotalInputTokens != 20_500 || record.TargetMatched != nil || !record.LatencyEligible || record.FitEligible {
+		t.Fatalf("provider-total usage incorrectly target-gated: %#v", record)
+	}
+	if record.ReasoningExpected || record.Timing.DecodeTokensPerSec != nil || record.Timing.VisibleTokensPerSec != nil || record.Timing.TPOTMS != nil || record.Timing.ObservedDecodeMS != nil || record.DecodeStatus != "non_comparable_delivery" {
+		t.Fatalf("managed CLI delivery produced comparable decode metrics = %#v", record)
+	}
+	assertFloat(t, record.Timing.EndToEndMS, 2)
+	if provider.requests[0].MaxOutputTokens != 0 {
+		t.Fatalf("managed unsupported output limit sent: %d", provider.requests[0].MaxOutputTokens)
+	}
+
+	report := NewReport(opts, Budget{}, []Target{target}, records)
+	if len(report.Aggregates) != 1 || report.Aggregates[0].TotalInputTokens == nil || *report.Aggregates[0].TotalInputTokens != 20_500 || report.Aggregates[0].OutputTokens == nil || *report.Aggregates[0].OutputTokens != 8 {
+		t.Fatalf("actual provider usage not aggregated: %#v", report.Aggregates)
+	}
+	if report.Aggregates[0].DecodeValidRuns != 0 || report.Aggregates[0].DecodeTokensPerSecond.Median != nil || report.Aggregates[0].TPOTMS.Median != nil || report.Aggregates[0].EndToEndMS.Median == nil {
+		t.Fatalf("managed aggregate exposed decode throughput or lost E2E timing: %#v", report.Aggregates[0])
+	}
+	limitations := strings.Join(report.Limitations, " ")
+	if !strings.Contains(limitations, "generated user payload") || !strings.Contains(limitations, "cache buckets shift") || !strings.Contains(limitations, "actual provider totals remain recorded") || !strings.Contains(limitations, "provider decode throughput and TPOT are unavailable") || !strings.Contains(limitations, "Provider-reported output usage and end-to-end timing remain recorded") {
+		t.Fatalf("managed payload limitation missing: %v", report.Limitations)
+	}
+	budget := ComputeBudgetForTarget(target, opts.Mode, opts.Scenarios, opts.Runs, opts.Warmups, true)
+	if budget.IncludesCalibration || budget.MaximumRequests != 2 {
+		t.Fatalf("managed quick budget still includes calibration: %#v", budget)
+	}
+}
+
+func TestMeasureResetsConversationAndUsesUniqueSessionPerRequest(t *testing.T) {
+	clock := newFakeClock()
+	turn := scriptedTurn{events: []timedEvent{
+		{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 100, OutputTokens: 1}}},
+		{event: llm.Event{Type: llm.EventDone}},
+	}}
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{turn, turn}}
+	for i := 0; i < 2; i++ {
+		record := (Runner{Clock: clock}).measure(context.Background(), targetFor(provider, true), baseOptions(), measureSpec{
+			phase: "measured", workload: "prefill", inputTarget: 100, outputTarget: 1, estimateTarget: 100, seed: int64(i + 1),
+		})
+		if !record.Success {
+			t.Fatalf("request %d failed: %#v", i, record)
+		}
+	}
+	if provider.resets != 2 || len(provider.requests) != 2 {
+		t.Fatalf("resets=%d requests=%d", provider.resets, len(provider.requests))
+	}
+	if provider.requests[0].SessionID == "" || provider.requests[0].SessionID == provider.requests[1].SessionID {
+		t.Fatalf("session IDs = %q, %q", provider.requests[0].SessionID, provider.requests[1].SessionID)
+	}
+	if !provider.requests[0].Ephemeral || !provider.requests[1].Ephemeral {
+		t.Fatal("benchmark requests were not ephemeral")
+	}
+}
+
+func TestRunnerStopsBeforeMeasuredRequestsWhenCalibrationValidationDetectsTruncation(t *testing.T) {
+	clock := newFakeClock()
+	turn := func(input int) scriptedTurn {
+		return scriptedTurn{events: []timedEvent{
+			{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: input, OutputTokens: 1}}},
+			{event: llm.Event{Type: llm.EventDone}},
+		}}
+	}
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{turn(100), turn(50)}}
+	opts := baseOptions()
+	opts.Scenarios = []Scenario{{InputTokens: 100, OutputTokens: 1, Workload: "prefill"}}
+	records, err := (Runner{Clock: clock}).RunTarget(context.Background(), targetFor(provider, false), opts)
+	if err == nil || !strings.Contains(err.Error(), "possible context truncation") {
+		t.Fatalf("calibration error = %v", err)
+	}
+	if len(records) != 2 || provider.next != 2 {
+		t.Fatalf("records=%d provider requests=%d", len(records), provider.next)
+	}
+}
+
+func TestCacheCapabilityAndTargetMismatchControlFitEligibility(t *testing.T) {
+	unknown := RunRecord{Success: true, TerminalReceived: true, UsageReceived: true, RequestedInput: 100, Usage: UsageRecord{TotalInputTokens: 100, ComputedInputTokens: 100}}
+	classifyCacheAndTarget(&unknown, Target{Capabilities: AdapterCapabilities{ReportsCacheReads: false}}, baseOptions())
+	finalizeEligibility(&unknown, Target{Capabilities: AdapterCapabilities{ReportsCacheReads: false}}, baseOptions(), "measured")
+	if unknown.CacheState != "unknown" || unknown.FitEligible {
+		t.Fatalf("unknown cache record = %#v", unknown)
+	}
+
+	known := RunRecord{Success: true, TerminalReceived: true, UsageReceived: true, RequestedInput: 100, Usage: UsageRecord{TotalInputTokens: 100, ComputedInputTokens: 100}}
+	knownTarget := Target{Capabilities: AdapterCapabilities{ReportsCacheReads: true}, AssumedContextLimit: 128_000}
+	classifyCacheAndTarget(&known, knownTarget, baseOptions())
+	finalizeEligibility(&known, knownTarget, baseOptions(), "measured")
+	if known.CacheState != "miss" || !known.FitEligible {
+		t.Fatalf("known cache record = %#v", known)
+	}
+
+	mismatch := RunRecord{Success: true, TerminalReceived: true, UsageReceived: true, RequestedInput: 100, Usage: UsageRecord{TotalInputTokens: 50, ComputedInputTokens: 50}}
+	classifyCacheAndTarget(&mismatch, knownTarget, baseOptions())
+	finalizeEligibility(&mismatch, knownTarget, baseOptions(), "measured")
+	if mismatch.TargetMatched == nil || *mismatch.TargetMatched || mismatch.LatencyEligible {
+		t.Fatalf("target mismatch was accepted: %#v", mismatch)
+	}
+	if !strings.Contains(strings.Join(mismatch.ExclusionReasons, " "), "truncation") {
+		t.Fatalf("mismatch reasons = %v", mismatch.ExclusionReasons)
+	}
+}
+
+func TestRunnerRetriesCacheContaminationOnceWithFreshPayload(t *testing.T) {
+	clock := newFakeClock()
+	turn := func(input, cached int) scriptedTurn {
+		return scriptedTurn{events: []timedEvent{
+			{after: time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "a"}},
+			{after: time.Millisecond, event: llm.Event{Type: llm.EventTextDelta, Text: "b"}},
+			{event: llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: input - cached, CachedInputTokens: cached, ProviderRawInputTokens: input, OutputTokens: 3}}},
+			{event: llm.Event{Type: llm.EventDone}},
+		}}
+	}
+	provider := &scriptedProvider{clock: clock, turns: []scriptedTurn{turn(100, 0), turn(100, 0), turn(100, 50), turn(100, 0)}}
+	opts := baseOptions()
+	opts.Scenarios = []Scenario{{InputTokens: 100, OutputTokens: 3, Workload: "prefill"}}
+	records, err := (Runner{Clock: clock}).RunTarget(context.Background(), targetFor(provider, true), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 4 || records[2].Attempt != 1 || records[3].Attempt != 2 {
+		t.Fatalf("records = %#v", records)
+	}
+	if records[2].PayloadSHA256 == records[3].PayloadSHA256 {
+		t.Fatal("cache retry reused payload")
+	}
+	if records[3].RetryReason != "cold_cache_contaminated" {
+		t.Fatalf("retry reason = %q", records[3].RetryReason)
+	}
+	aggregates := AggregateRuns(records)
+	if len(aggregates) != 1 || aggregates[0].MeasuredRuns != 1 || aggregates[0].FitValidRuns != 1 {
+		t.Fatalf("aggregates = %#v", aggregates)
+	}
+}
+
+func TestSmallSampleSummaryAndFitMinimums(t *testing.T) {
+	small := summarize([]float64{1, 2, 3, 100})
+	if small.P95 != nil || small.Label != "min_median_max" || small.Median == nil || *small.Median != 2.5 {
+		t.Fatalf("small summary = %#v", small)
+	}
+	large := summarize([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	if large.P95 == nil || *large.P95 != 10 {
+		t.Fatalf("large summary = %#v", large)
+	}
+
+	record := func(input int, ttft float64) RunRecord {
+		return RunRecord{Provider: "p", RequestedModel: "m", Phase: "measured", Workload: "prefill", Run: 1, Attempt: 1, RequestedInput: input, RequestedOutput: 16, FitEligible: true, Usage: UsageRecord{ComputedInputTokens: input}, Timing: TimingRecord{ActivityTTFTMS: floatPtr(ttft)}}
+	}
+	two := []RunRecord{record(1_000, 100), record(4_000, 400)}
+	if fits := ComputeFits(two); len(fits) != 0 {
+		t.Fatalf("fit emitted from two lengths: %#v", fits)
+	}
+	three := append(two, record(15_000, 1_500))
+	fits := ComputeFits(three)
+	if len(fits) != 1 || fits[0].Range != "1K-16K" || fits[0].DistinctLengths != 3 {
+		t.Fatalf("three-length fits = %#v", fits)
+	}
+}
+
+func TestAggregatesUseLatestAttemptAndEligibleTokenMedians(t *testing.T) {
+	matched := true
+	record := func(run, attempt, order, input int, eligible bool) RunRecord {
+		return RunRecord{
+			Provider: "p", RequestedModel: "m", Phase: "measured", Workload: "prefill",
+			Run: run, Attempt: attempt, Order: order, RequestedInput: 1_000, RequestedOutput: 16,
+			Success: true, UsageReceived: true, LatencyEligible: eligible, FitEligible: eligible, TargetMatched: &matched,
+			Usage: UsageRecord{TotalInputTokens: input, ComputedInputTokens: input, OutputTokens: input / 10},
+		}
+	}
+	records := []RunRecord{
+		record(1, 1, 1, 100, true),
+		record(1, 2, 2, 9_000, false),
+		record(1, 2, 3, 1_000, true), // latest order wins when attempt metadata ties
+		record(2, 1, 4, 3_000, false),
+	}
+	aggregates := AggregateRuns(records)
+	if len(aggregates) != 1 {
+		t.Fatalf("aggregates = %#v", aggregates)
+	}
+	got := aggregates[0]
+	if got.MeasuredRuns != 2 || got.FitValidRuns != 1 || got.ComputedInputTokens == nil || *got.ComputedInputTokens != 1_000 {
+		t.Fatalf("aggregate = %#v", got)
+	}
+	if got.OutputTokens == nil || *got.OutputTokens != 100 {
+		t.Fatalf("eligible output median = %v", got.OutputTokens)
+	}
+}
+
+func TestFitRangesAreHalfOpenAtSharedBoundaries(t *testing.T) {
+	record := func(input int) RunRecord {
+		return RunRecord{Provider: "p", RequestedModel: "m", Phase: "measured", Workload: "prefill", Run: input, Attempt: 1, RequestedInput: input, RequestedOutput: 16, FitEligible: true, Usage: UsageRecord{ComputedInputTokens: input}, Timing: TimingRecord{ActivityTTFTMS: floatPtr(float64(input) / 10)}}
+	}
+	records := []RunRecord{
+		record(1_000), record(4_000), record(15_000),
+		record(16_000), record(32_000), record(63_000),
+	}
+	fits := ComputeFits(records)
+	if len(fits) != 2 || fits[0].Range != "1K-16K" || fits[0].DistinctLengths != 3 || fits[1].Range != "16K-64K" || fits[1].DistinctLengths != 3 {
+		t.Fatalf("fits = %#v", fits)
+	}
+}
+
+func TestWarmupsExcludedAndJSONHasNullMetricsWithoutPayload(t *testing.T) {
+	records := []RunRecord{
+		{Provider: "p", RequestedModel: "m", Phase: "warmup", RequestedInput: 100, RequestedOutput: 10, Success: true},
+		{Provider: "p", RequestedModel: "m", Phase: "measured", Workload: "decode", Run: 1, Attempt: 1, RequestedInput: 100, RequestedOutput: 10, Success: true},
+	}
+	aggregates := AggregateRuns(records)
+	if len(aggregates) != 1 || aggregates[0].MeasuredRuns != 1 {
+		t.Fatalf("warmup entered aggregate: %#v", aggregates)
+	}
+	records[1].PayloadSHA256 = strings.Repeat("a", 64)
+	encoded, err := json.Marshal(records[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	if strings.Contains(text, "benchmark-id") || strings.Contains(text, "authorization") {
+		t.Fatalf("JSON leaked prompt or secret-shaped field: %s", text)
+	}
+	if !strings.Contains(text, `"decode_tokens_per_second":null`) {
+		t.Fatalf("unavailable metric was not JSON null: %s", text)
+	}
+}
+
+func TestReportRecordsAssumedContextLimitAndProminentWarning(t *testing.T) {
+	opts := baseOptions()
+	opts.AssumedContextLimit = 128_000
+	target := targetFor(nil, false)
+	target.ProviderKey = "ollama"
+	target.ProviderType = "ollama"
+	target.RequestedModel = "local-model"
+	target.AssumedContextLimit = 128_000
+
+	report := NewReport(opts, Budget{}, []Target{target}, nil)
+	if report.Benchmark.AssumedContextLimit != 128_000 || len(report.Targets) != 1 || report.Targets[0].AssumedContextLimit != 128_000 {
+		t.Fatalf("assumed context metadata = %#v", report)
+	}
+	limitations := strings.Join(report.Limitations, " ")
+	if !strings.Contains(limitations, "EXPERT OVERRIDE") || !strings.Contains(limitations, "num_ctx") || !strings.Contains(limitations, "truncated requests are invalid") {
+		t.Fatalf("limitations = %v", report.Limitations)
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(encoded), `"assumed_context_limit":128000`) < 2 {
+		t.Fatalf("JSON does not record benchmark and target assumed limits: %s", encoded)
+	}
+	var human strings.Builder
+	WriteHuman(&human, report)
+	if !strings.Contains(human.String(), "WARNING: EXPERT OVERRIDE") || !strings.Contains(human.String(), "Assumed context limit: 128000 tokens") {
+		t.Fatalf("human report = %s", human.String())
+	}
+}
+
+func TestMeasureHardTimeout(t *testing.T) {
+	provider := timeoutProvider{}
+	opts := baseOptions()
+	opts.Timeout = time.Nanosecond
+	record := (Runner{}).measure(context.Background(), targetFor(provider, false), opts, measureSpec{
+		phase: "measured", workload: "prefill", inputTarget: 100, outputTarget: 1, estimateTarget: 100,
+	})
+	if !record.TimedOut || record.Error != context.DeadlineExceeded.Error() || record.Success {
+		t.Fatalf("timeout record = %#v", record)
+	}
+}
+
+type timeoutProvider struct{}
+
+func (timeoutProvider) Name() string                   { return "timeout" }
+func (timeoutProvider) Credential() string             { return "mock" }
+func (timeoutProvider) Capabilities() llm.Capabilities { return llm.Capabilities{} }
+func (timeoutProvider) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func assertFloat(t *testing.T, actual *float64, expected float64) {
+	t.Helper()
+	if actual == nil || math.Abs(*actual-expected) > 1e-9 {
+		if actual == nil {
+			t.Fatalf("value = nil, want %v", expected)
+		}
+		t.Fatalf("value = %v, want %v", *actual, expected)
+	}
+}

--- a/internal/benchmark/measure.go
+++ b/internal/benchmark/measure.go
@@ -1,0 +1,377 @@
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+type measureSpec struct {
+	phase          string
+	workload       string
+	run            int
+	attempt        int
+	order          int
+	seed           int64
+	inputTarget    int
+	outputTarget   int
+	estimateTarget int
+	retryReason    string
+}
+
+func (r Runner) measure(ctx context.Context, target Target, opts Options, spec measureSpec) RunRecord {
+	clock := r.clock()
+	payload := GeneratePayload(spec.seed, spec.estimateTarget, spec.workload, spec.outputTarget, target.Capabilities.SupportsOutputLimit)
+	record := RunRecord{
+		Provider:           target.ProviderKey,
+		ProviderType:       target.ProviderType,
+		RequestedModel:     target.RequestedModel,
+		Phase:              spec.phase,
+		Workload:           spec.workload,
+		Run:                spec.run,
+		Attempt:            spec.attempt,
+		Order:              spec.order,
+		Seed:               spec.seed,
+		PayloadSHA256:      payload.SHA256,
+		PayloadBytes:       payload.Bytes,
+		PayloadWords:       payload.Words,
+		RequestedInput:     spec.inputTarget,
+		InputTargetMeaning: inputTargetMeaning(target, opts.Mode),
+		LocalEstimate:      payload.Estimated,
+		RequestedOutput:    spec.outputTarget,
+		OutputLimitStatus:  "enforced_by_adapter",
+		ReasoningEffort:    opts.ReasoningEffort,
+		ReasoningExpected:  target.ReasoningExpected || opts.ReasoningEffort != "",
+		ServiceTier:        target.ServiceTier,
+		ReportsCacheReads:  target.Capabilities.ReportsCacheReads,
+		MeasurementScope:   target.Capabilities.MeasurementScope,
+		RetryPolicy:        "provider retries disabled; benchmark may retry once with a fresh payload after cache contamination",
+		RetryReason:        spec.retryReason,
+		CacheState:         "unknown",
+		DecodeStatus:       "unavailable",
+	}
+	if !target.Capabilities.SupportsOutputLimit {
+		record.OutputLimitStatus = "unsupported_not_enforced"
+	}
+	if opts.TemperatureSet && target.Capabilities.SupportsTemperature {
+		value := opts.Temperature
+		record.Temperature = &value
+	}
+
+	req := llm.Request{
+		Model:           target.RequestedModel,
+		SessionID:       "benchmark-" + payload.SHA256,
+		Ephemeral:       true,
+		Messages:        []llm.Message{{Role: llm.RoleUser, Parts: []llm.Part{{Type: llm.PartText, Text: payload.Text}}}},
+		ReasoningEffort: opts.ReasoningEffort,
+		ServiceTier:     target.ServiceTier,
+		ServiceTierSet:  target.ServiceTier != "",
+		Temperature:     opts.Temperature,
+		TemperatureSet:  opts.TemperatureSet && target.Capabilities.SupportsTemperature,
+	}
+	if target.Capabilities.SupportsOutputLimit {
+		req.MaxOutputTokens = spec.outputTarget
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	// Benchmarks are independent requests, never turns in a provider-managed
+	// conversation. Reset any connection-local Responses continuation before the
+	// timed boundary; SessionID is also unique so server routing cannot join runs.
+	if resetter, ok := target.Provider.(interface{ ResetConversation() }); ok {
+		resetter.ResetConversation()
+	}
+
+	tStart := clock.Now()
+	record.StartedAt = tStart
+	stream, err := target.Provider.Stream(requestCtx, req)
+	if err != nil {
+		tEnd := clock.Now()
+		setEndToEnd(&record, tStart, tEnd)
+		classifyRunError(&record, requestCtx, err)
+		finalizeEligibility(&record, target, opts, spec.phase)
+		return record
+	}
+	defer stream.Close()
+
+	var (
+		firstActivity        *time.Time
+		firstText            *time.Time
+		lastActivity         *time.Time
+		lastText             *time.Time
+		terminalTime         *time.Time
+		firstActivityWasText bool
+	)
+
+	for {
+		event, recvErr := stream.Recv()
+		now := clock.Now()
+		if recvErr != nil {
+			if errors.Is(recvErr, io.EOF) {
+				if !record.TerminalReceived {
+					record.Error = "stream ended without terminal completion"
+				}
+			} else {
+				classifyRunError(&record, requestCtx, recvErr)
+			}
+			terminalTime = &now
+			break
+		}
+
+		switch event.Type {
+		case llm.EventTextDelta:
+			if event.Text != "" {
+				record.ActivityEvents++
+				record.VisibleTextEvents++
+				if firstActivity == nil {
+					firstActivityWasText = true
+				}
+				setFirst(&firstActivity, now)
+				setFirst(&firstText, now)
+				lastActivity = timePtr(now)
+				lastText = timePtr(now)
+			}
+		case llm.EventReasoningDelta:
+			if event.Text != "" || event.ReasoningEncryptedContent != "" {
+				record.ActivityEvents++
+				record.ReasoningObserved = true
+				setFirst(&firstActivity, now)
+				lastActivity = timePtr(now)
+			}
+		case llm.EventUsage:
+			if event.Use != nil {
+				record.UsageReceived = true
+				record.Usage = normalizeUsage(*event.Use, target.Capabilities)
+			}
+		case llm.EventRetry:
+			record.RetryEvents++
+			record.RetryWaitSeconds += event.RetryWaitSecs
+		case llm.EventAttemptDiscard:
+			record.AttemptDiscards++
+		case llm.EventModelSwitch:
+			record.ObservedModels = append(record.ObservedModels, ModelSwitch{Model: event.Model, ReasoningEffort: event.ReasoningEffort})
+		case llm.EventError:
+			if intentionalOutputLimitStop(event.Err, record) {
+				record.OutputLimitReached = true
+				record.OutputLimitStatus = "reached_intentionally"
+				record.TerminalReceived = true
+			} else if event.Err != nil {
+				classifyRunError(&record, requestCtx, event.Err)
+			} else {
+				record.Error = "provider stream error"
+			}
+			terminalTime = &now
+		case llm.EventDone:
+			record.TerminalReceived = true
+			terminalTime = &now
+		}
+		if terminalTime != nil {
+			break
+		}
+	}
+
+	if terminalTime == nil {
+		now := clock.Now()
+		terminalTime = &now
+	}
+	setEndToEnd(&record, tStart, *terminalTime)
+	if firstActivity != nil {
+		record.Timing.ActivityTTFTMS = durationMS(*firstActivity, tStart)
+	}
+	if firstText != nil {
+		record.Timing.VisibleTTFTMS = durationMS(*firstText, tStart)
+	}
+	record.ObservableReasoningWindow = record.ReasoningObserved && !firstActivityWasText
+	if target.Capabilities.IncrementalStream {
+		deriveDecodeMetrics(&record, firstActivity, lastActivity, firstText, lastText, record.ReasoningExpected)
+	} else {
+		record.DecodeStatus = "non_comparable_delivery"
+	}
+	classifyCacheAndTarget(&record, target, opts)
+	record.Success = record.Error == "" && record.TerminalReceived
+	finalizeEligibility(&record, target, opts, spec.phase)
+	return record
+}
+
+func normalizeUsage(usage llm.Usage, capabilities AdapterCapabilities) UsageRecord {
+	total := usage.ProviderRawInputTokens
+	source := "provider_raw"
+	if total <= 0 {
+		total = usage.InputTokens + usage.CachedInputTokens + usage.CacheWriteTokens
+		source = "normalized_components"
+	}
+	if total <= 0 {
+		source = "unavailable"
+	}
+	record := UsageRecord{
+		DirectInputTokens:   usage.InputTokens,
+		TotalInputTokens:    total,
+		ComputedInputTokens: usage.InputTokens + usage.CacheWriteTokens,
+		OutputTokens:        usage.OutputTokens,
+		TokenCountSource:    source,
+	}
+	if capabilities.ReportsCacheReads {
+		record.CachedInputTokens = intPtr(usage.CachedInputTokens)
+	}
+	if capabilities.ReportsCacheWrites {
+		record.CacheWriteTokens = intPtr(usage.CacheWriteTokens)
+	}
+	if capabilities.ReportsReasoningTokens {
+		record.ReasoningTokens = intPtr(usage.ReasoningTokens)
+	}
+	if usage.ProviderRawInputTokens > 0 {
+		record.ProviderRawInputTokens = intPtr(usage.ProviderRawInputTokens)
+	}
+	return record
+}
+
+func classifyCacheAndTarget(record *RunRecord, target Target, opts Options) {
+	if record.Usage.TotalInputTokens > 0 && !UsesGeneratedPayloadTarget(target, opts.Mode) {
+		matched := math.Abs(float64(record.Usage.TotalInputTokens-record.RequestedInput))/float64(record.RequestedInput) <= opts.TargetTolerance
+		record.TargetMatched = &matched
+	}
+	if !target.Capabilities.ReportsCacheReads || record.Usage.TotalInputTokens <= 0 {
+		record.CacheState = "unknown"
+		return
+	}
+	ratio := float64(intValue(record.Usage.CachedInputTokens)) / float64(record.Usage.TotalInputTokens)
+	record.CacheRatio = &ratio
+	switch {
+	case ratio <= opts.CacheTolerance:
+		record.CacheState = "miss"
+	case ratio >= 1-opts.CacheTolerance:
+		record.CacheState = "hit"
+	default:
+		record.CacheState = "partial"
+	}
+}
+
+func deriveDecodeMetrics(record *RunRecord, firstActivity, lastActivity, firstText, lastText *time.Time, reasoningExpected bool) {
+	if record.ActivityEvents < 2 || firstActivity == nil || lastActivity == nil || !lastActivity.After(*firstActivity) {
+		if record.ActivityEvents == 1 {
+			record.DecodeStatus = "non_incremental"
+		} else {
+			record.DecodeStatus = "insufficient_activity"
+		}
+		return
+	}
+
+	observed := lastActivity.Sub(*firstActivity)
+	record.Timing.ObservedDecodeMS = floatPtr(float64(observed) / float64(time.Millisecond))
+	output := record.Usage.OutputTokens
+	reasoningTokens := intValue(record.Usage.ReasoningTokens)
+	if reasoningTokens > 0 && !record.ObservableReasoningWindow {
+		if record.VisibleTextEvents < 2 || firstText == nil || lastText == nil || !lastText.After(*firstText) {
+			record.DecodeStatus = "hidden_reasoning_unobservable"
+			return
+		}
+		visibleOutputAfterFirst := output - reasoningTokens - 1
+		if visibleOutputAfterFirst <= 0 {
+			record.DecodeStatus = "hidden_reasoning_unobservable"
+			return
+		}
+		visibleDuration := lastText.Sub(*firstText)
+		record.Timing.VisibleDecodeMS = floatPtr(float64(visibleDuration) / float64(time.Millisecond))
+		record.Timing.VisibleTokensPerSec = floatPtr(float64(visibleOutputAfterFirst) / visibleDuration.Seconds())
+		record.DecodeStatus = "visible_only_hidden_reasoning_excluded"
+		return
+	}
+	if reasoningExpected && !record.ObservableReasoningWindow && record.Usage.ReasoningTokens == nil {
+		record.DecodeStatus = "reasoning_detail_unavailable"
+		return
+	}
+	if output < 2 {
+		record.DecodeStatus = "insufficient_output_tokens"
+		return
+	}
+
+	countAfterFirst := output - 1
+	record.Timing.DecodeTokensPerSec = floatPtr(float64(countAfterFirst) / observed.Seconds())
+	record.Timing.TPOTMS = floatPtr(float64(observed) / float64(time.Millisecond) / float64(countAfterFirst))
+	record.DecodeStatus = "observed_incremental"
+}
+
+func finalizeEligibility(record *RunRecord, target Target, opts Options, phase string) {
+	if phase != "measured" {
+		record.ExclusionReasons = append(record.ExclusionReasons, "not_measured")
+		return
+	}
+	if !record.Success {
+		record.ExclusionReasons = append(record.ExclusionReasons, "failed_or_incomplete")
+	}
+	if record.RetryEvents > 0 || record.AttemptDiscards > 0 {
+		record.ExclusionReasons = append(record.ExclusionReasons, "provider_retry_or_discard")
+	}
+	if record.TargetMatched != nil && !*record.TargetMatched {
+		record.ExclusionReasons = append(record.ExclusionReasons, "input_target_mismatch_possible_truncation_or_prefix_reuse")
+	}
+	if target.Capabilities.ReportsCacheReads && record.CacheRatio != nil && *record.CacheRatio > opts.CacheTolerance {
+		record.ExclusionReasons = append(record.ExclusionReasons, "cold_cache_contaminated")
+	}
+
+	record.LatencyEligible = record.Success && record.RetryEvents == 0 && record.AttemptDiscards == 0 &&
+		(record.TargetMatched == nil || *record.TargetMatched) &&
+		!(target.Capabilities.ReportsCacheReads && record.CacheRatio != nil && *record.CacheRatio > opts.CacheTolerance)
+	record.FitEligible = record.LatencyEligible && record.Usage.TotalInputTokens > 0
+	if record.Usage.TotalInputTokens <= 0 {
+		record.ExclusionReasons = append(record.ExclusionReasons, "provider_input_tokens_unavailable")
+	}
+	if UsesGeneratedPayloadTarget(target, opts.Mode) {
+		record.FitEligible = false
+		record.ExclusionReasons = append(record.ExclusionReasons, "generated_payload_target_not_comparable_to_provider_total_input")
+	}
+	if !target.Capabilities.ReportsCacheReads && !opts.AllowUnknownCache {
+		record.FitEligible = false
+		record.ExclusionReasons = append(record.ExclusionReasons, "cache_state_unknown_use_allow_unknown_cache_for_token_fits")
+	}
+}
+
+func intentionalOutputLimitStop(err error, record RunRecord) bool {
+	var incomplete *llm.ResponsesIncompleteError
+	return errors.As(err, &incomplete) && incomplete.Reason == "max_output_tokens" &&
+		record.UsageReceived && record.RequestedOutput > 0 &&
+		record.Usage.OutputTokens == record.RequestedOutput
+}
+
+func classifyRunError(record *RunRecord, ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+	record.Error = err.Error()
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		record.TimedOut = true
+		record.Error = context.DeadlineExceeded.Error()
+	} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		record.Cancelled = true
+		record.Error = context.Canceled.Error()
+	}
+}
+
+func setFirst(dst **time.Time, value time.Time) {
+	if *dst == nil {
+		*dst = timePtr(value)
+	}
+}
+
+func setEndToEnd(record *RunRecord, start, end time.Time) {
+	record.Timing.EndToEndMS = durationMS(end, start)
+}
+
+func durationMS(end, start time.Time) *float64 {
+	return floatPtr(float64(end.Sub(start)) / float64(time.Millisecond))
+}
+
+func timePtr(value time.Time) *time.Time { return &value }
+func floatPtr(value float64) *float64    { return &value }
+func intPtr(value int) *int              { return &value }
+func intValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}

--- a/internal/benchmark/report.go
+++ b/internal/benchmark/report.go
@@ -1,0 +1,335 @@
+package benchmark
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+func DefaultProfile(mode string) ([]Scenario, int, int, error) {
+	switch mode {
+	case "balanced":
+		return []Scenario{
+			{InputTokens: 2_000, OutputTokens: 128, Workload: "decode"},
+			{InputTokens: 16_000, OutputTokens: 16, Workload: "prefill"},
+			{InputTokens: 64_000, OutputTokens: 16, Workload: "prefill"},
+		}, 3, 1, nil
+	case "quick":
+		return []Scenario{{InputTokens: 2_000, OutputTokens: 128, Workload: "decode"}}, 3, 1, nil
+	case "decode":
+		return []Scenario{{InputTokens: 2_000, OutputTokens: 256, Workload: "decode"}}, 5, 1, nil
+	case "prefill":
+		return scenariosForInputs([]int{1_000, 4_000, 16_000, 32_000, 64_000, 96_000, 128_000}, 16, "prefill"), 3, 1, nil
+	case "long-context":
+		return scenariosForInputs([]int{32_000, 64_000, 96_000, 128_000, 256_000, 512_000}, 16, "prefill"), 3, 1, nil
+	default:
+		return nil, 0, 0, fmt.Errorf("invalid benchmark mode %q (want balanced, quick, decode, prefill, or long-context)", mode)
+	}
+}
+
+func ScenariosForOverride(mode string, inputs []int, output int) []Scenario {
+	workload := "prefill"
+	if mode == "quick" || mode == "decode" {
+		workload = "decode"
+	}
+	return scenariosForInputs(inputs, output, workload)
+}
+
+func scenariosForInputs(inputs []int, output int, workload string) []Scenario {
+	out := make([]Scenario, 0, len(inputs))
+	for _, input := range inputs {
+		out = append(out, Scenario{InputTokens: input, OutputTokens: output, Workload: workload})
+	}
+	return out
+}
+
+func ComputeBudget(targetCount int, scenarios []Scenario, runs, warmups int, outputNotGuaranteed bool) Budget {
+	return computeBudget(targetCount, scenarios, runs, warmups, outputNotGuaranteed, true)
+}
+
+func ComputeBudgetForTarget(target Target, mode string, scenarios []Scenario, runs, warmups int, outputNotGuaranteed bool) Budget {
+	return computeBudget(1, scenarios, runs, warmups, outputNotGuaranteed, !UsesGeneratedPayloadTarget(target, mode))
+}
+
+func computeBudget(targetCount int, scenarios []Scenario, runs, warmups int, outputNotGuaranteed, includesCalibration bool) Budget {
+	budget := Budget{
+		IncludesCalibration:     includesCalibration,
+		IncludesWarmups:         warmups > 0,
+		IncludesRetryAllowance:  true,
+		CacheWriteBillingRisk:   true,
+		OutputBudgetIsRequested: outputNotGuaranteed,
+		Notes: []string{
+			"Input totals are maximum requested payload/provider tokens, not billed-token predictions.",
+			"Each measured cold request reserves one fresh-payload retry for detected cache contamination.",
+			"Cache-write tokens are computed input and may be billed differently by the provider.",
+		},
+	}
+	calibrationRequests := 0
+	if includesCalibration {
+		calibrationRequests = 2
+		budget.Notes = append(budget.Notes, "Each scenario uses a fresh calibration request plus a fresh validation request before warmups.")
+	}
+	requestsPerScenario := calibrationRequests + warmups + runs*2
+	for _, scenario := range scenarios {
+		budget.MaximumRequests += requestsPerScenario * targetCount
+		budget.MaximumTotalInput += int64(scenario.InputTokens * requestsPerScenario * targetCount)
+		budget.MaximumTotalOutput += int64(scenario.OutputTokens * requestsPerScenario * targetCount)
+		budget.MaximumRequestInput = max(budget.MaximumRequestInput, scenario.InputTokens)
+		budget.MaximumRequestOutput = max(budget.MaximumRequestOutput, scenario.OutputTokens)
+	}
+	if outputNotGuaranteed {
+		budget.Notes = append(budget.Notes, "At least one adapter cannot enforce MaxOutputTokens; its output total is a disclosed requested ceiling only.")
+	}
+	return budget
+}
+
+// AssumedContextLimitLimitation describes the safety boundary of the expert
+// Ollama context eligibility override.
+func AssumedContextLimitLimitation(limit int) string {
+	return fmt.Sprintf("EXPERT OVERRIDE: assumed Ollama context limit %d is used only for benchmark safety eligibility. term-llm did not discover, verify, or configure server num_ctx; provider-reported input target matching remains mandatory, and truncated requests are invalid.", limit)
+}
+
+func NewReport(opts Options, budget Budget, targets []Target, records []RunRecord) Report {
+	metadata := make([]TargetMetadata, 0, len(targets))
+	limitations := []string{
+		"Timings are client-observed at the llm.Provider/llm.Stream boundary, not server-side phase telemetry.",
+		"Transport chunks are not treated as token boundaries; throughput uses provider-reported token counts only.",
+		"Cold, sequential measurements only; warm-cache and concurrent workloads are intentionally not implemented in schema version 1.",
+	}
+	if opts.AssumedContextLimit > 0 {
+		limitations = append(limitations, AssumedContextLimitLimitation(opts.AssumedContextLimit))
+	}
+	for _, target := range targets {
+		providerName := target.ProviderKey
+		credentialType := "unavailable"
+		if target.Provider != nil {
+			providerName = target.Provider.Name()
+			credentialType = target.Provider.Credential()
+		}
+		entry := TargetMetadata{
+			ProviderKey:         target.ProviderKey,
+			ProviderType:        target.ProviderType,
+			ProviderName:        providerName,
+			CredentialType:      credentialType,
+			RequestedModel:      target.RequestedModel,
+			InputTargetMeaning:  inputTargetMeaning(target, opts.Mode),
+			InputLimit:          target.InputLimit,
+			ConfiguredNumCtx:    target.ConfiguredNumCtx,
+			AssumedContextLimit: target.AssumedContextLimit,
+			ServiceTier:         target.ServiceTier,
+			Capabilities:        target.Capabilities,
+			ReasoningEffort:     opts.ReasoningEffort,
+			ReasoningExpected:   target.ReasoningExpected || opts.ReasoningEffort != "",
+			OutputLimitMeaning:  "enforced_by_adapter",
+			Error:               target.Error,
+		}
+		if opts.TemperatureSet && target.Capabilities.SupportsTemperature {
+			value := opts.Temperature
+			entry.Temperature = &value
+		}
+		if !target.Capabilities.SupportsOutputLimit {
+			entry.OutputLimitMeaning = "requested_but_adapter_does_not_enforce"
+		}
+		if !target.Capabilities.ReportsCacheReads {
+			limitations = append(limitations, fmt.Sprintf("%s:%s does not expose trustworthy cache-read telemetry; cache state is unknown.", target.ProviderKey, target.RequestedModel))
+		}
+		if target.Capabilities.ManagedContext {
+			limitations = append(limitations, fmt.Sprintf("%s:%s timing is subprocess-inclusive and not directly comparable to HTTP/API adapters.", target.ProviderKey, target.RequestedModel))
+		}
+		if !target.Capabilities.IncrementalStream {
+			limitations = append(limitations, fmt.Sprintf("%s:%s output is delivered through a non-incremental or bursty adapter boundary; provider decode throughput and TPOT are unavailable. Provider-reported output usage and end-to-end timing remain recorded for separate analysis.", target.ProviderKey, target.RequestedModel))
+		}
+		if UsesGeneratedPayloadTarget(target, opts.Mode) {
+			limitations = append(limitations, fmt.Sprintf("%s:%s --input-tokens targets the generated user payload only; provider-reported total input includes fixed CLI/system overhead and can vary as cache buckets shift, so provider-total calibration and target matching are disabled while actual provider totals remain recorded.", target.ProviderKey, target.RequestedModel))
+		}
+		metadata = append(metadata, entry)
+	}
+	return Report{
+		SchemaVersion: SchemaVersion,
+		Benchmark: BenchmarkMetadata{
+			Mode:                opts.Mode,
+			Cache:               opts.Cache,
+			Seed:                opts.Seed,
+			Runs:                opts.Runs,
+			Warmups:             opts.Warmups,
+			Concurrency:         opts.Concurrency,
+			TimeoutSeconds:      opts.Timeout.Seconds(),
+			CacheTolerance:      opts.CacheTolerance,
+			TargetTolerance:     opts.TargetTolerance,
+			AllowUnknownCache:   opts.AllowUnknownCache,
+			AssumedContextLimit: opts.AssumedContextLimit,
+			RetryPolicy:         "provider retries disabled; one benchmark-level fresh-payload retry only after detected cache contamination",
+			TimingBoundary:      "client-observed at llm.Provider.Stream boundary",
+		},
+		Budget:         budget,
+		TermLLMVersion: opts.TermLLMVersion,
+		Targets:        metadata,
+		Runs:           records,
+		Aggregates:     AggregateRuns(records),
+		Fits:           ComputeFits(records),
+		Limitations:    deduplicate(limitations),
+	}
+}
+
+func WriteBudget(w io.Writer, mode string, budget Budget) {
+	fmt.Fprintf(w, "Benchmark token budget (%s):\n", mode)
+	fmt.Fprintf(w, "  maximum requests: %d\n", budget.MaximumRequests)
+	fmt.Fprintf(w, "  maximum request: %d input + %d requested output tokens\n", budget.MaximumRequestInput, budget.MaximumRequestOutput)
+	fmt.Fprintf(w, "  maximum total: %d input + %d requested output tokens\n", budget.MaximumTotalInput, budget.MaximumTotalOutput)
+	if budget.IncludesCalibration {
+		fmt.Fprintln(w, "  includes calibration plus validation, warmups, and one fresh-payload cache-contamination retry per measured request")
+	} else {
+		fmt.Fprintln(w, "  includes warmups and one fresh-payload cache-contamination retry per measured request; provider-total calibration is disabled for generated-payload targets")
+	}
+	fmt.Fprintln(w, "  cache writes count as computed input and may have provider-specific billing")
+	if budget.OutputBudgetIsRequested {
+		fmt.Fprintln(w, "  warning: at least one adapter cannot enforce the requested output ceiling")
+	}
+}
+
+func WriteHuman(w io.Writer, report Report) {
+	fmt.Fprintf(w, "\nMode: %s | cache: %s | concurrency: %d\n", report.Benchmark.Mode, report.Benchmark.Cache, report.Benchmark.Concurrency)
+	fmt.Fprintf(w, "Runs: %d warmup + %d measured per scenario | seed: %d\n", report.Benchmark.Warmups, report.Benchmark.Runs, report.Benchmark.Seed)
+	fmt.Fprintln(w, "Timing: client-observed at llm.Provider.Stream boundary")
+	if report.Benchmark.AssumedContextLimit > 0 {
+		fmt.Fprintf(w, "WARNING: %s\n", AssumedContextLimitLimitation(report.Benchmark.AssumedContextLimit))
+	}
+
+	for _, target := range report.Targets {
+		fmt.Fprintf(w, "\nProvider: %s (%s)\nModel: %s\n", target.ProviderName, target.ProviderKey, target.RequestedModel)
+		if target.Error != "" {
+			fmt.Fprintf(w, "Status: failed — %s\n", target.Error)
+			continue
+		}
+		if target.AssumedContextLimit > 0 {
+			fmt.Fprintf(w, "Assumed context limit: %d tokens (eligibility only; server num_ctx unchanged)\n", target.AssumedContextLimit)
+		}
+		fmt.Fprintf(w, "Cache telemetry: %s", yesNo(target.Capabilities.ReportsCacheReads))
+		if target.Capabilities.CacheTelemetryNote != "" {
+			fmt.Fprintf(w, " — %s", target.Capabilities.CacheTelemetryNote)
+		}
+		fmt.Fprintln(w)
+		if target.Capabilities.ManagedContext {
+			fmt.Fprintln(w, "Measurement scope: subprocess-inclusive (managed provider opt-in)")
+		}
+		if !target.Capabilities.IncrementalStream {
+			fmt.Fprintln(w, "Decode throughput: unavailable (adapter delivery is non-incremental or bursty; use provider output usage and E2E timing for separate analysis)")
+		}
+		if target.InputTargetMeaning == "generated_user_payload" {
+			fmt.Fprintln(w, "Input target: generated user payload; provider total is reported but not calibrated or target-gated")
+		}
+		if !target.Capabilities.SupportsOutputLimit {
+			fmt.Fprintln(w, "Output limit: unsupported by adapter; actual provider output tokens are reported")
+		}
+		successes, failures, timeouts, retryEvents, discarded := targetRunCounts(report.Runs, target.ProviderKey, target.RequestedModel)
+		fmt.Fprintf(w, "Raw measured attempts: %d success, %d failure (%d timeout), %d provider retry events, %d attempt discards\n", successes, failures, timeouts, retryEvents, discarded)
+		fmt.Fprintln(w, "Workload  Input target  Provider input  Computed  Cache read/write  Output  Activity TTFT min/med/max  Visible TTFT min/med/max  Effective input tok/s  Decode tok/s  TPOT ms  E2E min/med/max  Latency/Fit")
+		for _, aggregate := range report.Aggregates {
+			if aggregate.Provider != target.ProviderKey || aggregate.RequestedModel != target.RequestedModel {
+				continue
+			}
+			decode := formatMedian(aggregate.DecodeTokensPerSecond)
+			if aggregate.DecodeTokensPerSecond.Median == nil {
+				decode = formatMedian(aggregate.VisibleTokensPerSecond)
+				if aggregate.VisibleTokensPerSecond.Median != nil {
+					decode += " visible"
+				}
+			}
+			fmt.Fprintf(w, "%-8s  %11d  %14s  %8s  %8s/%-8s  %6s  %25s  %24s  %21s  %12s  %7s  %15s  %d/%d | %d/%d\n",
+				aggregate.Workload,
+				aggregate.RequestedInput,
+				formatNumber(aggregate.TotalInputTokens),
+				formatNumber(aggregate.ComputedInputTokens),
+				formatNumber(aggregate.CachedInputTokens),
+				formatNumber(aggregate.CacheWriteTokens),
+				formatNumber(aggregate.OutputTokens),
+				formatDurationDistribution(aggregate.ActivityTTFTMS),
+				formatDurationDistribution(aggregate.VisibleTTFTMS),
+				formatMedian(aggregate.EffectiveInputTokensRate),
+				decode,
+				formatMedian(aggregate.TPOTMS),
+				formatDurationDistribution(aggregate.EndToEndMS),
+				aggregate.LatencyValidRuns,
+				aggregate.MeasuredRuns,
+				aggregate.FitValidRuns,
+				aggregate.MeasuredRuns,
+			)
+			if aggregate.CacheState == "unknown" {
+				fmt.Fprintln(w, "                      cache state: unknown (zero cached tokens is not treated as a cache miss)")
+			}
+		}
+	}
+
+	if len(report.Fits) > 0 {
+		fmt.Fprintln(w, "\nLocal client-observed effective prefill slopes:")
+		for _, fit := range report.Fits {
+			fmt.Fprintf(w, "  %s:%s %s: %.0f tok/s (%d lengths, %d valid runs)\n", fit.Provider, fit.RequestedModel, fit.Range, fit.EffectiveTokensPerSec, fit.DistinctLengths, fit.ValidRuns)
+		}
+	} else {
+		fmt.Fprintln(w, "\nLocal client-observed effective prefill slopes: unavailable (requires at least three distinct valid lengths in a range; unknown cache telemetry also requires --allow-unknown-cache)")
+	}
+	fmt.Fprintln(w, "\nThese are client-observed measurements, not server phase timings.")
+}
+
+func targetRunCounts(records []RunRecord, provider, model string) (successes, failures, timeouts, retryEvents, discards int) {
+	for _, record := range records {
+		if record.Provider != provider || record.RequestedModel != model || record.Phase != "measured" {
+			continue
+		}
+		if record.Success {
+			successes++
+		} else {
+			failures++
+		}
+		if record.TimedOut {
+			timeouts++
+		}
+		retryEvents += record.RetryEvents
+		discards += record.AttemptDiscards
+	}
+	return successes, failures, timeouts, retryEvents, discards
+}
+
+func formatDurationDistribution(distribution Distribution) string {
+	if distribution.Min == nil || distribution.Median == nil || distribution.Max == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f/%.2f/%.2fs", *distribution.Min/1000, *distribution.Median/1000, *distribution.Max/1000)
+}
+
+func formatMedian(distribution Distribution) string {
+	if distribution.Median == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f", *distribution.Median)
+}
+
+func formatNumber(value *float64) string {
+	if value == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.0f", *value)
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "reported"
+	}
+	return "not reported"
+}
+
+func deduplicate(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/benchmark/runner.go
+++ b/internal/benchmark/runner.go
@@ -1,0 +1,173 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+)
+
+type scheduledRun struct {
+	scenario int
+	run      int
+}
+
+type RecordCallbackError struct {
+	Err error
+}
+
+func (e *RecordCallbackError) Error() string { return "write benchmark record: " + e.Err.Error() }
+func (e *RecordCallbackError) Unwrap() error { return e.Err }
+
+func (r Runner) runTarget(ctx context.Context, target Target, opts Options) ([]RunRecord, error) {
+	if target.Provider == nil {
+		return nil, fmt.Errorf("benchmark target %s:%s has no provider", target.ProviderKey, target.RequestedModel)
+	}
+	if opts.Timeout <= 0 {
+		return nil, fmt.Errorf("benchmark timeout must be positive")
+	}
+	if len(opts.Scenarios) == 0 {
+		return nil, fmt.Errorf("benchmark has no scenarios")
+	}
+
+	records := make([]RunRecord, 0, len(opts.Scenarios)*(opts.Runs+opts.Warmups+1))
+	calibratedEstimates := make([]int, len(opts.Scenarios))
+	order := 0
+	emit := func(record RunRecord) error {
+		records = append(records, record)
+		if opts.OnRecord != nil {
+			if err := opts.OnRecord(record); err != nil {
+				return &RecordCallbackError{Err: err}
+			}
+		}
+		return nil
+	}
+
+	// Calibrate each distinct scenario with provider-reported input usage, then
+	// validate the adjusted payload before any warmup or measured request. The
+	// second fresh request distinguishes tokenizer-estimate error from context
+	// truncation (notably Ollama silently capping prompt_eval_count). Managed CLI
+	// providers in quick/decode mode intentionally skip this: their fixed system
+	// overhead and shifting cache buckets are not part of the generated payload
+	// target and make provider-total calibration unstable.
+	generatedPayloadTarget := UsesGeneratedPayloadTarget(target, opts.Mode)
+	for i, scenario := range opts.Scenarios {
+		calibratedEstimates[i] = scenario.InputTokens
+		if !generatedPayloadTarget {
+			order++
+			seed := DeriveSeed(opts.Seed, target.ProviderKey, target.RequestedModel, "calibration", i, 1, order)
+			record := r.measure(ctx, target, opts, measureSpec{
+				phase:          "calibration",
+				workload:       scenario.Workload,
+				attempt:        1,
+				order:          order,
+				seed:           seed,
+				inputTarget:    scenario.InputTokens,
+				outputTarget:   scenario.OutputTokens,
+				estimateTarget: scenario.InputTokens,
+			})
+			if err := emit(record); err != nil {
+				return records, err
+			}
+			if ctx.Err() != nil {
+				return records, ctx.Err()
+			}
+			if !record.Success || record.Usage.TotalInputTokens <= 0 {
+				return records, fmt.Errorf("calibration for %s:%s at %d tokens did not return usable provider input tokens: %s", target.ProviderKey, target.RequestedModel, scenario.InputTokens, record.Error)
+			}
+			ratio := float64(scenario.InputTokens) / float64(record.Usage.TotalInputTokens)
+			if ratio < 0.25 || ratio > 4 {
+				return records, fmt.Errorf("calibration for %s:%s at %d tokens was implausible (provider reported %d); possible truncation or cache reuse", target.ProviderKey, target.RequestedModel, scenario.InputTokens, record.Usage.TotalInputTokens)
+			}
+			calibratedEstimates[i] = max(32, int(math.Round(float64(record.LocalEstimate)*ratio)))
+
+			order++
+			seed = DeriveSeed(opts.Seed, target.ProviderKey, target.RequestedModel, "calibration", i, 2, order)
+			record = r.measure(ctx, target, opts, measureSpec{
+				phase:          "calibration",
+				workload:       scenario.Workload,
+				attempt:        2,
+				order:          order,
+				seed:           seed,
+				inputTarget:    scenario.InputTokens,
+				outputTarget:   scenario.OutputTokens,
+				estimateTarget: calibratedEstimates[i],
+			})
+			if err := emit(record); err != nil {
+				return records, err
+			}
+			if ctx.Err() != nil {
+				return records, ctx.Err()
+			}
+			if !record.Success || record.Usage.TotalInputTokens <= 0 || record.TargetMatched == nil || !*record.TargetMatched {
+				return records, fmt.Errorf("calibration validation for %s:%s at %d tokens did not match the target (provider reported %d): possible context truncation or cache reuse", target.ProviderKey, target.RequestedModel, scenario.InputTokens, record.Usage.TotalInputTokens)
+			}
+		}
+
+		for warmup := 0; warmup < opts.Warmups; warmup++ {
+			order++
+			seed := DeriveSeed(opts.Seed, target.ProviderKey, target.RequestedModel, "warmup", i, warmup, order)
+			record := r.measure(ctx, target, opts, measureSpec{
+				phase:          "warmup",
+				workload:       scenario.Workload,
+				run:            warmup + 1,
+				attempt:        1,
+				order:          order,
+				seed:           seed,
+				inputTarget:    scenario.InputTokens,
+				outputTarget:   scenario.OutputTokens,
+				estimateTarget: calibratedEstimates[i],
+			})
+			if err := emit(record); err != nil {
+				return records, err
+			}
+			if ctx.Err() != nil {
+				return records, ctx.Err()
+			}
+		}
+	}
+
+	// Interleave repetitions and randomize target order within each repetition so
+	// context length is not confounded with run order.
+	schedule := make([]scheduledRun, 0, len(opts.Scenarios)*opts.Runs)
+	rng := rand.New(rand.NewSource(DeriveSeed(opts.Seed, target.ProviderKey, target.RequestedModel, "schedule")))
+	for run := 1; run <= opts.Runs; run++ {
+		for _, scenarioIndex := range rng.Perm(len(opts.Scenarios)) {
+			schedule = append(schedule, scheduledRun{scenario: scenarioIndex, run: run})
+		}
+	}
+
+	for _, scheduled := range schedule {
+		scenario := opts.Scenarios[scheduled.scenario]
+		retryReason := ""
+		for attempt := 1; attempt <= 2; attempt++ {
+			order++
+			seed := DeriveSeed(opts.Seed, target.ProviderKey, target.RequestedModel, "measured", scheduled.scenario, scheduled.run, attempt, order)
+			record := r.measure(ctx, target, opts, measureSpec{
+				phase:          "measured",
+				workload:       scenario.Workload,
+				run:            scheduled.run,
+				attempt:        attempt,
+				order:          order,
+				seed:           seed,
+				inputTarget:    scenario.InputTokens,
+				outputTarget:   scenario.OutputTokens,
+				estimateTarget: calibratedEstimates[scheduled.scenario],
+				retryReason:    retryReason,
+			})
+			if err := emit(record); err != nil {
+				return records, err
+			}
+			if ctx.Err() != nil {
+				return records, ctx.Err()
+			}
+			cacheContaminated := target.Capabilities.ReportsCacheReads && record.CacheRatio != nil && *record.CacheRatio > opts.CacheTolerance
+			if !cacheContaminated || attempt == 2 {
+				break
+			}
+			retryReason = "cold_cache_contaminated"
+		}
+	}
+
+	return records, nil
+}

--- a/internal/benchmark/types.go
+++ b/internal/benchmark/types.go
@@ -1,0 +1,296 @@
+package benchmark
+
+import (
+	"context"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+const SchemaVersion = 1
+
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+type AdapterCapabilities struct {
+	ReportsCacheReads       bool   `json:"reports_cache_reads"`
+	ReportsCacheWrites      bool   `json:"reports_cache_writes"`
+	ReportsReasoningTokens  bool   `json:"reports_reasoning_tokens"`
+	SupportsOutputLimit     bool   `json:"supports_output_limit"`
+	SupportsTemperature     bool   `json:"supports_temperature"`
+	SupportsReasoningEffort bool   `json:"supports_reasoning_effort"`
+	MinimumOutputTokens     int    `json:"minimum_safe_output_tokens,omitempty"`
+	IncrementalStream       bool   `json:"incremental_stream"`
+	ManagedContext          bool   `json:"managed_context"`
+	MeasurementScope        string `json:"measurement_scope"`
+	CacheTelemetryNote      string `json:"cache_telemetry_note"`
+	OutputLimitSupportNote  string `json:"output_limit_support_note,omitempty"`
+}
+
+type Target struct {
+	ProviderKey         string
+	ProviderType        string
+	RequestedModel      string
+	Provider            llm.Provider
+	Capabilities        AdapterCapabilities
+	InputLimit          int
+	ConfiguredNumCtx    int
+	AssumedContextLimit int
+	ServiceTier         string
+	ReasoningExpected   bool
+	Error               string
+}
+
+type Scenario struct {
+	InputTokens  int    `json:"input_tokens"`
+	OutputTokens int    `json:"output_tokens"`
+	Workload     string `json:"workload"`
+}
+
+// UsesGeneratedPayloadTarget reports whether input targets describe the locally
+// generated user payload instead of provider-total input usage. Managed CLI
+// adapters add variable system/context overhead, so provider-total calibration
+// is not meaningful for their quick/decode latency workloads.
+func UsesGeneratedPayloadTarget(target Target, mode string) bool {
+	return target.Capabilities.ManagedContext && (mode == "quick" || mode == "decode")
+}
+
+func inputTargetMeaning(target Target, mode string) string {
+	if UsesGeneratedPayloadTarget(target, mode) {
+		return "generated_user_payload"
+	}
+	return "provider_total_calibrated"
+}
+
+type Options struct {
+	Mode                string
+	Cache               string
+	Scenarios           []Scenario
+	Runs                int
+	Warmups             int
+	Concurrency         int
+	Seed                int64
+	ReasoningEffort     string
+	Temperature         float32
+	TemperatureSet      bool
+	Timeout             time.Duration
+	CacheTolerance      float64
+	TargetTolerance     float64
+	AllowUnknownCache   bool
+	AssumedContextLimit int
+	TermLLMVersion      string
+	OnRecord            func(RunRecord) error
+}
+
+type Budget struct {
+	MaximumRequests         int      `json:"maximum_requests"`
+	MaximumRequestInput     int      `json:"maximum_request_input_tokens"`
+	MaximumRequestOutput    int      `json:"maximum_request_output_tokens"`
+	MaximumTotalInput       int64    `json:"maximum_total_input_tokens"`
+	MaximumTotalOutput      int64    `json:"maximum_total_output_tokens"`
+	IncludesCalibration     bool     `json:"includes_calibration"`
+	IncludesWarmups         bool     `json:"includes_warmups"`
+	IncludesRetryAllowance  bool     `json:"includes_cache_contamination_retry_allowance"`
+	CacheWriteBillingRisk   bool     `json:"cache_write_billing_risk"`
+	OutputBudgetIsRequested bool     `json:"output_budget_is_requested_not_guaranteed"`
+	Notes                   []string `json:"notes"`
+}
+
+type BenchmarkMetadata struct {
+	Mode                string  `json:"mode"`
+	Cache               string  `json:"cache"`
+	Seed                int64   `json:"seed"`
+	Runs                int     `json:"runs"`
+	Warmups             int     `json:"warmups"`
+	Concurrency         int     `json:"concurrency"`
+	TimeoutSeconds      float64 `json:"timeout_seconds"`
+	CacheTolerance      float64 `json:"cache_tolerance"`
+	TargetTolerance     float64 `json:"target_tolerance"`
+	AllowUnknownCache   bool    `json:"allow_unknown_cache"`
+	AssumedContextLimit int     `json:"assumed_context_limit,omitempty"`
+	RetryPolicy         string  `json:"retry_policy"`
+	TimingBoundary      string  `json:"timing_boundary"`
+}
+
+type TargetMetadata struct {
+	ProviderKey         string              `json:"provider"`
+	ProviderType        string              `json:"provider_type"`
+	ProviderName        string              `json:"provider_name"`
+	CredentialType      string              `json:"credential_type"`
+	RequestedModel      string              `json:"requested_model"`
+	InputTargetMeaning  string              `json:"input_target_meaning"`
+	InputLimit          int                 `json:"input_limit,omitempty"`
+	ConfiguredNumCtx    int                 `json:"configured_num_ctx,omitempty"`
+	AssumedContextLimit int                 `json:"assumed_context_limit,omitempty"`
+	ServiceTier         string              `json:"service_tier,omitempty"`
+	Capabilities        AdapterCapabilities `json:"capabilities"`
+	ReasoningEffort     string              `json:"reasoning_effort,omitempty"`
+	ReasoningExpected   bool                `json:"reasoning_expected"`
+	Temperature         *float32            `json:"temperature"`
+	OutputLimitMeaning  string              `json:"output_limit_meaning"`
+	Error               string              `json:"error,omitempty"`
+}
+
+type UsageRecord struct {
+	DirectInputTokens      int    `json:"direct_input_tokens"`
+	CachedInputTokens      *int   `json:"cached_input_tokens"`
+	CacheWriteTokens       *int   `json:"cache_write_tokens"`
+	ProviderRawInputTokens *int   `json:"provider_raw_input_tokens"`
+	TotalInputTokens       int    `json:"total_input_tokens"`
+	ComputedInputTokens    int    `json:"computed_input_tokens"`
+	OutputTokens           int    `json:"output_tokens"`
+	ReasoningTokens        *int   `json:"reasoning_tokens"`
+	TokenCountSource       string `json:"token_count_source"`
+}
+
+type TimingRecord struct {
+	ActivityTTFTMS      *float64 `json:"activity_ttft_ms"`
+	VisibleTTFTMS       *float64 `json:"visible_ttft_ms"`
+	EndToEndMS          *float64 `json:"end_to_end_ms"`
+	ObservedDecodeMS    *float64 `json:"observed_decode_ms"`
+	VisibleDecodeMS     *float64 `json:"visible_decode_ms"`
+	DecodeTokensPerSec  *float64 `json:"decode_tokens_per_second"`
+	VisibleTokensPerSec *float64 `json:"visible_decode_tokens_per_second"`
+	TPOTMS              *float64 `json:"tpot_ms"`
+}
+
+type ModelSwitch struct {
+	Model           string `json:"model"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+}
+
+type RunRecord struct {
+	Provider                  string        `json:"provider"`
+	ProviderType              string        `json:"provider_type"`
+	RequestedModel            string        `json:"requested_model"`
+	ObservedModels            []ModelSwitch `json:"observed_model_switches,omitempty"`
+	Phase                     string        `json:"phase"`
+	Workload                  string        `json:"workload"`
+	Run                       int           `json:"run"`
+	Attempt                   int           `json:"attempt"`
+	Order                     int           `json:"order"`
+	StartedAt                 time.Time     `json:"started_at"`
+	Seed                      int64         `json:"seed"`
+	PayloadSHA256             string        `json:"payload_sha256"`
+	PayloadBytes              int           `json:"payload_bytes"`
+	PayloadWords              int           `json:"payload_words"`
+	RequestedInput            int           `json:"requested_input_tokens"`
+	InputTargetMeaning        string        `json:"input_target_meaning"`
+	LocalEstimate             int           `json:"local_estimated_input_tokens"`
+	RequestedOutput           int           `json:"requested_output_tokens"`
+	OutputLimitStatus         string        `json:"output_limit_status"`
+	ReasoningEffort           string        `json:"reasoning_effort,omitempty"`
+	ReasoningExpected         bool          `json:"reasoning_expected"`
+	ServiceTier               string        `json:"service_tier,omitempty"`
+	Temperature               *float32      `json:"temperature"`
+	ReportsCacheReads         bool          `json:"reports_cache_reads"`
+	MeasurementScope          string        `json:"measurement_scope"`
+	RetryPolicy               string        `json:"retry_policy"`
+	UsageReceived             bool          `json:"usage_received"`
+	Usage                     UsageRecord   `json:"usage"`
+	CacheState                string        `json:"cache_state"`
+	CacheRatio                *float64      `json:"cache_ratio"`
+	TargetMatched             *bool         `json:"target_matched"`
+	ActivityEvents            int           `json:"activity_events"`
+	VisibleTextEvents         int           `json:"visible_text_events"`
+	ReasoningObserved         bool          `json:"reasoning_observed"`
+	ObservableReasoningWindow bool          `json:"observable_reasoning_window"`
+	DecodeStatus              string        `json:"decode_status"`
+	Timing                    TimingRecord  `json:"timing"`
+	RetryEvents               int           `json:"retry_events"`
+	RetryWaitSeconds          float64       `json:"retry_wait_seconds"`
+	AttemptDiscards           int           `json:"attempt_discards"`
+	RetryReason               string        `json:"retry_reason,omitempty"`
+	OutputLimitReached        bool          `json:"output_limit_reached"`
+	TerminalReceived          bool          `json:"terminal_received"`
+	Success                   bool          `json:"success"`
+	TimedOut                  bool          `json:"timed_out"`
+	Cancelled                 bool          `json:"cancelled"`
+	Error                     string        `json:"error,omitempty"`
+	LatencyEligible           bool          `json:"latency_eligible"`
+	FitEligible               bool          `json:"fit_eligible"`
+	ExclusionReasons          []string      `json:"exclusion_reasons,omitempty"`
+}
+
+type Distribution struct {
+	Count  int      `json:"count"`
+	Label  string   `json:"label"`
+	Min    *float64 `json:"min"`
+	Median *float64 `json:"median"`
+	Max    *float64 `json:"max"`
+	P95    *float64 `json:"p95"`
+}
+
+type Aggregate struct {
+	Provider                 string       `json:"provider"`
+	RequestedModel           string       `json:"requested_model"`
+	Workload                 string       `json:"workload"`
+	RequestedInput           int          `json:"requested_input_tokens"`
+	RequestedOutput          int          `json:"requested_output_tokens"`
+	MeasuredRuns             int          `json:"measured_runs"`
+	SuccessfulRuns           int          `json:"successful_runs"`
+	LatencyValidRuns         int          `json:"latency_valid_runs"`
+	FitValidRuns             int          `json:"fit_valid_runs"`
+	DecodeValidRuns          int          `json:"decode_valid_runs"`
+	ErrorRuns                int          `json:"error_runs"`
+	CacheState               string       `json:"cache_state"`
+	ComputedInputTokens      *float64     `json:"median_computed_input_tokens"`
+	TotalInputTokens         *float64     `json:"median_provider_total_input_tokens"`
+	CachedInputTokens        *float64     `json:"median_cached_input_tokens"`
+	CacheWriteTokens         *float64     `json:"median_cache_write_tokens"`
+	OutputTokens             *float64     `json:"median_output_tokens"`
+	ActivityTTFTMS           Distribution `json:"activity_ttft_ms"`
+	VisibleTTFTMS            Distribution `json:"visible_ttft_ms"`
+	EndToEndMS               Distribution `json:"end_to_end_ms"`
+	DecodeTokensPerSecond    Distribution `json:"decode_tokens_per_second"`
+	VisibleTokensPerSecond   Distribution `json:"visible_decode_tokens_per_second"`
+	TPOTMS                   Distribution `json:"tpot_ms"`
+	EffectiveInputTokensRate Distribution `json:"client_observed_effective_input_tokens_per_second"`
+}
+
+type Fit struct {
+	Provider                string  `json:"provider"`
+	RequestedModel          string  `json:"requested_model"`
+	Range                   string  `json:"range"`
+	MinimumInputTokens      int     `json:"minimum_input_tokens"`
+	MaximumInputTokens      int     `json:"maximum_input_tokens"`
+	DistinctLengths         int     `json:"distinct_lengths"`
+	ValidRuns               int     `json:"valid_runs"`
+	SlopeSecondsPerToken    float64 `json:"slope_seconds_per_token"`
+	EffectiveTokensPerSec   float64 `json:"client_observed_effective_prefill_tokens_per_second"`
+	InterceptSeconds        float64 `json:"intercept_seconds"`
+	MedianAbsoluteErrorSecs float64 `json:"median_absolute_error_seconds"`
+	Method                  string  `json:"method"`
+}
+
+type Report struct {
+	SchemaVersion  int               `json:"schema_version"`
+	Benchmark      BenchmarkMetadata `json:"benchmark"`
+	Budget         Budget            `json:"budget"`
+	TermLLMVersion string            `json:"term_llm_version"`
+	Targets        []TargetMetadata  `json:"targets"`
+	Runs           []RunRecord       `json:"runs"`
+	Aggregates     []Aggregate       `json:"aggregates"`
+	Fits           []Fit             `json:"fits"`
+	Limitations    []string          `json:"limitations"`
+}
+
+type Runner struct {
+	Clock Clock
+}
+
+func (r Runner) clock() Clock {
+	if r.Clock == nil {
+		return realClock{}
+	}
+	return r.Clock
+}
+
+func (r Runner) RunTarget(ctx context.Context, target Target, opts Options) ([]RunRecord, error) {
+	return r.runTarget(ctx, target, opts)
+}

--- a/internal/benchmark/workload.go
+++ b/internal/benchmark/workload.go
@@ -1,0 +1,84 @@
+package benchmark
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+var payloadVocabulary = []string{
+	"amber", "apricot", "atlas", "birch", "brook", "cedar", "cinder", "clover",
+	"cobalt", "comet", "copper", "coral", "dawn", "delta", "ember", "fern",
+	"flint", "forest", "garden", "glade", "granite", "harbor", "hazel", "island",
+	"ivory", "juniper", "lantern", "laurel", "linen", "lotus", "maple", "meadow",
+	"mist", "moss", "nectar", "oasis", "olive", "onyx", "orbit", "pebble",
+	"pine", "plum", "prairie", "quartz", "reed", "river", "robin", "saffron",
+	"sage", "sand", "silver", "spruce", "stone", "syntax", "teal", "timber",
+	"topaz", "valley", "vector", "violet", "willow", "winter", "wren", "zephyr",
+}
+
+type Payload struct {
+	Text      string
+	SHA256    string
+	Bytes     int
+	Words     int
+	Estimated int
+}
+
+func DeriveSeed(seed int64, dimensions ...any) int64 {
+	h := sha256.New()
+	var raw [8]byte
+	binary.LittleEndian.PutUint64(raw[:], uint64(seed))
+	_, _ = h.Write(raw[:])
+	for _, dimension := range dimensions {
+		_, _ = fmt.Fprintf(h, "\x00%v", dimension)
+	}
+	sum := h.Sum(nil)
+	return int64(binary.LittleEndian.Uint64(sum[:8]))
+}
+
+func GeneratePayload(seed int64, estimatedTokens int, workload string, outputTokens int, supportsOutputLimit bool) Payload {
+	if estimatedTokens < 32 {
+		estimatedTokens = 32
+	}
+	instruction := "Reply with only: OK"
+	if !supportsOutputLimit {
+		marker := fmt.Sprintf("BENCHMARK-END-%016x", uint64(seed))
+		instruction = fmt.Sprintf("Write one concise paragraph of approximately %d words about the value of careful measurement. End the paragraph with the exact marker %s. Do not repeat words or phrases mechanically to reach the requested length, do not repeat the marker, and do not write or continue anything after it.", outputTokens, marker)
+	} else if workload == "decode" {
+		instruction = fmt.Sprintf("Reply with exactly %d occurrences of the word amber separated by single spaces and nothing else.", outputTokens)
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+	var b strings.Builder
+	b.Grow(estimatedTokens * 4)
+	fmt.Fprintf(&b, "benchmark-id %016x\n", uint64(seed))
+	words := 0
+	// EstimateTokens is bytes/4. Account for the final instruction while filling
+	// the random body so the full provider-visible user payload approaches the
+	// requested local estimate.
+	targetBytes := estimatedTokens * 4
+	for b.Len()+len(instruction)+2 < targetBytes {
+		if words > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(payloadVocabulary[rng.Intn(len(payloadVocabulary))])
+		words++
+	}
+	b.WriteByte('\n')
+	b.WriteString(instruction)
+	text := b.String()
+	sum := sha256.Sum256([]byte(text))
+	return Payload{
+		Text:      text,
+		SHA256:    hex.EncodeToString(sum[:]),
+		Bytes:     len(text),
+		Words:     words,
+		Estimated: llm.EstimateTokens(text),
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1190,6 +1190,21 @@ func ModelConfigForProviderModel(cfg *Config, providerName, modelName string) (P
 	return ProviderModelConfig{}, false
 }
 
+// UpstreamModelForProviderModel returns the provider-facing model ID for a
+// configured alias while preserving a declared reasoning-effort suffix.
+// Unconfigured model names are returned unchanged.
+func UpstreamModelForProviderModel(cfg *Config, providerName, modelName string) string {
+	modelName = strings.TrimSpace(modelName)
+	entry, ok := ModelConfigForProviderModel(cfg, providerName, modelName)
+	if !ok || strings.TrimSpace(entry.ID) == "" {
+		return modelName
+	}
+	if effort := providerModelConfigMatchedEffort(entry, modelName); effort != "" {
+		return strings.TrimSpace(entry.ID) + "-" + effort
+	}
+	return strings.TrimSpace(entry.ID)
+}
+
 // DisplayModelForProviderModel returns the user-facing name for a configured model.
 // When a models[] object defines an alias, the alias takes display precedence even
 // if callers track the upstream model id internally. Configured reasoning-effort

--- a/internal/llm/chatgpt.go
+++ b/internal/llm/chatgpt.go
@@ -78,7 +78,7 @@ func NewChatGPTProviderWithOptions(model string, opts ChatGPTProviderOptions) (*
 			if !errors.Is(refreshErr, oauth.ErrChatGPTRefreshTokenInvalid) {
 				return nil, fmt.Errorf("token refresh failed: %w", refreshErr)
 			}
-			fmt.Println("Token refresh failed. Re-authentication required.")
+			fmt.Fprintln(os.Stderr, "Token refresh failed. Re-authentication required.")
 			creds, err = PromptForChatGPTAuth()
 			if err != nil {
 				return nil, err
@@ -131,7 +131,7 @@ func PromptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
 			"Run 'term-llm auth login chatgpt' interactively first to authenticate")
 	}
 
-	fmt.Println("ChatGPT provider requires authentication.")
+	fmt.Fprintln(os.Stderr, "ChatGPT provider requires authentication.")
 
 	// Wire Ctrl-C through to the full auth wait (device-code poll OR
 	// browser callback). The 15-minute cap matches the server-side
@@ -143,7 +143,7 @@ func PromptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
 
 	oauthCreds, err := runChatGPTDeviceCodeFlow(ctx)
 	if errors.Is(err, oauth.ErrChatGPTDeviceCodeNotEnabled) {
-		fmt.Println("(device-code login unavailable — falling back to browser flow)")
+		fmt.Fprintln(os.Stderr, "(device-code login unavailable — falling back to browser flow)")
 		oauthCreds, err = runChatGPTBrowserFlow(ctx)
 	}
 	if err != nil {
@@ -160,7 +160,7 @@ func PromptForChatGPTAuth() (*credentials.ChatGPTCredentials, error) {
 		return nil, fmt.Errorf("failed to save credentials: %w", err)
 	}
 
-	fmt.Println("Authentication successful!")
+	fmt.Fprintln(os.Stderr, "Authentication successful!")
 	return creds, nil
 }
 
@@ -169,22 +169,22 @@ func runChatGPTDeviceCodeFlow(ctx context.Context) (*oauth.ChatGPTCredentials, e
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("\nTo sign in with ChatGPT:\n")
-	fmt.Printf("  1. Open this URL in any browser: %s\n", dc.VerificationURL)
-	fmt.Printf("  2. Enter this one-time code:     %s\n\n", dc.UserCode)
-	fmt.Print("Waiting for approval (Ctrl-C to cancel)...")
+	fmt.Fprint(os.Stderr, "\nTo sign in with ChatGPT:\n")
+	fmt.Fprintf(os.Stderr, "  1. Open this URL in any browser: %s\n", dc.VerificationURL)
+	fmt.Fprintf(os.Stderr, "  2. Enter this one-time code:     %s\n\n", dc.UserCode)
+	fmt.Fprint(os.Stderr, "Waiting for approval (Ctrl-C to cancel)...")
 
 	creds, err := oauth.AuthenticateChatGPTDevice(ctx, dc)
 	if err != nil {
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
 		return nil, err
 	}
-	fmt.Println(" done!")
+	fmt.Fprintln(os.Stderr, " done!")
 	return creds, nil
 }
 
 func runChatGPTBrowserFlow(ctx context.Context) (*oauth.ChatGPTCredentials, error) {
-	fmt.Print("Press Enter to open browser and sign in with your ChatGPT account...")
+	fmt.Fprint(os.Stderr, "Press Enter to open browser and sign in with your ChatGPT account...")
 	if err := waitForEnterOrInterrupt(); err != nil {
 		return nil, err
 	}

--- a/internal/llm/chatgpt_test.go
+++ b/internal/llm/chatgpt_test.go
@@ -443,3 +443,78 @@ func TestChatGPTStream_ReasoningSummaryByOutputIndex(t *testing.T) {
 		t.Fatalf("reasoning tokens = %d, want 1", usageEvent.Use.ReasoningTokens)
 	}
 }
+
+func TestChatGPTProviderResetConversationClearsResponsesState(t *testing.T) {
+	provider := NewChatGPTProviderWithCreds(&credentials.ChatGPTCredentials{
+		AccessToken: "test-token",
+		AccountID:   "test-account",
+		ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+	}, "gpt-5.6-luna")
+	provider.responsesClient = NewChatGPTResponsesClient(provider.creds)
+	provider.responsesClient.LastResponseID = "resp_previous"
+	provider.responsesClient.responseStateSessionID = "benchmark-old"
+
+	provider.ResetConversation()
+
+	if provider.responsesClient.LastResponseID != "" || provider.responsesClient.responseStateSessionID != "" {
+		t.Fatalf("responses state was not reset: id=%q session=%q", provider.responsesClient.LastResponseID, provider.responsesClient.responseStateSessionID)
+	}
+}
+
+func TestChatGPTStreamOmitsUnsupportedOutputLimit(t *testing.T) {
+	originalClient := chatGPTHTTPClient
+	defer func() { chatGPTHTTPClient = originalClient }()
+
+	var body []byte
+	var sessionID string
+	chatGPTHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		sessionID = req.Header.Get("session_id")
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+				`event: response.completed`,
+				`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+				`data: [DONE]`,
+			}, "\n"))),
+			Header: make(http.Header),
+		}, nil
+	})}
+
+	provider := NewChatGPTProviderWithCreds(&credentials.ChatGPTCredentials{
+		AccessToken: "test-token",
+		AccountID:   "test-account",
+		ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+	}, "gpt-5.6-luna-low")
+	stream, err := provider.Stream(context.Background(), Request{
+		SessionID:       "benchmark-unique-request",
+		Messages:        []Message{UserText("hello")},
+		MaxOutputTokens: 77,
+	})
+	if err != nil {
+		t.Fatalf("stream creation failed: %v", err)
+	}
+	defer stream.Close()
+	drainStreamToDone(t, stream)
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if sessionID != "benchmark-unique-request" {
+		t.Fatalf("session_id header = %q", sessionID)
+	}
+	if got, ok := payload["max_output_tokens"]; ok {
+		t.Fatalf("unsupported max_output_tokens was forwarded: %v", got)
+	}
+	if _, ok := payload["temperature"]; ok {
+		t.Fatalf("temperature should be omitted for unsupported ChatGPT benchmark control: %v", payload["temperature"])
+	}
+	if _, ok := payload["top_p"]; ok {
+		t.Fatalf("top_p should be omitted: %v", payload["top_p"])
+	}
+}

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -1081,6 +1081,7 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 				InputTokens:       resultMsg.Usage.InputTokens,
 				OutputTokens:      resultMsg.Usage.OutputTokens,
 				CachedInputTokens: resultMsg.Usage.CacheReadInputTokens,
+				CacheWriteTokens:  resultMsg.Usage.CacheCreationInputTokens,
 			}
 		}
 	}
@@ -1833,9 +1834,10 @@ type claudeResultMessage struct {
 	Result            string            `json:"result"`
 	PermissionDenials []json.RawMessage `json:"permission_denials"`
 	Usage             struct {
-		InputTokens          int `json:"input_tokens"`
-		OutputTokens         int `json:"output_tokens"`
-		CacheReadInputTokens int `json:"cache_read_input_tokens"`
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	} `json:"usage"`
 	TotalCostUSD float64 `json:"total_cost_usd"`
 }

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -1197,6 +1197,32 @@ func TestClaudeBinProvider_EphemeralSystemLineDoesNotReplaceSession(t *testing.T
 	}
 }
 
+func TestClaudeBinProviderParsesCacheCreationInputTokens(t *testing.T) {
+	provider := NewClaudeBinProvider("sonnet", nil)
+	var usage *Usage
+	sawText := false
+	fallback := ""
+	handled := false
+	events := make(chan Event, 1)
+	err := provider.handleClaudeLine(
+		context.Background(),
+		`{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":12,"output_tokens":3,"cache_read_input_tokens":5,"cache_creation_input_tokens":127000}}`,
+		false,
+		eventSender{ctx: context.Background(), ch: events},
+		&usage,
+		&sawText,
+		&fallback,
+		&handled,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage == nil || usage.InputTokens != 12 || usage.CachedInputTokens != 5 || usage.CacheWriteTokens != 127_000 {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
 func TestClaudeBinProvider_ResetConversationClearsResumeState(t *testing.T) {
 	p := NewClaudeBinProvider("sonnet", nil)
 	p.sessionID = "resume-abc"

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -293,6 +293,21 @@ func NewProviderByName(cfg *config.Config, name string, model string) (Provider,
 	return WrapWithRetry(provider, DefaultRetryConfig()), nil
 }
 
+// NewProviderByNameNoRetry creates the same provider as NewProviderByName but
+// returns the underlying adapter without the production retry wrapper. It is
+// intended for controlled callers such as benchmarks where an implicit retry
+// would hide attempt boundaries and could reuse a now-cacheable payload.
+func NewProviderByNameNoRetry(cfg *config.Config, name string, model string) (Provider, error) {
+	provider, err := NewProviderByName(cfg, name, model)
+	if err != nil {
+		return nil, err
+	}
+	if retryProvider, ok := provider.(*RetryProvider); ok {
+		return retryProvider.inner, nil
+	}
+	return provider, nil
+}
+
 // NewFastProvider creates a lightweight provider instance for the specified provider key.
 // Resolution order:
 // 1. providers.<name>.fast_provider + fast_model

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -263,3 +263,21 @@ func TestOpenAICompatReasoningParserOptionsReadsExplicitConfig(t *testing.T) {
 		t.Fatalf("thinkingParam = %q, want custom_thinking", thinkingParam)
 	}
 }
+
+func TestNewProviderByNameNoRetryReturnsUnderlyingAdapter(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
+	provider, err := NewProviderByNameNoRetry(cfg, "ollama", "qwen:7b")
+	if err != nil {
+		t.Fatalf("NewProviderByNameNoRetry: %v", err)
+	}
+	if _, ok := provider.(*OllamaProvider); !ok {
+		t.Fatalf("provider type = %T, want *OllamaProvider", provider)
+	}
+	wrapped, err := NewProviderByName(cfg, "ollama", "qwen:7b")
+	if err != nil {
+		t.Fatalf("NewProviderByName: %v", err)
+	}
+	if _, ok := wrapped.(*RetryProvider); !ok {
+		t.Fatalf("production provider type = %T, want *RetryProvider", wrapped)
+	}
+}


### PR DESCRIPTION
## Summary

Add `term-llm benchmark`, a provider-neutral inference benchmark for measuring client-observed startup latency, decode delivery, cold-prefix input processing, and long-context behavior without routing requests through the agent engine, tools, sessions, or search.

The command supports:

- `balanced`, `quick`, `decode`, `prefill`, and `long-context` profiles
- dynamic enumeration of every installed model for local Ollama providers
- direct providers such as `chatgpt:luna`
- explicit opt-in for managed/subprocess providers such as `claude-bin:haiku`
- human output, complete JSON reports, and append-only per-request JSONL
- deterministic early-unique random payloads to defeat reusable prefix caches
- calibration and provider-reported target validation to detect silent context truncation
- direct, cache-read, and cache-write input accounting
- activity TTFT, visible TTFT, E2E latency, TPOT, and decode tok/s where transport semantics support them
- robust local prefill slopes rather than one global short-context extrapolation
- per-target failure isolation during multi-model runs
- `--assume-context-limit` as an explicit safety eligibility override for Ollama probes; it never configures or claims server `num_ctx`

## Measurement semantics

The benchmark records monotonic timing at the `llm.Provider` / `llm.Stream` boundary:

```text
activity_ttft = first model activity - request start
visible_ttft  = first visible text - request start
e2e_latency   = terminal stream event - request start
decode_time   = last activity - first activity
decode_tok/s  = (provider output tokens - 1) / decode_time
TPOT          = decode_time / (provider output tokens - 1)
```

Decode metrics are omitted for hidden-reasoning windows, single-event/non-incremental streams, and managed CLI adapters whose event delivery is bursty rather than token-paced.

Cold prefill accounting uses:

```text
computed input = direct input + cache-write input
total input    = provider raw input when available,
                 otherwise direct + cache-read + cache-write
cache ratio    = cache-read / total input
```

Cache-write tokens are included because Anthropic-family cold requests may report newly processed tokens as cache creation rather than ordinary input.

## Cache and truncation controls

- Every calibration, warmup, measured request, and contamination retry gets fresh generated content beginning near the start of the provider-visible payload.
- Cache state is capability-driven; a numeric zero never proves that an adapter reports cache reads.
- The default cold-cache contamination threshold is **1%**.
- The default provider-token target tolerance is **15%**.
- Unknown-cache adapters require `--allow-unknown-cache` before input fits are emitted.
- Provider-reported token mismatches remain invalid even when `--assume-context-limit` permits attempting a larger Ollama request.
- With fewer than 10 samples summaries use min/median/max; p95 is emitted only with at least 10 valid samples.
- Local slope fits require at least 3 distinct valid input lengths and never extrapolate beyond their measured interval.

## Provider integration

- Add a no-retry provider constructor so benchmark samples do not inherit the normal long-running retry wrapper.
- Reset stateful provider conversation state and assign an independent benchmark session per request.
- Parse `cache_creation_input_tokens` from `claude-bin` into normalized cache-write usage.
- Keep ChatGPT's unsupported `max_output_tokens` off the wire and use a bounded natural completion instruction instead.
- Record managed/subprocess timing as non-comparable to direct HTTP/API decode throughput.

## Token budgets

The command prints the maximum request and token budget before dispatch. Budgets include:

```text
2 calibration/validation requests
+ configured warmups
+ measured runs
+ one fresh-payload cache-contamination retry allowance per measured run
```

For example, the default quick profile uses 2K requested input and 128 requested output with 1 warmup and 3 measured runs. The maximum budget is 9 requests, 18K input tokens, and 1,152 requested output tokens per target.

## Live validation

The implementation was exercised against all 36 installed local Ollama models, `chatgpt:luna`, and `claude-bin:haiku`.

Highlights:

- All 36 Ollama models were dynamically discovered and attempted.
- A quick 2K/128-token workload produced 30 aggregates and correctly isolated model-load, renderer, context-limit, truncation, and premature-SSE failures.
- A cold 2K/16K/64K probe exposed exact provider truncation boundaries around 4,098, 8,194, and 16,386 tokens instead of mislabeling those requests as long-context results.
- Seven Qwen context variants completed the full 2K/16K/64K cold sweep; their median marginal prefill rate fell from roughly 6,855 tok/s over 2K–16K to roughly 5,106 tok/s over 16K–64K.
- `chatgpt:luna` completed 3/3 measured requests with independent cold-cache state; activity and visible TTFT remain separate.
- `claude-bin:haiku` completed 3/3 measured requests, while decode tok/s was correctly suppressed as non-comparable subprocess burst delivery.

## Tests

- `go test ./internal/benchmark ./internal/llm`
- isolated `go test ./cmd`
- previously completed isolated `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

A non-isolated `go test ./cmd` is affected by the host's global skill catalogue and failed two unrelated skill-discovery tests; the same package passes with an isolated HOME/XDG environment.
