### PR TITLE
fix: An oversized CLI diagnostic line can deadlock provider streaming

### DIFF
--- a/internal/llm/agy_bin.go
+++ b/internal/llm/agy_bin.go
@@ -481,15 +481,13 @@ func (p *AgyBinProvider) runCommand(ctx context.Context, args []string, prompt, 
 	}()
 	go func() {
 		defer close(stderrDone)
-		sc := bufio.NewScanner(stderr)
-		sc.Buffer(make([]byte, 64<<10), 1<<20)
-		for sc.Scan() {
-			line := redact(sc.Text())
+		_ = drainCLIDiagnosticLines(stderr, func(rawLine string) {
+			line := redact(rawLine)
 			if debug {
 				fmt.Fprintf(os.Stderr, "[agy stderr] %s\n", line)
 			}
 			recordCLITailLine(&stderrMu, &stderrTail, line, agyStderrTailMaxLines)
-		}
+		})
 	}()
 	bridge := &cliTurnBridge{toolReqCh: make(chan cliToolRequest, 64), done: make(chan struct{})}
 	if exposeBridge {
@@ -508,6 +506,9 @@ func (p *AgyBinProvider) runCommand(ctx context.Context, args []string, prompt, 
 		cancel()
 	}
 	scanErr := <-scanErrCh
+	if scanErr != nil {
+		cancel()
+	}
 	<-stderrDone
 	waitErr := cmd.Wait()
 	if dispatchErr != nil {

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -772,15 +772,12 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
-		stderrScanner := bufio.NewScanner(stderr)
-		stderrScanner.Buffer(make([]byte, 64*1024), 1024*1024)
-		for stderrScanner.Scan() {
-			line := stderrScanner.Text()
+		_ = drainCLIDiagnosticLines(stderr, func(line string) {
 			if debug {
 				fmt.Fprintf(os.Stderr, "[claude stderr] %s\n", line)
 			}
 			recordCLITailLine(&stderrMu, &stderrTail, line, claudeStderrTailMaxLines)
-		}
+		})
 	}()
 
 	// Write prompt to stdin and close
@@ -838,6 +835,15 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 	// Wait for scanner to finish BEFORE cmd.Wait().
 	// Go docs: "It is incorrect to call Wait before all reads from the pipe have completed."
 	scanErr := <-scanErrCh
+	if scanErr != nil {
+		// A framing error stops the stdout reader. Kill the process before its
+		// unread output fills the pipe and makes Wait block forever.
+		if cmd.Cancel != nil {
+			_ = cmd.Cancel()
+		} else if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	}
 
 	// Now safe to call Wait() — all pipe reads are done.
 	cmdErr := cmd.Wait()

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -187,6 +187,61 @@ func TestClaudeBinProvider_prepareClaudeCommand_ConfiguresProcessGroupWaitDelayA
 	}
 }
 
