### PR TITLE
fix(grok): do not abort ACP turns on leaked native tools

### DIFF
--- a/internal/llm/grok_acp.go
+++ b/internal/llm/grok_acp.go
@@ -147,7 +147,15 @@ func (h *grokACPHandler) HandleNotification(_ context.Context, method string, pa
 		return
 	}
 	if toolName != "" && !grokACPToolAllowed(toolName, turn.nativeSearch) {
-		turn.err = fmt.Errorf("Grok ACP restricted profile attempted native tool %q", toolName)
+		// Grok still proposes native builtins (grep, todo_write, read_file, …)
+		// even with --disallowed-tools and the restricted profile. Those calls
+		// are not executed: permission requests are cancelled, and the MCP
+		// bridge is the only EventToolCall source. Failing the turn made
+		// grok-bin unusable because one leaked builtin aborted later MCP
+		// text and tool events. Ignore the leak and keep the turn alive.
+		if update.SessionUpdate == "tool_call" {
+			turn.reasoningItem++
+		}
 		h.mu.Unlock()
 		return
 	}
@@ -306,9 +314,9 @@ func (h *grokACPHandler) waitToolBarrier(ctx context.Context, timeout time.Durat
 
 func (h *grokACPHandler) HandleRequest(_ context.Context, method string, params json.RawMessage) (any, *acp.RPCError) {
 	if method == "session/request_permission" {
-		// The restricted Grok profile should never need native-tool approval.
-		// Cancel unexpected requests rather than granting access outside the
-		// term-llm tool registry.
+		// Cancel native-tool approval rather than granting access outside the
+		// term-llm tool registry. The matching tool_call is ignored, not a
+		// turn-ending error, so the model can continue via MCP.
 		return map[string]any{"outcome": map[string]any{"outcome": "cancelled"}}, nil
 	}
 	return nil, acp.MethodNotFound(method)

--- a/internal/llm/grok_acp_test.go
+++ b/internal/llm/grok_acp_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -159,23 +160,33 @@ func TestGrokACPHandlerSeparatesThoughtsAcrossHiddenToolCall(t *testing.T) {
 	}
 }
 
-func TestGrokACPHandlerRejectsNativeToolLeak(t *testing.T) {
+func TestGrokACPHandlerIgnoresNativeToolLeak(t *testing.T) {
+	events := make(chan Event, 2)
 	handler := &grokACPHandler{}
-	handler.beginTurn(eventSender{}, false, false)
+	handler.beginTurn(eventSender{ctx: context.Background(), ch: events}, false, false)
 	defer handler.endTurn()
-	handler.HandleNotification(context.Background(), "session/update", json.RawMessage(`{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"native-1","title":"Read file","_meta":{"x.ai/tool":{"name":"read_file"}}}}`))
-	if err := handler.turnError(); err == nil || !strings.Contains(err.Error(), "native tool") {
-		t.Fatalf("native tool error = %v", err)
+
+	for _, name := range []string{"read_file", "grep", "todo_write"} {
+		handler.HandleNotification(context.Background(), "session/update", json.RawMessage(fmt.Sprintf(`{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"native-%s","title":%q,"_meta":{"x.ai/tool":{"name":%q}}}}`, name, name, name)))
+	}
+	handler.HandleNotification(context.Background(), "session/update", json.RawMessage(`{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"still going"}}}`))
+
+	if err := handler.turnError(); err != nil {
+		t.Fatalf("native tool leak should not fail the turn: %v", err)
+	}
+	got := <-events
+	if got.Type != EventTextDelta || got.Text != "still going" {
+		t.Fatalf("event after native leak = %+v", got)
 	}
 }
 
-func TestGrokACPHandlerRejectsNativeToolLeakWithRichContent(t *testing.T) {
+func TestGrokACPHandlerIgnoresNativeToolLeakWithRichContent(t *testing.T) {
 	handler := &grokACPHandler{}
 	handler.beginTurn(eventSender{}, false, false)
 	defer handler.endTurn()
 	handler.HandleNotification(context.Background(), "session/update", json.RawMessage(`{"sessionId":"s","update":{"sessionUpdate":"tool_call_update","toolCallId":"native-1","content":[{"type":"content","content":{"type":"text","text":"details"}}],"_meta":{"x.ai/tool":{"name":"read_file"}}}}`))
-	if err := handler.turnError(); err == nil || !strings.Contains(err.Error(), "native tool") {
-		t.Fatalf("native tool error = %v", err)
+	if err := handler.turnError(); err != nil {
+		t.Fatalf("native tool leak should not fail the turn: %v", err)
 	}
 }
 
@@ -364,7 +375,7 @@ func TestGrokACPHandlerAllowsNativeSearchOnlyWhenEnabled(t *testing.T) {
 		update        string
 		wantTurnError bool
 	}{
-		{name: "named disabled", update: `{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"web-1","_meta":{"x.ai/tool":{"name":"web_search"}}}}`, wantTurnError: true},
+		{name: "named disabled", update: `{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"web-1","_meta":{"x.ai/tool":{"name":"web_search"}}}}`},
 		{name: "named enabled", nativeSearch: true, update: `{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"web-1","_meta":{"x.ai/tool":{"name":"web_search"}}}}`},
 		{name: "backend disabled", update: `{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"x-1","kind":"search","_meta":{"backend":true}}}`, wantTurnError: true},
 		{name: "backend enabled", nativeSearch: true, update: `{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"x-1","kind":"search","_meta":{"backend":true}}}`},


### PR DESCRIPTION
## Why

`grok-bin` ACP fail-closed when Grok proposed a native builtin (`todo_write`, `grep`, `read_file`, …) even though the restricted profile and `--disallowed-tools` already prevent execution.

That showed up as:

```
Error: Grok ACP restricted profile attempted native tool "todo_write"
Error: Grok ACP restricted profile attempted native tool "grep"
```

and killed the rest of the turn, including later MCP tool results.

## Change

Ignore disallowed native `tool_call` / `tool_call_update` notifications instead of setting `turn.err`. Permission requests stay cancelled. MCP `search_tool` / `use_tool` remain the only executable path.

## Test

`go test ./internal/llm/ -count=1 -run 'GrokACP|GrokBinProviderBuildACP'`