### PR TITLE
fix: Idle runtime cleanup can permanently wedge the session janitor

### DIFF
--- a/cmd/serve_session.go
+++ b/cmd/serve_session.go
@@ -7,11 +7,14 @@ import (
 	"time"
 )
 
+const defaultServeSessionRetirementTimeout = 2 * time.Second
+
 type serveSessionManager struct {
-	ttl     time.Duration
-	max     int
-	factory func(context.Context) (*serveRuntime, error)
-	onEvict func(rt *serveRuntime) // called when a session is evicted
+	ttl               time.Duration
+	max               int
+	factory           func(context.Context) (*serveRuntime, error)
+	onEvict           func(rt *serveRuntime) // called when a session is evicted
+	retirementTimeout time.Duration
 
 	mu       sync.Mutex
 	sessions map[string]*serveRuntime
@@ -28,12 +31,13 @@ type sessionCreateInFlight struct {
 
 func newServeSessionManager(ttl time.Duration, max int, factory func(context.Context) (*serveRuntime, error)) *serveSessionManager {
 	m := &serveSessionManager{
-		ttl:      ttl,
-		max:      max,
-		factory:  factory,
-		sessions: make(map[string]*serveRuntime),
-		creating: make(map[string]*sessionCreateInFlight),
-		stopCh:   make(chan struct{}),
+		ttl:               ttl,
+		max:               max,
+		factory:           factory,
+		retirementTimeout: defaultServeSessionRetirementTimeout,
+		sessions:          make(map[string]*serveRuntime),
+		creating:          make(map[string]*sessionCreateInFlight),
+		stopCh:            make(chan struct{}),
 	}
 	go m.janitor()
 	return m
@@ -66,11 +70,24 @@ func (m *serveSessionManager) evictExpired() {
 	m.mu.Unlock()
 
 	for _, rt := range stale {
-		if m.onEvict != nil {
-			m.onEvict(rt)
-		}
-		rt.Close()
+		m.retireRuntime(rt)
 	}
+}
+
+func (m *serveSessionManager) retireRuntime(rt *serveRuntime) {
+	if rt == nil {
+		return
+	}
+	if m.onEvict != nil {
+		m.onEvict(rt)
+	}
+	timeout := m.retirementTimeout
+	if timeout <= 0 {
+		timeout = defaultServeSessionRetirementTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	rt.CloseContext(ctx)
 }
 
 func (m *serveSessionManager) evictOldestIdleLocked() *serveRuntime {
@@ -186,12 +203,7 @@ func (m *serveSessionManager) GetOrCreate(ctx context.Context, id string) (*serv
 	if duplicate != nil {
 		duplicate.Close()
 	}
-	if evicted != nil {
-		if m.onEvict != nil {
-			m.onEvict(evicted)
-		}
-		evicted.Close()
-	}
+	m.retireRuntime(evicted)
 	if inflight.err != nil {
 		if rt != nil && inflight.rt == nil {
 			rt.Close()
@@ -270,12 +282,7 @@ func (m *serveSessionManager) GetOrCreateWith(ctx context.Context, id string, cr
 	if duplicate != nil {
 		duplicate.Close()
 	}
-	if evicted != nil {
-		if m.onEvict != nil {
-			m.onEvict(evicted)
-		}
-		evicted.Close()
-	}
+	m.retireRuntime(evicted)
 	if inflight.err != nil {
 		if rt != nil && inflight.rt == nil {
 			rt.Close()
@@ -379,18 +386,8 @@ func (m *serveSessionManager) ReplaceIdleWith(ctx context.Context, id string, sh
 	if duplicate != nil {
 		duplicate.Close()
 	}
-	if retired != nil {
-		if m.onEvict != nil {
-			m.onEvict(retired)
-		}
-		retired.Close()
-	}
-	if evicted != nil {
-		if m.onEvict != nil {
-			m.onEvict(evicted)
-		}
-		evicted.Close()
-	}
+	m.retireRuntime(retired)
+	m.retireRuntime(evicted)
 	if inflight.err != nil {
 		if rt != nil && inflight.rt == nil {
 			rt.Close()
@@ -472,12 +469,7 @@ func (m *serveSessionManager) BeginSwap(ctx context.Context, id string, create f
 		if closeCandidate != nil {
 			closeCandidate.Close()
 		}
-		if evicted != nil {
-			if m.onEvict != nil {
-				m.onEvict(evicted)
-			}
-			evicted.Close()
-		}
+		m.retireRuntime(evicted)
 		if inflight.err != nil {
 			if rt != nil && closeCandidate == nil && inflight.rt == nil {
 				rt.Close()
@@ -501,10 +493,7 @@ func (m *serveSessionManager) BeginSwap(ctx context.Context, id string, create f
 				}
 				m.mu.Unlock()
 				if previous != nil && previous != candidate {
-					if m.onEvict != nil {
-						m.onEvict(previous)
-					}
-					previous.Close()
+					m.retireRuntime(previous)
 				}
 			})
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1927,6 +1927,40 @@ func TestServeAuthMiddleware(t *testing.T) {
 	}
 }
 
+type serveSessionBlockingCleanupProvider struct {
+	started     chan struct{}
+	release     chan struct{}
+	done        chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+	doneOnce    sync.Once
+}
+
+func newServeSessionBlockingCleanupProvider() *serveSessionBlockingCleanupProvider {
+	return &serveSessionBlockingCleanupProvider{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+func (p *serveSessionBlockingCleanupProvider) Name() string       { return "blocking-cleanup" }
+func (p *serveSessionBlockingCleanupProvider) Credential() string { return "test" }
+func (p *serveSessionBlockingCleanupProvider) Capabilities() llm.Capabilities {
+	return llm.Capabilities{}
+}
+func (p *serveSessionBlockingCleanupProvider) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	return nil, errors.New("not used")
+}
+func (p *serveSessionBlockingCleanupProvider) CleanupMCP() {
+	p.startedOnce.Do(func() { close(p.started) })
+	<-p.release
+	p.doneOnce.Do(func() { close(p.done) })
+}
+func (p *serveSessionBlockingCleanupProvider) unblock() {
+	p.releaseOnce.Do(func() { close(p.release) })
+}
+
 func TestServeSessionManager_GetOrCreateSingleFactoryCall(t *testing.T) {
 	var calls int32
 	manager := newServeSessionManager(time.Minute, 10, func(ctx context.Context) (*serveRuntime, error) {
@@ -2030,6 +2064,62 @@ func TestServeSessionManager_EvictExpiredSkipsActiveRun(t *testing.T) {
 	}
 	if got := evictions.Load(); got != 1 {
 		t.Fatalf("evictions after inactive session sweep = %d, want 1", got)
+	}
+}
+
+func TestServeSessionManager_EvictExpiredBoundsBlockingCleanup(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 10, nil)
+	manager.retirementTimeout = 50 * time.Millisecond
+	defer manager.Close()
+
+	provider := newServeSessionBlockingCleanupProvider()
+	t.Cleanup(func() {
+		provider.unblock()
+		select {
+		case <-provider.done:
+		case <-time.After(time.Second):
+			t.Error("blocking cleanup did not finish after release")
+		}
+	})
+	blocked := &serveRuntime{provider: provider}
+	blocked.lastUsedUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	manager.mu.Lock()
+	manager.sessions["blocked"] = blocked
+	manager.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		manager.evictExpired()
+		close(done)
+	}()
+
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("blocking cleanup did not start")
+	}
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expired-session eviction remained blocked in provider cleanup")
+	}
+
+	followup, followupProvider := newCloseTrackingServeRuntime()
+	followup.lastUsedUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+	manager.mu.Lock()
+	manager.sessions["followup"] = followup
+	manager.mu.Unlock()
+
+	manager.evictExpired()
+	if !followupProvider.closed.Load() {
+		t.Fatal("subsequent expired runtime was not cleaned up")
+	}
+	manager.mu.Lock()
+	_, exists := manager.sessions["followup"]
+	manager.mu.Unlock()
+	if exists {
+		t.Fatal("subsequent expired runtime was not evicted")
 	}
 }
 
@@ -2149,6 +2239,57 @@ func TestServeSessionManager_GetOrCreateSkipsEvictingActiveRunAtCapacity(t *test
 	case <-busyCtx.Done():
 		t.Fatal("expected active session not to be cancelled during capacity eviction")
 	default:
+	}
+}
+
+func TestServeSessionManager_GetOrCreateBoundsCapacityCleanup(t *testing.T) {
+	created := &serveRuntime{}
+	manager := newServeSessionManager(time.Minute, 1, func(context.Context) (*serveRuntime, error) {
+		return created, nil
+	})
+	manager.retirementTimeout = 50 * time.Millisecond
+	defer manager.Close()
+
+	provider := newServeSessionBlockingCleanupProvider()
+	t.Cleanup(func() {
+		provider.unblock()
+		select {
+		case <-provider.done:
+		case <-time.After(time.Second):
+			t.Error("blocking cleanup did not finish after release")
+		}
+	})
+	idle := &serveRuntime{provider: provider}
+	idle.lastUsedUnixNano.Store(time.Now().Add(-time.Hour).UnixNano())
+	manager.mu.Lock()
+	manager.sessions["idle"] = idle
+	manager.mu.Unlock()
+
+	type result struct {
+		rt  *serveRuntime
+		err error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		rt, err := manager.GetOrCreate(context.Background(), "new")
+		resultCh <- result{rt: rt, err: err}
+	}()
+
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("capacity cleanup did not start")
+	}
+	select {
+	case got := <-resultCh:
+		if got.err != nil {
+			t.Fatalf("GetOrCreate error: %v", got.err)
+		}
+		if got.rt != created {
+			t.Fatalf("GetOrCreate runtime = %p, want %p", got.rt, created)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("GetOrCreate remained blocked in evicted runtime cleanup")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a two-second bounded retirement path for session runtimes.
- Kept `onEvict` synchronous, then used `serveRuntime.CloseContext` so a stalled MCP `session.Close` or provider `CleanupMCP` can continue only in the runtime's isolated cleanup goroutine instead of blocking the caller forever.
- Routed TTL eviction, capacity eviction, and other manager-owned idle-runtime retirement paths through the same helper.
- Added regression coverage with a fake provider whose cleanup blocks, including both janitor progress and capacity replacement.

## Why this is high-value

Jarvis's long-running web service exercises session retirement every day. Previously, one third-party cleanup hook that never returned could permanently stop the sole TTL janitor. The same failure at the 1000-session capacity boundary could also hang the request opening a replacement session. Bounding retirement keeps reclamation and new-session requests moving while preserving eviction callbacks and eventual cleanup behavior.

## Validation

- `go build ./...`
- `go test ./cmd -run 'TestServeSessionManager_(EvictExpiredBoundsBlockingCleanup|GetOrCreateBoundsCapacityCleanup)$' -count=10`
- `go test -race ./cmd -run 'TestServeSessionManager_(EvictExpiredBoundsBlockingCleanup|GetOrCreateBoundsCapacityCleanup)$' -count=1`
- `XDG_CONFIG_HOME=<empty temp dir> go test ./...`

The initial unisolated `go test ./...` run hit two unrelated existing `cmd` test failures because Jarvis's real user skill catalogue exhausted those tests' visible-skill limits and hid their project fixtures. Re-running the full suite with an empty temporary `XDG_CONFIG_HOME` passed.