+func TestClaudeBinProvider_OversizedStderrLineDoesNotBlock(t *testing.T) {
+	err := runFakeClaudeCommand(t, `#!/bin/sh
+cat >/dev/null
+head -c 3145728 /dev/zero | tr '\000' x >&2
+printf '%s\n' '{"type":"system","session_id":"test-session","model":"sonnet","tools":[]}'
+printf '%s\n' '{"type":"result","is_error":false,"result":"ok","usage":{"input_tokens":1,"output_tokens":1,"cache_read_input_tokens":0}}'
+`)
+	if err != nil {
+		t.Fatalf("runClaudeCommand: %v", err)
+	}
+}
+
+func TestClaudeBinProvider_OversizedStdoutRecordCancelsProcess(t *testing.T) {
+	err := runFakeClaudeCommand(t, `#!/bin/sh
+cat >/dev/null
+head -c 12582912 /dev/zero | tr '\000' x
+`)
+	if err == nil || !strings.Contains(err.Error(), "reading claude output") {
+		t.Fatalf("runClaudeCommand error = %v, want stdout read error", err)
+	}
+}
+
+func runFakeClaudeCommand(t *testing.T, script string) error {
+	t.Helper()
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resultCh := make(chan error, 1)
+	go func() {
+		provider := NewClaudeBinProvider("sonnet", nil)
+		resultCh <- provider.runClaudeCommand(ctx, nil, "", "prompt", "", false, eventSender{
+			ctx: ctx,
+			ch:  make(chan Event, 8),
+		}, true, false)
+	}()
+
+	select {
+	case err := <-resultCh:
+		return err
+	case <-time.After(5 * time.Second):
+		cancel()
+		select {
+		case <-resultCh:
+		case <-time.After(3 * time.Second):
+		}
+		t.Fatal("fake Claude command remained blocked on an oversized pipe record")
+		return nil
+	}
+}
+
 func TestClaudeBinProvider_StreamUsesWorkingDir(t *testing.T) {
 	binDir := t.TempDir()
 	cwdFile := filepath.Join(t.TempDir(), "cwd.txt")

--- a/internal/llm/cli_bin_shared.go
+++ b/internal/llm/cli_bin_shared.go
@@ -1,10 +1,12 @@
 package llm
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -17,7 +19,10 @@ import (
 	"github.com/samsaffron/term-llm/internal/mcphttp"
 )
 
-const cliDiagnosticLineMaxBytes = 4 * 1024
+const (
+	cliDiagnosticLineMaxBytes     = 4 * 1024
+	cliDiagnosticLineReadMaxBytes = 1024 * 1024
+)
 
 // mcpCallCounter generates process-unique IDs for CLI-provider MCP tool calls.
 var mcpCallCounter atomic.Int64
@@ -537,6 +542,66 @@ func firstUsefulCLIDiagnosticLine(text string) string {
 		return truncateOneLine(line, 240)
 	}
 	return ""
+}
+
+func drainCLIDiagnosticLines(r io.Reader, handle func(string)) error {
+	reader := bufio.NewReaderSize(r, 64*1024)
+	line := make([]byte, 0, 64*1024)
+	var lineBytes int64
+	oversized := false
+
+	emit := func() {
+		if oversized {
+			handle(fmt.Sprintf("[oversized diagnostic line omitted: %d bytes]", lineBytes))
+		} else {
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
+			handle(string(line))
+		}
+		line = line[:0]
+		lineBytes = 0
+		oversized = false
+	}
+
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		terminated := len(fragment) > 0 && fragment[len(fragment)-1] == '\n'
+		if terminated {
+			fragment = fragment[:len(fragment)-1]
+		}
+		lineBytes += int64(len(fragment))
+		if !oversized {
+			if lineBytes <= cliDiagnosticLineReadMaxBytes {
+				line = append(line, fragment...)
+			} else {
+				// Do not retain a partial oversized diagnostic: it could be a
+				// prefix of a prompt or credential that redaction expects whole.
+				line = line[:0]
+				oversized = true
+			}
+		}
+		if terminated {
+			emit()
+		}
+
+		switch err {
+		case nil:
+			continue
+		case bufio.ErrBufferFull:
+			continue
+		case io.EOF:
+			if !terminated && lineBytes > 0 {
+				emit()
+			}
+			return nil
+		default:
+			if !terminated && lineBytes > 0 {
+				emit()
+			}
+			return err
+		}
+	}
 }
 
 func recordCLITailLine(mu *sync.Mutex, tail *[]string, line string, maxLines int) {

--- a/internal/llm/cli_bin_shared_test.go
+++ b/internal/llm/cli_bin_shared_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bytes"
 	"context"
 	"go/ast"
 	"go/parser"
@@ -76,6 +77,29 @@ func TestNewCLICommandAppliesWorkingDirectoryPolicy(t *testing.T) {
 				t.Fatalf("Dir = %q, want %q", cmd.Dir, tt.want)
 			}
 		})
+	}
+}
+
+func TestDrainCLIDiagnosticLinesDrainsOversizedLineAndUnterminatedTail(t *testing.T) {
+	oversizedBytes := cliDiagnosticLineReadMaxBytes + 2*1024*1024
+	input := bytes.NewReader(append(bytes.Repeat([]byte("x"), oversizedBytes), []byte("\nshort\r\nfinal")...))
+	var lines []string
+	if err := drainCLIDiagnosticLines(input, func(line string) {
+		lines = append(lines, line)
+	}); err != nil {
+		t.Fatalf("drainCLIDiagnosticLines: %v", err)
+	}
+	if input.Len() != 0 {
+		t.Fatalf("reader has %d bytes left; diagnostics were not fully drained", input.Len())
+	}
+	if len(lines) != 3 {
+		t.Fatalf("lines = %#v, want oversized marker plus two lines", lines)
+	}
+	if !strings.Contains(lines[0], "oversized diagnostic line omitted") || strings.Contains(lines[0], "x") {
+		t.Fatalf("oversized line marker = %q", lines[0])
+	}
+	if lines[1] != "short" || lines[2] != "final" {
+		t.Fatalf("remaining lines = %#v, want [short final]", lines[1:])
 	}
 }
 

--- a/internal/llm/cursor_bin.go
+++ b/internal/llm/cursor_bin.go
@@ -438,15 +438,13 @@ func (p *CursorBinProvider) runCursorCommand(ctx context.Context, args []string,
 	}()
 	go func() {
 		defer close(stderrDone)
-		scanner := bufio.NewScanner(stderr)
-		scanner.Buffer(make([]byte, 64<<10), 1<<20)
-		for scanner.Scan() {
-			line := redactDiagnostic(scanner.Text())
+		_ = drainCLIDiagnosticLines(stderr, func(rawLine string) {
+			line := redactDiagnostic(rawLine)
 			if debug {
 				fmt.Fprintf(os.Stderr, "[cursor stderr] %s\n", line)
 			}
 			recordCLITailLine(&stderrMu, &stderrTail, line, cursorStderrTailMaxLines)
-		}
+		})
 	}()
 
 	bridge := &cliTurnBridge{toolReqCh: make(chan cliToolRequest, 64), done: make(chan struct{})}
