### PR TITLE
feat: add durable concurrent worker threads

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -210,9 +210,11 @@ func runChat(cmd *cobra.Command, args []string) error {
 
 	handoverAutoSend := ""
 	relaunchHandoff := chatRelaunchHandoff{}
+	workerRuntime := &chatWorkerRuntime{}
+	defer func() { _ = workerRuntime.Close() }()
 	chatHandoverApprovalMode = nil
 	for {
-		nextResumeID, nextAutoSend, err := runChatOnce(ctx, cmd, initialText, cliAgent, resumeRequested, resumeID, handoverAutoSend, &relaunchHandoff)
+		nextResumeID, nextAutoSend, err := runChatOnce(ctx, cmd, initialText, cliAgent, resumeRequested, resumeID, handoverAutoSend, &relaunchHandoff, workerRuntime)
 		if err != nil {
 			return err
 		}
@@ -318,10 +320,19 @@ func toolManagerHasPathCapableTools(manager *tools.ToolManager) bool {
 	return false
 }
 
-func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string, relaunchHandoff *chatRelaunchHandoff) (string, string, error) {
+func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string, relaunchHandoff *chatRelaunchHandoff, workerRuntimes ...*chatWorkerRuntime) (string, string, error) {
 	cfg, err := loadConfigWithSetup()
 	if err != nil {
 		return "", "", err
+	}
+	var workerRuntime *chatWorkerRuntime
+	if len(workerRuntimes) > 0 {
+		workerRuntime = workerRuntimes[0]
+	}
+	if workerRuntime != nil {
+		if err := workerRuntime.Ensure(cfg); err != nil {
+			return "", "", fmt.Errorf("initialize worker runtime: %w", err)
+		}
 	}
 	rawConfigInstructions := cfg.Chat.Instructions
 
@@ -647,6 +658,9 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 		chatPlatformMessage = agent.PlatformMessages.For("chat")
 	}
 	model := chat.NewWithFastProviderAndApproval(cfg, provider, fastProvider, engine, providerKey, modelName, mcpManager, settings.MaxTurns, forceExternalSearch, chatNoWebFetch, settings.Search, enabledLocalTools, settings.Tools, settings.MCP, false, initialText, store, sess, useAltScreen, chatAutoSend, autoSendMode, chatTextMode, agentName, chatPlatformMessage, resolvedYolo, desiredApprovalMode, toolMgr)
+	if workerRuntime != nil {
+		model.SetWorkerController(workerRuntime)
+	}
 	model.SetAgentMentionCapability(runtimeAgentMentionCapability{engine: model.CurrentAgentMentionEngine, manager: toolMgr})
 	if sess != nil {
 		model.SetConversationBranch(sessionIsConversationBranch(context.Background(), store, sess.ID))

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -143,7 +143,9 @@ Slash commands:
   /inspect     - View conversation/tool details
   /compact     - Compact conversation context
   /resume      - Browse and resume previous sessions
-  /tree        - Browse paths or branch from an earlier message
+  /tree        - Browse paths, workers, and mailbox reports
+  /main        - Return from a worker session to its coordinator
+  /report      - Brief the coordinator from a completed worker session
   /reload      - Re-exec current binary and resume session
   /handover    - Hand conversation to another agent`,
 	RunE:              runChat,

--- a/cmd/chat_workers.go
+++ b/cmd/chat_workers.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+	"github.com/samsaffron/term-llm/internal/tui/chat"
+)
+
+const (
+	threadWorkerLabelKey   = "term_llm_thread_worker"
+	threadWorkerLabelValue = "durable"
+	threadWorkerTimeout    = 60 * time.Minute
+)
+
+const threadWorkerSystemMessage = `You are a durable background worker attached to a coordinating chat.
+Work only on the task supplied by the user. This MVP uses a flat topology: do not launch nested workers or attempt to steer the coordinator.
+Use the report tool for useful progress or blockers. Before finishing, call report with kind=result and a concise, self-contained outcome. Mailbox reports remain outside the coordinator's context until the user explicitly imports one.
+The coordinator may share this working directory. Avoid broad or unrelated edits and report any concurrency risk before proceeding.`
+
+type chatWorkerRuntime struct {
+	mu      sync.Mutex
+	manager *jobsV2Manager
+	cfg     *config.Config
+}
+
+func (r *chatWorkerRuntime) Ensure(cfg *config.Config) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.manager != nil {
+		return nil
+	}
+	if cfg == nil {
+		return fmt.Errorf("worker runtime configuration is unavailable")
+	}
+	r.cfg = cloneConfigForServeJob(cfg)
+	fallback := resolvedApprovalMode{Mode: tools.ModePrompt, Source: approvalModeSourceBuiltinDefault}
+	executor := newServeJobsExecutorWithApprovalResolver(r.cfg, fallback, r.resolveApproval)
+	manager, err := newThreadWorkerJobsV2Manager("", 2, executor, r.notifyDone)
+	if err != nil {
+		return err
+	}
+	r.manager = manager
+	return nil
+}
+
+func (r *chatWorkerRuntime) Close() error {
+	r.mu.Lock()
+	manager := r.manager
+	r.manager = nil
+	r.mu.Unlock()
+	if manager == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return manager.CloseContext(ctx)
+}
+
+func (r *chatWorkerRuntime) withWorkerStore(ctx context.Context, fn func(session.WorkerStore, session.Store) error) error {
+	r.mu.Lock()
+	cfg := r.cfg
+	r.mu.Unlock()
+	if cfg == nil {
+		return fmt.Errorf("worker runtime is not initialized")
+	}
+	store, cleanup := InitSessionStore(cfg, io.Discard)
+	defer cleanup()
+	workerStore, ok := session.AsWorkerStore(store)
+	if !ok {
+		return session.ErrWorkersUnsupported
+	}
+	return fn(workerStore, store)
+}
+
+func (r *chatWorkerRuntime) resolveApproval(ctx context.Context, cfg jobsV2LLMConfig) (resolvedApprovalMode, error) {
+	if !cfg.Worker || strings.TrimSpace(cfg.ParentSessionID) == "" || strings.TrimSpace(cfg.SessionID) == "" {
+		return resolvedApprovalMode{}, fmt.Errorf("thread worker approval requires durable parent linkage")
+	}
+	resolved := resolvedApprovalMode{Mode: tools.ModePrompt, Source: approvalModeSourceSession}
+	err := r.withWorkerStore(ctx, func(workerStore session.WorkerStore, store session.Store) error {
+		edge, err := workerStore.GetWorker(ctx, cfg.SessionID)
+		if err != nil {
+			return fmt.Errorf("load worker edge: %w", err)
+		}
+		if edge.CoordinatorSessionID != cfg.ParentSessionID {
+			return fmt.Errorf("worker parent does not match durable edge")
+		}
+		parent, err := store.Get(ctx, edge.CoordinatorSessionID)
+		if err != nil {
+			return fmt.Errorf("load worker coordinator: %w", err)
+		}
+		switch parent.ApprovalMode {
+		case session.ApprovalModeAuto:
+			resolved.Mode = tools.ModeAuto
+		case session.ApprovalModeYolo:
+			resolved.Mode = tools.ModeYolo
+		default:
+			resolved.Mode = tools.ModePrompt
+		}
+		if cfg.WorkerApprovalMode != "" {
+			requested, err := parseCLIApprovalMode(cfg.WorkerApprovalMode)
+			if err != nil {
+				return err
+			}
+			if requested != resolved.Mode {
+				return fmt.Errorf("worker approval %s exceeds or differs from durable coordinator approval %s", requested, resolved.Mode)
+			}
+			resolved.Mode = requested
+		}
+		return workerStore.UpdateWorkerStatus(ctx, edge.ChildSessionID, session.WorkerRunning)
+	})
+	return resolved, err
+}
+
+func (r *chatWorkerRuntime) StartWorker(ctx context.Context, req chat.WorkerStartRequest) (chat.WorkerStartResult, error) {
+	r.mu.Lock()
+	manager := r.manager
+	r.mu.Unlock()
+	if manager == nil {
+		return chat.WorkerStartResult{}, fmt.Errorf("worker runtime is not initialized")
+	}
+	if strings.TrimSpace(req.ChildSessionID) == "" || strings.TrimSpace(req.CoordinatorSessionID) == "" {
+		return chat.WorkerStartResult{}, fmt.Errorf("worker session linkage is required")
+	}
+	persist := true
+	cfg := jobsV2LLMConfig{
+		AgentName: "developer", Instructions: req.Task, PersistSession: &persist,
+		SessionID: req.ChildSessionID, SessionName: "Worker: " + session.TruncateSummary(req.Task),
+		ParentSessionID: req.CoordinatorSessionID, Worker: true, WorkerApprovalMode: req.ApprovalMode.String(),
+		Cwd: req.Cwd, Provider: req.Provider, Model: req.Model, Tools: req.Tools,
+		Search: req.Search, SystemMessage: threadWorkerSystemMessage,
+	}
+	runnerConfig, err := json.Marshal(cfg)
+	if err != nil {
+		return chat.WorkerStartResult{}, err
+	}
+	labels, _ := json.Marshal(map[string]string{threadWorkerLabelKey: threadWorkerLabelValue, "child_session_id": req.ChildSessionID})
+	job, err := manager.CreateJob(jobsV2Job{
+		Name: "thread-" + session.ShortID(req.ChildSessionID), Enabled: true,
+		RunnerType: jobsV2RunnerLLM, RunnerConfig: runnerConfig,
+		TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`),
+		ConcurrencyPolicy: "forbid", MaxConcurrentRuns: 1,
+		RetryPolicy:    json.RawMessage(`{"max_attempts":1}`),
+		TimeoutSeconds: int(threadWorkerTimeout / time.Second), MisfirePolicy: jobsV2MisfireSkip,
+		Labels: labels,
+	})
+	if err != nil {
+		return chat.WorkerStartResult{}, err
+	}
+	run, err := manager.TriggerJob(job.ID)
+	if err != nil {
+		_ = manager.DeleteJob(job.ID, true)
+		return chat.WorkerStartResult{}, err
+	}
+	return chat.WorkerStartResult{JobID: job.ID, RunID: run.ID}, nil
+}
+
+func (r *chatWorkerRuntime) CancelWorker(_ context.Context, runID string) error {
+	r.mu.Lock()
+	manager := r.manager
+	r.mu.Unlock()
+	if manager == nil {
+		return fmt.Errorf("worker runtime is not initialized")
+	}
+	if strings.TrimSpace(runID) == "" {
+		return fmt.Errorf("worker run id is empty")
+	}
+	_, err := manager.CancelRun(runID)
+	return err
+}
+
+func terminalWorkerStatus(status jobsV2RunStatus) session.WorkerStatus {
+	switch status {
+	case jobsV2RunSucceeded:
+		return session.WorkerDone
+	case jobsV2RunCancelled:
+		return session.WorkerCancelled
+	default:
+		return session.WorkerFailed
+	}
+}
+
+func synthesizedWorkerBody(status jobsV2RunStatus, result jobsV2RunResult, exitReason, errText string) string {
+	body := strings.TrimSpace(result.Response)
+	if body == "" {
+		body = strings.TrimSpace(result.Stdout)
+	}
+	if body == "" {
+		body = strings.TrimSpace(errText)
+	}
+	if body == "" {
+		body = fmt.Sprintf("Worker finished with status %s (%s).", status, exitReason)
+	}
+	return body
+}
+
+func (r *chatWorkerRuntime) notifyDone(ctx context.Context, run jobsV2Run, job jobsV2Job, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) error {
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(job.RunnerConfig, &cfg); err != nil || !cfg.Worker {
+		return nil
+	}
+	return r.withWorkerStore(ctx, func(workerStore session.WorkerStore, _ session.Store) error {
+		edge, err := workerStore.GetWorker(ctx, cfg.SessionID)
+		if err != nil {
+			return err
+		}
+		hasResult, err := workerStore.HasWorkerReportKind(ctx, edge.ChildSessionID, session.WorkerReportResult)
+		if err != nil {
+			return err
+		}
+		if !hasResult {
+			metadata, _ := json.Marshal(map[string]any{
+				"status": status, "exit_reason": exitReason, "truncated": truncated,
+				"run_id": run.ID, "job_id": job.ID,
+			})
+			title := "Worker completed"
+			if status != jobsV2RunSucceeded {
+				title = "Worker ended: " + string(status)
+			}
+			if _, err := workerStore.AddWorkerReport(ctx, session.WorkerReport{
+				ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+				DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+				Title: title, Body: synthesizedWorkerBody(status, result, exitReason, errText),
+				Metadata: metadata, Origin: "terminal_synthesis",
+			}); err != nil {
+				return err
+			}
+		}
+		if err := workerStore.UpdateWorkerStatus(ctx, edge.ChildSessionID, terminalWorkerStatus(status)); err != nil && !errors.Is(err, session.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}

--- a/cmd/chat_workers.go
+++ b/cmd/chat_workers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,10 +18,15 @@ import (
 )
 
 const (
-	threadWorkerLabelKey   = "term_llm_thread_worker"
-	threadWorkerLabelValue = "durable"
-	threadWorkerTimeout    = 60 * time.Minute
+	threadWorkerLabelKey            = "term_llm_thread_worker"
+	threadWorkerLabelValue          = "durable"
+	threadWorkerOwnerLabelKey       = "thread_owner_id"
+	threadWorkerCoordinatorLabelKey = "coordinator_session_id"
+	threadWorkerChildLabelKey       = "child_session_id"
+	threadWorkerTimeout             = 60 * time.Minute
 )
+
+var threadWorkerUnstartedGracePeriod = 2 * time.Second
 
 const threadWorkerSystemMessage = `You are a durable background worker attached to a coordinating chat.
 Work only on the task supplied by the user. This MVP uses a flat topology: do not launch nested workers or attempt to steer the coordinator.
@@ -122,6 +128,15 @@ func (r *chatWorkerRuntime) resolveApproval(ctx context.Context, cfg jobsV2LLMCo
 	return resolved, err
 }
 
+func (r *chatWorkerRuntime) OwnerID() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.manager == nil {
+		return ""
+	}
+	return r.manager.workerID
+}
+
 func (r *chatWorkerRuntime) StartWorker(ctx context.Context, req chat.WorkerStartRequest) (chat.WorkerStartResult, error) {
 	r.mu.Lock()
 	manager := r.manager
@@ -144,7 +159,12 @@ func (r *chatWorkerRuntime) StartWorker(ctx context.Context, req chat.WorkerStar
 	if err != nil {
 		return chat.WorkerStartResult{}, err
 	}
-	labels, _ := json.Marshal(map[string]string{threadWorkerLabelKey: threadWorkerLabelValue, "child_session_id": req.ChildSessionID})
+	labels, _ := json.Marshal(map[string]string{
+		threadWorkerLabelKey:            threadWorkerLabelValue,
+		threadWorkerOwnerLabelKey:       manager.workerID,
+		threadWorkerCoordinatorLabelKey: req.CoordinatorSessionID,
+		threadWorkerChildLabelKey:       req.ChildSessionID,
+	})
 	job, err := manager.CreateJob(jobsV2Job{
 		Name: "thread-" + session.ShortID(req.ChildSessionID), Enabled: true,
 		RunnerType: jobsV2RunnerLLM, RunnerConfig: runnerConfig,
@@ -165,18 +185,238 @@ func (r *chatWorkerRuntime) StartWorker(ctx context.Context, req chat.WorkerStar
 	return chat.WorkerStartResult{JobID: job.ID, RunID: run.ID}, nil
 }
 
-func (r *chatWorkerRuntime) CancelWorker(_ context.Context, runID string) error {
+func decodeThreadWorkerLabels(job jobsV2Job) map[string]string {
+	labels := map[string]string{}
+	_ = json.Unmarshal(job.Labels, &labels)
+	return labels
+}
+
+func (r *chatWorkerRuntime) finishWorkerEdge(ctx context.Context, workerStore session.WorkerStore, edge session.WorkerEdge, status session.WorkerStatus, title, body string, metadata json.RawMessage) error {
+	return workerStore.FinishWorker(ctx, edge.ChildSessionID, status, session.WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+		Title: title, Body: body, Metadata: metadata, Origin: "terminal_synthesis",
+	})
+}
+
+func (r *chatWorkerRuntime) adoptWorkerOwner(ctx context.Context, manager *jobsV2Manager, workerStore session.WorkerStore, edge *session.WorkerEdge) (bool, error) {
+	if edge.OwnerID == manager.workerID {
+		return true, nil
+	}
+	live, err := manager.threadOwnerLive(edge.OwnerID)
+	if err != nil {
+		return false, err
+	}
+	if live {
+		return false, nil
+	}
+	changed, err := workerStore.SetWorkerOwner(ctx, edge.ChildSessionID, edge.OwnerID, manager.workerID)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		refreshed, err := workerStore.GetWorker(ctx, edge.ChildSessionID)
+		if err != nil {
+			return false, err
+		}
+		*edge = refreshed
+		return edge.OwnerID == manager.workerID, nil
+	}
+	edge.OwnerID = manager.workerID
+	return true, nil
+}
+
+func (r *chatWorkerRuntime) adoptThreadJob(ctx context.Context, manager *jobsV2Manager, edge session.WorkerEdge, job *jobsV2Job) (bool, error) {
+	labels := decodeThreadWorkerLabels(*job)
+	if labels[threadWorkerLabelKey] != threadWorkerLabelValue || labels[threadWorkerChildLabelKey] != edge.ChildSessionID || labels[threadWorkerCoordinatorLabelKey] != edge.CoordinatorSessionID {
+		return false, fmt.Errorf("worker job linkage does not match durable edge")
+	}
+	ownerID := labels[threadWorkerOwnerLabelKey]
+	if ownerID == manager.workerID {
+		return true, nil
+	}
+	live, err := manager.threadOwnerLive(ownerID)
+	if err != nil {
+		return false, err
+	}
+	if live {
+		return false, nil
+	}
+	labels[threadWorkerOwnerLabelKey] = manager.workerID
+	updated, err := json.Marshal(labels)
+	if err != nil {
+		return false, err
+	}
+	result, err := manager.db.ExecContext(ctx, `UPDATE jobs_v2 SET labels = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND COALESCE(labels, '') = ?`, string(updated), job.ID, string(job.Labels))
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if rows == 0 {
+		refreshed, err := manager.GetJob(job.ID)
+		if err != nil {
+			return false, err
+		}
+		*job = refreshed
+		return decodeThreadWorkerLabels(refreshed)[threadWorkerOwnerLabelKey] == manager.workerID, nil
+	}
+	job.Labels = updated
+	manager.notifyWorkers(1)
+	return true, nil
+}
+
+func jobsV2RunIsTerminal(status jobsV2RunStatus) bool {
+	switch status {
+	case jobsV2RunSucceeded, jobsV2RunFailed, jobsV2RunCancelled, jobsV2RunTimedOut, jobsV2RunSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *chatWorkerRuntime) reconcileWorker(ctx context.Context, manager *jobsV2Manager, workerStore session.WorkerStore, edge session.WorkerEdge) error {
+	if !edge.Status.Active() {
+		return nil
+	}
+	owned, err := r.adoptWorkerOwner(ctx, manager, workerStore, &edge)
+	if err != nil || !owned {
+		return err
+	}
+	if strings.TrimSpace(edge.RunID) == "" || strings.TrimSpace(edge.JobID) == "" {
+		if time.Since(edge.UpdatedAt) < threadWorkerUnstartedGracePeriod {
+			return nil
+		}
+		return r.finishWorkerEdge(ctx, workerStore, edge, session.WorkerFailed,
+			"Worker execution was not started", "The chat exited before a durable worker run was recorded; no work was retried.", nil)
+	}
+	job, err := manager.GetJob(edge.JobID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return r.finishWorkerEdge(ctx, workerStore, edge, session.WorkerFailed,
+			"Worker execution record is missing", "The durable worker job no longer exists; no work was retried.", nil)
+	}
+	if err != nil {
+		return err
+	}
+	owned, err = r.adoptThreadJob(ctx, manager, edge, &job)
+	if err != nil || !owned {
+		return err
+	}
+	run, err := manager.GetRun(edge.RunID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return r.finishWorkerEdge(ctx, workerStore, edge, session.WorkerFailed,
+			"Worker execution record is missing", "The durable worker run no longer exists; no work was retried.", nil)
+	}
+	if err != nil {
+		return err
+	}
+	if jobsV2RunIsTerminal(run.Status) {
+		result := jobsV2RunResult{
+			Stdout: run.Stdout, Stderr: run.Stderr, Thinking: run.Thinking, Response: run.Response,
+			SessionID: run.SessionID, ExitReason: run.ExitReason, Truncated: run.Truncated,
+			TurnCount: run.TurnCount, InputTokens: run.InputTokens, OutputTokens: run.OutputTokens,
+		}
+		if run.ExitCode != nil {
+			result.ExitCode = *run.ExitCode
+		}
+		return r.notifyDone(ctx, run, job, run.Status, result, run.ExitReason, run.Truncated, run.Error)
+	}
+	if err := manager.recoverRuns(); err != nil {
+		return err
+	}
+	manager.notifyWorkers(1)
+	return nil
+}
+
+func (r *chatWorkerRuntime) ReconcileWorkers(ctx context.Context, coordinatorSessionID string) error {
 	r.mu.Lock()
 	manager := r.manager
 	r.mu.Unlock()
 	if manager == nil {
 		return fmt.Errorf("worker runtime is not initialized")
 	}
-	if strings.TrimSpace(runID) == "" {
-		return fmt.Errorf("worker run id is empty")
+	return r.withWorkerStore(ctx, func(workerStore session.WorkerStore, _ session.Store) error {
+		edges, err := workerStore.ListWorkers(ctx, strings.TrimSpace(coordinatorSessionID))
+		if err != nil {
+			return err
+		}
+		for _, edge := range edges {
+			if err := r.reconcileWorker(ctx, manager, workerStore, edge); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (r *chatWorkerRuntime) CancelWorker(ctx context.Context, req chat.WorkerCancelRequest) error {
+	r.mu.Lock()
+	manager := r.manager
+	r.mu.Unlock()
+	if manager == nil {
+		return fmt.Errorf("worker runtime is not initialized")
 	}
-	_, err := manager.CancelRun(runID)
-	return err
+	return r.withWorkerStore(ctx, func(workerStore session.WorkerStore, _ session.Store) error {
+		edge, err := workerStore.GetWorker(ctx, req.ChildSessionID)
+		if err != nil {
+			return err
+		}
+		if edge.CoordinatorSessionID != strings.TrimSpace(req.CoordinatorSessionID) {
+			return fmt.Errorf("worker coordinator does not match cancellation request")
+		}
+		owned, err := r.adoptWorkerOwner(ctx, manager, workerStore, &edge)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			return fmt.Errorf("worker is owned by another live chat")
+		}
+		runID := strings.TrimSpace(edge.RunID)
+		if runID == "" {
+			runID = strings.TrimSpace(req.RunID)
+		}
+		if runID == "" {
+			return r.finishWorkerEdge(ctx, workerStore, edge, session.WorkerCancelled,
+				"Stale worker cleared", "No durable execution was recorded; the stale active edge was safely cleared.", nil)
+		}
+		run, err := manager.GetRun(runID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return r.finishWorkerEdge(ctx, workerStore, edge, session.WorkerCancelled,
+				"Stale worker cleared", "The durable execution run was missing; the stale active edge was safely cleared.", nil)
+		}
+		if err != nil {
+			return err
+		}
+		job, err := manager.GetJob(run.JobID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return r.finishWorkerEdge(ctx, workerStore, edge, session.WorkerCancelled,
+				"Stale worker cleared", "The durable execution record was missing; the stale active edge was safely cleared.", nil)
+		}
+		if err != nil {
+			return err
+		}
+		owned, err = r.adoptThreadJob(ctx, manager, edge, &job)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			return fmt.Errorf("worker run is owned by another live chat")
+		}
+		run, err = manager.CancelRun(runID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return r.finishWorkerEdge(ctx, workerStore, edge, session.WorkerCancelled,
+				"Stale worker cleared", "The durable execution run was missing; the stale active edge was safely cleared.", nil)
+		}
+		if err != nil {
+			return err
+		}
+		if jobsV2RunIsTerminal(run.Status) {
+			return r.reconcileWorker(ctx, manager, workerStore, edge)
+		}
+		return nil
+	})
 }
 
 func terminalWorkerStatus(status jobsV2RunStatus) session.WorkerStatus {
@@ -214,31 +454,15 @@ func (r *chatWorkerRuntime) notifyDone(ctx context.Context, run jobsV2Run, job j
 		if err != nil {
 			return err
 		}
-		hasResult, err := workerStore.HasWorkerReportKind(ctx, edge.ChildSessionID, session.WorkerReportResult)
-		if err != nil {
-			return err
+		metadata, _ := json.Marshal(map[string]any{
+			"status": status, "exit_reason": exitReason, "truncated": truncated,
+			"run_id": run.ID, "job_id": job.ID,
+		})
+		title := "Worker completed"
+		if status != jobsV2RunSucceeded {
+			title = "Worker ended: " + string(status)
 		}
-		if !hasResult {
-			metadata, _ := json.Marshal(map[string]any{
-				"status": status, "exit_reason": exitReason, "truncated": truncated,
-				"run_id": run.ID, "job_id": job.ID,
-			})
-			title := "Worker completed"
-			if status != jobsV2RunSucceeded {
-				title = "Worker ended: " + string(status)
-			}
-			if _, err := workerStore.AddWorkerReport(ctx, session.WorkerReport{
-				ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
-				DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
-				Title: title, Body: synthesizedWorkerBody(status, result, exitReason, errText),
-				Metadata: metadata, Origin: "terminal_synthesis",
-			}); err != nil {
-				return err
-			}
-		}
-		if err := workerStore.UpdateWorkerStatus(ctx, edge.ChildSessionID, terminalWorkerStatus(status)); err != nil && !errors.Is(err, session.ErrNotFound) {
-			return err
-		}
-		return nil
+		return r.finishWorkerEdge(ctx, workerStore, edge, terminalWorkerStatus(status), title,
+			synthesizedWorkerBody(status, result, exitReason, errText), metadata)
 	})
 }

--- a/cmd/chat_workers_reconcile_test.go
+++ b/cmd/chat_workers_reconcile_test.go
@@ -1,0 +1,300 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tui/chat"
+)
+
+func newReconciliationRuntime(t *testing.T) (*chatWorkerRuntime, *session.SQLiteStore, *jobsV2Manager) {
+	t.Helper()
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "sessions.db")
+	cfg := &config.Config{Sessions: config.SessionsConfig{Enabled: true, Path: sessionPath}}
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: sessionPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	parent := &session.Session{
+		ID: "main", Provider: "mock", ProviderKey: "mock", Model: "model",
+		Mode: session.ModeChat, Origin: session.OriginTUI, ApprovalMode: session.ApprovalModePrompt,
+		CWD: t.TempDir(), CreatedAt: time.Now(), UpdatedAt: time.Now(), Status: session.StatusActive,
+	}
+	if err := store.Create(context.Background(), parent); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &chatWorkerRuntime{cfg: cfg}
+	manager, err := newJobsV2ManagerConfigured(filepath.Join(dir, "thread.db"), 0, nil, runtime.notifyDone, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.manager = manager
+	t.Cleanup(func() { _ = runtime.Close() })
+	return runtime, store, manager
+}
+
+func createReconciliationExecution(t *testing.T, store *session.SQLiteStore, manager *jobsV2Manager) (session.WorkerEdge, jobsV2Job, jobsV2Run) {
+	t.Helper()
+	edge, err := store.CreateWorkerOwned(context.Background(), "main", manager.workerID, "reconcile fixture")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runnerConfig, _ := json.Marshal(workerLLMConfig(edge))
+	labels, _ := json.Marshal(map[string]string{
+		threadWorkerLabelKey:            threadWorkerLabelValue,
+		threadWorkerOwnerLabelKey:       manager.workerID,
+		threadWorkerCoordinatorLabelKey: edge.CoordinatorSessionID,
+		threadWorkerChildLabelKey:       edge.ChildSessionID,
+	})
+	job, err := manager.CreateJob(jobsV2Job{
+		Name: "thread-" + session.ShortID(edge.ChildSessionID), Enabled: true,
+		RunnerType: jobsV2RunnerLLM, RunnerConfig: runnerConfig,
+		TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`),
+		ConcurrencyPolicy: "forbid", MaxConcurrentRuns: 1,
+		RetryPolicy: json.RawMessage(`{"max_attempts":1}`), TimeoutSeconds: 300,
+		MisfirePolicy: jobsV2MisfireSkip, Labels: labels,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := manager.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetWorkerExecution(context.Background(), edge.ChildSessionID, job.ID, run.ID); err != nil {
+		t.Fatal(err)
+	}
+	edge.JobID, edge.RunID = job.ID, run.ID
+	return edge, job, run
+}
+
+func waitForWorkerTerminal(t *testing.T, store *session.SQLiteStore, childID string) session.WorkerEdge {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		edge, err := store.GetWorker(context.Background(), childID)
+		if err == nil && edge.Status.Terminal() {
+			return edge
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	edge, err := store.GetWorker(context.Background(), childID)
+	t.Fatalf("worker did not become terminal: %#v, %v", edge, err)
+	return session.WorkerEdge{}
+}
+
+func TestChatWorkerReconcileClearsCrashedUnstartedEdge(t *testing.T) {
+	runtime, store, manager := newReconciliationRuntime(t)
+	oldGrace := threadWorkerUnstartedGracePeriod
+	threadWorkerUnstartedGracePeriod = 0
+	t.Cleanup(func() { threadWorkerUnstartedGracePeriod = oldGrace })
+	edge, err := store.CreateWorkerOwned(context.Background(), "main", "dead-owner", "never started")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.ReconcileWorkers(context.Background(), edge.CoordinatorSessionID); err != nil {
+		t.Fatal(err)
+	}
+	loaded := waitForWorkerTerminal(t, store, edge.ChildSessionID)
+	if loaded.Status != session.WorkerFailed || loaded.OwnerID != manager.workerID {
+		t.Fatalf("reconciled edge = %#v", loaded)
+	}
+	reports, err := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if err != nil || len(reports) != 1 || reports[0].Kind != session.WorkerReportResult || reports[0].Origin != "terminal_synthesis" {
+		t.Fatalf("terminal reports = %#v, %v", reports, err)
+	}
+}
+
+func TestChatWorkerReconcileSynthesizesMissedTerminalOnce(t *testing.T) {
+	runtime, store, manager := newReconciliationRuntime(t)
+	edge, _, run := createReconciliationExecution(t, store, manager)
+	if _, err := manager.db.Exec(`UPDATE job_runs_v2 SET status = ?, finished_at = CURRENT_TIMESTAMP, exit_reason = ?, lease_expires_at = NULL WHERE id = ?`, jobsV2RunCancelled, exitReasonCancelled, run.ID); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := runtime.ReconcileWorkers(context.Background(), edge.CoordinatorSessionID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	loaded := waitForWorkerTerminal(t, store, edge.ChildSessionID)
+	if loaded.Status != session.WorkerCancelled {
+		t.Fatalf("worker status = %s", loaded.Status)
+	}
+	reports, _ := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if len(reports) != 1 {
+		t.Fatalf("terminal reconciliation produced %d results: %#v", len(reports), reports)
+	}
+}
+
+func TestJobsV2ExpiredCancelRecoveryNotifiesMailbox(t *testing.T) {
+	_, store, manager := newReconciliationRuntime(t)
+	edge, _, run := createReconciliationExecution(t, store, manager)
+	if _, err := manager.db.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = 'dead', lease_expires_at = ? WHERE id = ?`, jobsV2RunCancelRequested, time.Now().Add(-time.Second).UnixMilli(), run.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.recoverRuns(); err != nil {
+		t.Fatal(err)
+	}
+	loaded := waitForWorkerTerminal(t, store, edge.ChildSessionID)
+	if loaded.Status != session.WorkerCancelled {
+		t.Fatalf("recovered cancel status = %s", loaded.Status)
+	}
+	reports, _ := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if len(reports) != 1 {
+		t.Fatalf("cancel recovery reports = %#v", reports)
+	}
+}
+
+func TestJobsV2WorkerLoopRevisitsInitiallyLiveLeaseWithoutRetry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jobs.db")
+	seed, err := newJobsV2Manager(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job, err := seed.CreateJob(jobsV2Job{
+		Name: "lease-revisit", Enabled: true, RunnerType: jobsV2RunnerProgram,
+		RunnerConfig: json.RawMessage(`{"command":"echo should-not-run"}`),
+		TriggerType:  jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := seed.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.db.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = 'crashed', lease_expires_at = ? WHERE id = ?`, jobsV2RunRunning, time.Now().Add(150*time.Millisecond).UnixMilli(), run.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := newJobsV2Manager(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var executions atomic.Int32
+	manager.runners[jobsV2RunnerProgram] = jobsV2RunnerFunc(func(context.Context, jobsV2Job, progressWriter) (jobsV2RunResult, error) {
+		executions.Add(1)
+		return jobsV2RunResult{}, nil
+	})
+	manager.workers = 1
+	manager.wg.Add(1)
+	go manager.workerLoop()
+	defer manager.Close()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := manager.GetRun(run.ID)
+		if err == nil && got.Status == jobsV2RunFailed {
+			if got.ExitReason != exitReasonWorkerLost || executions.Load() != 0 {
+				t.Fatalf("recovered run = %#v, executions=%d", got, executions.Load())
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	got, _ := manager.GetRun(run.ID)
+	t.Fatalf("expired lease was not revisited: %#v", got)
+}
+
+func TestThreadJobsDatabaseIsIsolatedFromOrdinaryJobsDatabase(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	ordinary, err := newJobsV2Manager("", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ordinary.Close()
+	thread, err := newThreadWorkerJobsV2Manager("", 1, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer thread.Close()
+	labels, _ := json.Marshal(map[string]string{
+		threadWorkerLabelKey: threadWorkerLabelValue, threadWorkerOwnerLabelKey: thread.workerID,
+		threadWorkerCoordinatorLabelKey: "main", threadWorkerChildLabelKey: "child",
+	})
+	if _, err := thread.CreateJob(jobsV2Job{
+		Name: "isolated-thread", Enabled: true, RunnerType: jobsV2RunnerProgram,
+		RunnerConfig: json.RawMessage(`{"command":"echo"}`), TriggerType: jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`), Labels: labels,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, total, err := ordinary.ListJobs(10, 0); err != nil || total != 0 {
+		t.Fatalf("ordinary jobs can see thread jobs: total=%d err=%v", total, err)
+	}
+	if _, total, err := thread.ListJobs(10, 0); err != nil || total != 1 {
+		t.Fatalf("thread jobs missing: total=%d err=%v", total, err)
+	}
+	ordinaryPath := filepath.Join(data, "term-llm", "jobs_v2.db")
+	threadPath := filepath.Join(data, "term-llm", "thread_jobs_v2.db")
+	if ordinaryPath == threadPath {
+		t.Fatal("thread and ordinary jobs paths are identical")
+	}
+	for _, path := range []string{ordinaryPath, threadPath} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("jobs database %s missing: %v", path, err)
+		}
+	}
+}
+
+func TestTwoThreadManagersEnforceLiveOwnerAffinityAndCrashAdoption(t *testing.T) {
+	runtimeA, store, managerA := newReconciliationRuntime(t)
+	managerB, err := newJobsV2ManagerConfigured(filepath.Join(filepath.Dir(runtimeA.cfg.Sessions.Path), "thread.db"), 0, nil, nil, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeB := &chatWorkerRuntime{cfg: runtimeA.cfg, manager: managerB}
+	edge, _, run := createReconciliationExecution(t, store, managerA)
+
+	if claimed, ok, err := managerB.claimNextRun(); err != nil || ok {
+		t.Fatalf("second manager claimed live owner's run: %#v ok=%v err=%v", claimed, ok, err)
+	}
+	err = runtimeB.CancelWorker(context.Background(), chat.WorkerCancelRequest{
+		ChildSessionID: edge.ChildSessionID, CoordinatorSessionID: edge.CoordinatorSessionID, RunID: edge.RunID,
+	})
+	if err == nil || err.Error() != "worker is owned by another live chat" {
+		t.Fatalf("foreign live cancellation error = %v", err)
+	}
+	if got, _ := managerA.GetRun(run.ID); got.Status != jobsV2RunQueued {
+		t.Fatalf("foreign manager changed run status: %s", got.Status)
+	}
+	if err := runtimeB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := managerA.GetRun(run.ID); got.Status != jobsV2RunQueued {
+		t.Fatalf("closing unrelated manager changed run status: %s", got.Status)
+	}
+
+	managerC, err := newJobsV2ManagerConfigured(filepath.Join(filepath.Dir(runtimeA.cfg.Sessions.Path), "thread.db"), 0, nil, nil, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeC := &chatWorkerRuntime{cfg: runtimeA.cfg, manager: managerC}
+	defer runtimeC.Close()
+	if _, err := managerA.db.Exec(`UPDATE thread_worker_owners_v1 SET lease_expires_at = ? WHERE owner_id = ?`, time.Now().Add(-time.Second).UnixMilli(), managerA.workerID); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtimeC.ReconcileWorkers(context.Background(), edge.CoordinatorSessionID); err != nil {
+		t.Fatal(err)
+	}
+	adopted, err := store.GetWorker(context.Background(), edge.ChildSessionID)
+	if err != nil || adopted.OwnerID != managerC.workerID {
+		t.Fatalf("adopted edge = %#v, %v", adopted, err)
+	}
+	claimed, ok, err := managerC.claimNextRun()
+	if err != nil || !ok || claimed.ID != run.ID {
+		t.Fatalf("crash-adopted claim = %#v ok=%v err=%v", claimed, ok, err)
+	}
+}

--- a/cmd/chat_workers_test.go
+++ b/cmd/chat_workers_test.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	runpkg "github.com/samsaffron/term-llm/internal/run"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+func newChatWorkerRuntimeTest(t *testing.T, mode session.SessionApprovalMode) (*chatWorkerRuntime, *session.SQLiteStore, session.WorkerEdge) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	cfg := &config.Config{Sessions: config.SessionsConfig{Enabled: true, Path: path}}
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Now()
+	parent := &session.Session{
+		ID: "main", Provider: "mock", ProviderKey: "mock", Model: "model",
+		Mode: session.ModeChat, Origin: session.OriginTUI, ApprovalMode: mode,
+		CWD: t.TempDir(), CreatedAt: now, UpdatedAt: now, Status: session.StatusActive,
+	}
+	if err := store.Create(context.Background(), parent); err != nil {
+		t.Fatal(err)
+	}
+	edge, err := store.CreateWorker(context.Background(), parent.ID, "harmless task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &chatWorkerRuntime{cfg: cfg}, store, edge
+}
+
+func workerLLMConfig(edge session.WorkerEdge) jobsV2LLMConfig {
+	return jobsV2LLMConfig{
+		AgentName: "developer", Instructions: edge.Task, Cwd: "/tmp",
+		SessionID: edge.ChildSessionID, ParentSessionID: edge.CoordinatorSessionID, Worker: true,
+	}
+}
+
+func TestCmdRunnerWorkerRegistersMailboxToolOnlyForWorker(t *testing.T) {
+	runtime, workerStore, edge := newChatWorkerRuntimeTest(t, session.ApprovalModePrompt)
+	_ = runtime
+	cfg := &config.Config{
+		DefaultProvider: "mock",
+		Providers:       map[string]config.ProviderConfig{"mock": {Model: "mock-model"}},
+		Agents:          config.AgentsConfig{UseBuiltin: true},
+	}
+	runner := newCmdRunner(cfg, cmdRunnerOptions{Store: workerStore, ApprovalMode: tools.ModePrompt, ApprovalModeSet: true}).(*cmdRunner)
+	env, err := runner.prepare(context.Background(), runpkg.Request{
+		Platform: runpkg.PlatformJob, AgentName: "developer", Prompt: "test",
+		ProviderInstance: llm.NewMockProvider("mock"), SessionID: edge.ChildSessionID,
+		ParentSessionID: edge.CoordinatorSessionID, IsWorker: true, Persist: true, Cwd: t.TempDir(),
+	}, eventSinkFunc(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.Close()
+	found := false
+	for _, spec := range env.llmReq.Tools {
+		found = found || spec.Name == tools.WorkerReportToolName
+	}
+	if !found {
+		t.Fatalf("worker request tools = %#v, report missing", env.llmReq.Tools)
+	}
+
+	ordinary, err := runner.prepare(context.Background(), runpkg.Request{
+		Platform: runpkg.PlatformJob, AgentName: "developer", Prompt: "test",
+		ProviderInstance: llm.NewMockProvider("mock"), SessionID: session.NewID(), Persist: true, Cwd: t.TempDir(),
+	}, eventSinkFunc(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ordinary.Close()
+	for _, spec := range ordinary.llmReq.Tools {
+		if spec.Name == tools.WorkerReportToolName {
+			t.Fatal("ordinary job received worker report tool")
+		}
+	}
+}
+
+func TestChatWorkerApprovalComesFromDurableCoordinator(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode session.SessionApprovalMode
+		want tools.ApprovalMode
+	}{
+		{name: "prompt", mode: session.ApprovalModePrompt, want: tools.ModePrompt},
+		{name: "auto", mode: session.ApprovalModeAuto, want: tools.ModeAuto},
+		{name: "yolo", mode: session.ApprovalModeYolo, want: tools.ModeYolo},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime, store, edge := newChatWorkerRuntimeTest(t, tc.mode)
+			resolved, err := runtime.resolveApproval(context.Background(), workerLLMConfig(edge))
+			if err != nil || resolved.Mode != tc.want || resolved.Source != approvalModeSourceSession {
+				t.Fatalf("resolved approval = %#v, %v", resolved, err)
+			}
+			loaded, _ := store.GetWorker(context.Background(), edge.ChildSessionID)
+			if loaded.Status != session.WorkerRunning {
+				t.Fatalf("worker status = %s", loaded.Status)
+			}
+		})
+	}
+}
+
+func TestChatWorkerApprovalRejectsForgedParent(t *testing.T) {
+	runtime, _, edge := newChatWorkerRuntimeTest(t, session.ApprovalModePrompt)
+	cfg := workerLLMConfig(edge)
+	cfg.ParentSessionID = "different-main"
+	if _, err := runtime.resolveApproval(context.Background(), cfg); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("forged parent error = %v", err)
+	}
+}
+
+func TestChatWorkerTerminalSynthesisAlwaysLeavesResult(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status jobsV2RunStatus
+		exit   string
+		err    string
+		want   session.WorkerStatus
+	}{
+		{name: "natural", status: jobsV2RunSucceeded, exit: exitReasonNatural, want: session.WorkerDone},
+		{name: "failed", status: jobsV2RunFailed, exit: exitReasonException, err: "provider failed", want: session.WorkerFailed},
+		{name: "timeout", status: jobsV2RunTimedOut, exit: exitReasonTimeout, err: "deadline exceeded", want: session.WorkerFailed},
+		{name: "cancelled", status: jobsV2RunCancelled, exit: exitReasonCancelled, err: "cancelled", want: session.WorkerCancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime, store, edge := newChatWorkerRuntimeTest(t, session.ApprovalModePrompt)
+			cfg := workerLLMConfig(edge)
+			raw, _ := json.Marshal(cfg)
+			job := jobsV2Job{ID: "job", RunnerConfig: raw}
+			run := jobsV2Run{ID: "run", JobID: job.ID}
+			if err := runtime.notifyDone(context.Background(), run, job, tc.status, jobsV2RunResult{SessionID: edge.ChildSessionID}, tc.exit, false, tc.err); err != nil {
+				t.Fatal(err)
+			}
+			reports, err := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+			if err != nil || len(reports) != 1 || reports[0].Kind != session.WorkerReportResult || reports[0].Origin != "terminal_synthesis" {
+				t.Fatalf("terminal reports = %#v, %v", reports, err)
+			}
+			loaded, _ := store.GetWorker(context.Background(), edge.ChildSessionID)
+			if loaded.Status != tc.want || !loaded.Status.Terminal() {
+				t.Fatalf("terminal status = %s, want %s", loaded.Status, tc.want)
+			}
+		})
+	}
+}
+
+func TestChatWorkerTerminalDoesNotDuplicateReportedResult(t *testing.T) {
+	runtime, store, edge := newChatWorkerRuntimeTest(t, session.ApprovalModePrompt)
+	_, err := store.AddWorkerReport(context.Background(), session.WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+		Title: "Explicit result", Body: "done", Origin: "worker_tool",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(workerLLMConfig(edge))
+	if err := runtime.notifyDone(context.Background(), jobsV2Run{ID: "run"}, jobsV2Job{ID: "job", RunnerConfig: raw}, jobsV2RunSucceeded, jobsV2RunResult{}, exitReasonNatural, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	reports, _ := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if len(reports) != 1 || reports[0].Origin != "worker_tool" {
+		t.Fatalf("explicit result was duplicated: %#v", reports)
+	}
+}
+
+func TestJobsV2ClaimPartitionKeepsThreadWorkersOnWorkerRunner(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+	ordinary, err := mgr.CreateJob(jobsV2Job{
+		Name: "ordinary", Enabled: true, RunnerType: jobsV2RunnerProgram,
+		RunnerConfig: json.RawMessage(`{"command":"echo"}`), TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	threadLabels, _ := json.Marshal(map[string]string{threadWorkerLabelKey: threadWorkerLabelValue})
+	thread, err := mgr.CreateJob(jobsV2Job{
+		Name: "thread", Enabled: true, RunnerType: jobsV2RunnerProgram,
+		RunnerConfig: json.RawMessage(`{"command":"echo"}`), TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`), Labels: threadLabels,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordinaryRun, _ := mgr.TriggerJob(ordinary.ID)
+	threadRun, _ := mgr.TriggerJob(thread.ID)
+	claimed, ok, err := mgr.claimNextRun()
+	if err != nil || !ok || claimed.ID != ordinaryRun.ID {
+		t.Fatalf("ordinary claim = %#v, %v, %v", claimed, ok, err)
+	}
+	mgr.claimThreadWorkers = true
+	claimed, ok, err = mgr.claimNextRun()
+	if err != nil || !ok || claimed.ID != threadRun.ID {
+		t.Fatalf("thread claim = %#v, %v, %v", claimed, ok, err)
+	}
+}

--- a/cmd/chat_workers_test.go
+++ b/cmd/chat_workers_test.go
@@ -188,7 +188,10 @@ func TestJobsV2ClaimPartitionKeepsThreadWorkersOnWorkerRunner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	threadLabels, _ := json.Marshal(map[string]string{threadWorkerLabelKey: threadWorkerLabelValue})
+	threadLabels, _ := json.Marshal(map[string]string{
+		threadWorkerLabelKey:      threadWorkerLabelValue,
+		threadWorkerOwnerLabelKey: mgr.workerID,
+	})
 	thread, err := mgr.CreateJob(jobsV2Job{
 		Name: "thread", Enabled: true, RunnerType: jobsV2RunnerProgram,
 		RunnerConfig: json.RawMessage(`{"command":"echo"}`), TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`), Labels: threadLabels,

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -354,6 +354,13 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 		if err := toolMgr.ConfigureWorkspacePersistence(ctx, store, workspaceSessionID); err != nil {
 			return nil, err
 		}
+		if req.IsWorker {
+			workerStore, ok := session.AsWorkerStore(store)
+			if !ok || strings.TrimSpace(req.ParentSessionID) == "" {
+				return nil, fmt.Errorf("worker mailbox persistence is unavailable")
+			}
+			toolMgr.Registry.RegisterWorkerReportTool(engine, workerStore, req.SessionID, req.ParentSessionID)
+		}
 	}
 
 	if settings.MCP != "" && !borrowedEngine {

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -234,17 +234,19 @@ var (
 )
 
 const (
-	jobsV2SchedulerMinDelay    = 100 * time.Millisecond
-	jobsV2SchedulerIdleDelay   = time.Minute
-	jobsV2SchedulerErrorDelay  = 200 * time.Millisecond
-	jobsV2WorkerMinDelay       = 100 * time.Millisecond
-	jobsV2WorkerIdleDelay      = time.Minute
-	jobsV2WorkerErrorDelay     = 200 * time.Millisecond
-	jobsV2FinishRunRetryWindow = 30 * time.Second
-	jobsV2FinishRunRetryDelay  = 50 * time.Millisecond
-	jobsV2FinishRunMaxDelay    = time.Second
-	jobsV2LeaseDuration        = 30 * time.Second
-	jobsV2HeartbeatInterval    = 5 * time.Second
+	jobsV2SchedulerMinDelay      = 100 * time.Millisecond
+	jobsV2SchedulerIdleDelay     = time.Minute
+	jobsV2SchedulerErrorDelay    = 200 * time.Millisecond
+	jobsV2WorkerMinDelay         = 100 * time.Millisecond
+	jobsV2WorkerIdleDelay        = time.Minute
+	jobsV2WorkerErrorDelay       = 200 * time.Millisecond
+	jobsV2FinishRunRetryWindow   = 30 * time.Second
+	jobsV2FinishRunRetryDelay    = 50 * time.Millisecond
+	jobsV2FinishRunMaxDelay      = time.Second
+	jobsV2LeaseDuration          = 30 * time.Second
+	jobsV2HeartbeatInterval      = 5 * time.Second
+	threadOwnerLeaseDuration     = 15 * time.Second
+	threadOwnerHeartbeatInterval = 3 * time.Second
 )
 
 type jobsV2ProgramConfig = jobs.ProgramConfig
@@ -593,6 +595,12 @@ CREATE TABLE IF NOT EXISTS job_run_events_v2 (
 
 CREATE INDEX IF NOT EXISTS idx_job_run_events_v2_run_id_id ON job_run_events_v2(run_id, id);
 DROP INDEX IF EXISTS idx_job_run_events_v2_run_id;
+
+CREATE TABLE IF NOT EXISTS thread_worker_owners_v1 (
+	owner_id TEXT PRIMARY KEY,
+	lease_expires_at INTEGER NOT NULL,
+	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 `
 
 func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*jobsV2Manager, error) {
@@ -698,6 +706,13 @@ func newJobsV2ManagerConfigured(dbPath string, workers int, llmExec serveJobsExe
 		notifyCtx:     notifyCtx,
 		notifyCancel:  notifyCancel,
 	}
+	if claimThreadWorkers {
+		if err := mgr.refreshThreadOwnerLease(); err != nil {
+			notifyCancel()
+			_ = db.Close()
+			return nil, fmt.Errorf("register thread worker owner: %w", err)
+		}
+	}
 
 	if err := mgr.recoverRuns(); err != nil {
 		notifyCancel()
@@ -714,6 +729,10 @@ func newJobsV2ManagerConfigured(dbPath string, workers int, llmExec serveJobsExe
 		mgr.wg.Add(1)
 		go mgr.schedulerLoop()
 	}
+	if claimThreadWorkers {
+		mgr.wg.Add(1)
+		go mgr.threadOwnerHeartbeatLoop()
+	}
 	for i := 0; i < mgr.workers; i++ {
 		mgr.wg.Add(1)
 		go mgr.workerLoop()
@@ -722,13 +741,19 @@ func newJobsV2ManagerConfigured(dbPath string, workers int, llmExec serveJobsExe
 	return mgr, nil
 }
 
-// newThreadWorkerJobsV2Manager reuses the jobs-v2 manager and database while
-// partitioning claims to durable /thread jobs. Ordinary serve managers exclude
-// that label, so neither runner can steal work requiring different approval and
-// mailbox wiring.
+// newThreadWorkerJobsV2Manager uses a dedicated database. This is a protocol
+// boundary, not just a claim convention: pre-upgrade serve-jobs processes that
+// have the ordinary jobs_v2.db open cannot claim or blanket-fail chat workers.
 func newThreadWorkerJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor, notifyDone jobsV2RunDoneNotifier) (*jobsV2Manager, error) {
 	if workers <= 0 {
 		workers = 1
+	}
+	if strings.TrimSpace(dbPath) == "" {
+		dataDir, err := session.GetDataDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve thread jobs data dir: %w", err)
+		}
+		dbPath = filepath.Join(dataDir, "thread_jobs_v2.db")
 	}
 	return newJobsV2ManagerConfigured(dbPath, workers, llmExec, notifyDone, true, false)
 }
@@ -747,13 +772,57 @@ func execJobsV2Schema(db *sql.DB) error {
 	return nil
 }
 
+func (m *jobsV2Manager) refreshThreadOwnerLease() error {
+	if m == nil || !m.claimThreadWorkers {
+		return nil
+	}
+	_, err := m.db.Exec(`
+		INSERT INTO thread_worker_owners_v1 (owner_id, lease_expires_at, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(owner_id) DO UPDATE SET lease_expires_at = excluded.lease_expires_at, updated_at = CURRENT_TIMESTAMP`,
+		m.workerID, time.Now().UTC().Add(threadOwnerLeaseDuration).UnixMilli())
+	return err
+}
+
+func (m *jobsV2Manager) threadOwnerHeartbeatLoop() {
+	defer m.wg.Done()
+	ticker := time.NewTicker(threadOwnerHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.doneChan():
+			return
+		case <-ticker.C:
+			if err := m.refreshThreadOwnerLease(); err != nil {
+				log.Printf("jobs v2: refresh thread owner lease: %v", err)
+			}
+		}
+	}
+}
+
+func (m *jobsV2Manager) threadOwnerLive(ownerID string) (bool, error) {
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return false, nil
+	}
+	var expires int64
+	err := m.db.QueryRow(`SELECT lease_expires_at FROM thread_worker_owners_v1 WHERE owner_id = ?`, ownerID).Scan(&expires)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return expires > time.Now().UTC().UnixMilli(), nil
+}
+
 func (m *jobsV2Manager) recoverRuns() error {
 	now := time.Now().UTC()
 	leaseCutoff := now.UnixMilli()
 	predicate, predicateArgs := m.threadWorkerClaimPredicate("j")
-	queryArgs := []any{jobsV2RunClaimed, jobsV2RunRunning, leaseCutoff}
+	queryArgs := []any{jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested, leaseCutoff}
 	queryArgs = append(queryArgs, predicateArgs...)
-	rows, err := m.db.Query(`SELECT r.id, r.job_id, r.attempt, r.trigger, r.scheduled_for, r.status, r.worker_id, r.session_id, r.started_at, r.finished_at, r.exit_code, r.error, r.stdout, r.stderr, r.thinking, r.response, r.exit_reason, r.truncated, r.turn_count, r.input_tokens, r.output_tokens, r.created_at, r.updated_at FROM job_runs_v2 r JOIN jobs_v2 j ON j.id = r.job_id WHERE r.status IN (?, ?) AND (r.lease_expires_at IS NULL OR r.lease_expires_at <= ?) AND `+predicate+` ORDER BY r.created_at ASC`, queryArgs...)
+	rows, err := m.db.Query(`SELECT r.id, r.job_id, r.attempt, r.trigger, r.scheduled_for, r.status, r.worker_id, r.session_id, r.started_at, r.finished_at, r.exit_code, r.error, r.stdout, r.stderr, r.thinking, r.response, r.exit_reason, r.truncated, r.turn_count, r.input_tokens, r.output_tokens, r.created_at, r.updated_at FROM job_runs_v2 r JOIN jobs_v2 j ON j.id = r.job_id WHERE r.status IN (?, ?, ?) AND (r.lease_expires_at IS NULL OR r.lease_expires_at <= ?) AND `+predicate+` ORDER BY r.created_at ASC`, queryArgs...)
 	if err != nil {
 		return fmt.Errorf("load expired interrupted runs: %w", err)
 	}
@@ -775,26 +844,12 @@ func (m *jobsV2Manager) recoverRuns() error {
 		return fmt.Errorf("close interrupted runs query: %w", err)
 	}
 
-	cancelArgs := []any{jobsV2RunCancelled, exitReasonCancelled, jobsV2RunCancelRequested, leaseCutoff}
-	cancelArgs = append(cancelArgs, predicateArgs...)
-	if _, err := m.db.Exec(`
-		UPDATE job_runs_v2
-		SET status = ?,
-			finished_at = CURRENT_TIMESTAMP,
-			exit_reason = ?,
-			lease_expires_at = NULL,
-			updated_at = CURRENT_TIMESTAMP
-		WHERE status = ? AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
-		  AND job_id IN (SELECT j.id FROM jobs_v2 j WHERE `+predicate+`)`, cancelArgs...); err != nil {
-		return fmt.Errorf("recover expired cancel requested runs: %w", err)
-	}
-
 	for _, run := range interrupted {
-		// Claim recovery ownership with a compare-and-swap. A live manager keeps
-		// extending its lease, so another manager starting on the same database
-		// cannot fail or steal that run.
-		res, err := m.db.Exec(`UPDATE job_runs_v2 SET worker_id = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?) AND (lease_expires_at IS NULL OR lease_expires_at <= ?)`,
-			m.workerID, now.Add(jobsV2LeaseDuration).UnixMilli(), run.ID, jobsV2RunClaimed, jobsV2RunRunning, leaseCutoff)
+		// Recovery never re-executes a claimed/running run: its side effects may
+		// already have happened. It only claims terminalization ownership.
+		res, err := m.db.Exec(`UPDATE job_runs_v2 SET worker_id = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?) AND (lease_expires_at IS NULL OR lease_expires_at <= ?)`,
+			m.workerID, now.Add(jobsV2LeaseDuration).UnixMilli(), run.ID,
+			jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested, leaseCutoff)
 		if err != nil {
 			return fmt.Errorf("claim interrupted run %s for recovery: %w", run.ID, err)
 		}
@@ -806,19 +861,20 @@ func (m *jobsV2Manager) recoverRuns() error {
 			exitCode = *run.ExitCode
 		}
 		result := jobsV2RunResult{
-			ExitCode:     exitCode,
-			Stdout:       run.Stdout,
-			Stderr:       run.Stderr,
-			Thinking:     run.Thinking,
-			Response:     run.Response,
-			SessionID:    run.SessionID,
-			ExitReason:   exitReasonWorkerLost,
-			Truncated:    run.Truncated,
-			TurnCount:    run.TurnCount,
-			InputTokens:  run.InputTokens,
-			OutputTokens: run.OutputTokens,
+			ExitCode: exitCode, Stdout: run.Stdout, Stderr: run.Stderr,
+			Thinking: run.Thinking, Response: run.Response, SessionID: run.SessionID,
+			Truncated: run.Truncated, TurnCount: run.TurnCount,
+			InputTokens: run.InputTokens, OutputTokens: run.OutputTokens,
 		}
-		if err := m.finishRun(run.ID, jobsV2RunFailed, result, errors.New("worker lost before run could finish"), run.Attempt); err != nil {
+		status := jobsV2RunFailed
+		runErr := errors.New("worker lost before run could finish")
+		result.ExitReason = exitReasonWorkerLost
+		if run.Status == jobsV2RunCancelRequested {
+			status = jobsV2RunCancelled
+			runErr = context.Canceled
+			result.ExitReason = exitReasonCancelled
+		}
+		if err := m.finishRun(run.ID, status, result, runErr, run.Attempt); err != nil {
 			return fmt.Errorf("recover interrupted run %s: %w", run.ID, err)
 		}
 	}
@@ -962,6 +1018,9 @@ func (m *jobsV2Manager) CloseContext(ctx context.Context) error {
 	case <-waitDone:
 		if m.notifyCancel != nil {
 			m.notifyCancel()
+		}
+		if m.claimThreadWorkers {
+			_, _ = m.db.Exec(`DELETE FROM thread_worker_owners_v1 WHERE owner_id = ?`, m.workerID)
 		}
 		return m.db.Close()
 	case <-ctx.Done():
@@ -1206,6 +1265,12 @@ func (m *jobsV2Manager) workerLoop() {
 		default:
 		}
 
+		if err := m.recoverRuns(); err != nil {
+			if !m.waitForWorkerWake(jobsV2WorkerErrorDelay) {
+				return
+			}
+			continue
+		}
 		run, ok, err := m.claimNextRun()
 		if err != nil {
 			if !m.waitForWorkerWake(jobsV2WorkerErrorDelay) {
@@ -1254,7 +1319,11 @@ func (m *jobsV2Manager) threadWorkerClaimPredicate(jobAlias string) (string, []a
 	}
 	expr := fmt.Sprintf("CASE WHEN json_valid(%[1]slabels) THEN COALESCE(json_extract(%[1]slabels, ?), '') ELSE '' END", jobAlias)
 	if m.claimThreadWorkers {
-		return expr + " = ?", []any{"$." + threadWorkerLabelKey, threadWorkerLabelValue}
+		ownerExpr := fmt.Sprintf("CASE WHEN json_valid(%[1]slabels) THEN COALESCE(json_extract(%[1]slabels, ?), '') ELSE '' END", jobAlias)
+		return expr + " = ? AND " + ownerExpr + " = ?", []any{
+			"$." + threadWorkerLabelKey, threadWorkerLabelValue,
+			"$." + threadWorkerOwnerLabelKey, m.workerID,
+		}
 	}
 	// Ordinary serve managers claim every non-thread job, including legacy rows
 	// whose labels column is NULL.
@@ -1278,6 +1347,18 @@ func (m *jobsV2Manager) nextWorkerDelayWithError(now time.Time) (time.Duration, 
 	}
 	if err == nil && nextRun.Valid {
 		delay = minDuration(delay, nextRun.Time.UTC().Sub(now.UTC()))
+	}
+
+	leaseArgs := []any{jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested}
+	leaseArgs = append(leaseArgs, predicateArgs...)
+	var nextLease sql.NullInt64
+	err = m.db.QueryRow(`SELECT MIN(r.lease_expires_at) FROM job_runs_v2 r JOIN jobs_v2 j ON j.id = r.job_id WHERE r.status IN (?, ?, ?) AND r.lease_expires_at IS NOT NULL AND `+predicate, leaseArgs...).Scan(&nextLease)
+	if err != nil {
+		return 0, err
+	}
+	if nextLease.Valid {
+		leaseTime := time.UnixMilli(nextLease.Int64).UTC()
+		delay = minDuration(delay, leaseTime.Sub(now.UTC()))
 	}
 
 	return clampJobsV2Delay(delay, jobsV2WorkerMinDelay, idleDelay), nil

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -243,6 +243,8 @@ const (
 	jobsV2FinishRunRetryWindow = 30 * time.Second
 	jobsV2FinishRunRetryDelay  = 50 * time.Millisecond
 	jobsV2FinishRunMaxDelay    = time.Second
+	jobsV2LeaseDuration        = 30 * time.Second
+	jobsV2HeartbeatInterval    = 5 * time.Second
 )
 
 type jobsV2ProgramConfig = jobs.ProgramConfig
@@ -296,16 +298,19 @@ type jobsV2NotifyOrigin struct {
 }
 
 type jobsV2LLMConfig struct {
-	AgentName      string              `json:"agent_name"`
-	Instructions   string              `json:"instructions"`
-	Progressive    bool                `json:"progressive,omitempty"`
-	StopWhen       string              `json:"stop_when,omitempty"`
-	ContinueWith   string              `json:"continue_with,omitempty"`
-	PersistSession *bool               `json:"persist_session,omitempty"`
-	SessionID      string              `json:"session_id,omitempty"`
-	SessionName    string              `json:"session_name,omitempty"`
-	NotifyWhenDone bool                `json:"notify_when_done,omitempty"`
-	NotifyOrigin   *jobsV2NotifyOrigin `json:"notify_origin,omitempty"`
+	AgentName          string              `json:"agent_name"`
+	Instructions       string              `json:"instructions"`
+	Progressive        bool                `json:"progressive,omitempty"`
+	StopWhen           string              `json:"stop_when,omitempty"`
+	ContinueWith       string              `json:"continue_with,omitempty"`
+	PersistSession     *bool               `json:"persist_session,omitempty"`
+	SessionID          string              `json:"session_id,omitempty"`
+	SessionName        string              `json:"session_name,omitempty"`
+	NotifyWhenDone     bool                `json:"notify_when_done,omitempty"`
+	NotifyOrigin       *jobsV2NotifyOrigin `json:"notify_origin,omitempty"`
+	ParentSessionID    string              `json:"parent_session_id,omitempty"`
+	Worker             bool                `json:"worker,omitempty"`
+	WorkerApprovalMode string              `json:"worker_approval_mode,omitempty"`
 
 	// cwd is REQUIRED: it roots this run's file/shell tools at a directory so a
 	// job never silently inherits the jobs server's process working directory.
@@ -495,11 +500,14 @@ func classifyRunError(err error, result jobsV2RunResult) (exitReason string, tru
 }
 
 type jobsV2Manager struct {
-	db         *sql.DB
-	workers    int
-	workerID   string
-	runners    map[jobsV2RunnerType]jobsV2Runner
-	notifyDone jobsV2RunDoneNotifier
+	db       *sql.DB
+	workers  int
+	workerID string
+	// claimThreadWorkers partitions embedded /thread execution from ordinary
+	// jobs-v2 managers sharing the same durable database.
+	claimThreadWorkers bool
+	runners            map[jobsV2RunnerType]jobsV2Runner
+	notifyDone         jobsV2RunDoneNotifier
 	// Idle timers are only fallbacks; job/run mutations wake the loops immediately.
 	schedulerIdleDelay time.Duration
 	workerIdleDelay    time.Duration
@@ -566,6 +574,7 @@ CREATE TABLE IF NOT EXISTS job_runs_v2 (
 	turn_count INTEGER NOT NULL DEFAULT 0,
 	input_tokens INTEGER NOT NULL DEFAULT 0,
 	output_tokens INTEGER NOT NULL DEFAULT 0,
+	lease_expires_at INTEGER,
 	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -591,6 +600,10 @@ func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*j
 }
 
 func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsExecutor, notifyDone jobsV2RunDoneNotifier) (*jobsV2Manager, error) {
+	return newJobsV2ManagerConfigured(dbPath, workers, llmExec, notifyDone, false, true)
+}
+
+func newJobsV2ManagerConfigured(dbPath string, workers int, llmExec serveJobsExecutor, notifyDone jobsV2RunDoneNotifier, claimThreadWorkers, runScheduler bool) (*jobsV2Manager, error) {
 	if workers < 0 {
 		workers = 1
 	}
@@ -635,6 +648,7 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 		`ALTER TABLE job_runs_v2 ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE job_runs_v2 ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE job_runs_v2 ADD COLUMN session_id TEXT`,
+		`ALTER TABLE job_runs_v2 ADD COLUMN lease_expires_at INTEGER`,
 	}
 	for _, migration := range migrations {
 		_, _ = db.Exec(migration)
@@ -664,6 +678,7 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 		db:                 db,
 		workers:            workers,
 		workerID:           "worker_" + randomSuffix(),
+		claimThreadWorkers: claimThreadWorkers,
 		notifyDone:         notifyDone,
 		schedulerIdleDelay: jobsV2SchedulerIdleDelay,
 		workerIdleDelay:    jobsV2WorkerIdleDelay,
@@ -695,14 +710,27 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 		return nil, err
 	}
 
-	mgr.wg.Add(1)
-	go mgr.schedulerLoop()
+	if runScheduler {
+		mgr.wg.Add(1)
+		go mgr.schedulerLoop()
+	}
 	for i := 0; i < mgr.workers; i++ {
 		mgr.wg.Add(1)
 		go mgr.workerLoop()
 	}
 
 	return mgr, nil
+}
+
+// newThreadWorkerJobsV2Manager reuses the jobs-v2 manager and database while
+// partitioning claims to durable /thread jobs. Ordinary serve managers exclude
+// that label, so neither runner can steal work requiring different approval and
+// mailbox wiring.
+func newThreadWorkerJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor, notifyDone jobsV2RunDoneNotifier) (*jobsV2Manager, error) {
+	if workers <= 0 {
+		workers = 1
+	}
+	return newJobsV2ManagerConfigured(dbPath, workers, llmExec, notifyDone, true, false)
 }
 
 func execJobsV2Schema(db *sql.DB) error {
@@ -720,15 +748,21 @@ func execJobsV2Schema(db *sql.DB) error {
 }
 
 func (m *jobsV2Manager) recoverRuns() error {
-	rows, err := m.db.Query(`SELECT id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at FROM job_runs_v2 WHERE status IN (?, ?) ORDER BY created_at ASC`, jobsV2RunClaimed, jobsV2RunRunning)
+	now := time.Now().UTC()
+	leaseCutoff := now.UnixMilli()
+	predicate, predicateArgs := m.threadWorkerClaimPredicate("j")
+	queryArgs := []any{jobsV2RunClaimed, jobsV2RunRunning, leaseCutoff}
+	queryArgs = append(queryArgs, predicateArgs...)
+	rows, err := m.db.Query(`SELECT r.id, r.job_id, r.attempt, r.trigger, r.scheduled_for, r.status, r.worker_id, r.session_id, r.started_at, r.finished_at, r.exit_code, r.error, r.stdout, r.stderr, r.thinking, r.response, r.exit_reason, r.truncated, r.turn_count, r.input_tokens, r.output_tokens, r.created_at, r.updated_at FROM job_runs_v2 r JOIN jobs_v2 j ON j.id = r.job_id WHERE r.status IN (?, ?) AND (r.lease_expires_at IS NULL OR r.lease_expires_at <= ?) AND `+predicate+` ORDER BY r.created_at ASC`, queryArgs...)
 	if err != nil {
-		return fmt.Errorf("load interrupted runs: %w", err)
+		return fmt.Errorf("load expired interrupted runs: %w", err)
 	}
 
 	var interrupted []jobsV2Run
 	for rows.Next() {
 		run, err := scanRunV2(rows)
 		if err != nil {
+			_ = rows.Close()
 			return fmt.Errorf("scan interrupted run: %w", err)
 		}
 		interrupted = append(interrupted, run)
@@ -741,20 +775,32 @@ func (m *jobsV2Manager) recoverRuns() error {
 		return fmt.Errorf("close interrupted runs query: %w", err)
 	}
 
+	cancelArgs := []any{jobsV2RunCancelled, exitReasonCancelled, jobsV2RunCancelRequested, leaseCutoff}
+	cancelArgs = append(cancelArgs, predicateArgs...)
 	if _, err := m.db.Exec(`
 		UPDATE job_runs_v2
 		SET status = ?,
 			finished_at = CURRENT_TIMESTAMP,
 			exit_reason = ?,
+			lease_expires_at = NULL,
 			updated_at = CURRENT_TIMESTAMP
-		WHERE status = ?`,
-		jobsV2RunCancelled,
-		exitReasonCancelled,
-		jobsV2RunCancelRequested); err != nil {
-		return fmt.Errorf("recover cancel requested runs: %w", err)
+		WHERE status = ? AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
+		  AND job_id IN (SELECT j.id FROM jobs_v2 j WHERE `+predicate+`)`, cancelArgs...); err != nil {
+		return fmt.Errorf("recover expired cancel requested runs: %w", err)
 	}
 
 	for _, run := range interrupted {
+		// Claim recovery ownership with a compare-and-swap. A live manager keeps
+		// extending its lease, so another manager starting on the same database
+		// cannot fail or steal that run.
+		res, err := m.db.Exec(`UPDATE job_runs_v2 SET worker_id = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?) AND (lease_expires_at IS NULL OR lease_expires_at <= ?)`,
+			m.workerID, now.Add(jobsV2LeaseDuration).UnixMilli(), run.ID, jobsV2RunClaimed, jobsV2RunRunning, leaseCutoff)
+		if err != nil {
+			return fmt.Errorf("claim interrupted run %s for recovery: %w", run.ID, err)
+		}
+		if affected, _ := res.RowsAffected(); affected == 0 {
+			continue
+		}
 		exitCode := 0
 		if run.ExitCode != nil {
 			exitCode = *run.ExitCode
@@ -891,7 +937,11 @@ func (m *jobsV2Manager) CloseContext(ctx context.Context) error {
 	if m.done != nil {
 		close(m.done)
 	}
-	if m.notifyCancel != nil {
+	// Ordinary server notifications may block on remote delivery, so preserve
+	// prompt shutdown by cancelling them immediately. Embedded /thread managers
+	// must first drain terminal callbacks: those callbacks are what persist the
+	// worker's final mailbox report when shutdown cancels an active child.
+	if !m.claimThreadWorkers && m.notifyCancel != nil {
 		m.notifyCancel()
 	}
 	cancels := make([]context.CancelFunc, 0, len(m.cancels))
@@ -910,8 +960,14 @@ func (m *jobsV2Manager) CloseContext(ctx context.Context) error {
 	}()
 	select {
 	case <-waitDone:
+		if m.notifyCancel != nil {
+			m.notifyCancel()
+		}
 		return m.db.Close()
 	case <-ctx.Done():
+		if m.notifyCancel != nil {
+			m.notifyCancel()
+		}
 		return ctx.Err()
 	}
 }
@@ -1192,6 +1248,19 @@ func (m *jobsV2Manager) nextWorkerDelay(now time.Time) time.Duration {
 	return delay
 }
 
+func (m *jobsV2Manager) threadWorkerClaimPredicate(jobAlias string) (string, []any) {
+	if jobAlias != "" {
+		jobAlias += "."
+	}
+	expr := fmt.Sprintf("CASE WHEN json_valid(%[1]slabels) THEN COALESCE(json_extract(%[1]slabels, ?), '') ELSE '' END", jobAlias)
+	if m.claimThreadWorkers {
+		return expr + " = ?", []any{"$." + threadWorkerLabelKey, threadWorkerLabelValue}
+	}
+	// Ordinary serve managers claim every non-thread job, including legacy rows
+	// whose labels column is NULL.
+	return expr + " <> ?", []any{"$." + threadWorkerLabelKey, threadWorkerLabelValue}
+}
+
 func (m *jobsV2Manager) nextWorkerDelayWithError(now time.Time) (time.Duration, error) {
 	idleDelay := m.workerIdleDelay
 	if idleDelay <= 0 {
@@ -1199,8 +1268,11 @@ func (m *jobsV2Manager) nextWorkerDelayWithError(now time.Time) (time.Duration, 
 	}
 	delay := idleDelay
 
+	predicate, predicateArgs := m.threadWorkerClaimPredicate("j")
+	args := []any{jobsV2RunQueued}
+	args = append(args, predicateArgs...)
 	var nextRun sql.NullTime
-	err := m.db.QueryRow(`SELECT scheduled_for FROM job_runs_v2 WHERE status = ? ORDER BY scheduled_for ASC LIMIT 1`, jobsV2RunQueued).Scan(&nextRun)
+	err := m.db.QueryRow(`SELECT r.scheduled_for FROM job_runs_v2 r JOIN jobs_v2 j ON j.id = r.job_id WHERE r.status = ? AND `+predicate+` ORDER BY r.scheduled_for ASC LIMIT 1`, args...).Scan(&nextRun)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return 0, err
 	}
@@ -1349,7 +1421,10 @@ func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
 	defer func() { _ = tx.Rollback() }()
 
 	now := time.Now().UTC()
-	row := tx.QueryRow(`SELECT id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at FROM job_runs_v2 WHERE status = ? AND scheduled_for <= ? ORDER BY scheduled_for ASC LIMIT 1`, jobsV2RunQueued, now)
+	predicate, predicateArgs := m.threadWorkerClaimPredicate("j")
+	args := []any{jobsV2RunQueued, now}
+	args = append(args, predicateArgs...)
+	row := tx.QueryRow(`SELECT r.id, r.job_id, r.attempt, r.trigger, r.scheduled_for, r.status, r.worker_id, r.session_id, r.started_at, r.finished_at, r.exit_code, r.error, r.stdout, r.stderr, r.thinking, r.response, r.exit_reason, r.truncated, r.turn_count, r.input_tokens, r.output_tokens, r.created_at, r.updated_at FROM job_runs_v2 r JOIN jobs_v2 j ON j.id = r.job_id WHERE r.status = ? AND r.scheduled_for <= ? AND `+predicate+` ORDER BY r.scheduled_for ASC LIMIT 1`, args...)
 	run, err := scanRunV2(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1358,7 +1433,8 @@ func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
 		return jobsV2Run{}, false, err
 	}
 
-	res, err := tx.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunClaimed, m.workerID, run.ID, jobsV2RunQueued)
+	leaseExpiresAt := now.Add(jobsV2LeaseDuration).UnixMilli()
+	res, err := tx.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunClaimed, m.workerID, leaseExpiresAt, run.ID, jobsV2RunQueued)
 	if err != nil {
 		return jobsV2Run{}, false, err
 	}
@@ -1377,7 +1453,7 @@ func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
 }
 
 func (m *jobsV2Manager) requeueClaimedRunAfterShutdown(runID string) {
-	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ? AND worker_id = ?`, jobsV2RunQueued, runID, jobsV2RunClaimed, m.workerID)
+	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = NULL, lease_expires_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ? AND worker_id = ?`, jobsV2RunQueued, runID, jobsV2RunClaimed, m.workerID)
 	if err != nil {
 		log.Printf("jobs v2: failed to requeue unstarted run %q during shutdown: %v", runID, err)
 		return
@@ -1392,6 +1468,44 @@ func (m *jobsV2Manager) requeueClaimedRunAfterShutdown(runID string) {
 	}
 	if err := m.addRunEvent(runID, "requeued", "run returned to queue during worker shutdown", map[string]any{"worker_id": m.workerID}); err != nil {
 		log.Printf("jobs v2: failed to record shutdown requeue event for run %q: %v", runID, err)
+	}
+}
+
+func (m *jobsV2Manager) heartbeatRun(ctx context.Context, runID string, cancel context.CancelFunc, stop <-chan struct{}) {
+	interval := jobsV2HeartbeatInterval
+	if interval <= 0 || interval >= jobsV2LeaseDuration {
+		interval = jobsV2LeaseDuration / 3
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-stop:
+			return
+		case <-ticker.C:
+			var status jobsV2RunStatus
+			err := m.db.QueryRow(`
+				UPDATE job_runs_v2
+				SET lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP
+				WHERE id = ? AND worker_id = ? AND status IN (?, ?)
+				RETURNING status`, time.Now().UTC().Add(jobsV2LeaseDuration).UnixMilli(), runID, m.workerID,
+				jobsV2RunRunning, jobsV2RunCancelRequested).Scan(&status)
+			if errors.Is(err, sql.ErrNoRows) {
+				cancel()
+				return
+			}
+			if err != nil {
+				// A transient SQLite error is not ownership loss. The current lease
+				// remains valid long enough for the next heartbeat/recovery decision.
+				continue
+			}
+			if status == jobsV2RunCancelRequested {
+				cancel()
+				return
+			}
+		}
 	}
 }
 
@@ -1438,7 +1552,7 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 	}()
 
 	started := time.Now().UTC()
-	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunRunning, started, run.ID, jobsV2RunClaimed)
+	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = ?, started_at = ?, lease_expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ? AND (worker_id = ? OR worker_id IS NULL)`, jobsV2RunRunning, m.workerID, started, started.Add(jobsV2LeaseDuration).UnixMilli(), run.ID, jobsV2RunClaimed, m.workerID)
 	if err != nil {
 		m.finishRunWithRetry(run.ID, jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("mark run running: %w", err), run.Attempt)
 		return
@@ -1448,17 +1562,27 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 		return
 	}
 	_ = m.addRunEvent(run.ID, "running", "run started", map[string]any{"worker_id": m.workerID})
+	stopHeartbeat := make(chan struct{})
+	heartbeatDone := make(chan struct{})
+	go func() {
+		defer close(heartbeatDone)
+		m.heartbeatRun(ctx, run.ID, cancel, stopHeartbeat)
+	}()
+	defer func() {
+		close(stopHeartbeat)
+		<-heartbeatDone
+	}()
 
 	// Build a progress writer that writes events and flushes partial response to DB.
 	pw := func(eventType, message string, data any) {
 		switch eventType {
 		case "response_flush":
 			// Update response column so GET /v2/runs/{id} shows partial output.
-			_, _ = m.db.Exec(`UPDATE job_runs_v2 SET response = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, message, run.ID)
+			_, _ = m.db.Exec(`UPDATE job_runs_v2 SET response = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND worker_id = ?`, message, run.ID, m.workerID)
 		case "progress_update":
 			if data != nil {
 				if payload, err := json.Marshal(data); err == nil {
-					_, _ = m.db.Exec(`UPDATE job_runs_v2 SET response = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, string(payload), run.ID)
+					_, _ = m.db.Exec(`UPDATE job_runs_v2 SET response = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND worker_id = ?`, string(payload), run.ID, m.workerID)
 				}
 			}
 			_ = m.addRunEvent(run.ID, eventType, message, data)
@@ -1539,14 +1663,15 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		errText = runErr.Error()
 	}
 	cancelledErrText := context.Canceled.Error()
-	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = CASE WHEN status = ? THEN ? ELSE ? END, finished_at = ?, exit_code = ?, error = CASE WHEN status = ? THEN ? ELSE ? END, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = ?, exit_reason = CASE WHEN status = ? THEN ? ELSE ? END, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?, ?)`,
+	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = CASE WHEN status = ? THEN ? ELSE ? END, finished_at = ?, exit_code = ?, error = CASE WHEN status = ? THEN ? ELSE ? END, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = ?, exit_reason = CASE WHEN status = ? THEN ? ELSE ? END, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, lease_expires_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?, ?) AND (status = ? OR worker_id = ? OR worker_id IS NULL)`,
 		jobsV2RunCancelRequested, jobsV2RunCancelled, status,
 		now, result.ExitCode,
 		jobsV2RunCancelRequested, cancelledErrText, errText,
 		result.Stdout, result.Stderr, result.Thinking, result.Response, result.SessionID,
 		jobsV2RunCancelRequested, exitReasonCancelled, exitReason,
 		boolToInt(truncated), result.TurnCount, result.InputTokens, result.OutputTokens,
-		runID, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested)
+		runID, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested,
+		jobsV2RunQueued, m.workerID)
 	if err != nil {
 		return err
 	}
@@ -2235,12 +2360,14 @@ func (m *jobsV2Manager) CancelRun(id string) (jobsV2Run, error) {
 				WHEN status IN (?, ?) THEN ?
 				ELSE finished_at
 			END,
+			lease_expires_at = CASE WHEN status IN (?, ?) THEN NULL ELSE lease_expires_at END,
 			updated_at = CURRENT_TIMESTAMP
 		WHERE id = ? AND status IN (?, ?, ?)
 		RETURNING status`,
 		jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunCancelled,
 		jobsV2RunCancelRequested,
 		jobsV2RunQueued, jobsV2RunClaimed, now,
+		jobsV2RunQueued, jobsV2RunClaimed,
 		id, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning,
 	).Scan(&transitioned)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -2255,6 +2382,9 @@ func (m *jobsV2Manager) CancelRun(id string) (jobsV2Run, error) {
 	switch transitioned {
 	case jobsV2RunCancelled:
 		_ = m.addRunEvent(id, "cancelled", "run cancelled before start", nil)
+		if run, getErr := m.GetRun(id); getErr == nil {
+			m.enqueueRunDoneNotification(run, jobsV2RunCancelled, jobsV2RunResult{SessionID: run.SessionID}, exitReasonCancelled, false, context.Canceled.Error())
+		}
 	case jobsV2RunCancelRequested:
 		_ = m.addRunEvent(id, "cancel_requested", "cancellation requested", nil)
 		m.mu.Lock()
@@ -3181,8 +3311,22 @@ func serveJobsRunnerOptions(approval resolvedApprovalMode) cmdRunnerOptions {
 	}
 }
 
+type serveJobsApprovalResolver func(context.Context, jobsV2LLMConfig) (resolvedApprovalMode, error)
+
 func newServeJobsExecutor(baseCfg *config.Config, approval resolvedApprovalMode) serveJobsExecutor {
+	return newServeJobsExecutorWithApprovalResolver(baseCfg, approval, nil)
+}
+
+func newServeJobsExecutorWithApprovalResolver(baseCfg *config.Config, approval resolvedApprovalMode, resolve serveJobsApprovalResolver) serveJobsExecutor {
 	return func(ctx context.Context, cfg jobsV2LLMConfig, onEvent func(llm.Event)) (serveJobsExecResult, error) {
+		runApproval := approval
+		if resolve != nil {
+			var err error
+			runApproval, err = resolve(ctx, cfg)
+			if err != nil {
+				return serveJobsExecResult{}, err
+			}
+		}
 		var search *bool
 		if cfg.Search {
 			v := true
@@ -3197,7 +3341,7 @@ func newServeJobsExecutor(baseCfg *config.Config, approval resolvedApprovalMode)
 			}
 		}
 
-		runner := newCmdRunner(baseCfg, serveJobsRunnerOptions(approval))
+		runner := newCmdRunner(baseCfg, serveJobsRunnerOptions(runApproval))
 
 		result, err := runner.Run(ctx, runpkg.Request{
 			Platform:        runpkg.PlatformJob,
@@ -3206,6 +3350,8 @@ func newServeJobsExecutor(baseCfg *config.Config, approval resolvedApprovalMode)
 			SessionID:       cfg.SessionID,
 			SessionName:     cfg.SessionName,
 			Persist:         cfg.sessionPersistenceEnabled(),
+			ParentSessionID: cfg.ParentSessionID,
+			IsWorker:        cfg.Worker,
 			Provider:        cfg.Provider,
 			Model:           cfg.Model,
 			Cwd:             cfg.Cwd,

--- a/cmd/serve_jobs_v2_notify_test.go
+++ b/cmd/serve_jobs_v2_notify_test.go
@@ -683,7 +683,10 @@ func TestJobsV2ThreadCloseAllowsTerminalNotification(t *testing.T) {
 		<-ctx.Done()
 		return jobsV2RunResult{}, ctx.Err()
 	})
-	labels, _ := json.Marshal(map[string]string{threadWorkerLabelKey: threadWorkerLabelValue})
+	labels, _ := json.Marshal(map[string]string{
+		threadWorkerLabelKey:      threadWorkerLabelValue,
+		threadWorkerOwnerLabelKey: mgr.workerID,
+	})
 	job, err := mgr.CreateJob(jobsV2Job{
 		Name: "thread-notify-on-close", Enabled: true, RunnerType: jobsV2RunnerProgram,
 		RunnerConfig: json.RawMessage(`{"command":"ignored"}`), TriggerType: jobsV2TriggerManual,

--- a/cmd/serve_jobs_v2_notify_test.go
+++ b/cmd/serve_jobs_v2_notify_test.go
@@ -664,3 +664,54 @@ func TestJobsV2CloseCancelsCompletionNotification(t *testing.T) {
 		t.Fatalf("notification attempts after shutdown = %d, want 1", got)
 	}
 }
+
+func TestJobsV2ThreadCloseAllowsTerminalNotification(t *testing.T) {
+	started := make(chan struct{})
+	notified := make(chan jobsV2RunStatus, 1)
+	mgr, err := newThreadWorkerJobsV2Manager(":memory:", 1, nil, func(ctx context.Context, _ jobsV2Run, _ jobsV2Job, status jobsV2RunStatus, _ jobsV2RunResult, _ string, _ bool, _ string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		notified <- status
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newThreadWorkerJobsV2Manager: %v", err)
+	}
+	mgr.runners[jobsV2RunnerProgram] = jobsV2RunnerFunc(func(ctx context.Context, _ jobsV2Job, _ progressWriter) (jobsV2RunResult, error) {
+		close(started)
+		<-ctx.Done()
+		return jobsV2RunResult{}, ctx.Err()
+	})
+	labels, _ := json.Marshal(map[string]string{threadWorkerLabelKey: threadWorkerLabelValue})
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name: "thread-notify-on-close", Enabled: true, RunnerType: jobsV2RunnerProgram,
+		RunnerConfig: json.RawMessage(`{"command":"ignored"}`), TriggerType: jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`), RetryPolicy: json.RawMessage(`{"max_attempts":1}`), Labels: labels,
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if _, err := mgr.TriggerJob(job.ID); err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not start")
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := mgr.CloseContext(closeCtx); err != nil {
+		t.Fatalf("CloseContext: %v", err)
+	}
+	select {
+	case status := <-notified:
+		if status != jobsV2RunCancelled {
+			t.Fatalf("notification status = %s, want %s", status, jobsV2RunCancelled)
+		}
+	default:
+		t.Fatal("thread terminal notification was cancelled during manager shutdown")
+	}
+}

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -1658,8 +1658,8 @@ func TestJobsV2TriggerJobRespectsMaxConcurrentRuns(t *testing.T) {
 
 	now := time.Now().UTC()
 	for _, runID := range []string{"run_existing_1", "run_existing_2"} {
-		_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, ?, ?)`,
-			runID, job.ID, now, jobsV2RunRunning, now, now)
+		_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, worker_id, lease_expires_at, created_at, updated_at) VALUES (?, ?, 1, 'manual', ?, ?, 'live-worker', ?, ?, ?)`,
+			runID, job.ID, now, jobsV2RunRunning, now.Add(jobsV2LeaseDuration).UnixMilli(), now, now)
 		if err != nil {
 			t.Fatalf("insert active run %s: %v", runID, err)
 		}
@@ -1809,8 +1809,8 @@ func TestJobsV2ScheduleOneRespectsMaxConcurrentRuns(t *testing.T) {
 
 	now := time.Now().UTC()
 	for _, runID := range []string{"run_existing_1", "run_existing_2"} {
-		_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, 'schedule', ?, ?, ?, ?)`,
-			runID, job.ID, now, jobsV2RunRunning, now, now)
+		_, err = mgr.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, worker_id, lease_expires_at, created_at, updated_at) VALUES (?, ?, 1, 'schedule', ?, ?, 'live-worker', ?, ?, ?)`,
+			runID, job.ID, now, jobsV2RunRunning, now.Add(jobsV2LeaseDuration).UnixMilli(), now, now)
 		if err != nil {
 			t.Fatalf("insert active run %s: %v", runID, err)
 		}

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -661,6 +661,99 @@ func TestJobsV2FinishRunDoesNotOverrideCancelRequested(t *testing.T) {
 	}
 }
 
+func TestJobsV2SecondManagerDoesNotRecoverLiveLeasedRun(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jobs.db")
+	mgr1, err := newJobsV2Manager(path, 1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mgr1.runners[jobsV2RunnerProgram] = jobsV2RunnerFunc(func(context.Context, jobsV2Job, progressWriter) (jobsV2RunResult, error) {
+		close(started)
+		<-release
+		return jobsV2RunResult{Stdout: "owned"}, nil
+	})
+	job, err := mgr1.CreateJob(jobsV2Job{
+		Name: "leased-owner", Enabled: true, RunnerType: jobsV2RunnerProgram,
+		RunnerConfig: json.RawMessage(`{"command":"ignored"}`), TriggerType: jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`), RetryPolicy: json.RawMessage(`{"max_attempts":1}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := mgr1.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first manager did not start run")
+	}
+
+	mgr2, err := newJobsV2Manager(path, 0, nil)
+	if err != nil {
+		t.Fatalf("start second manager: %v", err)
+	}
+	live, err := mgr2.GetRun(run.ID)
+	if err != nil || live.Status != jobsV2RunRunning || live.WorkerID != mgr1.workerID {
+		t.Fatalf("second manager changed live run: %#v, %v", live, err)
+	}
+	close(release)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		finished, err := mgr2.GetRun(run.ID)
+		if err == nil && finished.Status == jobsV2RunSucceeded {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("owned run did not finish successfully: %#v, %v", finished, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_ = mgr2.Close()
+	_ = mgr1.Close()
+}
+
+func TestJobsV2RecoveryClaimsOnlyExpiredLease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jobs.db")
+	seed, err := newJobsV2Manager(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job, err := seed.CreateJob(jobsV2Job{
+		Name: "expired-lease", Enabled: true, RunnerType: jobsV2RunnerProgram,
+		RunnerConfig: json.RawMessage(`{"command":"ignored"}`), TriggerType: jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`), RetryPolicy: json.RawMessage(`{"max_attempts":1}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := seed.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.db.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = 'dead', lease_expires_at = ? WHERE id = ?`, jobsV2RunRunning, time.Now().Add(-time.Minute).UnixMilli(), run.ID); err != nil {
+		t.Fatal(err)
+	}
+	_ = seed.Close()
+
+	recovering, err := newJobsV2Manager(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovering.Close()
+	recovered, err := recovering.GetRun(run.ID)
+	if err != nil || recovered.Status != jobsV2RunFailed || recovered.ExitReason != exitReasonWorkerLost {
+		t.Fatalf("expired run = %#v, %v", recovered, err)
+	}
+	var lease sql.NullInt64
+	if err := recovering.db.QueryRow(`SELECT lease_expires_at FROM job_runs_v2 WHERE id = ?`, run.ID).Scan(&lease); err != nil || lease.Valid {
+		t.Fatalf("terminal lease = %#v, %v", lease, err)
+	}
+}
+
 func TestJobsV2CreateDefaultsEnabledWhenOmitted(t *testing.T) {
 	mgr, err := newJobsV2Manager(":memory:", 0, nil)
 	if err != nil {

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -197,17 +197,20 @@ type NotifyOrigin struct {
 }
 
 type LLMConfig struct {
-	AgentName      string        `json:"agent_name"`
-	Instructions   string        `json:"instructions"`
-	Progressive    bool          `json:"progressive,omitempty"`
-	StopWhen       string        `json:"stop_when,omitempty"`
-	ContinueWith   string        `json:"continue_with,omitempty"`
-	PersistSession *bool         `json:"persist_session,omitempty"`
-	SessionID      string        `json:"session_id,omitempty"`
-	SessionName    string        `json:"session_name,omitempty"`
-	NotifyWhenDone bool          `json:"notify_when_done,omitempty"`
-	NotifyOrigin   *NotifyOrigin `json:"notify_origin,omitempty"`
-	Cwd            string        `json:"cwd"`
+	AgentName          string        `json:"agent_name"`
+	Instructions       string        `json:"instructions"`
+	Progressive        bool          `json:"progressive,omitempty"`
+	StopWhen           string        `json:"stop_when,omitempty"`
+	ContinueWith       string        `json:"continue_with,omitempty"`
+	PersistSession     *bool         `json:"persist_session,omitempty"`
+	SessionID          string        `json:"session_id,omitempty"`
+	SessionName        string        `json:"session_name,omitempty"`
+	NotifyWhenDone     bool          `json:"notify_when_done,omitempty"`
+	NotifyOrigin       *NotifyOrigin `json:"notify_origin,omitempty"`
+	ParentSessionID    string        `json:"parent_session_id,omitempty"`
+	Worker             bool          `json:"worker,omitempty"`
+	WorkerApprovalMode string        `json:"worker_approval_mode,omitempty"`
+	Cwd                string        `json:"cwd"`
 
 	Provider        string   `json:"provider,omitempty"`
 	Model           string   `json:"model,omitempty"`
@@ -250,6 +253,16 @@ func ValidateRunnerConfig(runnerType RunnerType, raw json.RawMessage) error {
 		}
 		if strings.TrimSpace(cfg.Cwd) == "" {
 			return fmt.Errorf("llm runner_config.cwd is required")
+		}
+		if cfg.Worker {
+			if strings.TrimSpace(cfg.SessionID) == "" || strings.TrimSpace(cfg.ParentSessionID) == "" {
+				return fmt.Errorf("worker runner_config requires session_id and parent_session_id")
+			}
+			switch strings.TrimSpace(cfg.WorkerApprovalMode) {
+			case "", "prompt", "auto", "yolo":
+			default:
+				return fmt.Errorf("worker runner_config.worker_approval_mode is invalid")
+			}
 		}
 	case RunnerProgram:
 	case "":

--- a/internal/llm/compaction.go
+++ b/internal/llm/compaction.go
@@ -1517,6 +1517,26 @@ func Compact(ctx context.Context, provider Provider, model, systemPrompt string,
 	return result, nil
 }
 
+// BriefingResult is the generated document and helper-call accounting shared by
+// handover and other control-plane briefings.
+type BriefingResult struct {
+	Document string
+	Model    string
+	Usage    Usage
+}
+
+// BriefingOptions controls the editorial instructions and whether generation
+// may branch from live provider state. Callers must only enable forking at a
+// settled provider boundary.
+type BriefingOptions struct {
+	EditorialPrompt         string
+	TriggerPrompt           string
+	PreparingAcknowledgment string
+	Operation               string
+	MaxOutputTokens         int
+	AllowProviderFork       bool
+}
+
 // HandoverResult describes the outcome of a handover compression.
 type HandoverResult struct {
 	Document    string    // The handover document text
@@ -1587,29 +1607,35 @@ func conversationEndsAtSettledAssistant(messages []Message) bool {
 	return len(pending) == 0
 }
 
-// Handover generates a handover document from the conversation history using
-// the outgoing provider. This is the Tier 2 fallback used when file-based
-// handover is not available. The result contains reconstructed messages suitable
-// for the new agent: [new system prompt] + [handover doc] + [assistant ack].
-func Handover(ctx context.Context, provider Provider, model, currentSystemPrompt, newSystemPrompt string, messages []Message, sourceAgent, targetAgent string, config CompactionConfig, options HandoverOptions) (*HandoverResult, error) {
+// GenerateBriefing prepares a self-contained control-plane document from a
+// conversation without creating a normal agent turn. It owns tool-history
+// settlement, isolated/forked provider selection, the ephemeral helper stream,
+// document collection, and usage accounting returned to the caller.
+func GenerateBriefing(ctx context.Context, provider Provider, model, currentSystemPrompt string, messages []Message, config CompactionConfig, options BriefingOptions) (*BriefingResult, error) {
 	if len(messages) == 0 {
-		return nil, fmt.Errorf("no messages to hand over")
+		return nil, fmt.Errorf("no messages to brief")
+	}
+	if strings.TrimSpace(options.EditorialPrompt) == "" || strings.TrimSpace(options.TriggerPrompt) == "" {
+		return nil, fmt.Errorf("briefing instructions are required")
+	}
+	operation := strings.TrimSpace(options.Operation)
+	if operation == "" {
+		operation = "briefing"
 	}
 
 	settledBoundary := conversationEndsAtSettledAssistant(messages)
 	messages = sanitizeToolHistory(messages)
 
-	prompt := fmt.Sprintf(handoverPromptTemplate, sourceAgent, targetAgent)
-	policy := Message{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: prompt}}}
-	trigger := UserText(handoverTriggerPrompt)
+	policy := Message{Role: RoleDeveloper, Parts: []Part{{Type: PartText, Text: options.EditorialPrompt}}}
+	trigger := UserText(options.TriggerPrompt)
 
 	// A settled assistant response is the exact provider boundary from which a
-	// handover can branch. Reuse that server-side state when the provider supports
-	// an isolated native fork; otherwise preserve the established full-history path.
-	var handoverProvider Provider
+	// helper can branch. Reuse that server-side state when supported; otherwise
+	// use an isolated full-history request so the live conversation is untouched.
+	var briefingProvider Provider
 	forked := options.AllowProviderFork && settledBoundary
 	if forked {
-		handoverProvider, forked = forkConversationProvider(provider)
+		briefingProvider, forked = forkConversationProvider(provider)
 	}
 
 	var reqMessages []Message
@@ -1621,25 +1647,32 @@ func Handover(ctx context.Context, provider Provider, model, currentSystemPrompt
 		}
 		reqMessages = append(reqMessages, policy, trigger)
 	} else {
-		handoverProvider = isolatedConversationProvider(provider)
+		briefingProvider = isolatedConversationProvider(provider)
 		inputLimit := config.InputLimit
 		if inputLimit <= 0 {
 			inputLimit = InputLimitForModel(model)
+		}
+		acknowledgment := strings.TrimSpace(options.PreparingAcknowledgment)
+		if acknowledgment == "" {
+			acknowledgment = "I'll now prepare the briefing."
 		}
 		reqMessages = buildHelperRequestMessages(
 			currentSystemPrompt,
 			messages,
 			inputLimit,
-			"I'll now prepare the handover briefing.",
+			acknowledgment,
 			policy,
 			trigger,
 		)
 	}
 
-	budget := 12_000 // Slightly larger budget than compaction for handover precision
+	budget := options.MaxOutputTokens
+	if budget <= 0 {
+		budget = defaultSummaryTokenBudget
+	}
 	budget = ClampOutputTokens(budget, model)
 
-	stream, err := handoverProvider.Stream(ctx, Request{
+	stream, err := briefingProvider.Stream(ctx, Request{
 		Model:                          model,
 		Messages:                       reqMessages,
 		MaxOutputTokens:                budget,
@@ -1648,28 +1681,55 @@ func Handover(ctx context.Context, provider Provider, model, currentSystemPrompt
 		IncludeDeveloperInContinuation: forked,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("handover stream failed: %w", err)
+		return nil, fmt.Errorf("%s stream failed: %w", operation, err)
 	}
 	defer stream.Close()
 
 	collected, err := CollectTextStream(stream, nil)
 	if err != nil {
-		return nil, fmt.Errorf("handover recv failed: %w", err)
+		return nil, fmt.Errorf("%s recv failed: %w", operation, err)
 	}
-	if strings.TrimSpace(collected.Text) == "" {
-		return nil, fmt.Errorf("handover produced empty document")
+	document := collected.Text
+	if strings.TrimSpace(document) == "" {
+		return nil, fmt.Errorf("%s produced empty document", operation)
+	}
+	return &BriefingResult{
+		Document: document,
+		Model:    strings.TrimSpace(model),
+		Usage:    collected.Usage,
+	}, nil
+}
+
+// Handover generates a handover document from the conversation history using
+// the outgoing provider. This is the Tier 2 fallback used when file-based
+// handover is not available. The result contains reconstructed messages suitable
+// for the new agent: [new system prompt] + [handover doc] + [assistant ack].
+func Handover(ctx context.Context, provider Provider, model, currentSystemPrompt, newSystemPrompt string, messages []Message, sourceAgent, targetAgent string, config CompactionConfig, options HandoverOptions) (*HandoverResult, error) {
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("no messages to hand over")
+	}
+	briefing, err := GenerateBriefing(ctx, provider, model, currentSystemPrompt, messages, config, BriefingOptions{
+		EditorialPrompt:         fmt.Sprintf(handoverPromptTemplate, sourceAgent, targetAgent),
+		TriggerPrompt:           handoverTriggerPrompt,
+		PreparingAcknowledgment: "I'll now prepare the handover briefing.",
+		Operation:               "handover",
+		MaxOutputTokens:         12_000,
+		AllowProviderFork:       options.AllowProviderFork,
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	// Reconstruct messages for the new agent with the new system prompt.
-	newMessages := ReconstructHandoverHistory(newSystemPrompt, collected.Text, sourceAgent, targetAgent)
+	newMessages := ReconstructHandoverHistory(newSystemPrompt, briefing.Document, sourceAgent, targetAgent)
 
 	return &HandoverResult{
-		Document:    collected.Text,
+		Document:    briefing.Document,
 		NewMessages: newMessages,
 		SourceAgent: sourceAgent,
 		TargetAgent: targetAgent,
-		Model:       strings.TrimSpace(model),
-		Usage:       collected.Usage,
+		Model:       briefing.Model,
+		Usage:       briefing.Usage,
 	}, nil
 }
 

--- a/internal/llm/compaction_test.go
+++ b/internal/llm/compaction_test.go
@@ -2293,6 +2293,44 @@ func TestForkConversationProvider_ClaudeBinUsesForkSession(t *testing.T) {
 	}
 }
 
+func TestGenerateBriefingUsesSharedHelperStreamWithCustomEditorialPolicy(t *testing.T) {
+	provider := NewMockProvider("test").AddTurn(MockTurn{
+		Text:  "## Outcome\nThe focused implementation is complete.",
+		Usage: Usage{InputTokens: 42, OutputTokens: 11, CachedInputTokens: 7},
+	})
+	messages := []Message{UserText("implement it"), AssistantText("implementation complete")}
+
+	result, err := GenerateBriefing(context.Background(), provider, "test-model", "system policy", messages, DefaultCompactionConfig(), BriefingOptions{
+		EditorialPrompt:         "Prioritize evidence and current state, not chronology.",
+		TriggerPrompt:           "Write the result report now.",
+		PreparingAcknowledgment: "I'll prepare the result report.",
+		MaxOutputTokens:         777,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBriefing: %v", err)
+	}
+	if result.Document != "## Outcome\nThe focused implementation is complete." || result.Model != "test-model" || result.Usage.InputTokens != 42 || result.Usage.OutputTokens != 11 || result.Usage.CachedInputTokens != 7 {
+		t.Fatalf("briefing result = %#v", result)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("requests = %#v", provider.Requests)
+	}
+	request := provider.Requests[0]
+	if !request.Ephemeral || request.MaxTurns != 1 || request.MaxOutputTokens != 777 {
+		t.Fatalf("helper request controls = %#v", request)
+	}
+	var requestText strings.Builder
+	for _, message := range request.Messages {
+		requestText.WriteString(MessageText(message))
+		requestText.WriteByte('\n')
+	}
+	for _, want := range []string{"implement it", "implementation complete", "Prioritize evidence and current state", "Write the result report now"} {
+		if !strings.Contains(requestText.String(), want) {
+			t.Fatalf("helper request missing %q:\n%s", want, requestText.String())
+		}
+	}
+}
+
 func TestHandoverEndToEnd(t *testing.T) {
 	provider := NewMockProvider("test")
 	provider.AddTurn(MockTurn{

--- a/internal/run/types.go
+++ b/internal/run/types.go
@@ -117,6 +117,7 @@ type Request struct {
 	// Sub-agent/session-linking options used by spawn_agent migrations.
 	ParentSessionID          string
 	IsSubagent               bool
+	IsWorker                 bool
 	Depth                    int
 	ApprovalRole             string
 	ApprovalTranscriptPrefix []llm.Message

--- a/internal/session/logger_worker.go
+++ b/internal/session/logger_worker.go
@@ -1,0 +1,120 @@
+package session
+
+import "context"
+
+func (s *LoggingStore) workerStore() (WorkerStore, error) {
+	store, ok := s.Store.(WorkerStore)
+	if !ok {
+		return nil, ErrWorkersUnsupported
+	}
+	return store, nil
+}
+
+func (s *LoggingStore) CreateWorker(ctx context.Context, coordinatorSessionID, task string) (WorkerEdge, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return WorkerEdge{}, err
+	}
+	edge, err := store.CreateWorker(ctx, coordinatorSessionID, task)
+	if err != nil {
+		s.logOnce("CreateWorker", err)
+	}
+	return edge, err
+}
+
+func (s *LoggingStore) SetWorkerExecution(ctx context.Context, childSessionID, jobID, runID string) error {
+	store, err := s.workerStore()
+	if err == nil {
+		err = store.SetWorkerExecution(ctx, childSessionID, jobID, runID)
+	}
+	if err != nil {
+		s.logOnce("SetWorkerExecution", err)
+	}
+	return err
+}
+
+func (s *LoggingStore) UpdateWorkerStatus(ctx context.Context, childSessionID string, status WorkerStatus) error {
+	store, err := s.workerStore()
+	if err == nil {
+		err = store.UpdateWorkerStatus(ctx, childSessionID, status)
+	}
+	if err != nil {
+		s.logOnce("UpdateWorkerStatus", err)
+	}
+	return err
+}
+
+func (s *LoggingStore) GetWorker(ctx context.Context, childSessionID string) (WorkerEdge, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return WorkerEdge{}, err
+	}
+	return store.GetWorker(ctx, childSessionID)
+}
+
+func (s *LoggingStore) ListWorkers(ctx context.Context, coordinatorSessionID string) ([]WorkerEdge, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.ListWorkers(ctx, coordinatorSessionID)
+}
+
+func (s *LoggingStore) AddWorkerReport(ctx context.Context, report WorkerReport) (WorkerReport, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return WorkerReport{}, err
+	}
+	created, err := store.AddWorkerReport(ctx, report)
+	if err != nil {
+		s.logOnce("AddWorkerReport", err)
+	}
+	return created, err
+}
+
+func (s *LoggingStore) ListWorkerReports(ctx context.Context, childSessionID string) ([]WorkerReport, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.ListWorkerReports(ctx, childSessionID)
+}
+
+func (s *LoggingStore) MarkWorkerReportRead(ctx context.Context, reportID int64) error {
+	store, err := s.workerStore()
+	if err == nil {
+		err = store.MarkWorkerReportRead(ctx, reportID)
+	}
+	if err != nil {
+		s.logOnce("MarkWorkerReportRead", err)
+	}
+	return err
+}
+
+func (s *LoggingStore) ImportWorkerReport(ctx context.Context, reportID int64) (*Message, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return nil, err
+	}
+	message, err := store.ImportWorkerReport(ctx, reportID)
+	if err != nil {
+		s.logOnce("ImportWorkerReport", err)
+	}
+	return message, err
+}
+
+func (s *LoggingStore) CountUnreadWorkerReports(ctx context.Context, coordinatorSessionID string) (int, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return 0, err
+	}
+	return store.CountUnreadWorkerReports(ctx, coordinatorSessionID)
+}
+
+func (s *LoggingStore) HasWorkerReportKind(ctx context.Context, childSessionID string, kind WorkerReportKind) (bool, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return false, err
+	}
+	return store.HasWorkerReportKind(ctx, childSessionID, kind)
+}

--- a/internal/session/logger_worker.go
+++ b/internal/session/logger_worker.go
@@ -22,6 +22,18 @@ func (s *LoggingStore) CreateWorker(ctx context.Context, coordinatorSessionID, t
 	return edge, err
 }
 
+func (s *LoggingStore) CreateWorkerOwned(ctx context.Context, coordinatorSessionID, ownerID, task string) (WorkerEdge, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return WorkerEdge{}, err
+	}
+	edge, err := store.CreateWorkerOwned(ctx, coordinatorSessionID, ownerID, task)
+	if err != nil {
+		s.logOnce("CreateWorkerOwned", err)
+	}
+	return edge, err
+}
+
 func (s *LoggingStore) SetWorkerExecution(ctx context.Context, childSessionID, jobID, runID string) error {
 	store, err := s.workerStore()
 	if err == nil {
@@ -33,6 +45,18 @@ func (s *LoggingStore) SetWorkerExecution(ctx context.Context, childSessionID, j
 	return err
 }
 
+func (s *LoggingStore) SetWorkerOwner(ctx context.Context, childSessionID, oldOwnerID, newOwnerID string) (bool, error) {
+	store, err := s.workerStore()
+	if err != nil {
+		return false, err
+	}
+	changed, err := store.SetWorkerOwner(ctx, childSessionID, oldOwnerID, newOwnerID)
+	if err != nil {
+		s.logOnce("SetWorkerOwner", err)
+	}
+	return changed, err
+}
+
 func (s *LoggingStore) UpdateWorkerStatus(ctx context.Context, childSessionID string, status WorkerStatus) error {
 	store, err := s.workerStore()
 	if err == nil {
@@ -40,6 +64,17 @@ func (s *LoggingStore) UpdateWorkerStatus(ctx context.Context, childSessionID st
 	}
 	if err != nil {
 		s.logOnce("UpdateWorkerStatus", err)
+	}
+	return err
+}
+
+func (s *LoggingStore) FinishWorker(ctx context.Context, childSessionID string, status WorkerStatus, report WorkerReport) error {
+	store, err := s.workerStore()
+	if err == nil {
+		err = store.FinishWorker(ctx, childSessionID, status, report)
+	}
+	if err != nil {
+		s.logOnce("FinishWorker", err)
 	}
 	return err
 }
@@ -109,12 +144,4 @@ func (s *LoggingStore) CountUnreadWorkerReports(ctx context.Context, coordinator
 		return 0, err
 	}
 	return store.CountUnreadWorkerReports(ctx, coordinatorSessionID)
-}
-
-func (s *LoggingStore) HasWorkerReportKind(ctx context.Context, childSessionID string, kind WorkerReportKind) (bool, error) {
-	store, err := s.workerStore()
-	if err != nil {
-		return false, err
-	}
-	return store.HasWorkerReportKind(ctx, childSessionID, kind)
 }

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -50,6 +50,7 @@ type SQLiteStore struct {
 	hasMessageStreamIdentity bool // true if messages table has response-scoped segment identity columns
 	hasMessageClientID       bool // true if messages table has client_message_id
 	hasSessionBranches       bool // true if session_branches table exists
+	hasSessionWorkers        bool // true if worker edge/mailbox tables exist
 }
 
 var _ MessageSequenceStore = (*SQLiteStore)(nil)
@@ -186,6 +187,50 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_session_branches_idempotency
     WHERE idempotency_key <> '';
 CREATE INDEX IF NOT EXISTS idx_session_branches_parent
     ON session_branches(parent_session_id);
+
+CREATE TABLE IF NOT EXISTS session_workers (
+    child_session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    coordinator_session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    task TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'blocked', 'done', 'failed', 'cancelled')),
+    job_id TEXT,
+    run_id TEXT,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    finished_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_session_workers_coordinator
+    ON session_workers(coordinator_session_id, created_at, child_session_id);
+CREATE INDEX IF NOT EXISTS idx_session_workers_status
+    ON session_workers(status, updated_at);
+
+CREATE TABLE IF NOT EXISTS session_worker_reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    child_session_id TEXT NOT NULL REFERENCES session_workers(child_session_id) ON DELETE CASCADE,
+    source_session_id TEXT NOT NULL,
+    destination_session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK (kind IN ('progress', 'result', 'blocker')),
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    origin TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    read_at TIMESTAMP,
+    imported_at TIMESTAMP,
+    imported_message_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL,
+    UNIQUE (child_session_id, sequence)
+);
+CREATE INDEX IF NOT EXISTS idx_session_worker_reports_destination
+    ON session_worker_reports(destination_session_id, read_at, created_at, id);
+CREATE INDEX IF NOT EXISTS idx_session_worker_reports_child
+    ON session_worker_reports(child_session_id, sequence, id);
+CREATE TRIGGER IF NOT EXISTS session_worker_reports_content_immutable
+BEFORE UPDATE OF child_session_id, source_session_id, destination_session_id, kind, title, body, metadata, origin, sequence, created_at
+ON session_worker_reports
+BEGIN
+    SELECT RAISE(ABORT, 'worker report content is immutable');
+END;
 
 -- Metadata table for current session tracking
 CREATE TABLE IF NOT EXISTS metadata (
@@ -329,6 +374,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 		store.probeSessionColumns()
 		store.probeMessageColumns()
 		store.probeBranchTable()
+		store.probeWorkerTables()
 	} else {
 		store.setCurrentColumns()
 	}
@@ -377,7 +423,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 46
+const schemaVersion = 47
 
 // migration represents a schema migration.
 type migration struct {
@@ -1284,6 +1330,61 @@ var migrations = []migration{
 				)`,
 				`CREATE INDEX IF NOT EXISTS idx_session_workspace_grants_session
 					ON session_workspace_grants(session_id, created_at, id)`,
+			} {
+				if _, err := db.Exec(statement); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
+	{
+		version:     47,
+		description: "create durable workers and mailbox reports",
+		up: func(db schemaExecutor) error {
+			for _, statement := range []string{
+				`CREATE TABLE IF NOT EXISTS session_workers (
+					child_session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+					coordinator_session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+					task TEXT NOT NULL,
+					status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'blocked', 'done', 'failed', 'cancelled')),
+					job_id TEXT,
+					run_id TEXT,
+					created_at TIMESTAMP NOT NULL,
+					updated_at TIMESTAMP NOT NULL,
+					finished_at TIMESTAMP
+				)`,
+				`CREATE INDEX IF NOT EXISTS idx_session_workers_coordinator
+					ON session_workers(coordinator_session_id, created_at, child_session_id)`,
+				`CREATE INDEX IF NOT EXISTS idx_session_workers_status
+					ON session_workers(status, updated_at)`,
+				`CREATE TABLE IF NOT EXISTS session_worker_reports (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_session_id TEXT NOT NULL REFERENCES session_workers(child_session_id) ON DELETE CASCADE,
+					source_session_id TEXT NOT NULL,
+					destination_session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+					kind TEXT NOT NULL CHECK (kind IN ('progress', 'result', 'blocker')),
+					title TEXT NOT NULL,
+					body TEXT NOT NULL,
+					metadata TEXT NOT NULL DEFAULT '{}',
+					origin TEXT NOT NULL,
+					sequence INTEGER NOT NULL,
+					read_at TIMESTAMP,
+					imported_at TIMESTAMP,
+					imported_message_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+					created_at TIMESTAMP NOT NULL,
+					UNIQUE (child_session_id, sequence)
+				)`,
+				`CREATE INDEX IF NOT EXISTS idx_session_worker_reports_destination
+					ON session_worker_reports(destination_session_id, read_at, created_at, id)`,
+				`CREATE INDEX IF NOT EXISTS idx_session_worker_reports_child
+					ON session_worker_reports(child_session_id, sequence, id)`,
+				`CREATE TRIGGER IF NOT EXISTS session_worker_reports_content_immutable
+					BEFORE UPDATE OF child_session_id, source_session_id, destination_session_id, kind, title, body, metadata, origin, sequence, created_at
+					ON session_worker_reports
+					BEGIN
+						SELECT RAISE(ABORT, 'worker report content is immutable');
+					END`,
 			} {
 				if _, err := db.Exec(statement); err != nil {
 					return err
@@ -4586,12 +4687,20 @@ func (s *SQLiteStore) setCurrentColumns() {
 	s.hasMessageStreamIdentity = true
 	s.hasMessageClientID = true
 	s.hasSessionBranches = true
+	s.hasSessionWorkers = true
 }
 
 func (s *SQLiteStore) probeBranchTable() {
 	var count int
 	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'session_branches'`).Scan(&count); err == nil {
 		s.hasSessionBranches = count > 0
+	}
+}
+
+func (s *SQLiteStore) probeWorkerTables() {
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('session_workers', 'session_worker_reports')`).Scan(&count); err == nil {
+		s.hasSessionWorkers = count == 2
 	}
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -191,6 +191,7 @@ CREATE INDEX IF NOT EXISTS idx_session_branches_parent
 CREATE TABLE IF NOT EXISTS session_workers (
     child_session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
     coordinator_session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    owner_id TEXT NOT NULL DEFAULT '',
     task TEXT NOT NULL,
     status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'blocked', 'done', 'failed', 'cancelled')),
     job_id TEXT,
@@ -423,7 +424,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // - Fresh databases get the full schema from `schema` const and start at this version
 // - Existing databases run migrations to reach this version
 // Increment when adding new migrations.
-const schemaVersion = 47
+const schemaVersion = 48
 
 // migration represents a schema migration.
 type migration struct {
@@ -1391,6 +1392,33 @@ var migrations = []migration{
 				}
 			}
 			return nil
+		},
+	},
+	{
+		version:     48,
+		description: "add durable worker runtime ownership",
+		up: func(db schemaExecutor) error {
+			rows, err := db.Query(`PRAGMA table_info(session_workers)`)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var cid, notNull, primaryKey int
+				var name, columnType string
+				var defaultValue any
+				if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+					return err
+				}
+				if name == "owner_id" {
+					return nil
+				}
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			_, err = db.Exec(`ALTER TABLE session_workers ADD COLUMN owner_id TEXT NOT NULL DEFAULT ''`)
+			return err
 		},
 	},
 }

--- a/internal/session/sqlite_worker.go
+++ b/internal/session/sqlite_worker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -23,6 +24,27 @@ func (s *SQLiteStore) requireWorkers() error {
 // edge in one immediate transaction. Runtime settings and non-yolo workspace
 // grants are inherited, but no transcript or provider state is copied.
 func (s *SQLiteStore) CreateWorker(ctx context.Context, coordinatorSessionID, task string) (WorkerEdge, error) {
+	return s.CreateWorkerOwned(ctx, coordinatorSessionID, "", task)
+}
+
+func canonicalWorkerCWD(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Clean(path)
+}
+
+// CreateWorkerOwned records the embedded chat runtime that owns the worker so
+// another live chat cannot claim or clear it. A later runtime may explicitly
+// adopt the edge after the owner's durable lease expires.
+func (s *SQLiteStore) CreateWorkerOwned(ctx context.Context, coordinatorSessionID, ownerID, task string) (WorkerEdge, error) {
 	if err := s.requireWorkers(); err != nil {
 		return WorkerEdge{}, err
 	}
@@ -50,25 +72,40 @@ func (s *SQLiteStore) CreateWorker(ctx context.Context, coordinatorSessionID, ta
 			_ = conn.Close()
 		}()
 
-		var active int
-		if err := conn.QueryRowContext(ctx, `
-			SELECT COUNT(1)
+		var coordinatorCWD string
+		if err := conn.QueryRowContext(ctx, `SELECT COALESCE(cwd, '') FROM sessions WHERE id = ?`, coordinatorSessionID).Scan(&coordinatorCWD); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("load coordinator workspace: %w", err)
+		}
+		coordinatorCWD = canonicalWorkerCWD(coordinatorCWD)
+		rows, err := conn.QueryContext(ctx, `
+			SELECT w.coordinator_session_id, COALESCE(child.cwd, '')
 			FROM session_workers w
 			JOIN sessions child ON child.id = w.child_session_id
-			WHERE w.status IN (?, ?, ?)
-			  AND (
-				w.coordinator_session_id = ?
-				OR (
-					NULLIF(TRIM(child.cwd), '') IS NOT NULL
-					AND NULLIF(TRIM(child.cwd), '') = (
-						SELECT NULLIF(TRIM(cwd), '') FROM sessions WHERE id = ?
-					)
-				)
-			  )`,
-			WorkerQueued, WorkerRunning, WorkerBlocked, coordinatorSessionID, coordinatorSessionID).Scan(&active); err != nil {
+			WHERE w.status IN (?, ?, ?)`, WorkerQueued, WorkerRunning, WorkerBlocked)
+		if err != nil {
 			return fmt.Errorf("check active workers: %w", err)
 		}
-		if active > 0 {
+		conflict := false
+		for rows.Next() {
+			var activeCoordinator, activeCWD string
+			if err := rows.Scan(&activeCoordinator, &activeCWD); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan active worker: %w", err)
+			}
+			conflict = conflict || activeCoordinator == coordinatorSessionID ||
+				(coordinatorCWD != "" && canonicalWorkerCWD(activeCWD) == coordinatorCWD)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan active workers: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close active workers: %w", err)
+		}
+		if conflict {
 			return fmt.Errorf("a worker is already active for this coordinator or workspace; wait, cancel it in /tree, or use an isolated worktree")
 		}
 
@@ -104,8 +141,8 @@ func (s *SQLiteStore) CreateWorker(ctx context.Context, coordinatorSessionID, ta
 		}
 		if _, err := conn.ExecContext(ctx, `
 			INSERT INTO session_workers (
-				child_session_id, coordinator_session_id, task, status, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?)`, childID, coordinatorSessionID, task, WorkerQueued, now, now); err != nil {
+				child_session_id, coordinator_session_id, owner_id, task, status, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?)`, childID, coordinatorSessionID, strings.TrimSpace(ownerID), task, WorkerQueued, now, now); err != nil {
 			return fmt.Errorf("create worker edge: %w", err)
 		}
 		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
@@ -113,7 +150,7 @@ func (s *SQLiteStore) CreateWorker(ctx context.Context, coordinatorSessionID, ta
 		}
 		committed = true
 		edge = WorkerEdge{
-			ChildSessionID: childID, CoordinatorSessionID: coordinatorSessionID,
+			ChildSessionID: childID, CoordinatorSessionID: coordinatorSessionID, OwnerID: strings.TrimSpace(ownerID),
 			Task: task, Status: WorkerQueued, CreatedAt: now, UpdatedAt: now,
 		}
 		return nil
@@ -137,6 +174,21 @@ func (s *SQLiteStore) SetWorkerExecution(ctx context.Context, childSessionID, jo
 	return nil
 }
 
+func (s *SQLiteStore) SetWorkerOwner(ctx context.Context, childSessionID, oldOwnerID, newOwnerID string) (bool, error) {
+	if err := s.requireWorkers(); err != nil {
+		return false, err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE session_workers SET owner_id = ?
+		WHERE child_session_id = ? AND owner_id = ?`, strings.TrimSpace(newOwnerID),
+		strings.TrimSpace(childSessionID), strings.TrimSpace(oldOwnerID))
+	if err != nil {
+		return false, fmt.Errorf("set worker owner: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	return rows > 0, err
+}
+
 func (s *SQLiteStore) UpdateWorkerStatus(ctx context.Context, childSessionID string, status WorkerStatus) error {
 	if err := s.requireWorkers(); err != nil {
 		return err
@@ -154,18 +206,42 @@ func (s *SQLiteStore) UpdateWorkerStatus(ctx context.Context, childSessionID str
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE session_workers SET status = ?, updated_at = ?,
 			finished_at = CASE WHEN ? IS NULL THEN finished_at ELSE ? END
-		WHERE child_session_id = ?`, status, now, finished, finished, strings.TrimSpace(childSessionID))
+		WHERE child_session_id = ? AND status NOT IN (?, ?, ?)`, status, now, finished, finished,
+		strings.TrimSpace(childSessionID), WorkerDone, WorkerFailed, WorkerCancelled)
 	if err != nil {
 		return fmt.Errorf("update worker status: %w", err)
 	}
 	if rows, _ := result.RowsAffected(); rows == 0 {
-		return ErrNotFound
+		var exists int
+		if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM session_workers WHERE child_session_id = ?`, strings.TrimSpace(childSessionID)).Scan(&exists); errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("check worker status target: %w", err)
+		}
 	}
 	return nil
 }
 
+// FinishWorker is idempotent: result insertion collapses concurrent terminal
+// synthesis to one immutable result, then the edge advances to a terminal state.
+func (s *SQLiteStore) FinishWorker(ctx context.Context, childSessionID string, status WorkerStatus, report WorkerReport) error {
+	if !status.Terminal() {
+		return fmt.Errorf("worker finish status %q is not terminal", status)
+	}
+	if strings.TrimSpace(report.ChildSessionID) == "" {
+		report.ChildSessionID = strings.TrimSpace(childSessionID)
+	}
+	if report.Kind != WorkerReportResult {
+		return fmt.Errorf("worker finish report must be a result")
+	}
+	if _, err := s.AddWorkerReport(ctx, report); err != nil {
+		return err
+	}
+	return s.UpdateWorkerStatus(ctx, childSessionID, status)
+}
+
 const workerEdgeSelect = `
-	SELECT w.child_session_id, w.coordinator_session_id, w.task, w.status,
+	SELECT w.child_session_id, w.coordinator_session_id, COALESCE(w.owner_id, ''), w.task, w.status,
 	       COALESCE(w.job_id, ''), COALESCE(w.run_id, ''),
 	       (SELECT COUNT(1) FROM session_worker_reports r
 	        WHERE r.child_session_id = w.child_session_id AND r.read_at IS NULL),
@@ -176,7 +252,7 @@ func scanWorkerEdge(scanner interface{ Scan(...any) error }) (WorkerEdge, error)
 	var edge WorkerEdge
 	var status string
 	var finished sql.NullTime
-	if err := scanner.Scan(&edge.ChildSessionID, &edge.CoordinatorSessionID, &edge.Task, &status,
+	if err := scanner.Scan(&edge.ChildSessionID, &edge.CoordinatorSessionID, &edge.OwnerID, &edge.Task, &status,
 		&edge.JobID, &edge.RunID, &edge.UnreadReports, &edge.CreatedAt, &edge.UpdatedAt, &finished); err != nil {
 		return WorkerEdge{}, err
 	}
@@ -252,6 +328,20 @@ func (s *SQLiteStore) AddWorkerReport(ctx context.Context, report WorkerReport) 
 		}
 		if report.SourceSessionID != report.ChildSessionID || report.DestinationSessionID != coordinator {
 			return fmt.Errorf("worker report route does not match durable worker edge")
+		}
+		if report.Kind == WorkerReportResult {
+			existing, err := scanWorkerReport(conn.QueryRowContext(ctx, workerReportSelect+` WHERE child_session_id = ? AND kind = ? ORDER BY sequence, id LIMIT 1`, report.ChildSessionID, WorkerReportResult))
+			if err == nil {
+				report = existing
+				if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+					return err
+				}
+				committed = true
+				return nil
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("check existing worker result: %w", err)
+			}
 		}
 		if err := conn.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence), -1) + 1 FROM session_worker_reports WHERE child_session_id = ?`, report.ChildSessionID).Scan(&report.Sequence); err != nil {
 			return fmt.Errorf("allocate worker report sequence: %w", err)
@@ -445,13 +535,4 @@ func (s *SQLiteStore) CountUnreadWorkerReports(ctx context.Context, coordinatorS
 	var count int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM session_worker_reports WHERE destination_session_id = ? AND read_at IS NULL`, strings.TrimSpace(coordinatorSessionID)).Scan(&count)
 	return count, err
-}
-
-func (s *SQLiteStore) HasWorkerReportKind(ctx context.Context, childSessionID string, kind WorkerReportKind) (bool, error) {
-	if err := s.requireWorkers(); err != nil {
-		return false, err
-	}
-	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM session_worker_reports WHERE child_session_id = ? AND kind = ?`, strings.TrimSpace(childSessionID), kind).Scan(&count)
-	return count > 0, err
 }

--- a/internal/session/sqlite_worker.go
+++ b/internal/session/sqlite_worker.go
@@ -329,7 +329,10 @@ func (s *SQLiteStore) AddWorkerReport(ctx context.Context, report WorkerReport) 
 		if report.SourceSessionID != report.ChildSessionID || report.DestinationSessionID != coordinator {
 			return fmt.Errorf("worker report route does not match durable worker edge")
 		}
-		if report.Kind == WorkerReportResult {
+		// Background completion has one canonical result: an explicit worker-tool
+		// result wins over terminal synthesis. A later interactive /report is a
+		// distinct user-requested briefing and therefore bypasses this collapse.
+		if report.Kind == WorkerReportResult && report.Origin != WorkerReportOriginInteractive {
 			existing, err := scanWorkerReport(conn.QueryRowContext(ctx, workerReportSelect+` WHERE child_session_id = ? AND kind = ? ORDER BY sequence, id LIMIT 1`, report.ChildSessionID, WorkerReportResult))
 			if err == nil {
 				report = existing

--- a/internal/session/sqlite_worker.go
+++ b/internal/session/sqlite_worker.go
@@ -1,0 +1,457 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func (s *SQLiteStore) requireWorkers() error {
+	if s == nil || !s.hasSessionWorkers {
+		return ErrWorkersUnsupported
+	}
+	return nil
+}
+
+// CreateWorker creates an empty child chat session and its non-branch worker
+// edge in one immediate transaction. Runtime settings and non-yolo workspace
+// grants are inherited, but no transcript or provider state is copied.
+func (s *SQLiteStore) CreateWorker(ctx context.Context, coordinatorSessionID, task string) (WorkerEdge, error) {
+	if err := s.requireWorkers(); err != nil {
+		return WorkerEdge{}, err
+	}
+	coordinatorSessionID = strings.TrimSpace(coordinatorSessionID)
+	task, err := normalizeWorkerTask(task)
+	if err != nil {
+		return WorkerEdge{}, err
+	}
+	if coordinatorSessionID == "" {
+		return WorkerEdge{}, ErrNotFound
+	}
+
+	var edge WorkerEdge
+	err = retryOnBusy(ctx, 5, func() error {
+		conn, err := s.beginImmediate(ctx)
+		if err != nil {
+			return err
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				rollbackImmediate(conn)
+				return
+			}
+			_ = conn.Close()
+		}()
+
+		var active int
+		if err := conn.QueryRowContext(ctx, `
+			SELECT COUNT(1)
+			FROM session_workers w
+			JOIN sessions child ON child.id = w.child_session_id
+			WHERE w.status IN (?, ?, ?)
+			  AND (
+				w.coordinator_session_id = ?
+				OR (
+					NULLIF(TRIM(child.cwd), '') IS NOT NULL
+					AND NULLIF(TRIM(child.cwd), '') = (
+						SELECT NULLIF(TRIM(cwd), '') FROM sessions WHERE id = ?
+					)
+				)
+			  )`,
+			WorkerQueued, WorkerRunning, WorkerBlocked, coordinatorSessionID, coordinatorSessionID).Scan(&active); err != nil {
+			return fmt.Errorf("check active workers: %w", err)
+		}
+		if active > 0 {
+			return fmt.Errorf("a worker is already active for this coordinator or workspace; wait, cancel it in /tree, or use an isolated worktree")
+		}
+
+		now := time.Now().UTC()
+		childID := NewID()
+		result, err := conn.ExecContext(ctx, `
+			INSERT INTO sessions (
+				id, number, name, summary, provider, provider_key, model,
+				reasoning_effort, reasoning_mode, mode, approval_mode, origin,
+				agent, cwd, worktree_dir, created_at, updated_at, archived,
+				pinned, parent_id, search, tools, mcp, status, compaction_seq
+			)
+			SELECT ?, (SELECT COALESCE(MAX(number), 0) + 1 FROM sessions), ?, ?,
+			       provider, provider_key, model, reasoning_effort, reasoning_mode,
+			       'chat', approval_mode, 'tui', 'developer', cwd, worktree_dir,
+			       ?, ?, FALSE, FALSE, NULL, search, tools, mcp, 'active', -1
+			FROM sessions WHERE id = ?`,
+			childID, "Worker: "+TruncateSummary(task), task, now, now, coordinatorSessionID)
+		if err != nil {
+			return fmt.Errorf("create worker session: %w", err)
+		}
+		if rows, _ := result.RowsAffected(); rows != 1 {
+			return ErrNotFound
+		}
+		if _, err := conn.ExecContext(ctx, `
+			INSERT INTO session_workspace_grants (
+				session_id, id, path, access, provenance, rationale, created_at, updated_at
+			)
+			SELECT ?, id, path, access, provenance, rationale, created_at, updated_at
+			FROM session_workspace_grants
+			WHERE session_id = ? AND LOWER(TRIM(provenance)) <> 'yolo'`, childID, coordinatorSessionID); err != nil {
+			return fmt.Errorf("copy worker workspace grants: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, `
+			INSERT INTO session_workers (
+				child_session_id, coordinator_session_id, task, status, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?)`, childID, coordinatorSessionID, task, WorkerQueued, now, now); err != nil {
+			return fmt.Errorf("create worker edge: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			return fmt.Errorf("commit worker creation: %w", err)
+		}
+		committed = true
+		edge = WorkerEdge{
+			ChildSessionID: childID, CoordinatorSessionID: coordinatorSessionID,
+			Task: task, Status: WorkerQueued, CreatedAt: now, UpdatedAt: now,
+		}
+		return nil
+	})
+	return edge, err
+}
+
+func (s *SQLiteStore) SetWorkerExecution(ctx context.Context, childSessionID, jobID, runID string) error {
+	if err := s.requireWorkers(); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE session_workers SET job_id = ?, run_id = ?, updated_at = ?
+		WHERE child_session_id = ?`, strings.TrimSpace(jobID), strings.TrimSpace(runID), time.Now().UTC(), strings.TrimSpace(childSessionID))
+	if err != nil {
+		return fmt.Errorf("set worker execution: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) UpdateWorkerStatus(ctx context.Context, childSessionID string, status WorkerStatus) error {
+	if err := s.requireWorkers(); err != nil {
+		return err
+	}
+	switch status {
+	case WorkerQueued, WorkerRunning, WorkerBlocked, WorkerDone, WorkerFailed, WorkerCancelled:
+	default:
+		return fmt.Errorf("invalid worker status %q", status)
+	}
+	now := time.Now().UTC()
+	var finished any
+	if status.Terminal() {
+		finished = now
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE session_workers SET status = ?, updated_at = ?,
+			finished_at = CASE WHEN ? IS NULL THEN finished_at ELSE ? END
+		WHERE child_session_id = ?`, status, now, finished, finished, strings.TrimSpace(childSessionID))
+	if err != nil {
+		return fmt.Errorf("update worker status: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+const workerEdgeSelect = `
+	SELECT w.child_session_id, w.coordinator_session_id, w.task, w.status,
+	       COALESCE(w.job_id, ''), COALESCE(w.run_id, ''),
+	       (SELECT COUNT(1) FROM session_worker_reports r
+	        WHERE r.child_session_id = w.child_session_id AND r.read_at IS NULL),
+	       w.created_at, w.updated_at, w.finished_at
+	FROM session_workers w`
+
+func scanWorkerEdge(scanner interface{ Scan(...any) error }) (WorkerEdge, error) {
+	var edge WorkerEdge
+	var status string
+	var finished sql.NullTime
+	if err := scanner.Scan(&edge.ChildSessionID, &edge.CoordinatorSessionID, &edge.Task, &status,
+		&edge.JobID, &edge.RunID, &edge.UnreadReports, &edge.CreatedAt, &edge.UpdatedAt, &finished); err != nil {
+		return WorkerEdge{}, err
+	}
+	edge.Status = WorkerStatus(status)
+	if finished.Valid {
+		t := finished.Time
+		edge.FinishedAt = &t
+	}
+	return edge, nil
+}
+
+func (s *SQLiteStore) GetWorker(ctx context.Context, childSessionID string) (WorkerEdge, error) {
+	if err := s.requireWorkers(); err != nil {
+		return WorkerEdge{}, err
+	}
+	edge, err := scanWorkerEdge(s.db.QueryRowContext(ctx, workerEdgeSelect+` WHERE w.child_session_id = ?`, strings.TrimSpace(childSessionID)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return WorkerEdge{}, ErrNotFound
+	}
+	if err != nil {
+		return WorkerEdge{}, fmt.Errorf("get worker: %w", err)
+	}
+	return edge, nil
+}
+
+func (s *SQLiteStore) ListWorkers(ctx context.Context, coordinatorSessionID string) ([]WorkerEdge, error) {
+	if err := s.requireWorkers(); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, workerEdgeSelect+` WHERE w.coordinator_session_id = ? ORDER BY w.created_at, w.child_session_id`, strings.TrimSpace(coordinatorSessionID))
+	if err != nil {
+		return nil, fmt.Errorf("list workers: %w", err)
+	}
+	defer rows.Close()
+	var workers []WorkerEdge
+	for rows.Next() {
+		edge, err := scanWorkerEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan worker: %w", err)
+		}
+		workers = append(workers, edge)
+	}
+	return workers, rows.Err()
+}
+
+func (s *SQLiteStore) AddWorkerReport(ctx context.Context, report WorkerReport) (WorkerReport, error) {
+	if err := s.requireWorkers(); err != nil {
+		return WorkerReport{}, err
+	}
+	report, err := normalizeWorkerReport(report)
+	if err != nil {
+		return WorkerReport{}, err
+	}
+	err = retryOnBusy(ctx, 5, func() error {
+		conn, err := s.beginImmediate(ctx)
+		if err != nil {
+			return err
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				rollbackImmediate(conn)
+				return
+			}
+			_ = conn.Close()
+		}()
+		var coordinator string
+		if err := conn.QueryRowContext(ctx, `SELECT coordinator_session_id FROM session_workers WHERE child_session_id = ?`, report.ChildSessionID).Scan(&coordinator); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return err
+		}
+		if report.SourceSessionID != report.ChildSessionID || report.DestinationSessionID != coordinator {
+			return fmt.Errorf("worker report route does not match durable worker edge")
+		}
+		if err := conn.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence), -1) + 1 FROM session_worker_reports WHERE child_session_id = ?`, report.ChildSessionID).Scan(&report.Sequence); err != nil {
+			return fmt.Errorf("allocate worker report sequence: %w", err)
+		}
+		report.CreatedAt = time.Now().UTC()
+		if err := conn.QueryRowContext(ctx, `
+			INSERT INTO session_worker_reports (
+				child_session_id, source_session_id, destination_session_id,
+				kind, title, body, metadata, origin, sequence, created_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+			report.ChildSessionID, report.SourceSessionID, report.DestinationSessionID,
+			report.Kind, report.Title, report.Body, string(report.Metadata), report.Origin,
+			report.Sequence, report.CreatedAt).Scan(&report.ID); err != nil {
+			return fmt.Errorf("insert worker report: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			return err
+		}
+		committed = true
+		return nil
+	})
+	return report, err
+}
+
+const workerReportSelect = `
+	SELECT id, child_session_id, source_session_id, destination_session_id,
+	       kind, title, body, metadata, origin, sequence, read_at,
+	       imported_at, COALESCE(imported_message_id, 0), created_at
+	FROM session_worker_reports`
+
+func scanWorkerReport(scanner interface{ Scan(...any) error }) (WorkerReport, error) {
+	var report WorkerReport
+	var kind, metadata string
+	var readAt, importedAt sql.NullTime
+	if err := scanner.Scan(&report.ID, &report.ChildSessionID, &report.SourceSessionID,
+		&report.DestinationSessionID, &kind, &report.Title, &report.Body, &metadata,
+		&report.Origin, &report.Sequence, &readAt, &importedAt,
+		&report.ImportedMessageID, &report.CreatedAt); err != nil {
+		return WorkerReport{}, err
+	}
+	report.Kind = WorkerReportKind(kind)
+	report.Metadata = json.RawMessage(metadata)
+	if readAt.Valid {
+		t := readAt.Time
+		report.ReadAt = &t
+	}
+	if importedAt.Valid {
+		t := importedAt.Time
+		report.ImportedAt = &t
+	}
+	return report, nil
+}
+
+func (s *SQLiteStore) ListWorkerReports(ctx context.Context, childSessionID string) ([]WorkerReport, error) {
+	if err := s.requireWorkers(); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, workerReportSelect+` WHERE child_session_id = ? ORDER BY sequence, id`, strings.TrimSpace(childSessionID))
+	if err != nil {
+		return nil, fmt.Errorf("list worker reports: %w", err)
+	}
+	defer rows.Close()
+	var reports []WorkerReport
+	for rows.Next() {
+		report, err := scanWorkerReport(rows)
+		if err != nil {
+			return nil, err
+		}
+		reports = append(reports, report)
+	}
+	return reports, rows.Err()
+}
+
+func (s *SQLiteStore) MarkWorkerReportRead(ctx context.Context, reportID int64) error {
+	if err := s.requireWorkers(); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE session_worker_reports SET read_at = COALESCE(read_at, ?) WHERE id = ?`, time.Now().UTC(), reportID)
+	if err != nil {
+		return fmt.Errorf("mark worker report read: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func workerImportText(report WorkerReport, edge WorkerEdge) string {
+	return fmt.Sprintf("[Imported worker report]\nWorker session: %s\nKind: %s\nTitle: %s\nTask: %s\n\n%s",
+		ShortID(report.SourceSessionID), report.Kind, report.Title, edge.Task, report.Body)
+}
+
+// ImportWorkerReport atomically appends an ordinary role=user message to the
+// coordinator and records immutable report provenance through import metadata.
+// Mailbox content is never serialized as developer/system authority.
+func (s *SQLiteStore) ImportWorkerReport(ctx context.Context, reportID int64) (*Message, error) {
+	if err := s.requireWorkers(); err != nil {
+		return nil, err
+	}
+	var imported *Message
+	var existingMessageID int64
+	err := retryOnBusy(ctx, 5, func() error {
+		conn, err := s.beginImmediate(ctx)
+		if err != nil {
+			return err
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				rollbackImmediate(conn)
+				return
+			}
+			_ = conn.Close()
+		}()
+		report, err := scanWorkerReport(conn.QueryRowContext(ctx, workerReportSelect+` WHERE id = ?`, reportID))
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		if report.ImportedAt != nil && report.ImportedMessageID == 0 {
+			return fmt.Errorf("worker report has already been imported; its attributed message no longer exists")
+		}
+		if report.ImportedMessageID != 0 {
+			existingMessageID = report.ImportedMessageID
+			if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+				return err
+			}
+			committed = true
+			return nil
+		}
+		var task string
+		if err := conn.QueryRowContext(ctx, `SELECT task FROM session_workers WHERE child_session_id = ? AND coordinator_session_id = ?`, report.ChildSessionID, report.DestinationSessionID).Scan(&task); err != nil {
+			return ErrNotFound
+		}
+		edge := WorkerEdge{Task: task}
+		text := workerImportText(report, edge)
+		llmMessage := llm.UserText(text)
+		message := NewMessage(report.DestinationSessionID, llmMessage, -1)
+		message.CreatedAt = time.Now().UTC()
+		partsJSON, err := message.PartsJSONForStorage(s.cfg.StripImageBase64)
+		if err != nil {
+			return err
+		}
+		if err := conn.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence), -1) + 1 FROM messages WHERE session_id = ?`, report.DestinationSessionID).Scan(&message.Sequence); err != nil {
+			return err
+		}
+		if err := conn.QueryRowContext(ctx, `
+			INSERT INTO messages (
+				session_id, role, parts, text_content, duration_ms, turn_index,
+				created_at, sequence, compaction_tail, client_message_id, response_id,
+				assistant_segment_ordinal, segment_start_sequence, segment_end_sequence
+			) VALUES (?, 'user', ?, ?, 0, 0, ?, ?, FALSE, '', '', -1, 0, 0)
+			RETURNING id`, report.DestinationSessionID, partsJSON, text, message.CreatedAt, message.Sequence).Scan(&message.ID); err != nil {
+			return fmt.Errorf("insert imported worker message: %w", err)
+		}
+		now := time.Now().UTC()
+		if _, err := conn.ExecContext(ctx, `
+			UPDATE sessions SET user_turns = user_turns + 1, updated_at = ?,
+				last_user_message_at = ?, last_message_at = ? WHERE id = ?`,
+			now, now, now, report.DestinationSessionID); err != nil {
+			return err
+		}
+		if _, err := s.bumpTranscriptRev(ctx, conn, report.DestinationSessionID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+			UPDATE session_worker_reports
+			SET read_at = COALESCE(read_at, ?), imported_at = ?, imported_message_id = ?
+			WHERE id = ? AND imported_at IS NULL`, now, now, message.ID, reportID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			return err
+		}
+		committed = true
+		imported = message
+		return nil
+	})
+	if err == nil && imported == nil && existingMessageID != 0 {
+		imported, err = s.GetMessageByID(ctx, existingMessageID)
+	}
+	return imported, err
+}
+
+func (s *SQLiteStore) CountUnreadWorkerReports(ctx context.Context, coordinatorSessionID string) (int, error) {
+	if err := s.requireWorkers(); err != nil {
+		return 0, err
+	}
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM session_worker_reports WHERE destination_session_id = ? AND read_at IS NULL`, strings.TrimSpace(coordinatorSessionID)).Scan(&count)
+	return count, err
+}
+
+func (s *SQLiteStore) HasWorkerReportKind(ctx context.Context, childSessionID string, kind WorkerReportKind) (bool, error) {
+	if err := s.requireWorkers(); err != nil {
+		return false, err
+	}
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM session_worker_reports WHERE child_session_id = ? AND kind = ?`, strings.TrimSpace(childSessionID), kind).Scan(&count)
+	return count > 0, err
+}

--- a/internal/session/worker.go
+++ b/internal/session/worker.go
@@ -43,6 +43,11 @@ const (
 	WorkerReportBlocker  WorkerReportKind = "blocker"
 )
 
+// WorkerReportOriginInteractive identifies a user-requested briefing generated
+// from a resumed worker child. Unlike the worker's terminal result, subsequent
+// interactive reports are separate immutable mailbox entries.
+const WorkerReportOriginInteractive = "interactive_report"
+
 const (
 	MaxWorkerTaskRunes        = 16_000
 	MaxWorkerReportTitleRunes = 200

--- a/internal/session/worker.go
+++ b/internal/session/worker.go
@@ -1,0 +1,165 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// WorkerStatus is the durable lifecycle state of a background worker.
+type WorkerStatus string
+
+const (
+	WorkerQueued    WorkerStatus = "queued"
+	WorkerRunning   WorkerStatus = "running"
+	WorkerBlocked   WorkerStatus = "blocked"
+	WorkerDone      WorkerStatus = "done"
+	WorkerFailed    WorkerStatus = "failed"
+	WorkerCancelled WorkerStatus = "cancelled"
+)
+
+func (s WorkerStatus) Terminal() bool {
+	switch s {
+	case WorkerDone, WorkerFailed, WorkerCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s WorkerStatus) Active() bool {
+	return s == WorkerQueued || s == WorkerRunning || s == WorkerBlocked
+}
+
+// WorkerReportKind identifies the mailbox event semantics.
+type WorkerReportKind string
+
+const (
+	WorkerReportProgress WorkerReportKind = "progress"
+	WorkerReportResult   WorkerReportKind = "result"
+	WorkerReportBlocker  WorkerReportKind = "blocker"
+)
+
+const (
+	MaxWorkerTaskRunes        = 16_000
+	MaxWorkerReportTitleRunes = 200
+	MaxWorkerReportBodyRunes  = 32_000
+	MaxWorkerMetadataBytes    = 8_192
+)
+
+var ErrWorkersUnsupported = errors.New("session: workers unsupported")
+
+// WorkerEdge is a separate durable relation. It intentionally does not use
+// session_branches: workers have no transcript fork anchor or copied prefix.
+type WorkerEdge struct {
+	ChildSessionID       string       `json:"child_session_id"`
+	CoordinatorSessionID string       `json:"coordinator_session_id"`
+	Task                 string       `json:"task"`
+	Status               WorkerStatus `json:"status"`
+	JobID                string       `json:"job_id,omitempty"`
+	RunID                string       `json:"run_id,omitempty"`
+	UnreadReports        int          `json:"unread_reports"`
+	CreatedAt            time.Time    `json:"created_at"`
+	UpdatedAt            time.Time    `json:"updated_at"`
+	FinishedAt           *time.Time   `json:"finished_at,omitempty"`
+}
+
+// WorkerReport is immutable mailbox content. Only read/import bookkeeping may
+// be updated after insertion.
+type WorkerReport struct {
+	ID                   int64            `json:"id"`
+	ChildSessionID       string           `json:"child_session_id"`
+	SourceSessionID      string           `json:"source_session_id"`
+	DestinationSessionID string           `json:"destination_session_id"`
+	Kind                 WorkerReportKind `json:"kind"`
+	Title                string           `json:"title"`
+	Body                 string           `json:"body"`
+	Metadata             json.RawMessage  `json:"metadata,omitempty"`
+	Origin               string           `json:"origin"`
+	Sequence             int              `json:"sequence"`
+	ReadAt               *time.Time       `json:"read_at,omitempty"`
+	ImportedAt           *time.Time       `json:"imported_at,omitempty"`
+	ImportedMessageID    int64            `json:"imported_message_id,omitempty"`
+	CreatedAt            time.Time        `json:"created_at"`
+}
+
+// WorkerStore is the optional durable worker/mailbox capability.
+type WorkerStore interface {
+	CreateWorker(ctx context.Context, coordinatorSessionID, task string) (WorkerEdge, error)
+	SetWorkerExecution(ctx context.Context, childSessionID, jobID, runID string) error
+	UpdateWorkerStatus(ctx context.Context, childSessionID string, status WorkerStatus) error
+	GetWorker(ctx context.Context, childSessionID string) (WorkerEdge, error)
+	ListWorkers(ctx context.Context, coordinatorSessionID string) ([]WorkerEdge, error)
+	AddWorkerReport(ctx context.Context, report WorkerReport) (WorkerReport, error)
+	ListWorkerReports(ctx context.Context, childSessionID string) ([]WorkerReport, error)
+	MarkWorkerReportRead(ctx context.Context, reportID int64) error
+	ImportWorkerReport(ctx context.Context, reportID int64) (*Message, error)
+	CountUnreadWorkerReports(ctx context.Context, coordinatorSessionID string) (int, error)
+	HasWorkerReportKind(ctx context.Context, childSessionID string, kind WorkerReportKind) (bool, error)
+}
+
+// AsWorkerStore resolves worker capability through the logging decorator.
+func AsWorkerStore(store Store) (WorkerStore, bool) {
+	if store == nil {
+		return nil, false
+	}
+	workerStore, ok := store.(WorkerStore)
+	return workerStore, ok
+}
+
+func normalizeWorkerText(value string, maxRunes int) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\x00", ""))
+	runes := []rune(value)
+	if maxRunes > 0 && len(runes) > maxRunes {
+		value = string(runes[:maxRunes])
+	}
+	return value
+}
+
+func normalizeWorkerTask(task string) (string, error) {
+	task = normalizeWorkerText(task, MaxWorkerTaskRunes)
+	if task == "" {
+		return "", fmt.Errorf("worker task is required")
+	}
+	return task, nil
+}
+
+func normalizeWorkerReport(report WorkerReport) (WorkerReport, error) {
+	report.ChildSessionID = strings.TrimSpace(report.ChildSessionID)
+	report.SourceSessionID = strings.TrimSpace(report.SourceSessionID)
+	report.DestinationSessionID = strings.TrimSpace(report.DestinationSessionID)
+	report.Title = normalizeWorkerText(report.Title, MaxWorkerReportTitleRunes)
+	report.Body = normalizeWorkerText(report.Body, MaxWorkerReportBodyRunes)
+	report.Origin = normalizeWorkerText(report.Origin, 64)
+	if report.ChildSessionID == "" || report.SourceSessionID == "" || report.DestinationSessionID == "" {
+		return WorkerReport{}, fmt.Errorf("worker report source and destination are required")
+	}
+	switch report.Kind {
+	case WorkerReportProgress, WorkerReportResult, WorkerReportBlocker:
+	default:
+		return WorkerReport{}, fmt.Errorf("worker report kind must be progress, result, or blocker")
+	}
+	if report.Title == "" {
+		report.Title = strings.ToUpper(string(report.Kind[:1])) + string(report.Kind[1:])
+	}
+	if report.Body == "" {
+		return WorkerReport{}, fmt.Errorf("worker report body is required")
+	}
+	if report.Origin == "" {
+		report.Origin = "worker_tool"
+	}
+	if len(report.Metadata) == 0 {
+		report.Metadata = json.RawMessage(`{}`)
+	}
+	if len(report.Metadata) > MaxWorkerMetadataBytes {
+		return WorkerReport{}, fmt.Errorf("worker report metadata exceeds %d bytes", MaxWorkerMetadataBytes)
+	}
+	var metadata any
+	if err := json.Unmarshal(report.Metadata, &metadata); err != nil {
+		return WorkerReport{}, fmt.Errorf("worker report metadata must be valid JSON: %w", err)
+	}
+	return report, nil
+}

--- a/internal/session/worker.go
+++ b/internal/session/worker.go
@@ -57,6 +57,7 @@ var ErrWorkersUnsupported = errors.New("session: workers unsupported")
 type WorkerEdge struct {
 	ChildSessionID       string       `json:"child_session_id"`
 	CoordinatorSessionID string       `json:"coordinator_session_id"`
+	OwnerID              string       `json:"owner_id,omitempty"`
 	Task                 string       `json:"task"`
 	Status               WorkerStatus `json:"status"`
 	JobID                string       `json:"job_id,omitempty"`
@@ -89,8 +90,11 @@ type WorkerReport struct {
 // WorkerStore is the optional durable worker/mailbox capability.
 type WorkerStore interface {
 	CreateWorker(ctx context.Context, coordinatorSessionID, task string) (WorkerEdge, error)
+	CreateWorkerOwned(ctx context.Context, coordinatorSessionID, ownerID, task string) (WorkerEdge, error)
 	SetWorkerExecution(ctx context.Context, childSessionID, jobID, runID string) error
+	SetWorkerOwner(ctx context.Context, childSessionID, oldOwnerID, newOwnerID string) (bool, error)
 	UpdateWorkerStatus(ctx context.Context, childSessionID string, status WorkerStatus) error
+	FinishWorker(ctx context.Context, childSessionID string, status WorkerStatus, report WorkerReport) error
 	GetWorker(ctx context.Context, childSessionID string) (WorkerEdge, error)
 	ListWorkers(ctx context.Context, coordinatorSessionID string) ([]WorkerEdge, error)
 	AddWorkerReport(ctx context.Context, report WorkerReport) (WorkerReport, error)
@@ -98,7 +102,6 @@ type WorkerStore interface {
 	MarkWorkerReportRead(ctx context.Context, reportID int64) error
 	ImportWorkerReport(ctx context.Context, reportID int64) (*Message, error)
 	CountUnreadWorkerReports(ctx context.Context, coordinatorSessionID string) (int, error)
-	HasWorkerReportKind(ctx context.Context, childSessionID string, kind WorkerReportKind) (bool, error)
 }
 
 // AsWorkerStore resolves worker capability through the logging decorator.

--- a/internal/session/worker_test.go
+++ b/internal/session/worker_test.go
@@ -1,0 +1,255 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func newWorkerStoreTest(t *testing.T) (*SQLiteStore, *Session) {
+	t.Helper()
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	coordinator := createWorkspaceTestSession(t, store, "coordinator")
+	coordinator.ApprovalMode = ApprovalModeAuto
+	coordinator.CWD = t.TempDir()
+	if err := store.Update(context.Background(), coordinator); err != nil {
+		t.Fatal(err)
+	}
+	return store, coordinator
+}
+
+func TestWorkerMigration47CreatesSeparateEdgesAndMailbox(t *testing.T) {
+	if schemaVersion != 47 {
+		t.Fatalf("schemaVersion = %d, want 47", schemaVersion)
+	}
+	found := false
+	for _, migration := range migrations {
+		found = found || migration.version == 47
+	}
+	if !found {
+		t.Fatal("migration 47 missing")
+	}
+
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"session_worker_reports", "session_workers"} {
+		if _, err := store.db.Exec("DROP TABLE " + table); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.db.Exec("UPDATE schema_version SET version = 46"); err != nil {
+		t.Fatal(err)
+	}
+	_ = store.Close()
+
+	upgraded, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upgraded.Close()
+	for _, table := range []string{"session_workers", "session_worker_reports"} {
+		var name string
+		if err := upgraded.db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&name); err != nil {
+			t.Fatalf("table %s missing: %v", table, err)
+		}
+	}
+}
+
+func TestWorkerIdentityDoesNotUseBranchOrIsSubagentPersistence(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	edge, err := store.CreateWorker(context.Background(), coordinator.ID, "inspect the parser")
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Get(context.Background(), edge.ChildSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if child.ParentID != "" || child.IsSubagent {
+		t.Fatalf("worker leaked into transient/branch identity: %#v", child)
+	}
+	var branches int
+	if err := store.db.QueryRow("SELECT COUNT(1) FROM session_branches WHERE child_session_id = ?", child.ID).Scan(&branches); err != nil {
+		t.Fatal(err)
+	}
+	if branches != 0 {
+		t.Fatalf("worker created %d branch edges", branches)
+	}
+	loaded, err := store.GetWorker(context.Background(), child.ID)
+	if err != nil || loaded.CoordinatorSessionID != coordinator.ID || loaded.Task != "inspect the parser" {
+		t.Fatalf("durable worker edge = %#v, %v", loaded, err)
+	}
+}
+
+func TestWorkerPreventsConflictingActiveSharedCWD(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	if _, err := store.CreateWorker(context.Background(), coordinator.ID, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateWorker(context.Background(), coordinator.ID, "second"); err == nil || !strings.Contains(err.Error(), "already active") {
+		t.Fatalf("second worker error = %v", err)
+	}
+
+	sameWorkspace := *coordinator
+	sameWorkspace.ID = "same-workspace"
+	sameWorkspace.Name = "same workspace"
+	sameWorkspace.CreatedAt = time.Now()
+	sameWorkspace.UpdatedAt = sameWorkspace.CreatedAt
+	if err := store.Create(context.Background(), &sameWorkspace); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateWorker(context.Background(), sameWorkspace.ID, "conflicting coordinator"); err == nil || !strings.Contains(err.Error(), "workspace") {
+		t.Fatalf("shared-workspace worker error = %v", err)
+	}
+
+	isolated := sameWorkspace
+	isolated.ID = "isolated-workspace"
+	isolated.Name = "isolated workspace"
+	isolated.CWD = t.TempDir()
+	isolated.CreatedAt = time.Now()
+	isolated.UpdatedAt = isolated.CreatedAt
+	if err := store.Create(context.Background(), &isolated); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateWorker(context.Background(), isolated.ID, "isolated coordinator"); err != nil {
+		t.Fatalf("isolated workspace worker blocked: %v", err)
+	}
+}
+
+func TestWorkerReportsAreBoundedImmutableAndImportedAsUser(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	edge, err := store.CreateWorker(context.Background(), coordinator.ID, "summarize tests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := store.AddWorkerReport(context.Background(), WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: coordinator.ID, Kind: WorkerReportResult,
+		Title: "Test summary", Body: "All focused tests passed.", Metadata: json.RawMessage(`{"suite":"focused"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Sequence != 0 || report.ID == 0 {
+		t.Fatalf("report identity = %#v", report)
+	}
+	if unread, err := store.CountUnreadWorkerReports(context.Background(), coordinator.ID); err != nil || unread != 1 {
+		t.Fatalf("unread = %d, %v", unread, err)
+	}
+	if _, err := store.db.Exec("UPDATE session_worker_reports SET body = 'laundered' WHERE id = ?", report.ID); err == nil || !strings.Contains(err.Error(), "immutable") {
+		t.Fatalf("direct content mutation error = %v", err)
+	}
+
+	imported, err := store.ImportWorkerReport(context.Background(), report.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported.Role != llm.RoleUser || !strings.Contains(imported.TextContent, "[Imported worker report]") || !strings.Contains(imported.TextContent, report.Body) {
+		t.Fatalf("imported message = %#v", imported)
+	}
+	for _, part := range imported.Parts {
+		if part.Type == llm.PartPathNote {
+			t.Fatalf("worker import used trusted developer path-note provenance: %#v", imported.Parts)
+		}
+	}
+	messages, err := store.GetMessages(context.Background(), coordinator.ID, 0, 0)
+	if err != nil || len(messages) != 1 || messages[0].Role != llm.RoleUser {
+		t.Fatalf("coordinator transcript = %#v, %v", messages, err)
+	}
+	second, err := store.ImportWorkerReport(context.Background(), report.ID)
+	if err != nil || second.ID != imported.ID {
+		t.Fatalf("idempotent import = %#v, %v", second, err)
+	}
+	messages, _ = store.GetMessages(context.Background(), coordinator.ID, 0, 0)
+	if len(messages) != 1 {
+		t.Fatalf("idempotent import duplicated transcript: %#v", messages)
+	}
+	reports, err := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if err != nil || reports[0].ImportedMessageID != imported.ID || reports[0].ReadAt == nil {
+		t.Fatalf("report import bookkeeping = %#v, %v", reports, err)
+	}
+	if _, err := store.db.Exec("DELETE FROM messages WHERE id = ?", imported.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ImportWorkerReport(context.Background(), report.ID); err == nil || !strings.Contains(err.Error(), "already been imported") {
+		t.Fatalf("reimport after attributed message deletion error = %v", err)
+	}
+	messages, _ = store.GetMessages(context.Background(), coordinator.ID, 0, 0)
+	if len(messages) != 0 {
+		t.Fatalf("reimport after deletion duplicated transcript: %#v", messages)
+	}
+}
+
+func TestWorkerReportValidationAndTerminalStatus(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	edge, err := store.CreateWorker(context.Background(), coordinator.ID, "bounded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.AddWorkerReport(context.Background(), WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: coordinator.ID, Kind: WorkerReportResult,
+		Title: "too much metadata", Body: "body", Metadata: json.RawMessage(`"` + strings.Repeat("x", MaxWorkerMetadataBytes) + `"`),
+	})
+	if err == nil {
+		t.Fatal("oversized metadata accepted")
+	}
+	if err := store.UpdateWorkerStatus(context.Background(), edge.ChildSessionID, WorkerDone); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.GetWorker(context.Background(), edge.ChildSessionID)
+	if err != nil || loaded.Status != WorkerDone || loaded.FinishedAt == nil {
+		t.Fatalf("terminal worker = %#v, %v", loaded, err)
+	}
+	if _, err := store.CreateWorker(context.Background(), coordinator.ID, "next after terminal"); err != nil {
+		t.Fatalf("terminal worker still blocked next launch: %v", err)
+	}
+}
+
+func TestWorkerCascadeDeletesReports(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	edge, _ := store.CreateWorker(context.Background(), coordinator.ID, "cascade")
+	report, _ := store.AddWorkerReport(context.Background(), WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: coordinator.ID, Kind: WorkerReportProgress, Title: "Started", Body: "Working.",
+	})
+	if err := store.Delete(context.Background(), edge.ChildSessionID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GetWorker(context.Background(), edge.ChildSessionID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("worker after cascade = %v", err)
+	}
+	var count int
+	if err := store.db.QueryRow("SELECT COUNT(1) FROM session_worker_reports WHERE id = ?", report.ID).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("report cascade count = %d, %v", count, err)
+	}
+}
+
+func TestWorkerReportReadMetadataMayMutateWithoutContentChange(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	edge, _ := store.CreateWorker(context.Background(), coordinator.ID, "read")
+	report, _ := store.AddWorkerReport(context.Background(), WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: coordinator.ID, Kind: WorkerReportProgress, Title: "Halfway", Body: "50 percent", Origin: "worker_tool",
+	})
+	if err := store.MarkWorkerReportRead(context.Background(), report.ID); err != nil {
+		t.Fatal(err)
+	}
+	reports, _ := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if reports[0].ReadAt == nil || reports[0].Title != report.Title || reports[0].Body != report.Body || reports[0].CreatedAt.Before(time.Time{}) {
+		t.Fatalf("read mutation changed content: %#v", reports[0])
+	}
+}

--- a/internal/session/worker_test.go
+++ b/internal/session/worker_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,16 +31,18 @@ func newWorkerStoreTest(t *testing.T) (*SQLiteStore, *Session) {
 	return store, coordinator
 }
 
-func TestWorkerMigration47CreatesSeparateEdgesAndMailbox(t *testing.T) {
-	if schemaVersion != 47 {
-		t.Fatalf("schemaVersion = %d, want 47", schemaVersion)
+func TestWorkerMigrationsCreateSeparateEdgesMailboxAndOwnership(t *testing.T) {
+	if schemaVersion != 48 {
+		t.Fatalf("schemaVersion = %d, want 48", schemaVersion)
 	}
-	found := false
+	found47 := false
+	found48 := false
 	for _, migration := range migrations {
-		found = found || migration.version == 47
+		found47 = found47 || migration.version == 47
+		found48 = found48 || migration.version == 48
 	}
-	if !found {
-		t.Fatal("migration 47 missing")
+	if !found47 || !found48 {
+		t.Fatalf("worker migrations missing: v47=%v v48=%v", found47, found48)
 	}
 
 	path := filepath.Join(t.TempDir(), "legacy.db")
@@ -65,6 +70,47 @@ func TestWorkerMigration47CreatesSeparateEdgesAndMailbox(t *testing.T) {
 		if err := upgraded.db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&name); err != nil {
 			t.Fatalf("table %s missing: %v", table, err)
 		}
+	}
+	var ownerColumn string
+	if err := upgraded.db.QueryRow(`SELECT name FROM pragma_table_info('session_workers') WHERE name = 'owner_id'`).Scan(&ownerColumn); err != nil {
+		t.Fatalf("worker owner column missing: %v", err)
+	}
+}
+
+func TestWorkerMigration48AddsOwnerToVersion47Table(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "version47.db")
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`DROP TABLE session_worker_reports`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`DROP TABLE session_workers`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`CREATE TABLE session_workers (
+		child_session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+		coordinator_session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+		task TEXT NOT NULL, status TEXT NOT NULL, job_id TEXT, run_id TEXT,
+		created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL, finished_at TIMESTAMP
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE schema_version SET version = 47`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	upgraded, err := NewSQLiteStore(Config{Enabled: true, Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upgraded.Close()
+	var ownerColumn string
+	if err := upgraded.db.QueryRow(`SELECT name FROM pragma_table_info('session_workers') WHERE name = 'owner_id'`).Scan(&ownerColumn); err != nil {
+		t.Fatalf("migration 48 owner column missing: %v", err)
 	}
 }
 
@@ -115,6 +161,39 @@ func TestWorkerPreventsConflictingActiveSharedCWD(t *testing.T) {
 		t.Fatalf("shared-workspace worker error = %v", err)
 	}
 
+	linkedRoot := t.TempDir()
+	linkedCWD := filepath.Join(t.TempDir(), "workspace-link")
+	if err := os.Symlink(linkedRoot, linkedCWD); err == nil {
+		linked := sameWorkspace
+		linked.ID = "linked-workspace"
+		linked.Name = "linked workspace"
+		linked.CWD = linkedCWD
+		linked.CreatedAt = time.Now()
+		linked.UpdatedAt = linked.CreatedAt
+		if err := store.Create(context.Background(), &linked); err != nil {
+			t.Fatal(err)
+		}
+		real := sameWorkspace
+		real.ID = "real-linked-workspace"
+		real.Name = "real linked workspace"
+		real.CWD = linkedRoot
+		real.CreatedAt = time.Now()
+		real.UpdatedAt = real.CreatedAt
+		if err := store.Create(context.Background(), &real); err != nil {
+			t.Fatal(err)
+		}
+		linkedEdge, err := store.CreateWorker(context.Background(), linked.ID, "linked owner")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.UpdateWorkerStatus(context.Background(), linkedEdge.ChildSessionID, WorkerRunning); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.CreateWorker(context.Background(), real.ID, "canonical conflict"); err == nil || !strings.Contains(err.Error(), "workspace") {
+			t.Fatalf("symlink-equivalent workspace error = %v", err)
+		}
+	}
+
 	isolated := sameWorkspace
 	isolated.ID = "isolated-workspace"
 	isolated.Name = "isolated workspace"
@@ -145,6 +224,18 @@ func TestWorkerReportsAreBoundedImmutableAndImportedAsUser(t *testing.T) {
 	}
 	if report.Sequence != 0 || report.ID == 0 {
 		t.Fatalf("report identity = %#v", report)
+	}
+	duplicate, err := store.AddWorkerReport(context.Background(), WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: coordinator.ID, Kind: WorkerReportResult,
+		Title: "Duplicate terminal", Body: "must not be appended",
+	})
+	if err != nil || duplicate.ID != report.ID {
+		t.Fatalf("duplicate terminal result = %#v, %v", duplicate, err)
+	}
+	terminalReports, err := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if err != nil || len(terminalReports) != 1 {
+		t.Fatalf("terminal result cardinality = %#v, %v", terminalReports, err)
 	}
 	if unread, err := store.CountUnreadWorkerReports(context.Background(), coordinator.ID); err != nil || unread != 1 {
 		t.Fatalf("unread = %d, %v", unread, err)
@@ -190,6 +281,103 @@ func TestWorkerReportsAreBoundedImmutableAndImportedAsUser(t *testing.T) {
 	messages, _ = store.GetMessages(context.Background(), coordinator.ID, 0, 0)
 	if len(messages) != 0 {
 		t.Fatalf("reimport after deletion duplicated transcript: %#v", messages)
+	}
+}
+
+func TestWorkerReportImportJoinsCompactedCoordinatorActiveContext(t *testing.T) {
+	ctx := context.Background()
+	store, coordinator := newWorkerStoreTest(t)
+	if err := store.AddMessage(ctx, coordinator.ID, NewMessage(coordinator.ID, llm.UserText("old question"), -1)); err != nil {
+		t.Fatal(err)
+	}
+	summary := NewMessage(coordinator.ID, llm.UserText("[Context Compaction]\nsummary"), -1)
+	ack := NewMessage(coordinator.ID, llm.AssistantText("I have the compacted context."), -1)
+	ack.CompactionTail = true
+	if err := store.CompactMessages(ctx, coordinator.ID, []Message{*summary, *ack}); err != nil {
+		t.Fatal(err)
+	}
+	compacted, err := store.Get(ctx, coordinator.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := compacted.CompactionSeq
+
+	edge, err := store.CreateWorker(ctx, coordinator.ID, "compacted report")
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := store.AddWorkerReport(ctx, WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: coordinator.ID, Kind: WorkerReportResult,
+		Title: "After compaction", Body: "new worker evidence",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	imported, err := store.ImportWorkerReport(ctx, report.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err := store.Get(ctx, coordinator.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.CompactionSeq != boundary || imported.Sequence < boundary {
+		t.Fatalf("import changed compaction boundary: boundary=%d session=%d import=%d", boundary, refreshed.CompactionSeq, imported.Sequence)
+	}
+	active, err := LoadActiveMessages(ctx, store, refreshed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) == 0 || active[len(active)-1].ID != imported.ID || !strings.Contains(active[len(active)-1].TextContent, report.Body) {
+		t.Fatalf("compacted active context missing import: %#v", active)
+	}
+}
+
+func TestWorkerConcurrentTerminalResultsCollapseAndTerminalStateDoesNotReopen(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	edge, err := store.CreateWorker(context.Background(), coordinator.ID, "concurrent terminal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const writers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.AddWorkerReport(context.Background(), WorkerReport{
+				ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+				DestinationSessionID: coordinator.ID, Kind: WorkerReportResult,
+				Title: fmt.Sprintf("Result %d", i), Body: "terminal",
+			})
+			errs <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	reports, err := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if err != nil || len(reports) != 1 {
+		t.Fatalf("terminal reports = %#v, %v", reports, err)
+	}
+	if err := store.UpdateWorkerStatus(context.Background(), edge.ChildSessionID, WorkerCancelled); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateWorkerStatus(context.Background(), edge.ChildSessionID, WorkerRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateWorkerStatus(context.Background(), edge.ChildSessionID, WorkerFailed); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.GetWorker(context.Background(), edge.ChildSessionID)
+	if err != nil || loaded.Status != WorkerCancelled {
+		t.Fatalf("terminal worker reopened/changed = %#v, %v", loaded, err)
 	}
 }
 

--- a/internal/session/worker_test.go
+++ b/internal/session/worker_test.go
@@ -208,6 +208,37 @@ func TestWorkerPreventsConflictingActiveSharedCWD(t *testing.T) {
 	}
 }
 
+func TestInteractiveWorkerResultAppendsAfterCanonicalTerminalResult(t *testing.T) {
+	store, coordinator := newWorkerStoreTest(t)
+	edge, err := store.CreateWorker(context.Background(), coordinator.ID, "continue after completion")
+	if err != nil {
+		t.Fatal(err)
+	}
+	terminal, err := store.AddWorkerReport(context.Background(), WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: WorkerReportResult,
+		Title: "Terminal", Body: "background complete", Origin: "terminal_synthesis",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	interactive, err := store.AddWorkerReport(context.Background(), WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: WorkerReportResult,
+		Title: "Interactive", Body: "continued result", Origin: WorkerReportOriginInteractive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if interactive.ID == terminal.ID || interactive.Sequence != terminal.Sequence+1 {
+		t.Fatalf("interactive result collapsed into terminal result: terminal=%#v interactive=%#v", terminal, interactive)
+	}
+	reports, err := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if err != nil || len(reports) != 2 || reports[1].Origin != WorkerReportOriginInteractive {
+		t.Fatalf("reports = %#v, %v", reports, err)
+	}
+}
+
 func TestWorkerReportsAreBoundedImmutableAndImportedAsUser(t *testing.T) {
 	store, coordinator := newWorkerStoreTest(t)
 	edge, err := store.CreateWorker(context.Background(), coordinator.ID, "summarize tests")

--- a/internal/session/workspace_test.go
+++ b/internal/session/workspace_test.go
@@ -19,8 +19,8 @@ func createWorkspaceTestSession(t *testing.T, store *SQLiteStore, id string) *Se
 }
 
 func TestWorkspaceGrantMigration46AndCRUDCascade(t *testing.T) {
-	if schemaVersion != 46 {
-		t.Fatalf("schemaVersion = %d, want 46", schemaVersion)
+	if schemaVersion < 46 {
+		t.Fatalf("schemaVersion = %d, want at least 46", schemaVersion)
 	}
 	foundMigration := false
 	for _, migration := range migrations {
@@ -97,8 +97,8 @@ func TestMigration46UpgradesVersion45Database(t *testing.T) {
 	if err := upgraded.db.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatal(err)
 	}
-	if version != 46 {
-		t.Fatalf("schema version = %d, want 46", version)
+	if version != schemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, schemaVersion)
 	}
 	var table string
 	if err := upgraded.db.QueryRow("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_workspace_grants'").Scan(&table); err != nil {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -266,6 +266,19 @@ func (r *LocalToolRegistry) RegisterWithEngine(engine *llm.Engine) {
 	}
 }
 
+// RegisterWorkerReportTool adds the durable mailbox tool to a worker-only
+// runtime after ordinary configured tools have been registered.
+func (r *LocalToolRegistry) RegisterWorkerReportTool(engine *llm.Engine, store session.WorkerStore, childSessionID, coordinatorSessionID string) {
+	if r == nil || engine == nil || store == nil {
+		return
+	}
+	tool := NewWorkerReportTool(store, childSessionID, coordinatorSessionID)
+	r.mu.Lock()
+	r.tools[WorkerReportToolName] = tool
+	r.mu.Unlock()
+	engine.RegisterTool(tool)
+}
+
 // SetPlanStore wires durable latest-snapshot persistence only when update_plan
 // was explicitly configured and registered.
 func (r *LocalToolRegistry) SetPlanStore(store session.Store) {

--- a/internal/tools/worker_report.go
+++ b/internal/tools/worker_report.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+const WorkerReportToolName = "report"
+
+// WorkerReportArgs is the structured mailbox envelope exposed to workers.
+type WorkerReportArgs struct {
+	Kind     session.WorkerReportKind `json:"kind"`
+	Title    string                   `json:"title"`
+	Body     string                   `json:"body"`
+	Metadata json.RawMessage          `json:"metadata,omitempty"`
+}
+
+// WorkerReportTool is registered only for durable /thread child runs.
+type WorkerReportTool struct {
+	store         session.WorkerStore
+	childID       string
+	coordinatorID string
+}
+
+func NewWorkerReportTool(store session.WorkerStore, childID, coordinatorID string) *WorkerReportTool {
+	return &WorkerReportTool{store: store, childID: strings.TrimSpace(childID), coordinatorID: strings.TrimSpace(coordinatorID)}
+}
+
+func (t *WorkerReportTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{
+		Name:        WorkerReportToolName,
+		Description: "Send a durable structured mailbox report to the coordinating chat. Use progress for useful milestones, blocker when unable to proceed, and result for the final outcome. Reports stay outside the coordinator's model context until the user explicitly imports one.",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"kind":     map[string]any{"type": "string", "enum": []string{"progress", "result", "blocker"}},
+				"title":    map[string]any{"type": "string", "maxLength": session.MaxWorkerReportTitleRunes},
+				"body":     map[string]any{"type": "string", "maxLength": session.MaxWorkerReportBodyRunes},
+				"metadata": map[string]any{"type": "object", "description": "Optional machine-readable provenance or summary fields."},
+			},
+			"required":             []string{"kind", "title", "body"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+func (t *WorkerReportTool) Preview(raw json.RawMessage) string {
+	var args WorkerReportArgs
+	_ = json.Unmarshal(raw, &args)
+	if title := strings.TrimSpace(args.Title); title != "" {
+		return fmt.Sprintf("%s: %s", args.Kind, title)
+	}
+	return "send worker report"
+}
+
+func (t *WorkerReportTool) Execute(ctx context.Context, raw json.RawMessage) (llm.ToolOutput, error) {
+	if t == nil || t.store == nil || t.childID == "" || t.coordinatorID == "" {
+		return llm.TextOutput("Worker mailbox is unavailable."), nil
+	}
+	var args WorkerReportArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return llm.TextOutput(fmt.Sprintf("Invalid report: %v", err)), nil
+	}
+	report, err := t.store.AddWorkerReport(ctx, session.WorkerReport{
+		ChildSessionID:       t.childID,
+		SourceSessionID:      t.childID,
+		DestinationSessionID: t.coordinatorID,
+		Kind:                 args.Kind,
+		Title:                args.Title,
+		Body:                 args.Body,
+		Metadata:             args.Metadata,
+		Origin:               "worker_tool",
+	})
+	if err != nil {
+		return llm.TextOutput(fmt.Sprintf("Report was not saved: %v", err)), nil
+	}
+	switch args.Kind {
+	case session.WorkerReportBlocker:
+		_ = t.store.UpdateWorkerStatus(ctx, t.childID, session.WorkerBlocked)
+	case session.WorkerReportProgress:
+		_ = t.store.UpdateWorkerStatus(ctx, t.childID, session.WorkerRunning)
+	}
+	return llm.TextOutput(fmt.Sprintf("Report #%d saved to the coordinator mailbox as %s.", report.Sequence+1, report.Kind)), nil
+}

--- a/internal/tools/worker_report_test.go
+++ b/internal/tools/worker_report_test.go
@@ -1,0 +1,81 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func workerReportToolStore(t *testing.T) (*session.SQLiteStore, session.WorkerEdge) {
+	t.Helper()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Now()
+	coordinator := &session.Session{ID: "main", Provider: "mock", Model: "mock", Mode: session.ModeChat, CreatedAt: now, UpdatedAt: now, Status: session.StatusActive}
+	if err := store.Create(context.Background(), coordinator); err != nil {
+		t.Fatal(err)
+	}
+	edge, err := store.CreateWorker(context.Background(), coordinator.ID, "test reporting")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, edge
+}
+
+func TestWorkerReportToolPersistsStructuredMailboxEvent(t *testing.T) {
+	store, edge := workerReportToolStore(t)
+	tool := NewWorkerReportTool(store, edge.ChildSessionID, edge.CoordinatorSessionID)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{
+		"kind":"progress","title":"Tests running","body":"Focused tests are green.","metadata":{"count":12}
+	}`))
+	if err != nil || !strings.Contains(out.Content, "saved") {
+		t.Fatalf("Execute = %#v, %v", out, err)
+	}
+	reports, err := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if err != nil || len(reports) != 1 {
+		t.Fatalf("reports = %#v, %v", reports, err)
+	}
+	if reports[0].Kind != session.WorkerReportProgress || reports[0].Title != "Tests running" || reports[0].Body != "Focused tests are green." || reports[0].Origin != "worker_tool" {
+		t.Fatalf("report = %#v", reports[0])
+	}
+	loaded, _ := store.GetWorker(context.Background(), edge.ChildSessionID)
+	if loaded.Status != session.WorkerRunning {
+		t.Fatalf("worker status = %s", loaded.Status)
+	}
+}
+
+func TestWorkerReportToolBlockerAndValidation(t *testing.T) {
+	store, edge := workerReportToolStore(t)
+	tool := NewWorkerReportTool(store, edge.ChildSessionID, edge.CoordinatorSessionID)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"kind":"blocker","title":"Need input","body":"Missing fixture."}`))
+	if err != nil || !strings.Contains(out.Content, "blocker") {
+		t.Fatalf("blocker = %#v, %v", out, err)
+	}
+	loaded, _ := store.GetWorker(context.Background(), edge.ChildSessionID)
+	if loaded.Status != session.WorkerBlocked {
+		t.Fatalf("worker status = %s", loaded.Status)
+	}
+	out, err = tool.Execute(context.Background(), json.RawMessage(`{"kind":"developer","title":"bad","body":"bad"}`))
+	if err != nil || !strings.Contains(out.Content, "not saved") {
+		t.Fatalf("invalid kind = %#v, %v", out, err)
+	}
+}
+
+func TestDefaultRegistryDoesNotExposeWorkerReport(t *testing.T) {
+	cfg := DefaultToolConfig()
+	registry, err := NewLocalToolRegistry(&cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := registry.Get(WorkerReportToolName); ok {
+		t.Fatal("ordinary registry exposed worker report tool")
+	}
+}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -363,6 +363,14 @@ type Model struct {
 	branchPathNotesRequest *BranchPathNotesRequest
 	queuedBranchSend       *pendingBranchSend
 
+	// Durable background worker supervision and mailbox state.
+	workerController    WorkerController
+	workerEdge          *session.WorkerEdge
+	workerUnreadReports int
+	workerTreeSelection *session.WorkerEdge
+	workerReportChoices map[int64]session.WorkerReport
+	pendingWorkerReport *session.WorkerReport
+
 	// If set, the caller should auto-send this message after handover restart.
 	pendingHandoverAutoSend string
 
@@ -1729,6 +1737,9 @@ func (m *Model) Init() tea.Cmd {
 	m.updateTextareaHeight()
 
 	baseCmds := []tea.Cmd{textarea.Blink, m.spinner.Tick}
+	if cmd := m.workerMailboxPollCmd(); cmd != nil {
+		baseCmds = append(baseCmds, cmd)
+	}
 	if (!m.fastMetadataLoaded || m.fastMetadataStale) && !m.fastMetadataLoading {
 		if cmd := m.loadModelMetadataCmd(); cmd != nil {
 			baseCmds = append(baseCmds, cmd)
@@ -1957,6 +1968,7 @@ func isParentChatMessage(msg tea.Msg) bool {
 	switch msg.(type) {
 	case streamEventMsg,
 		tickMsg,
+		workerMailboxPollMsg,
 		streamRenderTickMsg,
 		ui.SmoothTickMsg,
 		ui.WaveTickMsg,
@@ -2241,6 +2253,9 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		if m.streaming || m.directShellRun != nil {
 			cmds = append(cmds, m.tickEvery())
 		}
+
+	case workerMailboxPollMsg:
+		cmds = append(cmds, m.handleWorkerMailboxPoll(msg))
 
 	case streamRenderTickMsg:
 		m.streamRenderTickPending = false

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -609,6 +609,13 @@ type (
 		result *llm.CompactionResult
 		err    error
 	}
+	reportDoneMsg struct {
+		sessionID  string
+		briefing   *llm.BriefingResult
+		report     session.WorkerReport
+		err        error
+		delivering bool
+	}
 	handoverDoneMsg struct {
 		result       *llm.HandoverResult
 		err          error
@@ -1978,6 +1985,7 @@ func isParentChatMessage(msg tea.Msg) bool {
 		copyStatusClearMsg,
 		compactStartedMsg,
 		compactDoneMsg,
+		reportDoneMsg,
 		handoverDoneMsg,
 		handoverRenameDoneMsg,
 		sessionSavedMsg,
@@ -2402,6 +2410,27 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 			m.engine.SetContextEstimateBaseline(0, 0)
 		}
 		return m.showFooterSuccess("Conversation compacted.")
+
+	case reportDoneMsg:
+		m.streaming = false
+		m.phase = "Thinking"
+		m.releaseStreamCancelFunc()
+		if msg.briefing != nil {
+			m.recordHandoverUsage(context.Background(), msg.sessionID, msg.briefing.Model, msg.briefing.Usage)
+		}
+		if msg.err != nil {
+			if errors.Is(msg.err, context.Canceled) || errors.Is(msg.err, context.DeadlineExceeded) {
+				return m.showFooterMuted("Report cancelled.")
+			}
+			if msg.delivering {
+				return m.showFooterError(fmt.Sprintf("Report delivery failed: %v", msg.err))
+			}
+			return m.showFooterError(fmt.Sprintf("Report preparation failed: %v", msg.err))
+		}
+		if msg.report.ID == 0 {
+			return m.showFooterError("Report delivery failed: no stored report returned.")
+		}
+		return m.showFooterSuccess(fmt.Sprintf("Report #%d sent to the coordinator mailbox.", msg.report.Sequence+1))
 
 	case handoverDoneMsg:
 		m.streaming = false

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -110,9 +110,20 @@ func AllCommands() []Command {
 			Usage:       "/clear",
 		},
 		{
+			Name:         "thread",
+			Description:  "Start a durable background worker",
+			Usage:        "/thread TASK",
+			ArgumentHint: "TASK",
+		},
+		{
 			Name:        "tree",
-			Description: "Browse conversation paths or branch from an earlier message",
+			Description: "Browse conversation paths, workers, and mailbox reports",
 			Usage:       "/tree",
+		},
+		{
+			Name:        "main",
+			Description: "Return from a worker session to its coordinator",
+			Usage:       "/main",
 		},
 		{
 			Name:        "undo",
@@ -542,8 +553,12 @@ func (m *Model) ExecuteCommand(input string) (tea.Model, tea.Cmd) {
 		return m.cmdGoal(args, rawArgs)
 	case "clear":
 		return m.cmdClear()
+	case "thread":
+		return m.cmdThread(rawArgs)
 	case "tree":
 		return m.cmdTree(args)
+	case "main":
+		return m.cmdMain(args)
 	case "undo":
 		return m.cmdUndoRedo(false, args)
 	case "redo":

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -126,6 +126,11 @@ func AllCommands() []Command {
 			Usage:       "/main",
 		},
 		{
+			Name:        "report",
+			Description: "Brief the coordinator from a completed worker session",
+			Usage:       "/report",
+		},
+		{
 			Name:        "undo",
 			Description: "Remove the latest user turn and everything after it",
 			Usage:       "/undo",
@@ -559,6 +564,8 @@ func (m *Model) ExecuteCommand(input string) (tea.Model, tea.Cmd) {
 		return m.cmdTree(args)
 	case "main":
 		return m.cmdMain(args)
+	case "report":
+		return m.cmdReport(args)
 	case "undo":
 		return m.cmdUndoRedo(false, args)
 	case "redo":

--- a/internal/tui/chat/dialog.go
+++ b/internal/tui/chat/dialog.go
@@ -23,6 +23,7 @@ const (
 	DialogModelPicker
 	DialogSessionList
 	DialogBranchTree
+	DialogWorkerReports
 	DialogBranchContext
 	DialogDirApproval
 	DialogMCPPicker
@@ -192,6 +193,11 @@ func (d *DialogModel) ShowBranchTree(items []DialogItem, currentItemID string) {
 	d.treeToolsVisible = false
 	d.treeExpandedTurns = make(map[string]bool)
 	d.filterItems()
+}
+
+// ShowWorkerReports opens worker actions and durable mailbox events.
+func (d *DialogModel) ShowWorkerReports(items []DialogItem, title string) {
+	d.showSessionItems(DialogWorkerReports, title, items, "")
 }
 
 // ShowBranchContext asks which context the new path should include.
@@ -377,6 +383,13 @@ func (d *DialogModel) ShowContent(title, content string) {
 // Content returns the raw content currently displayed by a content dialog.
 func (d *DialogModel) Content() string {
 	return strings.Join(d.contentLines, "\n")
+}
+
+// SetContentFooter customizes static-dialog actions while preserving its body.
+func (d *DialogModel) SetContentFooter(footer string) {
+	if d.dialogType == DialogContent {
+		d.contentFooter = strings.TrimSpace(footer)
+	}
 }
 
 func (d *DialogModel) GetDirApprovalPath() string {

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -568,8 +568,32 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Handle dialog first if open
 	if m.dialog.IsOpen() {
 		if m.dialog.Type() == DialogContent {
+			if m.pendingWorkerReport != nil && key.Matches(msg, key.NewBinding(key.WithKeys("i"))) {
+				return m.importPendingWorkerReport()
+			}
 			m.dialog.Update(msg)
+			if !m.dialog.IsOpen() {
+				m.pendingWorkerReport = nil
+			}
 			return m, nil
+		}
+		if m.dialog.Type() == DialogWorkerReports {
+			switch {
+			case key.Matches(msg, key.NewBinding(key.WithKeys("enter", "tab"))):
+				selected := m.dialog.Selected()
+				if selected == nil {
+					return m, nil
+				}
+				m.dialog.Close()
+				return m.handleWorkerReportsSelection(selected.ID)
+			case key.Matches(msg, key.NewBinding(key.WithKeys("esc", "q", "ctrl+c"))):
+				m.dialog.Close()
+				m.workerTreeSelection = nil
+				return m, nil
+			default:
+				m.dialog.Update(msg)
+				return m, nil
+			}
 		}
 		// Conversation tree supports type-to-search while preserving arrow-key navigation.
 		if m.dialog.Type() == DialogBranchTree {

--- a/internal/tui/chat/render.go
+++ b/internal/tui/chat/render.go
@@ -733,6 +733,19 @@ func (m *Model) buildFooterLayout() footerLayout {
 		appendMetaRow(pendingStyle.Render("  ⏳ " + pendingText + " (will incorporate)"))
 	}
 
+	if m.workerUnreadReports > 0 {
+		mailStyle := lipgloss.NewStyle().Foreground(theme.Secondary).Bold(true)
+		noun := "reports"
+		if m.workerUnreadReports == 1 {
+			noun = "report"
+		}
+		appendMetaRow(mailStyle.Render(fmt.Sprintf("  ✉ %d unread worker %s · /tree", m.workerUnreadReports, noun)))
+	}
+	if m.workerChildReadOnly() {
+		workerStyle := lipgloss.NewStyle().Foreground(theme.Warning).Bold(true)
+		appendMetaRow(workerStyle.Render("  Worker is active · read-only transcript · /main returns to coordinator"))
+	}
+
 	if len(m.files) > 0 {
 		var fileNames []string
 		for _, f := range m.files {
@@ -765,6 +778,8 @@ func (m *Model) buildFooterLayout() footerLayout {
 		m.textarea.Placeholder = "Shell command running…"
 	} else if shellComposer {
 		m.textarea.Placeholder = "Type a shell command…"
+	} else if m.workerChildReadOnly() {
+		m.textarea.Placeholder = "Worker is running; use /main or /tree…"
 	} else {
 		m.textarea.Placeholder = "Type a message..."
 	}

--- a/internal/tui/chat/side_question_test.go
+++ b/internal/tui/chat/side_question_test.go
@@ -738,7 +738,7 @@ func TestSideAndOnlySideIsStreamingLocalCommand(t *testing.T) {
 	if !isStreamingLocalSlashCommand("/side question") {
 		t.Fatal("/side should be available while main streams")
 	}
-	if isStreamingLocalSlashCommand("/main") || isSlashCommandLike("/main") {
-		t.Fatal("/main should not exist")
+	if isStreamingLocalSlashCommand("/main") || !isSlashCommandLike("/main") {
+		t.Fatal("/main should exist but remain unavailable while the current chat streams")
 	}
 }

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -476,6 +476,9 @@ func (m *Model) ensureContextMessages() {
 }
 
 func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
+	if m.workerChildReadOnly() {
+		return m.showFooterWarning("This running worker transcript is read-only. Use /main to continue the coordinator chat.")
+	}
 	if m.directShellRun != nil {
 		return m.showFooterWarning("Wait for the shell command to finish or press Esc to cancel it.")
 	}

--- a/internal/tui/chat/tree.go
+++ b/internal/tui/chat/tree.go
@@ -134,24 +134,39 @@ func (m *Model) cmdTree(args []string) (tea.Model, tea.Cmd) {
 		return m.showFooterError("Session storage does not support conversation branching.")
 	}
 	ctx := context.Background()
-	tree, err := branchStore.GetBranchTree(ctx, m.sess.ID)
+	treeSessionID := m.sess.ID
+	workerStore, workerStoreOK := session.AsWorkerStore(m.store)
+	currentIsWorker := false
+	if workerStoreOK {
+		if edge, edgeErr := workerStore.GetWorker(ctx, m.sess.ID); edgeErr == nil {
+			treeSessionID = edge.CoordinatorSessionID
+			currentIsWorker = true
+		}
+	}
+	tree, err := branchStore.GetBranchTree(ctx, treeSessionID)
 	if err != nil {
 		return m.showFooterError(fmt.Sprintf("Load conversation tree: %v", err))
 	}
-	messages, err := m.store.GetMessages(ctx, m.sess.ID, 0, 0)
-	if err != nil {
-		return m.showFooterError(fmt.Sprintf("Load branch points: %v", err))
+	messages := []session.Message(nil)
+	if !currentIsWorker {
+		messages, err = m.store.GetMessages(ctx, m.sess.ID, 0, 0)
+		if err != nil {
+			return m.showFooterError(fmt.Sprintf("Load branch points: %v", err))
+		}
 	}
 	mutationStore, ok := m.store.(session.TranscriptUndoRedoStore)
 	if !ok {
 		return m.showFooterError("Session storage does not support revision-safe branching.")
 	}
-	state, err := mutationStore.TranscriptMutationState(ctx, m.sess.ID)
-	if err != nil {
-		return m.showFooterError(fmt.Sprintf("Load conversation revision: %v", err))
+	state := session.TranscriptMutationState{}
+	if !currentIsWorker {
+		state, err = mutationStore.TranscriptMutationState(ctx, m.sess.ID)
+		if err != nil {
+			return m.showFooterError(fmt.Sprintf("Load conversation revision: %v", err))
+		}
 	}
 
-	items := make([]DialogItem, 0, len(tree.Nodes)+len(messages))
+	items := make([]DialogItem, 0, len(tree.Nodes)+len(messages)+4)
 	depths := branchTreeDepths(tree)
 	for _, node := range tree.Nodes {
 		marker := "○"
@@ -166,6 +181,15 @@ func (m *Model) cmdTree(args []string) (tea.Model, tea.Cmd) {
 		items = append(items, DialogItem{
 			ID: "path:" + node.SessionID, Label: label, Description: description, Category: "Existing paths",
 		})
+	}
+	if workerStoreOK {
+		workers, workerErr := workerStore.ListWorkers(ctx, treeSessionID)
+		if workerErr != nil {
+			return m.showFooterError(fmt.Sprintf("Load workers: %v", workerErr))
+		}
+		for _, worker := range workers {
+			items = append(items, workerTreeItem(worker, m.sess.ID))
+		}
 	}
 
 	m.branchTreeChoices = make(map[string]conversationBranchPoint)
@@ -250,6 +274,9 @@ func (m *Model) cmdTree(args []string) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) handleBranchTreeSelection(choiceID string) (tea.Model, tea.Cmd) {
+	if strings.HasPrefix(choiceID, "worker:") {
+		return m.openWorkerReports(strings.TrimPrefix(choiceID, "worker:"))
+	}
 	if strings.HasPrefix(choiceID, "path:") {
 		sessionID := strings.TrimPrefix(choiceID, "path:")
 		if m.sess != nil && sessionID == m.sess.ID {

--- a/internal/tui/chat/workers.go
+++ b/internal/tui/chat/workers.go
@@ -32,11 +32,19 @@ type WorkerStartResult struct {
 	RunID string
 }
 
+type WorkerCancelRequest struct {
+	ChildSessionID       string
+	CoordinatorSessionID string
+	RunID                string
+}
+
 // WorkerController is implemented by cmd so the TUI does not depend on the
 // jobs-v2 HTTP/server package.
 type WorkerController interface {
+	OwnerID() string
 	StartWorker(context.Context, WorkerStartRequest) (WorkerStartResult, error)
-	CancelWorker(context.Context, string) error
+	CancelWorker(context.Context, WorkerCancelRequest) error
+	ReconcileWorkers(context.Context, string) error
 }
 
 type workerMailboxPollMsg struct {
@@ -88,9 +96,17 @@ func (m *Model) workerMailboxPollCmd() tea.Cmd {
 		return nil
 	}
 	sessionID := m.sess.ID
+	controller := m.workerController
 	return tea.Tick(time.Second, func(time.Time) tea.Msg {
 		edge, edgeErr := workerStore.GetWorker(context.Background(), sessionID)
 		coordinatorID := sessionID
+		if edgeErr == nil {
+			coordinatorID = edge.CoordinatorSessionID
+		}
+		if controller != nil {
+			_ = controller.ReconcileWorkers(context.Background(), coordinatorID)
+			edge, edgeErr = workerStore.GetWorker(context.Background(), sessionID)
+		}
 		var edgePtr *session.WorkerEdge
 		if edgeErr == nil {
 			edgeCopy := edge
@@ -111,15 +127,11 @@ func (m *Model) handleWorkerMailboxPoll(msg workerMailboxPollMsg) tea.Cmd {
 
 func recordWorkerStartFailure(workerStore session.WorkerStore, edge session.WorkerEdge, title string, startErr error) {
 	ctx := context.Background()
-	_ = workerStore.UpdateWorkerStatus(ctx, edge.ChildSessionID, session.WorkerFailed)
-	if hasResult, err := workerStore.HasWorkerReportKind(ctx, edge.ChildSessionID, session.WorkerReportResult); err == nil && hasResult {
-		return
-	}
 	body := "Worker execution could not be started."
 	if startErr != nil {
 		body = startErr.Error()
 	}
-	_, _ = workerStore.AddWorkerReport(ctx, session.WorkerReport{
+	_ = workerStore.FinishWorker(ctx, edge.ChildSessionID, session.WorkerFailed, session.WorkerReport{
 		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
 		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
 		Title: title, Body: body, Origin: "terminal_synthesis",
@@ -138,6 +150,9 @@ func (m *Model) cmdThread(task string) (tea.Model, tea.Cmd) {
 	if m.store == nil || m.sess == nil {
 		return m.showFooterError("A stored coordinator session is required.")
 	}
+	if m.transcriptMutationBusy() {
+		return m.showFooterWarning("Cannot start a worker while conversation work is active.")
+	}
 	workerStore, ok := session.AsWorkerStore(m.store)
 	if !ok {
 		return m.showFooterError("Session storage does not support durable workers.")
@@ -148,7 +163,7 @@ func (m *Model) cmdThread(task string) (tea.Model, tea.Cmd) {
 		return m.showFooterError(fmt.Sprintf("Check worker identity: %v", err))
 	}
 
-	edge, err := workerStore.CreateWorker(m.rootContext(), m.sess.ID, task)
+	edge, err := workerStore.CreateWorkerOwned(m.rootContext(), m.sess.ID, m.workerController.OwnerID(), task)
 	if err != nil {
 		return m.showFooterWarning(fmt.Sprintf("Start worker: %v", err))
 	}
@@ -167,7 +182,9 @@ func (m *Model) cmdThread(task string) (tea.Model, tea.Cmd) {
 		return m.showFooterError(fmt.Sprintf("Start worker execution: %v", err))
 	}
 	if err := workerStore.SetWorkerExecution(context.Background(), edge.ChildSessionID, result.JobID, result.RunID); err != nil {
-		_ = m.workerController.CancelWorker(context.Background(), result.RunID)
+		_ = m.workerController.CancelWorker(context.Background(), WorkerCancelRequest{
+			ChildSessionID: edge.ChildSessionID, CoordinatorSessionID: edge.CoordinatorSessionID, RunID: result.RunID,
+		})
 		recordWorkerStartFailure(workerStore, edge, "Worker execution could not be saved", err)
 		return m.showFooterError(fmt.Sprintf("Save worker execution: %v", err))
 	}
@@ -247,8 +264,8 @@ func (m *Model) openWorkerReports(childSessionID string) (tea.Model, tea.Cmd) {
 	m.workerTreeSelection = &edge
 	m.workerReportChoices = make(map[int64]session.WorkerReport, len(reports))
 	items := []DialogItem{{ID: "worker-open:" + childSessionID, Label: "Open worker session", Description: "Running workers open read-only"}}
-	if edge.Status.Active() && edge.RunID != "" {
-		items = append(items, DialogItem{ID: "worker-cancel:" + childSessionID, Label: "Cancel worker", Description: "Request jobs-v2 cancellation"})
+	if edge.Status.Active() {
+		items = append(items, DialogItem{ID: "worker-cancel:" + childSessionID, Label: "Cancel or reconcile worker", Description: "Safely cancel execution or clear a stale active edge"})
 	}
 	for i := len(reports) - 1; i >= 0; i-- {
 		report := reports[i]
@@ -277,7 +294,11 @@ func (m *Model) handleWorkerReportsSelection(id string) (tea.Model, tea.Cmd) {
 		if m.workerTreeSelection == nil || m.workerController == nil {
 			return m.showFooterError("Worker cancellation is unavailable.")
 		}
-		if err := m.workerController.CancelWorker(m.rootContext(), m.workerTreeSelection.RunID); err != nil {
+		if err := m.workerController.CancelWorker(m.rootContext(), WorkerCancelRequest{
+			ChildSessionID:       m.workerTreeSelection.ChildSessionID,
+			CoordinatorSessionID: m.workerTreeSelection.CoordinatorSessionID,
+			RunID:                m.workerTreeSelection.RunID,
+		}); err != nil {
 			return m.showFooterError(fmt.Sprintf("Cancel worker: %v", err))
 		}
 		return m.showFooterMuted("Worker cancellation requested.")
@@ -306,6 +327,9 @@ func (m *Model) handleWorkerReportsSelection(id string) (tea.Model, tea.Cmd) {
 func (m *Model) importPendingWorkerReport() (tea.Model, tea.Cmd) {
 	if m.pendingWorkerReport == nil {
 		return m, nil
+	}
+	if m.transcriptMutationBusy() {
+		return m.showFooterWarning("Cannot import a worker report while conversation work is active.")
 	}
 	workerStore, ok := session.AsWorkerStore(m.store)
 	if !ok {

--- a/internal/tui/chat/workers.go
+++ b/internal/tui/chat/workers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/terminaltext"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -211,6 +212,101 @@ func (m *Model) cmdMain(args []string) (tea.Model, tea.Cmd) {
 		return m.showFooterError(fmt.Sprintf("Find coordinator: %v", err))
 	}
 	return m.requestResumeSession(edge.CoordinatorSessionID)
+}
+
+const interactiveReportPrompt = `Prepare a concise, self-contained result briefing for the coordinator of this worker session. Report the useful outcome and current state, not a chronological narration.
+
+Prioritize:
+- outcome and current state;
+- concrete evidence and decisions;
+- changes made and artifacts produced, including useful paths or identifiers;
+- verification performed and its results;
+- caveats, blockers, and clearly remaining work.
+
+The coordinator will receive only this document, so preserve facts needed to understand or act on the result. Do not address the user, mention this instruction, invent work, or imply that mailbox delivery has already happened. Use clear headings and compact prose. Aim for approximately 250–600 words, removing narrative detail before substantive evidence.`
+
+const interactiveReportTrigger = "Create the coordinator result briefing now."
+
+func interactiveReportTitle(edge session.WorkerEdge) string {
+	task := session.TruncateSummary(edge.Task)
+	if task == "" {
+		return "Interactive worker result"
+	}
+	return "Interactive result: " + task
+}
+
+// cmdReport generates a control-plane briefing from the active child context and
+// delivers it directly to the durable coordinator mailbox. It never appends a
+// normal turn to either transcript and deliberately avoids handover file/scripts.
+func (m *Model) cmdReport(args []string) (tea.Model, tea.Cmd) {
+	m.setTextareaValue("")
+	if len(args) != 0 {
+		return m.showFooterError("Usage: /report")
+	}
+	if m.transcriptMutationBusy() || m.pendingHandover != nil || m.handoverPreview != nil {
+		return m.showFooterWarning("Cannot prepare a report while conversation work is active.")
+	}
+	if m.store == nil || m.sess == nil || strings.TrimSpace(m.sess.ID) == "" {
+		return m.showFooterError("/report is available only in a durable worker child session.")
+	}
+	workerStore, ok := session.AsWorkerStore(m.store)
+	if !ok {
+		return m.showFooterError("/report is available only in a durable worker child session.")
+	}
+	edge, err := workerStore.GetWorker(m.rootContext(), m.sess.ID)
+	if errors.Is(err, session.ErrNotFound) {
+		return m.showFooterError("/report is available only in a durable worker child session.")
+	}
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Check worker report destination: %v", err))
+	}
+	if edge.Status.Active() {
+		return m.showFooterWarning("Cannot prepare a report while the background worker is still active.")
+	}
+	if m.provider == nil {
+		return m.showFooterError("Report preparation is unavailable: no provider is configured.")
+	}
+
+	currentSystemPrompt, messages := m.snapshotActiveHelperConversation()
+	if len(messages) == 0 {
+		return m.showFooterError("Report preparation requires conversation history in this worker session.")
+	}
+	ctx := m.beginHelperStream("Preparing report", true)
+	provider := m.provider
+	model := m.modelName
+	config := m.helperCompactionConfig()
+	sessionID := m.sess.ID
+
+	return m, tea.Batch(
+		func() tea.Msg {
+			briefing, err := llm.GenerateBriefing(ctx, provider, model, currentSystemPrompt, messages, config, llm.BriefingOptions{
+				EditorialPrompt:         interactiveReportPrompt,
+				TriggerPrompt:           interactiveReportTrigger,
+				PreparingAcknowledgment: "I'll now prepare the coordinator result briefing.",
+				Operation:               "report",
+				MaxOutputTokens:         2_000,
+				AllowProviderFork:       true,
+			})
+			if err != nil {
+				return reportDoneMsg{sessionID: sessionID, err: err}
+			}
+			report, err := workerStore.AddWorkerReport(ctx, session.WorkerReport{
+				ChildSessionID:       edge.ChildSessionID,
+				SourceSessionID:      edge.ChildSessionID,
+				DestinationSessionID: edge.CoordinatorSessionID,
+				Kind:                 session.WorkerReportResult,
+				Title:                interactiveReportTitle(edge),
+				Body:                 briefing.Document,
+				Origin:               session.WorkerReportOriginInteractive,
+			})
+			if err != nil {
+				return reportDoneMsg{sessionID: sessionID, briefing: briefing, err: err, delivering: true}
+			}
+			return reportDoneMsg{sessionID: sessionID, briefing: briefing, report: report}
+		},
+		m.spinner.Tick,
+		m.tickEvery(),
+	)
 }
 
 func workerStatusLabel(status session.WorkerStatus) string {

--- a/internal/tui/chat/workers.go
+++ b/internal/tui/chat/workers.go
@@ -1,0 +1,334 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/terminaltext"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+// WorkerStartRequest carries the durable child identity and its inherited run
+// settings to the outer chat-owned jobs-v2 supervisor.
+type WorkerStartRequest struct {
+	ChildSessionID       string
+	CoordinatorSessionID string
+	Task                 string
+	Cwd                  string
+	Provider             string
+	Model                string
+	Tools                string
+	Search               bool
+	ApprovalMode         tools.ApprovalMode
+}
+
+type WorkerStartResult struct {
+	JobID string
+	RunID string
+}
+
+// WorkerController is implemented by cmd so the TUI does not depend on the
+// jobs-v2 HTTP/server package.
+type WorkerController interface {
+	StartWorker(context.Context, WorkerStartRequest) (WorkerStartResult, error)
+	CancelWorker(context.Context, string) error
+}
+
+type workerMailboxPollMsg struct {
+	coordinatorID string
+	unread        int
+	edge          *session.WorkerEdge
+}
+
+func (m *Model) SetWorkerController(controller WorkerController) {
+	m.workerController = controller
+	m.refreshWorkerIdentity(context.Background())
+}
+
+func (m *Model) refreshWorkerIdentity(ctx context.Context) {
+	m.workerEdge = nil
+	if m == nil || m.store == nil || m.sess == nil {
+		return
+	}
+	workerStore, ok := session.AsWorkerStore(m.store)
+	if !ok {
+		return
+	}
+	edge, err := workerStore.GetWorker(ctx, m.sess.ID)
+	if err == nil {
+		m.workerEdge = &edge
+	}
+}
+
+func (m *Model) workerCoordinatorID() string {
+	if m.workerEdge != nil {
+		return m.workerEdge.CoordinatorSessionID
+	}
+	if m.sess != nil {
+		return m.sess.ID
+	}
+	return ""
+}
+
+func (m *Model) workerChildReadOnly() bool {
+	return m.workerEdge != nil && m.workerEdge.Status.Active()
+}
+
+func (m *Model) workerMailboxPollCmd() tea.Cmd {
+	if m == nil || m.store == nil || m.sess == nil {
+		return nil
+	}
+	workerStore, ok := session.AsWorkerStore(m.store)
+	if !ok {
+		return nil
+	}
+	sessionID := m.sess.ID
+	return tea.Tick(time.Second, func(time.Time) tea.Msg {
+		edge, edgeErr := workerStore.GetWorker(context.Background(), sessionID)
+		coordinatorID := sessionID
+		var edgePtr *session.WorkerEdge
+		if edgeErr == nil {
+			edgeCopy := edge
+			edgePtr = &edgeCopy
+			coordinatorID = edge.CoordinatorSessionID
+		}
+		unread, _ := workerStore.CountUnreadWorkerReports(context.Background(), coordinatorID)
+		return workerMailboxPollMsg{coordinatorID: coordinatorID, unread: unread, edge: edgePtr}
+	})
+}
+
+func (m *Model) handleWorkerMailboxPoll(msg workerMailboxPollMsg) tea.Cmd {
+	m.workerUnreadReports = msg.unread
+	m.workerEdge = msg.edge
+	m.bumpContentVersion()
+	return m.workerMailboxPollCmd()
+}
+
+func recordWorkerStartFailure(workerStore session.WorkerStore, edge session.WorkerEdge, title string, startErr error) {
+	ctx := context.Background()
+	_ = workerStore.UpdateWorkerStatus(ctx, edge.ChildSessionID, session.WorkerFailed)
+	if hasResult, err := workerStore.HasWorkerReportKind(ctx, edge.ChildSessionID, session.WorkerReportResult); err == nil && hasResult {
+		return
+	}
+	body := "Worker execution could not be started."
+	if startErr != nil {
+		body = startErr.Error()
+	}
+	_, _ = workerStore.AddWorkerReport(ctx, session.WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+		Title: title, Body: body, Origin: "terminal_synthesis",
+	})
+}
+
+func (m *Model) cmdThread(task string) (tea.Model, tea.Cmd) {
+	task = strings.TrimSpace(task)
+	if task == "" {
+		m.setTextareaValue("")
+		return m.showFooterError("Usage: /thread TASK")
+	}
+	if m.workerController == nil {
+		return m.showFooterError("Background workers are unavailable in this chat runtime.")
+	}
+	if m.store == nil || m.sess == nil {
+		return m.showFooterError("A stored coordinator session is required.")
+	}
+	workerStore, ok := session.AsWorkerStore(m.store)
+	if !ok {
+		return m.showFooterError("Session storage does not support durable workers.")
+	}
+	if _, err := workerStore.GetWorker(context.Background(), m.sess.ID); err == nil {
+		return m.showFooterWarning("Nested worker threads are not supported. Use /main first.")
+	} else if !errors.Is(err, session.ErrNotFound) {
+		return m.showFooterError(fmt.Sprintf("Check worker identity: %v", err))
+	}
+
+	edge, err := workerStore.CreateWorker(m.rootContext(), m.sess.ID, task)
+	if err != nil {
+		return m.showFooterWarning(fmt.Sprintf("Start worker: %v", err))
+	}
+	child, err := m.store.Get(m.rootContext(), edge.ChildSessionID)
+	if err != nil {
+		recordWorkerStartFailure(workerStore, edge, "Worker session could not be loaded", err)
+		return m.showFooterError(fmt.Sprintf("Load worker session: %v", err))
+	}
+	result, err := m.workerController.StartWorker(m.rootContext(), WorkerStartRequest{
+		ChildSessionID: edge.ChildSessionID, CoordinatorSessionID: edge.CoordinatorSessionID,
+		Task: edge.Task, Cwd: child.CWD, Provider: child.ProviderKey, Model: child.Model,
+		Tools: child.Tools, Search: child.Search, ApprovalMode: m.requestedApprovalMode,
+	})
+	if err != nil {
+		recordWorkerStartFailure(workerStore, edge, "Worker failed to start", err)
+		return m.showFooterError(fmt.Sprintf("Start worker execution: %v", err))
+	}
+	if err := workerStore.SetWorkerExecution(context.Background(), edge.ChildSessionID, result.JobID, result.RunID); err != nil {
+		_ = m.workerController.CancelWorker(context.Background(), result.RunID)
+		recordWorkerStartFailure(workerStore, edge, "Worker execution could not be saved", err)
+		return m.showFooterError(fmt.Sprintf("Save worker execution: %v", err))
+	}
+	m.setTextareaValue("")
+	return m.showFooterSuccess(fmt.Sprintf("Worker started · %s · use /tree to supervise", session.ShortID(edge.ChildSessionID)))
+}
+
+func (m *Model) cmdMain(args []string) (tea.Model, tea.Cmd) {
+	if len(args) != 0 {
+		return m.showFooterError("Usage: /main")
+	}
+	if m.store == nil || m.sess == nil {
+		return m.showFooterMuted("Already in the main coordinator session.")
+	}
+	workerStore, ok := session.AsWorkerStore(m.store)
+	if !ok {
+		return m.showFooterMuted("Already in the main coordinator session.")
+	}
+	edge, err := workerStore.GetWorker(context.Background(), m.sess.ID)
+	if errors.Is(err, session.ErrNotFound) {
+		return m.showFooterMuted("Already in the main coordinator session.")
+	}
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Find coordinator: %v", err))
+	}
+	return m.requestResumeSession(edge.CoordinatorSessionID)
+}
+
+func workerStatusLabel(status session.WorkerStatus) string {
+	switch status {
+	case session.WorkerQueued:
+		return "queued"
+	case session.WorkerRunning:
+		return "running"
+	case session.WorkerBlocked:
+		return "blocked"
+	case session.WorkerDone:
+		return "done"
+	case session.WorkerFailed:
+		return "failed"
+	case session.WorkerCancelled:
+		return "cancelled"
+	default:
+		return string(status)
+	}
+}
+
+func workerTreeItem(edge session.WorkerEdge, currentSessionID string) DialogItem {
+	marker := "○"
+	if edge.ChildSessionID == currentSessionID {
+		marker = "●"
+	}
+	unread := ""
+	if edge.UnreadReports > 0 {
+		unread = fmt.Sprintf(" · %d unread", edge.UnreadReports)
+	}
+	preview := terminaltext.SanitizeSingleLine(edge.Task)
+	return DialogItem{
+		ID: "worker:" + edge.ChildSessionID, Label: fmt.Sprintf("%s %s · %s", marker, session.TruncateSummary(preview), workerStatusLabel(edge.Status)),
+		Description: session.ShortID(edge.ChildSessionID) + unread, Category: "Workers",
+	}
+}
+
+func (m *Model) openWorkerReports(childSessionID string) (tea.Model, tea.Cmd) {
+	workerStore, ok := session.AsWorkerStore(m.store)
+	if !ok {
+		return m.showFooterError("Worker mailbox is unavailable.")
+	}
+	edge, err := workerStore.GetWorker(context.Background(), childSessionID)
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Load worker: %v", err))
+	}
+	reports, err := workerStore.ListWorkerReports(context.Background(), childSessionID)
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Load worker reports: %v", err))
+	}
+	m.workerTreeSelection = &edge
+	m.workerReportChoices = make(map[int64]session.WorkerReport, len(reports))
+	items := []DialogItem{{ID: "worker-open:" + childSessionID, Label: "Open worker session", Description: "Running workers open read-only"}}
+	if edge.Status.Active() && edge.RunID != "" {
+		items = append(items, DialogItem{ID: "worker-cancel:" + childSessionID, Label: "Cancel worker", Description: "Request jobs-v2 cancellation"})
+	}
+	for i := len(reports) - 1; i >= 0; i-- {
+		report := reports[i]
+		m.workerReportChoices[report.ID] = report
+		state := "read"
+		if report.ReadAt == nil {
+			state = "unread"
+		}
+		if report.ImportedAt != nil {
+			state = "imported"
+		}
+		items = append(items, DialogItem{
+			ID: fmt.Sprintf("worker-report:%d", report.ID), Label: fmt.Sprintf("%s · %s", report.Kind, report.Title),
+			Description: fmt.Sprintf("report %d · %s", report.Sequence+1, state), Category: "Reports",
+		})
+	}
+	m.dialog.ShowWorkerReports(items, "Worker · "+session.ShortID(childSessionID))
+	return m, nil
+}
+
+func (m *Model) handleWorkerReportsSelection(id string) (tea.Model, tea.Cmd) {
+	switch {
+	case strings.HasPrefix(id, "worker-open:"):
+		return m.requestResumeSession(strings.TrimPrefix(id, "worker-open:"))
+	case strings.HasPrefix(id, "worker-cancel:"):
+		if m.workerTreeSelection == nil || m.workerController == nil {
+			return m.showFooterError("Worker cancellation is unavailable.")
+		}
+		if err := m.workerController.CancelWorker(m.rootContext(), m.workerTreeSelection.RunID); err != nil {
+			return m.showFooterError(fmt.Sprintf("Cancel worker: %v", err))
+		}
+		return m.showFooterMuted("Worker cancellation requested.")
+	case strings.HasPrefix(id, "worker-report:"):
+		var reportID int64
+		if _, err := fmt.Sscanf(strings.TrimPrefix(id, "worker-report:"), "%d", &reportID); err != nil {
+			return m.showFooterError("Invalid worker report selection.")
+		}
+		report, ok := m.workerReportChoices[reportID]
+		if !ok {
+			return m.showFooterError("Worker report is no longer available.")
+		}
+		if workerStore, ok := session.AsWorkerStore(m.store); ok {
+			_ = workerStore.MarkWorkerReportRead(context.Background(), report.ID)
+		}
+		m.pendingWorkerReport = &report
+		content := fmt.Sprintf("Kind: %s\nSource: %s\nOrigin: %s\n\n%s", report.Kind, session.ShortID(report.SourceSessionID), report.Origin, report.Body)
+		m.dialog.ShowContent(report.Title, content)
+		m.dialog.SetContentFooter("i import into coordinator as user · ↑/↓ scroll · esc close")
+		return m, nil
+	default:
+		return m.showFooterError("Unknown worker action.")
+	}
+}
+
+func (m *Model) importPendingWorkerReport() (tea.Model, tea.Cmd) {
+	if m.pendingWorkerReport == nil {
+		return m, nil
+	}
+	workerStore, ok := session.AsWorkerStore(m.store)
+	if !ok {
+		return m.showFooterError("Worker mailbox is unavailable.")
+	}
+	message, err := workerStore.ImportWorkerReport(m.rootContext(), m.pendingWorkerReport.ID)
+	if err != nil {
+		return m.showFooterError(fmt.Sprintf("Import worker report: %v", err))
+	}
+	m.pendingWorkerReport = nil
+	m.dialog.Close()
+	if m.sess != nil && message != nil && message.SessionID == m.sess.ID {
+		alreadyLoaded := false
+		for i := range m.messages {
+			alreadyLoaded = alreadyLoaded || m.messages[i].ID == message.ID
+		}
+		if !alreadyLoaded {
+			m.messages = append(m.messages, *message)
+			m.invalidateHistoryCache()
+		}
+	}
+	if m.workerUnreadReports > 0 {
+		m.workerUnreadReports--
+	}
+	return m.showFooterSuccess("Worker report imported as an attributed user message.")
+}

--- a/internal/tui/chat/workers_test.go
+++ b/internal/tui/chat/workers_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -337,4 +338,229 @@ func TestWorkerMailboxPollUpdatesBadgeWithoutChangingFocus(t *testing.T) {
 	if !strings.Contains(footer, "1 unread worker report") {
 		t.Fatalf("footer badge missing: %q", footer)
 	}
+}
+
+func newCompletedWorkerReportChat(t *testing.T, response string) (*Model, *session.SQLiteStore, session.WorkerEdge, *llm.MockProvider) {
+	t.Helper()
+	coordinatorModel, store, _ := newWorkerChatTest(t)
+	ctx := context.Background()
+	edge, err := store.CreateWorker(ctx, coordinatorModel.sess.ID, "verify the mailbox implementation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	persist := func(message llm.Message) {
+		t.Helper()
+		if err := store.AddMessage(ctx, edge.ChildSessionID, session.NewMessage(edge.ChildSessionID, message, -1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	persist(llm.UserText("inspect the mailbox code"))
+	persist(llm.AssistantText("The initial worker run found the durable edge."))
+	if err := store.FinishWorker(ctx, edge.ChildSessionID, session.WorkerDone, session.WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+		Title: "Background result", Body: "The original background run completed.", Origin: "terminal_synthesis",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	edge, err = store.GetWorker(ctx, edge.ChildSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Get(ctx, edge.ChildSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := llm.NewMockProvider("mock").AddTurn(llm.MockTurn{
+		Text:  response,
+		Usage: llm.Usage{InputTokens: 60, OutputTokens: 25, CachedInputTokens: 10},
+	})
+	worker := newCmdTestModel(store)
+	worker.sess = child
+	worker.provider = provider
+	worker.providerKey = "mock"
+	worker.modelName = "model"
+	worker.messages, err = store.GetMessages(ctx, child.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return worker, store, edge, provider
+}
+
+func runInteractiveReport(t *testing.T, model *Model) *Model {
+	t.Helper()
+	updated, cmd := model.ExecuteCommand("/report")
+	model = updated.(*Model)
+	if cmd == nil || !model.streaming || model.phase != "Preparing report" {
+		t.Fatalf("report preparation state: cmd=%v streaming=%v phase=%q", cmd != nil, model.streaming, model.phase)
+	}
+	batch := commandBatch(t, cmd)
+	if len(batch) != 3 {
+		t.Fatalf("report command batch len = %d, want helper + spinner + tick", len(batch))
+	}
+	msg := batch[0]()
+	done, ok := msg.(reportDoneMsg)
+	if !ok {
+		t.Fatalf("report command returned %T, want reportDoneMsg", msg)
+	}
+	updated, _ = model.Update(done)
+	return updated.(*Model)
+}
+
+func TestCompletedWorkerCanReportAfterInteractiveContinuation(t *testing.T) {
+	body := "## Outcome\nThe mailbox path is correct.\n\n## Verification\nFocused tests passed.\n\n## Caveats\nNo blockers remain."
+	m, store, edge, provider := newCompletedWorkerReportChat(t, body)
+	ctx := context.Background()
+	for _, message := range []llm.Message{
+		llm.UserText("Continue interactively and verify the final edge."),
+		llm.AssistantText("Interactive continuation confirmed the coordinator route."),
+	} {
+		stored := session.NewMessage(edge.ChildSessionID, message, -1)
+		if err := store.AddMessage(ctx, edge.ChildSessionID, stored); err != nil {
+			t.Fatal(err)
+		}
+		m.messages = append(m.messages, *stored)
+	}
+
+	m = runInteractiveReport(t, m)
+	if !strings.Contains(m.footerMessage, "sent to the coordinator mailbox") || m.sess.ID != edge.ChildSessionID || m.RequestedResumeSessionID() != "" || m.quitting {
+		t.Fatalf("report completion state: footer=%q session=%q resume=%q quitting=%v", m.footerMessage, m.sess.ID, m.RequestedResumeSessionID(), m.quitting)
+	}
+	reports, err := store.ListWorkerReports(ctx, edge.ChildSessionID)
+	if err != nil || len(reports) != 2 {
+		t.Fatalf("reports = %#v, %v", reports, err)
+	}
+	report := reports[1]
+	if report.Kind != session.WorkerReportResult || report.Origin != session.WorkerReportOriginInteractive || report.Body != body || !strings.Contains(report.Title, "verify the mailbox implementation") || report.DestinationSessionID != edge.CoordinatorSessionID {
+		t.Fatalf("interactive report = %#v", report)
+	}
+	coordinatorMessages, err := store.GetMessages(ctx, edge.CoordinatorSessionID, 0, 0)
+	if err != nil || len(coordinatorMessages) != 0 {
+		t.Fatalf("report entered coordinator transcript: %#v, %v", coordinatorMessages, err)
+	}
+	childMessages, err := store.GetMessages(ctx, edge.ChildSessionID, 0, 0)
+	if err != nil || len(childMessages) != 4 {
+		t.Fatalf("report changed child transcript: %#v, %v", childMessages, err)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider requests = %#v", provider.Requests)
+	}
+	requestText := fmt.Sprint(provider.Requests[0].Messages)
+	for _, want := range []string{"Continue interactively", "Interactive continuation confirmed", "outcome and current state", "250–600 words"} {
+		if !strings.Contains(requestText, want) {
+			t.Fatalf("report helper request missing %q: %s", want, requestText)
+		}
+	}
+	calls, _ := m.stats.UsageCalls()
+	if len(calls) != 1 || !calls[0].Handover || calls[0].Model != "model" {
+		t.Fatalf("report helper usage = %#v", calls)
+	}
+}
+
+func TestReportUsesOnlyActivePostCompactionContext(t *testing.T) {
+	m, store, edge, provider := newCompletedWorkerReportChat(t, "Active context report")
+	m.messages = []session.Message{
+		*session.NewMessage(edge.ChildSessionID, llm.UserText("hidden pre-compaction request"), 0),
+		*session.NewMessage(edge.ChildSessionID, llm.AssistantText("hidden pre-compaction result"), 1),
+		*session.NewMessage(edge.ChildSessionID, llm.UserText("active compacted summary"), 2),
+		*session.NewMessage(edge.ChildSessionID, llm.AssistantText("active post-compaction evidence"), 3),
+	}
+	m.compactionIdx = 2
+
+	m = runInteractiveReport(t, m)
+	if !strings.Contains(m.footerMessage, "sent") {
+		t.Fatalf("report footer = %q", m.footerMessage)
+	}
+	requestText := fmt.Sprint(provider.Requests[0].Messages)
+	if strings.Contains(requestText, "hidden pre-compaction") || !strings.Contains(requestText, "active compacted summary") || !strings.Contains(requestText, "active post-compaction evidence") {
+		t.Fatalf("post-compaction report context = %s", requestText)
+	}
+	reports, _ := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+	if len(reports) != 2 || reports[1].Body != "Active context report" {
+		t.Fatalf("reports = %#v", reports)
+	}
+}
+
+func TestReportRejectsArgumentsCoordinatorAndActiveWork(t *testing.T) {
+	m, store, edge, provider := newCompletedWorkerReportChat(t, "unused")
+	updated, cmd := m.ExecuteCommand("/report anything")
+	m = updated.(*Model)
+	if cmd == nil || m.footerMessage != "Usage: /report" {
+		t.Fatalf("argument rejection: cmd=%v footer=%q", cmd != nil, m.footerMessage)
+	}
+
+	coordinator, err := store.Get(context.Background(), edge.CoordinatorSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinatorModel := newCmdTestModel(store)
+	coordinatorModel.sess = coordinator
+	updated, _ = coordinatorModel.ExecuteCommand("/report")
+	if footer := updated.(*Model).footerMessage; !strings.Contains(footer, "only in a durable worker child") {
+		t.Fatalf("coordinator rejection = %q", footer)
+	}
+
+	for _, state := range []struct {
+		name  string
+		apply func(*Model)
+	}{
+		{name: "streaming", apply: func(m *Model) { m.streaming = true }},
+		{name: "transcript mutation", apply: func(m *Model) { m.transcriptMutationInFlight = true }},
+		{name: "handover helper", apply: func(m *Model) { m.pendingHandover = &handoverDoneMsg{} }},
+	} {
+		t.Run(state.name, func(t *testing.T) {
+			busy, _, _, busyProvider := newCompletedWorkerReportChat(t, "unused")
+			state.apply(busy)
+			updated, _ := busy.ExecuteCommand("/report")
+			busy = updated.(*Model)
+			if !strings.Contains(busy.footerMessage, "conversation work is active") || len(busyProvider.Requests) != 0 {
+				t.Fatalf("busy report: footer=%q requests=%#v", busy.footerMessage, busyProvider.Requests)
+			}
+		})
+	}
+	if len(provider.Requests) != 0 {
+		t.Fatalf("argument rejection invoked provider: %#v", provider.Requests)
+	}
+}
+
+type failingInteractiveReportStore struct {
+	*session.SQLiteStore
+	err error
+}
+
+func (s *failingInteractiveReportStore) AddWorkerReport(context.Context, session.WorkerReport) (session.WorkerReport, error) {
+	return session.WorkerReport{}, s.err
+}
+
+func TestReportGenerationAndStorageFailuresDoNotDeliver(t *testing.T) {
+	t.Run("generation", func(t *testing.T) {
+		m, store, edge, _ := newCompletedWorkerReportChat(t, "unused")
+		m.provider = llm.NewMockProvider("mock").AddError(errors.New("helper unavailable"))
+		m = runInteractiveReport(t, m)
+		if !strings.Contains(m.footerMessage, "Report preparation failed") || !strings.Contains(m.footerMessage, "helper unavailable") {
+			t.Fatalf("generation failure footer = %q", m.footerMessage)
+		}
+		reports, _ := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+		if len(reports) != 1 {
+			t.Fatalf("generation failure delivered report: %#v", reports)
+		}
+	})
+
+	t.Run("storage", func(t *testing.T) {
+		m, store, edge, _ := newCompletedWorkerReportChat(t, "Generated but not stored")
+		storageErr := errors.New("mailbox disk full")
+		m.store = &failingInteractiveReportStore{SQLiteStore: store, err: storageErr}
+		m = runInteractiveReport(t, m)
+		if !strings.Contains(m.footerMessage, "Report delivery failed") || !strings.Contains(m.footerMessage, storageErr.Error()) {
+			t.Fatalf("storage failure footer = %q", m.footerMessage)
+		}
+		reports, _ := store.ListWorkerReports(context.Background(), edge.ChildSessionID)
+		if len(reports) != 1 {
+			t.Fatalf("storage failure delivered report: %#v", reports)
+		}
+		calls, _ := m.stats.UsageCalls()
+		if len(calls) != 1 || !calls[0].Handover {
+			t.Fatalf("storage failure lost helper usage: %#v", calls)
+		}
+	})
 }

--- a/internal/tui/chat/workers_test.go
+++ b/internal/tui/chat/workers_test.go
@@ -18,6 +18,8 @@ type fakeWorkerController struct {
 	err      error
 }
 
+func (c *fakeWorkerController) OwnerID() string { return "owner-test" }
+
 func (c *fakeWorkerController) StartWorker(_ context.Context, req WorkerStartRequest) (WorkerStartResult, error) {
 	c.requests = append(c.requests, req)
 	if c.err != nil {
@@ -26,10 +28,12 @@ func (c *fakeWorkerController) StartWorker(_ context.Context, req WorkerStartReq
 	return WorkerStartResult{JobID: "job-1", RunID: "run-1"}, nil
 }
 
-func (c *fakeWorkerController) CancelWorker(_ context.Context, runID string) error {
-	c.cancel = append(c.cancel, runID)
+func (c *fakeWorkerController) CancelWorker(_ context.Context, req WorkerCancelRequest) error {
+	c.cancel = append(c.cancel, req.RunID)
 	return c.err
 }
+
+func (c *fakeWorkerController) ReconcileWorkers(context.Context, string) error { return c.err }
 
 func newWorkerChatTest(t *testing.T) (*Model, *session.SQLiteStore, *fakeWorkerController) {
 	t.Helper()
@@ -149,6 +153,132 @@ func TestTreeSupervisesWorkerReportsAndExplicitImportIsUser(t *testing.T) {
 
 func fmtInt64(value int64) string {
 	return fmt.Sprintf("%d", value)
+}
+
+func TestCompactedCoordinatorImportAppendsAfterBoundary(t *testing.T) {
+	m, store, _ := newWorkerChatTest(t)
+	ctx := context.Background()
+	if err := store.AddMessage(ctx, m.sess.ID, session.NewMessage(m.sess.ID, llm.UserText("old prompt"), -1)); err != nil {
+		t.Fatal(err)
+	}
+	summary := session.NewMessage(m.sess.ID, llm.UserText("[Context Compaction]\nsummary"), -1)
+	ack := session.NewMessage(m.sess.ID, llm.AssistantText("Compacted context loaded."), -1)
+	ack.CompactionTail = true
+	if err := store.CompactMessages(ctx, m.sess.ID, []session.Message{*summary, *ack}); err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err := store.Get(ctx, m.sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.sess = refreshed
+	m.messages, m.compactionIdx, err = loadSessionMessagesForScrollback(ctx, store, refreshed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeBoundary := m.sess.CompactionSeq
+
+	edge, err := store.CreateWorker(ctx, m.sess.ID, "compacted mailbox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := store.AddWorkerReport(ctx, session.WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+		Title: "Fresh result", Body: "post-compaction evidence",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.pendingWorkerReport = &report
+	updated, _ := m.importPendingWorkerReport()
+	m = updated.(*Model)
+	if len(m.messages) == 0 || !strings.Contains(m.messages[len(m.messages)-1].TextContent, report.Body) {
+		t.Fatalf("UI compacted transcript missing imported tail: %#v", m.messages)
+	}
+	after, err := store.Get(ctx, m.sess.ID)
+	if err != nil || after.CompactionSeq != beforeBoundary {
+		t.Fatalf("compaction boundary changed: before=%d after=%#v err=%v", beforeBoundary, after, err)
+	}
+	active, err := session.LoadActiveMessages(ctx, store, after)
+	if err != nil || len(active) == 0 || !strings.Contains(active[len(active)-1].TextContent, report.Body) {
+		t.Fatalf("active compacted context missing report: %#v, %v", active, err)
+	}
+}
+
+func TestThreadAndReportImportWaitForTranscriptMutationBoundary(t *testing.T) {
+	for _, state := range []struct {
+		name  string
+		apply func(*Model)
+	}{
+		{name: "streaming", apply: func(m *Model) { m.streaming = true }},
+		{name: "mutation", apply: func(m *Model) { m.transcriptMutationInFlight = true }},
+	} {
+		t.Run(state.name, func(t *testing.T) {
+			m, store, controller := newWorkerChatTest(t)
+			state.apply(m)
+			updated, _ := m.ExecuteCommand("/thread must wait")
+			m = updated.(*Model)
+			if len(controller.requests) != 0 {
+				t.Fatalf("busy /thread started worker: %#v", controller.requests)
+			}
+			workers, err := store.ListWorkers(context.Background(), m.sess.ID)
+			if err != nil || len(workers) != 0 {
+				t.Fatalf("busy /thread created edge: %#v, %v", workers, err)
+			}
+			if !strings.Contains(m.footerMessage, "conversation work is active") {
+				t.Fatalf("busy /thread footer = %q", m.footerMessage)
+			}
+
+			// Build a mailbox report without going through /thread, then verify the
+			// same boundary protects the transcript append and in-memory ordering.
+			edge, err := store.CreateWorker(context.Background(), m.sess.ID, "report fixture")
+			if err != nil {
+				t.Fatal(err)
+			}
+			report, err := store.AddWorkerReport(context.Background(), session.WorkerReport{
+				ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+				DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+				Title: "Deferred", Body: "Do not interleave me.",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			m.pendingWorkerReport = &report
+			before := len(m.messages)
+			updated, _ = m.importPendingWorkerReport()
+			m = updated.(*Model)
+			if m.pendingWorkerReport == nil || len(m.messages) != before {
+				t.Fatalf("busy import changed UI transcript: pending=%#v messages=%d", m.pendingWorkerReport, len(m.messages))
+			}
+			messages, err := store.GetMessages(context.Background(), m.sess.ID, 0, 0)
+			if err != nil || len(messages) != 0 {
+				t.Fatalf("busy import changed durable transcript: %#v, %v", messages, err)
+			}
+			if !strings.Contains(m.footerMessage, "Cannot import") {
+				t.Fatalf("busy import footer = %q", m.footerMessage)
+			}
+		})
+	}
+}
+
+func TestActiveWorkerAlwaysOffersSafeCancelOrReconcileAction(t *testing.T) {
+	m, store, _ := newWorkerChatTest(t)
+	edge, err := store.CreateWorker(context.Background(), m.sess.ID, "stale queued edge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, _ := m.openWorkerReports(edge.ChildSessionID)
+	m = updated.(*Model)
+	found := false
+	for _, item := range m.dialog.items {
+		if item.ID == "worker-cancel:"+edge.ChildSessionID {
+			found = strings.Contains(item.Label, "reconcile") && strings.Contains(item.Description, "stale")
+		}
+	}
+	if !found {
+		t.Fatalf("active edge without run has no safe action: %#v", m.dialog.items)
+	}
 }
 
 func TestMainReturnsWorkerToCoordinatorAndActiveChildIsReadOnly(t *testing.T) {

--- a/internal/tui/chat/workers_test.go
+++ b/internal/tui/chat/workers_test.go
@@ -1,0 +1,210 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type fakeWorkerController struct {
+	requests []WorkerStartRequest
+	cancel   []string
+	err      error
+}
+
+func (c *fakeWorkerController) StartWorker(_ context.Context, req WorkerStartRequest) (WorkerStartResult, error) {
+	c.requests = append(c.requests, req)
+	if c.err != nil {
+		return WorkerStartResult{}, c.err
+	}
+	return WorkerStartResult{JobID: "job-1", RunID: "run-1"}, nil
+}
+
+func (c *fakeWorkerController) CancelWorker(_ context.Context, runID string) error {
+	c.cancel = append(c.cancel, runID)
+	return c.err
+}
+
+func newWorkerChatTest(t *testing.T) (*Model, *session.SQLiteStore, *fakeWorkerController) {
+	t.Helper()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Now()
+	coordinator := &session.Session{
+		ID: "main", Provider: "mock", ProviderKey: "mock", Model: "model",
+		Mode: session.ModeChat, Origin: session.OriginTUI, ApprovalMode: session.ApprovalModePrompt,
+		CWD: t.TempDir(), CreatedAt: now, UpdatedAt: now, Status: session.StatusActive,
+	}
+	if err := store.Create(context.Background(), coordinator); err != nil {
+		t.Fatal(err)
+	}
+	m := newCmdTestModel(store)
+	m.sess = coordinator
+	m.providerKey = coordinator.ProviderKey
+	m.modelName = coordinator.Model
+	m.toolsStr = "read_file"
+	controller := &fakeWorkerController{}
+	m.SetWorkerController(controller)
+	return m, store, controller
+}
+
+func TestThreadStartsDurableWorkerWithoutMutatingCoordinatorTranscript(t *testing.T) {
+	m, store, controller := newWorkerChatTest(t)
+	updated, _ := m.ExecuteCommand("/thread inspect the harmless fixture")
+	m = updated.(*Model)
+	if len(controller.requests) != 1 || controller.requests[0].Task != "inspect the harmless fixture" || controller.requests[0].CoordinatorSessionID != m.sess.ID {
+		t.Fatalf("worker request = %#v", controller.requests)
+	}
+	workers, err := store.ListWorkers(context.Background(), m.sess.ID)
+	if err != nil || len(workers) != 1 || workers[0].RunID != "run-1" || workers[0].Status != session.WorkerQueued {
+		t.Fatalf("workers = %#v, %v", workers, err)
+	}
+	messages, err := store.GetMessages(context.Background(), m.sess.ID, 0, 0)
+	if err != nil || len(messages) != 0 {
+		t.Fatalf("thread command mutated coordinator transcript: %#v, %v", messages, err)
+	}
+	if !strings.Contains(m.footerMessage, "Worker started") || !strings.Contains(m.footerMessage, "/tree") {
+		t.Fatalf("thread footer = %q", m.footerMessage)
+	}
+}
+
+func TestThreadStartFailureLeavesTerminalMailboxResult(t *testing.T) {
+	m, store, controller := newWorkerChatTest(t)
+	controller.err = fmt.Errorf("runner unavailable")
+	updated, _ := m.ExecuteCommand("/thread harmless failure")
+	m = updated.(*Model)
+	workers, err := store.ListWorkers(context.Background(), m.sess.ID)
+	if err != nil || len(workers) != 1 || workers[0].Status != session.WorkerFailed {
+		t.Fatalf("failed worker = %#v, %v", workers, err)
+	}
+	reports, err := store.ListWorkerReports(context.Background(), workers[0].ChildSessionID)
+	if err != nil || len(reports) != 1 || reports[0].Kind != session.WorkerReportResult || reports[0].Origin != "terminal_synthesis" || !strings.Contains(reports[0].Body, controller.err.Error()) {
+		t.Fatalf("failure reports = %#v, %v", reports, err)
+	}
+	messages, err := store.GetMessages(context.Background(), m.sess.ID, 0, 0)
+	if err != nil || len(messages) != 0 {
+		t.Fatalf("start failure entered coordinator transcript: %#v, %v", messages, err)
+	}
+}
+
+func TestTreeSupervisesWorkerReportsAndExplicitImportIsUser(t *testing.T) {
+	m, store, controller := newWorkerChatTest(t)
+	updated, _ := m.ExecuteCommand("/thread summarize the fixture")
+	m = updated.(*Model)
+	workers, _ := store.ListWorkers(context.Background(), m.sess.ID)
+	edge := workers[0]
+	report, err := store.AddWorkerReport(context.Background(), session.WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportResult,
+		Title: "Fixture summary", Body: "The fixture is harmless.", Origin: "worker_tool",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, _ = m.cmdTree(nil)
+	m = updated.(*Model)
+	var workerID string
+	for _, item := range m.dialog.items {
+		if item.Category == "Workers" {
+			workerID = item.ID
+			if !strings.Contains(item.Description, "1 unread") || !strings.Contains(item.Label, "queued") {
+				t.Fatalf("worker tree item = %#v", item)
+			}
+		}
+	}
+	if workerID == "" {
+		t.Fatalf("tree has no Workers category: %#v", m.dialog.items)
+	}
+	m.dialog.Close()
+	updated, _ = m.handleBranchTreeSelection(workerID)
+	m = updated.(*Model)
+	if m.dialog.Type() != DialogWorkerReports {
+		t.Fatalf("worker selection dialog = %v", m.dialog.Type())
+	}
+	m.dialog.Close()
+	updated, _ = m.handleWorkerReportsSelection("worker-report:" + fmtInt64(report.ID))
+	m = updated.(*Model)
+	if m.dialog.Type() != DialogContent || !strings.Contains(m.dialog.Content(), report.Body) || m.pendingWorkerReport == nil {
+		t.Fatalf("report content dialog = type:%v content:%q pending:%#v", m.dialog.Type(), m.dialog.Content(), m.pendingWorkerReport)
+	}
+	updated, _ = m.importPendingWorkerReport()
+	m = updated.(*Model)
+	messages, err := store.GetMessages(context.Background(), edge.CoordinatorSessionID, 0, 0)
+	if err != nil || len(messages) != 1 || messages[0].Role != llm.RoleUser || !strings.Contains(messages[0].TextContent, "Imported worker report") {
+		t.Fatalf("imported transcript = %#v, %v", messages, err)
+	}
+	if len(controller.requests) != 1 {
+		t.Fatalf("import unexpectedly started another worker: %#v", controller.requests)
+	}
+}
+
+func fmtInt64(value int64) string {
+	return fmt.Sprintf("%d", value)
+}
+
+func TestMainReturnsWorkerToCoordinatorAndActiveChildIsReadOnly(t *testing.T) {
+	m, store, controller := newWorkerChatTest(t)
+	_, _ = m.ExecuteCommand("/thread observe only")
+	workers, _ := store.ListWorkers(context.Background(), m.sess.ID)
+	edge := workers[0]
+	if err := store.UpdateWorkerStatus(context.Background(), edge.ChildSessionID, session.WorkerRunning); err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Get(context.Background(), edge.ChildSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerModel := newCmdTestModel(store)
+	workerModel.sess = child
+	workerModel.SetWorkerController(controller)
+	updated, _ := workerModel.sendMessage("try to write")
+	workerModel = updated.(*Model)
+	if !strings.Contains(workerModel.footerMessage, "read-only") {
+		t.Fatalf("running child send footer = %q", workerModel.footerMessage)
+	}
+	updated, cmd := workerModel.cmdMain(nil)
+	workerModel = updated.(*Model)
+	if cmd == nil || workerModel.RequestedResumeSessionID() != edge.CoordinatorSessionID {
+		t.Fatalf("/main navigation = cmd:%v resume:%q", cmd != nil, workerModel.RequestedResumeSessionID())
+	}
+
+	updated, _ = m.cmdMain(nil)
+	m = updated.(*Model)
+	if !strings.Contains(m.footerMessage, "Already") {
+		t.Fatalf("coordinator /main footer = %q", m.footerMessage)
+	}
+}
+
+func TestWorkerMailboxPollUpdatesBadgeWithoutChangingFocus(t *testing.T) {
+	m, store, _ := newWorkerChatTest(t)
+	m.textarea.Focus()
+	m.setTextareaValue("draft")
+	edge, _ := store.CreateWorker(context.Background(), m.sess.ID, "poll")
+	_, _ = store.AddWorkerReport(context.Background(), session.WorkerReport{
+		ChildSessionID: edge.ChildSessionID, SourceSessionID: edge.ChildSessionID,
+		DestinationSessionID: edge.CoordinatorSessionID, Kind: session.WorkerReportProgress,
+		Title: "Update", Body: "Still working.",
+	})
+	cmd := m.workerMailboxPollCmd()
+	if cmd == nil {
+		t.Fatal("mailbox poll command missing")
+	}
+	msg := cmd().(workerMailboxPollMsg)
+	_ = m.handleWorkerMailboxPoll(msg)
+	if m.workerUnreadReports != 1 || m.textarea.Value() != "draft" || !m.textarea.Focused() {
+		t.Fatalf("poll state = unread:%d draft:%q focused:%v", m.workerUnreadReports, m.textarea.Value(), m.textarea.Focused())
+	}
+	footer := m.buildFooterLayout().view
+	if !strings.Contains(footer, "1 unread worker report") {
+		t.Fatalf("footer badge missing: %q", footer)
+	}
+}


### PR DESCRIPTION
## Summary

Add durable concurrent worker threads to interactive chat, with an explicit mailbox boundary between worker output and coordinator context.

- `/thread TASK` starts a background worker attached to the current coordinator session
- `/tree` shows worker state and unread reports, and supports opening, cancelling/reconciling, previewing, and importing results
- `/main` returns from a worker session to its coordinator
- worker-only `report` tool emits structured `progress`, `result`, and `blocker` events
- reports remain control-plane state until explicitly imported as attributed user content
- terminal completion synthesizes a result when the worker does not emit one

## Architecture

Worker relationships and reports use dedicated session-domain tables rather than overloading conversation-fork edges:

- `session_workers` stores coordinator/child relationships and durable lifecycle state
- `session_worker_reports` stores immutable report content plus read/import metadata
- worker transcripts remain single-writer
- report bodies never receive developer/system authority

Worker execution reuses jobs-v2, with additional safety for interactive ownership:

- dedicated `thread_jobs_v2.db` isolates worker runs from ordinary and older jobs daemons
- per-run ownership leases prevent one live chat from claiming or cancelling another chat's workers
- expired ownership is reconciled without retrying side-effecting active runs
- worker approval is resolved from the durable coordinator and cannot exceed it
- every terminal path produces exactly one terminal mailbox result

The MVP deliberately keeps a flat coordinator/worker topology and does not auto-merge worktrees or steer active workers.

## Safety and recovery

- blocks report import and `/thread` creation during active transcript mutation/streaming
- reconciles stale queued/running/cancel-requested worker edges
- provides `Cancel or reconcile worker` even when startup failed before a run ID was saved
- prevents simultaneous active workers sharing a coordinator or canonicalized workspace
- keeps reports outside model context until explicit user import
- imports remain valid across compaction boundaries

## Validation

Passed:

- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go test -race ./internal/session -run 'WorkerConcurrentTerminal|WorkerPreventsConflicting'`
- `go test -race ./cmd -run 'ChatWorkerReconcile|ExpiredCancelRecovery|WorkerLoopRevisits|TwoThreadManagers'`
- `git diff --check`

Also exercised end-to-end in a virtual TTY with `chatgpt:gpt-5.6-luna`:

1. spawned a worker with `/thread`
2. observed the unread mailbox notification
3. previewed and imported its result through `/tree`
4. opened the child session and returned with `/main`
5. confirmed the coordinator model could use the imported result

## Scope

29 files, approximately `+3914/-98`. Much of the size is migrations, durable lifecycle/reconciliation, jobs ownership safety, and focused regression tests; the user-facing command surface is intentionally small.


## Interactive follow-up reporting

A resumed, completed worker can now be continued as a normal interactive session and then publish a fresh mailbox briefing with bare `/report`.

- `/report` reuses the control-plane briefing generation machinery extracted from `/handover`
- it summarizes the active post-compaction child context, including interactive follow-up turns
- it writes an immutable `result` report with `origin=interactive_report`
- it remains in the child; `/main` remains navigation only
- it never creates a normal turn or enters the coordinator context automatically
- handover-specific scripts, confirmation, target-session creation, and switching remain separate

Live virtual-TTY validation with `chatgpt:gpt-5.6-luna` covered:

1. spawn with `/thread`
2. open the completed worker
3. continue it interactively with an independent verification request
4. run bare `/report`
5. return through `/main`
6. preview/import the new interactive report
7. confirm the coordinator can answer from the imported briefing