@@ -462,6 +460,9 @@ func (p *CursorBinProvider) runCursorCommand(ctx context.Context, args []string,
 		cancel()
 	}
 	scanErr := <-scanErrCh
+	if scanErr != nil {
+		cancel()
+	}
 	waitErr := cmd.Wait()
 	<-stderrDone
 	if dispatchErr != nil {

--- a/internal/llm/grok_acp.go
+++ b/internal/llm/grok_acp.go
@@ -1,7 +1,6 @@
 package llm
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -740,15 +739,13 @@ func (p *GrokBinProvider) startGrokACPProcess(ctx context.Context, req Request, 
 	redactDiagnostic := p.grokACPDiagnosticRedactor(req.Messages, cmd.Env)
 	go func() {
 		defer close(process.stderrDone)
-		scanner := bufio.NewScanner(stderr)
-		scanner.Buffer(make([]byte, 64<<10), 1<<20)
-		for scanner.Scan() {
-			line := redactDiagnostic(scanner.Text())
+		_ = drainCLIDiagnosticLines(stderr, func(rawLine string) {
+			line := redactDiagnostic(rawLine)
 			if debug {
 				fmt.Fprintf(os.Stderr, "[grok stderr] %s\n", line)
 			}
 			recordCLITailLine(&process.stderrMu, &process.stderrTail, line, grokStderrTailMaxLines)
-		}
+		})
 	}()
 	go func() {
 		process.waitErr = cmd.Wait()

--- a/internal/llm/grok_bin.go
+++ b/internal/llm/grok_bin.go
@@ -607,15 +607,12 @@ func (p *GrokBinProvider) runGrokCommand(
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
-		scanner := bufio.NewScanner(stderr)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			line := scanner.Text()
+		_ = drainCLIDiagnosticLines(stderr, func(line string) {
 			if debug {
 				fmt.Fprintf(os.Stderr, "[grok stderr] %s\n", redactGrokSystemPrompt(line, systemPrompt))
 			}
 			recordCLITailLine(&stderrMu, &stderrTail, line, grokStderrTailMaxLines)
-		}
+		})
 	}()
 
 	lineCh := make(chan string, 256)
@@ -657,6 +654,13 @@ func (p *GrokBinProvider) runGrokCommand(
 		}
 	}
 	scanErr := <-scanErrCh
+	if scanErr != nil {
+		if cmd.Cancel != nil {
+			_ = cmd.Cancel()
+		} else if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	}
 	cmdErr := cmd.Wait()
 	<-stderrDone
 


### PR DESCRIPTION
## What changed

- Replaced the 1 MiB-limited stderr scanners used by Claude, Grok, Cursor, Agy, and Grok ACP with a shared bounded line reader that continues draining oversized records.
- Keeps diagnostic memory bounded at 1 MiB per line and records an omission marker instead of retaining a partial oversized line that could bypass whole-value redaction.
- Cancels CLI subprocesses when their stdout framing scanner fails, so unread stdout cannot fill the pipe while the caller waits for process exit.
- Added fake-Claude regression coverage for both a 3 MiB unterminated stderr line and an oversized unterminated stdout record, plus direct coverage of bounded diagnostic draining.

## Why this is high-value

Jarvis uses these CLI providers on ordinary web, Telegram, and terminal turns, which do not necessarily have deadlines. Previously, one large provider diagnostic could stop the stderr scanner, fill the OS pipe, and leave the provider turn blocked forever with no final error or completion event. The same pipe-deadlock pattern existed across multiple CLI providers, so a shared draining reader removes a catastrophic stuck-turn failure from heavily used paths while preserving bounded diagnostics.

## Validation

- `gofmt -w` on all changed Go files
- `go build ./...` — passed
- `go test ./internal/llm -run 'TestDrainCLIDiagnosticLines|TestClaudeBinProvider_Oversized' -count=1` — passed
- `go test -race ./internal/llm -run 'TestDrainCLIDiagnosticLines|TestClaudeBinProvider_Oversized' -count=1` — passed
- `go test ./...` — all packages passed except two unrelated `cmd` tests (`TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`). They fail reproducibly in isolation because this host exposes 31 globally configured skills while the tests' metadata limits show only 8/10, omitting their temporary fixture skill; no `cmd` or skill-discovery code is changed here.
- `git diff --check` — passed
