### PR TITLE
feat(web): add Hub agent links to sidebar

### DIFF
--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -36,7 +36,7 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 			t.Fatalf("%s=%d lines, must be below 1500", name, lines[name])
 		}
 	}
-	if lines["app-render.js"] > 3145 || lines["app-core.js"] > 2650 {
+	if lines["app-render.js"] > 3145 || lines["app-core.js"] > 2651 {
 		t.Fatalf("shell/render grew beyond baseline: %v", lines)
 	}
 	for _, name := range []string{"active-response.js", "conversation.js", "transcript-window.js"} {
@@ -76,8 +76,8 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	// Keep focused transport/completion/branching boundaries from weakening the
 	// pre-existing ratchet: legacy production code must still decrease, while each
 	// extracted module gets a narrow independent ceiling.
-	if legacyProductionLines >= 20570 {
-		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20570", legacyProductionLines)
+	if legacyProductionLines >= 20686 {
+		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20686", legacyProductionLines)
 	}
 	if transportLines["app-network.js"] > 600 || transportLines["app-webrtc.js"] > 725 {
 		t.Fatalf("transport modules grew beyond focused budgets: %v", transportLines)
@@ -368,7 +368,18 @@ func TestApplicationFetchesUseSharedNetworkLayer(t *testing.T) {
 		if readErr != nil {
 			return readErr
 		}
-		if strings.Contains(string(body), "fetch(") {
+		source := string(body)
+		if path == "static/app-sidebar.js" {
+			// Hub auth is a same-origin cookie and must not inherit the proxied
+			// node's API headers or retry/auth behavior. This native fetch remains
+			// narrowly bounded by its local AbortController timeout.
+			const hubFetch = "fetch(context.apiURL, { signal: controller.signal })"
+			if count := strings.Count(source, hubFetch); count != 1 {
+				t.Errorf("%s has %d plain Hub fetches, want exactly 1", path, count)
+			}
+			source = strings.Replace(source, hubFetch, "", 1)
+		}
+		if strings.Contains(source, "fetch(") {
 			t.Errorf("%s bypasses app.apiFetch", path)
 		}
 		return nil

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -331,6 +331,7 @@ const elements = {
   newChatBtn: document.getElementById('newChatBtn'),
   widgetsOpenBtn: document.getElementById('widgetsOpenBtn'),
   backToHubLink: document.getElementById('backToHubLink'),
+  hubAgentLinks: document.getElementById('hubAgentLinks'),
   widgetsModal: document.getElementById('widgetsModal'),
   widgetsModalList: document.getElementById('widgetsModalList'),
   widgetsModalCloseBtn: document.getElementById('widgetsModalCloseBtn'),

--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -172,6 +172,206 @@ const applyBackToHubLink = () => {
   link.classList.remove('hidden');
 };
 
+const HUB_AGENT_LINKS_REFRESH_MS = 60000;
+const HUB_AGENT_LINKS_FETCH_TIMEOUT_MS = 10000;
+let hubAgentLinksLastFetchAt = null;
+let hubAgentLinksFetchPromise = null;
+let hubAgentLinksRefreshTimer = null;
+let hubAgentLinksHasValidRender = false;
+
+const compareCodeUnits = (left, right) => {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+};
+
+const safeHubPath = (value) => (
+  typeof value === 'string' && /^\/(?![\\/])/.test(value) ? value : ''
+);
+
+const appendHubQuery = (path, query) => {
+  const hashIndex = path.indexOf('#');
+  const base = hashIndex === -1 ? path : path.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : path.slice(hashIndex);
+  const separator = base.includes('?')
+    ? (base.endsWith('?') || base.endsWith('&') ? '' : '&')
+    : '?';
+  return `${base}${separator}${query}${hash}`;
+};
+
+const hubAgentTarget = (node) => {
+  const sessions = node?.sessions;
+  const resumePath = safeHubPath(sessions?.resume_path);
+  if (resumePath) return resumePath;
+
+  const activePath = safeHubPath(Array.isArray(sessions?.active) ? sessions.active[0]?.resume_path : '');
+  if (activePath) return activePath;
+
+  const recentPath = safeHubPath(Array.isArray(sessions?.recent) ? sessions.recent[0]?.resume_path : '');
+  if (recentPath) return recentPath;
+
+  const newSessionPath = safeHubPath(node?.new_session_path);
+  if (newSessionPath) return newSessionPath;
+
+  const proxyPath = safeHubPath(node?.proxy_path);
+  return proxyPath ? appendHubQuery(proxyPath, 'new=1') : '';
+};
+
+const hubAgentLinksContext = () => {
+  if (!elements.hubAgentLinks) return null;
+  const hub = window.TERM_LLM_HUB;
+  const rawURL = hub && typeof hub.url === 'string' ? hub.url : '';
+  const origin = typeof window.location?.origin === 'string' ? window.location.origin : '';
+  if (!rawURL || !origin) return null;
+
+  try {
+    const parsed = new URL(rawURL, `${origin}/`);
+    if (parsed.origin !== origin) return null;
+    const hubPath = parsed.pathname.replace(/\/+$/, '');
+    return {
+      apiURL: `${hubPath}/api/nodes`,
+      nodeId: String(hub.nodeId || ''),
+    };
+  } catch (_) {
+    return null;
+  }
+};
+
+const clearHubAgentLinks = () => {
+  elements.hubAgentLinks?.replaceChildren();
+  elements.hubAgentLinks?.classList.add('hidden');
+};
+
+const renderHubAgentLinks = (nodes, context) => {
+  const candidates = nodes
+    .filter((node) => node?.status?.reachable === true)
+    .map((node) => {
+      const id = String(node.id || '');
+      const rawName = String(node.name || '');
+      return {
+        node,
+        id,
+        rawName,
+        displayName: rawName || id,
+        target: hubAgentTarget(node),
+      };
+    })
+    .filter((entry) => entry.displayName && entry.target)
+    .sort((left, right) => (
+      compareCodeUnits(left.displayName.toLowerCase(), right.displayName.toLowerCase())
+      || compareCodeUnits(left.rawName, right.rawName)
+      || compareCodeUnits(left.id, right.id)
+    ));
+
+  const rows = candidates.map(({ node, id, displayName, target }) => {
+    const link = createEl('a', 'hub-agent-link');
+    link.href = target;
+    if (id && id === context.nodeId) link.setAttribute('aria-current', 'true');
+
+    const sessions = node.sessions;
+    const active = Number(sessions?.active_count) > 0
+      || (Array.isArray(sessions?.active) && sessions.active.length > 0);
+    if (active) {
+      const dot = createEl('span', 'hub-agent-active');
+      dot.title = 'Active session';
+      dot.setAttribute('aria-hidden', 'true');
+      link.appendChild(dot);
+      link.appendChild(createEl('span', 'visually-hidden', 'Active session'));
+    }
+    link.appendChild(createEl('span', 'hub-agent-name', displayName));
+    return link;
+  });
+
+  elements.hubAgentLinks.replaceChildren(...rows);
+  elements.hubAgentLinks.classList.toggle('hidden', rows.length === 0);
+};
+
+const fetchHubAgentLinks = () => {
+  const context = hubAgentLinksContext();
+  if (!context || document.visibilityState === 'hidden') {
+    if (!context) clearHubAgentLinks();
+    return Promise.resolve(false);
+  }
+  if (hubAgentLinksFetchPromise) return hubAgentLinksFetchPromise;
+
+  hubAgentLinksLastFetchAt = Date.now();
+  const request = (async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), HUB_AGENT_LINKS_FETCH_TIMEOUT_MS);
+    try {
+      // Hub auth is a same-origin cookie. Do not use node API auth helpers here.
+      const response = await fetch(context.apiURL, { signal: controller.signal });
+      if (response.status >= 400 && response.status < 500) {
+        clearHubAgentLinks();
+        hubAgentLinksHasValidRender = false;
+        return false;
+      }
+      if (!response.ok) throw new Error(`Hub nodes request failed (${response.status})`);
+      const data = await response.json();
+      if (!Array.isArray(data?.nodes)) throw new Error('Hub nodes response is invalid');
+      renderHubAgentLinks(data.nodes, context);
+      hubAgentLinksHasValidRender = true;
+      return true;
+    } catch (_) {
+      if (!hubAgentLinksHasValidRender) clearHubAgentLinks();
+      return false;
+    } finally {
+      clearTimeout(timeout);
+    }
+  })();
+
+  const trackedRequest = request.finally(() => {
+    if (hubAgentLinksFetchPromise === trackedRequest) hubAgentLinksFetchPromise = null;
+  });
+  hubAgentLinksFetchPromise = trackedRequest;
+  return trackedRequest;
+};
+
+const clearHubAgentLinksRefreshTimer = () => {
+  if (hubAgentLinksRefreshTimer === null) return;
+  clearTimeout(hubAgentLinksRefreshTimer);
+  hubAgentLinksRefreshTimer = null;
+};
+
+const refreshHubAgentLinks = () => {
+  const context = hubAgentLinksContext();
+  if (!context) {
+    clearHubAgentLinksRefreshTimer();
+    clearHubAgentLinks();
+    return Promise.resolve(false);
+  }
+  if (document.visibilityState === 'hidden') return Promise.resolve(false);
+  if (hubAgentLinksFetchPromise) return hubAgentLinksFetchPromise;
+
+  const elapsed = hubAgentLinksLastFetchAt === null
+    ? HUB_AGENT_LINKS_REFRESH_MS
+    : Date.now() - hubAgentLinksLastFetchAt;
+  if (elapsed >= HUB_AGENT_LINKS_REFRESH_MS) {
+    clearHubAgentLinksRefreshTimer();
+    return fetchHubAgentLinks();
+  }
+
+  if (hubAgentLinksRefreshTimer === null) {
+    hubAgentLinksRefreshTimer = setTimeout(() => {
+      hubAgentLinksRefreshTimer = null;
+      if (document.visibilityState !== 'hidden') void fetchHubAgentLinks();
+    }, HUB_AGENT_LINKS_REFRESH_MS - Math.max(0, elapsed));
+  }
+  return Promise.resolve(false);
+};
+
+const handleHubAgentLinksVisibility = () => {
+  if (document.visibilityState === 'hidden') {
+    clearHubAgentLinksRefreshTimer();
+    return;
+  }
+  void refreshHubAgentLinks();
+};
+
+const handleHubAgentLinksFocus = () => {
+  if (document.visibilityState !== 'hidden') void refreshHubAgentLinks();
+};
+
 if (elements.widgetsOpenBtn) elements.widgetsOpenBtn.addEventListener('click', openWidgetsModal);
 if (elements.widgetsModalCloseBtn) elements.widgetsModalCloseBtn.addEventListener('click', closeWidgetsModal);
 if (elements.widgetsModal) {
@@ -201,6 +401,8 @@ document.addEventListener('keydown', (event) => {
   }
 });
 if (elements.sidebarSearchInput) elements.sidebarSearchInput.addEventListener('input', scheduleSidebarSearch);
+document.addEventListener('visibilitychange', handleHubAgentLinksVisibility);
+window.addEventListener('focus', handleHubAgentLinksFocus);
 
 // ===== Sidebar status polling =====
 const SIDEBAR_POLL_ACTIVE = 2000;
@@ -427,8 +629,11 @@ const handleFetchTransportFallback = () => {
 };
 
 applyBackToHubLink();
+void refreshHubAgentLinks();
 
 Object.assign(app, {
+  HUB_AGENT_LINKS_REFRESH_MS,
+  HUB_AGENT_LINKS_FETCH_TIMEOUT_MS,
   SIDEBAR_POLL_ACTIVE,
   SIDEBAR_POLL_VISIBLE_ACTIVE,
   SIDEBAR_POLL_IDLE,
@@ -456,6 +661,9 @@ Object.assign(app, {
   handleFetchTransportFallback,
   renderWidgetSidebar,
   applyBackToHubLink,
+  renderHubAgentLinks,
+  fetchHubAgentLinks,
+  refreshHubAgentLinks,
   scheduleSidebarSearch
 });
 })();

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -1343,6 +1343,54 @@
       display: none;
     }
 
+    .hub-agent-links {
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+      margin: -0.05rem 0 0.1rem;
+      padding: 0 0.35rem 0 1.65rem;
+    }
+
+    .hub-agent-links.hidden {
+      display: none;
+    }
+
+    .hub-agent-link {
+      min-width: 0;
+      border-radius: 7px;
+      color: var(--text-muted);
+      display: flex;
+      align-items: center;
+      gap: 0.38rem;
+      padding: 0.3rem 0.45rem;
+      font-size: 0.78rem;
+      font-weight: 600;
+      line-height: 1.2;
+      text-decoration: none;
+    }
+
+    .hub-agent-link:hover,
+    .hub-agent-link[aria-current="true"] {
+      background: var(--surface-2);
+      color: var(--text);
+    }
+
+    .hub-agent-name {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .hub-agent-active {
+      width: 0.38rem;
+      height: 0.38rem;
+      flex: 0 0 0.38rem;
+      border-radius: 999px;
+      background: #22c55e;
+      box-shadow: 0 0 0 0.14rem rgba(34, 197, 94, 0.12);
+    }
+
     .sidebar-search-wrap {
       padding: 0 0.55rem 0.45rem;
       flex-shrink: 0;

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -337,6 +337,8 @@ async function createSessionsHarness(options = {}) {
 
   const elementMap = new Map();
   const getElement = (id) => {
+    // Session lifecycle tests do not model the Hub agent navigation fixture.
+    if (id === 'hubAgentLinks') return null;
     if (!elementMap.has(id)) elementMap.set(id, makeNode());
     return elementMap.get(id);
   };
@@ -4279,7 +4281,8 @@ async function testPreConnectedVisibilityDoesNotStartSidebarStatusPoll() {
       });
     },
     onInitializeStarted({ windowObj }) {
-      visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0] || null;
+      const handlers = windowObj.document.listeners.visibilitychange || [];
+      visibilityHandler = handlers[handlers.length - 1] || null;
       if (!visibilityHandler) return;
       windowObj.document.visibilityState = 'hidden';
       void visibilityHandler({ type: 'visibilitychange' });
@@ -4343,7 +4346,8 @@ async function testHealthyVisibilityDoesNotAbortActiveStream() {
   controller._heartbeatAbort = false;
   app.state.abortController = controller;
 
-  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const visibilityHandlers = windowObj.document.listeners.visibilitychange || [];
+  const visibilityHandler = visibilityHandlers[visibilityHandlers.length - 1];
   windowObj.document.visibilityState = 'visible';
   await visibilityHandler({ type: 'visibilitychange' });
   if (controller.signal.aborted || controller._heartbeatAbort) {
@@ -4387,7 +4391,8 @@ async function testVisibilityResumeRestoresPreBackgroundTailOwnership() {
   appRef = app;
   await app.stopSidebarStatusPoll();
   autoScrollAtStatus.length = 0;
-  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const visibilityHandlers = windowObj.document.listeners.visibilitychange || [];
+  const visibilityHandler = visibilityHandlers[visibilityHandlers.length - 1];
   if (!visibilityHandler) {
     fail(name, 'expected visibilitychange listener');
     return;
@@ -4548,7 +4553,8 @@ async function testSidebarStatusPollRecoversIdempotentlyAfterPageShow() {
   app.state.activeSessionId = session.id;
   app.state.draftSessionActive = false;
 
-  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const visibilityHandlers = windowObj.document.listeners.visibilitychange || [];
+  const visibilityHandler = visibilityHandlers[visibilityHandlers.length - 1];
   const pageshowHandlers = windowObj.listeners.pageshow || [];
   const pageshowHandler = pageshowHandlers[pageshowHandlers.length - 1];
   if (!visibilityHandler || !pageshowHandler) {
@@ -4656,7 +4662,8 @@ async function testHiddenInFlightSidebarPollCannotRescheduleOrApplyStaleStatus()
     fail(name, 'expected a status request to remain in flight');
     return;
   }
-  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const visibilityHandlers = windowObj.document.listeners.visibilitychange || [];
+  const visibilityHandler = visibilityHandlers[visibilityHandlers.length - 1];
   windowObj.document.visibilityState = 'hidden';
   await visibilityHandler({ type: 'visibilitychange' });
   resolveStatus();
@@ -4723,7 +4730,8 @@ async function testReconnectBackoffWakeSignalsReuseExistingLoop() {
   app.state.draftSessionActive = false;
   app.state.abortController = null;
 
-  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const visibilityHandlers = windowObj.document.listeners.visibilitychange || [];
+  const visibilityHandler = visibilityHandlers[visibilityHandlers.length - 1];
   const onlineHandler = (windowObj.listeners.online || [])[0];
   const pageshowHandlers = windowObj.listeners.pageshow || [];
   const pageshowHandler = pageshowHandlers[pageshowHandlers.length - 1];
@@ -6951,7 +6959,8 @@ async function testBottomPinnedTranscriptSyncKeepsFollowingTail() {
   app.state.draftSessionActive = false;
   app.state.autoScroll = true;
   await app.stopSidebarStatusPoll();
-  const visibilityHandler = (windowObj.document.listeners.visibilitychange || [])[0];
+  const visibilityHandlers = windowObj.document.listeners.visibilitychange || [];
+  const visibilityHandler = visibilityHandlers[visibilityHandlers.length - 1];
   if (!visibilityHandler) {
     fail(name, 'expected visibilitychange listener');
     return;

--- a/internal/serveui/static/app_sidebar_test.js
+++ b/internal/serveui/static/app_sidebar_test.js
@@ -111,8 +111,10 @@ function createHarness(options = {}) {
     widgetsModalCloseBtn: new Element('button'),
     sidebarSearchInput: new Element('input'),
     backToHubLink: new Element('a'),
+    hubAgentLinks: new Element('nav'),
   };
   elements.backToHubLink.classList.add('back-to-hub-link', 'hidden');
+  elements.hubAgentLinks.classList.add('hub-agent-links', 'hidden');
   const state = {
     widgets: [],
     widgetsLoaded: false,
@@ -139,23 +141,62 @@ function createHarness(options = {}) {
   };
   const document = new Element('document');
   document.createElement = (tag) => new Element(tag);
+  document.visibilityState = options.visibilityState || 'visible';
   const navigator = { platform: options.platform || 'Linux x86_64' };
+  const origin = options.origin || 'https://node.example.test';
+  const windowObj = new Element('window');
+  windowObj.TermLLMApp = app;
+  windowObj.TERM_LLM_HUB = options.hub;
+  windowObj.location = {
+    origin,
+    pathname: options.pathname || '/chat/',
+    protocol: `${new URL(origin).protocol}`,
+    host: new URL(origin).host,
+  };
+  const nativeFetchRequests = [];
+  const apiFetchRequests = [];
+  const nativeFetchImpl = options.nativeFetch || (async () => nodesResponse([]));
+  const apiFetchImpl = options.apiFetch || options.fetch || (async () => new Response(JSON.stringify({ sessions: [] }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }));
+  const trackedNativeFetch = (...args) => {
+    nativeFetchRequests.push(args);
+    return nativeFetchImpl(...args);
+  };
+  const DateImpl = options.now
+    ? class extends Date { static now() { return options.now(); } }
+    : Date;
   const context = {
-    window: { TermLLMApp: app, TERM_LLM_HUB: options.hub },
+    window: windowObj,
     document,
     navigator,
+    URL,
     URLSearchParams,
+    Date: DateImpl,
     console,
-    clearTimeout,
-    setTimeout: options.setTimeout || ((fn) => { fn(); return 1; }),
-    fetch: options.fetch || (async () => new Response(JSON.stringify({ sessions: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+    clearTimeout: options.clearTimeout || clearTimeout,
+    setTimeout: options.setTimeout || setTimeout,
+    fetch: trackedNativeFetch,
     Response,
     AbortController,
   };
   context.globalThis = context;
-  app.apiFetch = (...args) => context.fetch(...args);
+  app.apiFetch = (...args) => {
+    apiFetchRequests.push(args);
+    return apiFetchImpl(...args);
+  };
   vm.runInNewContext(source, context, { filename: 'app-sidebar.js' });
-  return { app, elements, state, document, get renderSidebarCount() { return renderSidebarCount; } };
+  return {
+    app,
+    elements,
+    state,
+    document,
+    window: windowObj,
+    nativeFetchRequests,
+    apiFetchRequests,
+    get renderSidebarCount() { return renderSidebarCount; },
+  };
 }
 
 function keydownEvent(overrides = {}) {
@@ -180,6 +221,42 @@ async function run(name, fn) {
   } catch (err) {
     fail(name, err.message, err.stack);
   }
+}
+
+const flushAsync = async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+};
+
+const nodesResponse = (nodes, status = 200) => new Response(JSON.stringify({ nodes }), {
+  status,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+function createFakeTimers() {
+  let nextId = 1;
+  const timers = [];
+  return {
+    timers,
+    setTimeout(fn, delay) {
+      const timer = { id: nextId, fn, delay, cleared: false, fired: false };
+      nextId += 1;
+      timers.push(timer);
+      return timer.id;
+    },
+    clearTimeout(id) {
+      const timer = timers.find((entry) => entry.id === id);
+      if (timer) timer.cleared = true;
+    },
+    active(delay) {
+      return timers.filter((timer) => !timer.cleared && !timer.fired
+        && (delay === undefined || timer.delay === delay));
+    },
+    fire(timer) {
+      timer.fired = true;
+      timer.fn();
+    },
+  };
 }
 
 (async () => {
@@ -216,9 +293,13 @@ async function run(name, fn) {
     assertEqual(elements.widgetsModalList.children.length, 0, 'modal list is cleared');
   });
 
-  await run('back to hub link stays hidden without hub context', () => {
-    const { elements } = createHarness();
+  await run('back to hub link stays hidden without hub context and makes no Hub request', async () => {
+    const { elements, nativeFetchRequests, apiFetchRequests } = createHarness();
+    await flushAsync();
     assert(elements.backToHubLink.classList.contains('hidden'), 'link is hidden without TERM_LLM_HUB');
+    assert(elements.hubAgentLinks.classList.contains('hidden'), 'agent links are hidden without TERM_LLM_HUB');
+    assertEqual(nativeFetchRequests.length, 0, 'no native request is made without Hub context');
+    assertEqual(apiFetchRequests.length, 0, 'no app API request is made without Hub context');
   });
 
   await run('back to hub link renders from hub context', () => {
@@ -233,9 +314,303 @@ async function run(name, fn) {
     assert(elements.backToHubLink.classList.contains('hidden'), 'link stays hidden when hub context has no url');
   });
 
+  await run('cross-origin Hub context keeps agent links hidden and makes zero requests', async () => {
+    const { elements, nativeFetchRequests, apiFetchRequests } = createHarness({
+      origin: 'https://node.example.test',
+      hub: { url: 'https://hub.example.test/hub/', nodeId: 'alpha' },
+    });
+    await flushAsync();
+
+    assert(elements.hubAgentLinks.classList.contains('hidden'), 'cross-origin agent links stay hidden');
+    assertEqual(elements.hubAgentLinks.children.length, 0, 'cross-origin list stays empty');
+    assertEqual(nativeFetchRequests.length, 0, 'cross-origin Hub performs no native fetches');
+    assertEqual(apiFetchRequests.length, 0, 'cross-origin Hub performs no app API fetches');
+  });
+
+  await run('Hub agents use native fetch at the mounted API URL with reachable stable order', async () => {
+    const { elements, nativeFetchRequests, apiFetchRequests } = createHarness({
+      hub: { url: '/hub/', nodeId: 'alpha-a' },
+      nativeFetch: async () => nodesResponse([
+        { id: 'beta', name: 'Beta', status: { reachable: true }, new_session_path: '/hub/node/beta/?new=1' },
+        { id: 'alpha-b', name: 'Alpha', status: { reachable: true }, new_session_path: '/hub/node/alpha-b/?new=1' },
+        { id: 'down', name: 'Aardvark', status: { reachable: false }, new_session_path: '/hub/node/down/?new=1' },
+        { id: 'alpha-z', name: 'alpha', status: { reachable: true }, new_session_path: '/hub/node/alpha-z/?new=1' },
+        { id: 'alpha-a', name: 'Alpha', status: { reachable: true }, new_session_path: '/hub/node/alpha-a/?new=1' },
+      ]),
+    });
+    await flushAsync();
+
+    assertEqual(String(nativeFetchRequests[0][0]), '/hub/api/nodes', 'mounted Hub API URL is exact');
+    assertEqual(nativeFetchRequests[0].length, 2, 'Hub request passes only native fetch options');
+    assert(nativeFetchRequests[0][1].signal instanceof AbortSignal, 'Hub request has an abort signal');
+    assertEqual(apiFetchRequests.length, 0, 'Hub request never uses app.apiFetch');
+    const links = elements.hubAgentLinks.querySelectorAll('.hub-agent-link');
+    assertEqual(links.length, 4, 'only reachable nodes with safe targets render');
+    assertEqual(links.map((link) => link.href).join(','), [
+      '/hub/node/alpha-a/?new=1',
+      '/hub/node/alpha-b/?new=1',
+      '/hub/node/alpha-z/?new=1',
+      '/hub/node/beta/?new=1',
+    ].join(','), 'agents sort by folded display name, raw name, then ID');
+    assert(!elements.hubAgentLinks.classList.contains('hidden'), 'valid agent list is visible');
+  });
+
+  await run('hidden Hub startup waits for visibility before fetching', async () => {
+    const { document, elements, nativeFetchRequests } = createHarness({
+      visibilityState: 'hidden',
+      hub: { url: '/hub/', nodeId: 'alpha' },
+      nativeFetch: async () => nodesResponse([
+        { id: 'alpha', name: 'Alpha', status: { reachable: true }, new_session_path: '/hub/node/alpha/?new=1' },
+      ]),
+    });
+    await flushAsync();
+    assertEqual(nativeFetchRequests.length, 0, 'hidden startup makes no Hub request');
+    assert(elements.hubAgentLinks.classList.contains('hidden'), 'hidden startup keeps the list hidden');
+
+    document.visibilityState = 'visible';
+    await document.dispatchEvent({ type: 'visibilitychange' });
+    await flushAsync();
+
+    assertEqual(nativeFetchRequests.length, 1, 'becoming visible fetches Hub agents');
+    assert(!elements.hubAgentLinks.classList.contains('hidden'), 'visible successful fetch reveals the list');
+  });
+
+  await run('empty Hub nodes response clears and hides the list', async () => {
+    const { elements } = createHarness({
+      hub: { url: '/hub/', nodeId: 'alpha' },
+      nativeFetch: async () => nodesResponse([]),
+    });
+    elements.hubAgentLinks.appendChild(new Element('a'));
+    elements.hubAgentLinks.classList.remove('hidden');
+    await flushAsync();
+
+    assert(elements.hubAgentLinks.classList.contains('hidden'), 'empty nodes hides the list');
+    assertEqual(elements.hubAgentLinks.children.length, 0, 'empty nodes clears stale rows');
+  });
+
+  await run('Hub agent targets follow resume, active, recent, new, and proxy precedence', async () => {
+    const { elements } = createHarness({
+      hub: { url: '/', nodeId: 'resume' },
+      nativeFetch: async () => nodesResponse([
+        {
+          id: 'resume', name: 'Direct', status: { reachable: true },
+          sessions: {
+            resume_path: '/node/resume/direct',
+            active: [{ resume_path: '/node/resume/active' }],
+            recent: [{ resume_path: '/node/resume/recent' }],
+          },
+          new_session_path: '/node/resume/?new=1', proxy_path: '/node/resume/',
+        },
+        {
+          id: 'active', name: 'From active', status: { reachable: true },
+          sessions: { active: [{ resume_path: '/node/active/session' }], recent: [{ resume_path: '/node/active/recent' }] },
+          new_session_path: '/node/active/?new=1',
+        },
+        {
+          id: 'recent', name: 'From recent', status: { reachable: true },
+          sessions: { resume_path: 'https://unsafe.test/session', recent: [{ resume_path: '/node/recent/session' }] },
+          new_session_path: '/node/recent/?new=1',
+        },
+        { id: 'new', name: 'New fallback', status: { reachable: true }, new_session_path: '/node/new/?new=1', proxy_path: '/node/new/' },
+        { id: 'proxy', name: 'Proxy fallback', status: { reachable: true }, new_session_path: 'javascript:bad', proxy_path: '/node/proxy/?source=hub#sessions' },
+        { id: 'unsafe', name: 'Unsafe', status: { reachable: true }, new_session_path: '//evil.test/', proxy_path: 'https://evil.test/' },
+        { id: 'unsafe-backslash', name: 'Unsafe backslash', status: { reachable: true }, new_session_path: '/\\evil.test/', proxy_path: '/\\\\evil.test/' },
+      ]),
+    });
+    await flushAsync();
+
+    const targetsByName = new Map(elements.hubAgentLinks.querySelectorAll('.hub-agent-link').map((link) => [
+      link.querySelector('.hub-agent-name').textContent,
+      link.href,
+    ]));
+    assertEqual(targetsByName.get('Direct'), '/node/resume/direct', 'sessions.resume_path wins');
+    assertEqual(targetsByName.get('From active'), '/node/active/session', 'first active resume path is used');
+    assertEqual(targetsByName.get('From recent'), '/node/recent/session', 'first recent resume path is used');
+    assertEqual(targetsByName.get('New fallback'), '/node/new/?new=1', 'new session path is used');
+    assertEqual(targetsByName.get('Proxy fallback'), '/node/proxy/?source=hub&new=1#sessions', 'proxy fallback safely appends the new query');
+    assert(!targetsByName.has('Unsafe'), 'node without a root-relative target is skipped');
+    assert(!targetsByName.has('Unsafe backslash'), 'backslash authority escapes are skipped');
+  });
+
+  await run('Hub agent activity dots and current-node state are accessible', async () => {
+    const { elements } = createHarness({
+      hub: { url: '/', nodeId: 'array-active' },
+      nativeFetch: async () => nodesResponse([
+        { id: 'count-active', name: 'Count active', status: { reachable: true }, sessions: { active_count: '2' }, new_session_path: '/node/count/' },
+        { id: 'array-active', name: 'Array active', status: { reachable: true }, sessions: { active: [{ resume_path: '/node/array/session' }] }, new_session_path: '/node/array/' },
+        { id: 'idle', name: 'Idle', status: { reachable: true }, sessions: { active_count: 0, active: [] }, new_session_path: '/node/idle/' },
+      ]),
+    });
+    await flushAsync();
+
+    const links = elements.hubAgentLinks.querySelectorAll('.hub-agent-link');
+    const current = links.find((link) => link.querySelector('.hub-agent-name').textContent === 'Array active');
+    assertEqual(current.getAttribute('aria-current'), 'true', 'current node is marked without claiming the current page');
+    const dots = elements.hubAgentLinks.querySelectorAll('.hub-agent-active');
+    assertEqual(dots.length, 2, 'active count and compatibility active array each render a dot');
+    dots.forEach((dot) => {
+      assertEqual(dot.title, 'Active session', 'active dot has a title');
+      assertEqual(dot.getAttribute('aria-hidden'), 'true', 'active dot is hidden from assistive technology');
+      assertEqual(dot.getAttribute('aria-label'), null, 'generic active dot has no aria-label');
+    });
+    const activeText = elements.hubAgentLinks.querySelectorAll('.visually-hidden');
+    assertEqual(activeText.length, 2, 'each active link contains accessible status text');
+    activeText.forEach((text) => assertEqual(text.textContent, 'Active session', 'active status text is explicit'));
+  });
+
+  await run('initial Hub 401 hides and clears agent links', async () => {
+    const { elements } = createHarness({
+      hub: { url: '/hub/', nodeId: 'alpha' },
+      nativeFetch: async () => new Response('unauthorized', { status: 401 }),
+    });
+    elements.hubAgentLinks.appendChild(new Element('a'));
+    elements.hubAgentLinks.classList.remove('hidden');
+    await flushAsync();
+
+    assert(elements.hubAgentLinks.classList.contains('hidden'), 'initial 401 hides the list');
+    assertEqual(elements.hubAgentLinks.children.length, 0, 'initial 401 clears stale rows');
+  });
+
+  await run('Hub 401 after success authoritatively clears the valid render', async () => {
+    let now = 1000;
+    let call = 0;
+    const { elements, nativeFetchRequests, window } = createHarness({
+      now: () => now,
+      hub: { url: '/hub/', nodeId: 'alpha' },
+      nativeFetch: async () => {
+        call += 1;
+        if (call === 1) return nodesResponse([
+          { id: 'alpha', name: 'Alpha', status: { reachable: true }, new_session_path: '/hub/node/alpha/?new=1' },
+        ]);
+        return new Response('unauthorized', { status: 401 });
+      },
+    });
+    await flushAsync();
+    assert(!elements.hubAgentLinks.classList.contains('hidden'), 'successful render starts visible');
+
+    now += 60000;
+    await window.dispatchEvent({ type: 'focus' });
+    await flushAsync();
+
+    assertEqual(nativeFetchRequests.length, 2, 'focus performs the authoritative auth refresh');
+    assert(elements.hubAgentLinks.classList.contains('hidden'), '401 after success hides the list');
+    assertEqual(elements.hubAgentLinks.children.length, 0, '401 after success clears valid rows');
+  });
+
+  await run('transient Hub refresh failure preserves the last valid render', async () => {
+    let now = 1000;
+    let call = 0;
+    const { elements, nativeFetchRequests, window } = createHarness({
+      now: () => now,
+      hub: { url: '/hub/', nodeId: 'alpha' },
+      nativeFetch: async () => {
+        call += 1;
+        if (call === 1) return nodesResponse([
+          { id: 'alpha', name: 'Alpha', status: { reachable: true }, new_session_path: '/hub/node/alpha/?new=1' },
+        ]);
+        return new Response('temporary failure', { status: 503 });
+      },
+    });
+    await flushAsync();
+    const initialLink = elements.hubAgentLinks.querySelector('.hub-agent-link');
+
+    now += 60000;
+    await window.dispatchEvent({ type: 'focus' });
+    await flushAsync();
+
+    assertEqual(nativeFetchRequests.length, 2, 'focus refreshes after the minimum interval');
+    assert(!elements.hubAgentLinks.classList.contains('hidden'), 'transient failure leaves the valid list visible');
+    assertEqual(elements.hubAgentLinks.querySelector('.hub-agent-link'), initialLink, 'transient failure preserves rendered rows');
+  });
+
+  await run('Hub focus and visibility refreshes share a 60 second throttle', async () => {
+    let now = 1000;
+    const clock = createFakeTimers();
+    const { app, document, nativeFetchRequests, window } = createHarness({
+      now: () => now,
+      hub: { url: '/', nodeId: 'alpha' },
+      nativeFetch: async () => nodesResponse([]),
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+    });
+    await flushAsync();
+
+    now += 1000;
+    await window.dispatchEvent({ type: 'focus' });
+    await document.dispatchEvent({ type: 'visibilitychange' });
+    assertEqual(nativeFetchRequests.length, 1, 'focus and visibility do not fetch inside the throttle window');
+    const refreshTimers = clock.active(59000);
+    assertEqual(refreshTimers.length, 1, 'return events share one trailing refresh timer');
+    assertEqual(refreshTimers[0].delay, 59000, 'trailing refresh waits for the remaining throttle interval');
+
+    clock.fire(refreshTimers[0]);
+    await flushAsync();
+    assertEqual(nativeFetchRequests.length, 2, 'trailing refresh fetches once');
+    assertEqual(clock.active(app.HUB_AGENT_LINKS_FETCH_TIMEOUT_MS).length, 0, 'completed fetch clears its timeout');
+  });
+
+  await run('Hub agent refresh stays single-flight', async () => {
+    let now = 1000;
+    let releaseFetch;
+    const pendingResponse = new Promise((resolve) => { releaseFetch = resolve; });
+    const { nativeFetchRequests, window } = createHarness({
+      now: () => now,
+      hub: { url: '/', nodeId: 'alpha' },
+      nativeFetch: async () => pendingResponse,
+    });
+    assertEqual(nativeFetchRequests.length, 1, 'startup begins one Hub request');
+
+    now += 60000;
+    await window.dispatchEvent({ type: 'focus' });
+    assertEqual(nativeFetchRequests.length, 1, 'focus reuses the startup request while it is in flight');
+
+    releaseFetch(nodesResponse([]));
+    await flushAsync();
+  });
+
+  await run('hung Hub fetch aborts and releases single-flight for a later refresh', async () => {
+    let now = 1000;
+    let firstSignal = null;
+    let call = 0;
+    const clock = createFakeTimers();
+    const { app, nativeFetchRequests, window } = createHarness({
+      now: () => now,
+      hub: { url: '/', nodeId: 'alpha' },
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      nativeFetch: async (_url, options) => {
+        call += 1;
+        if (call > 1) return nodesResponse([]);
+        firstSignal = options.signal;
+        return new Promise((resolve, reject) => {
+          if (options.signal.aborted) {
+            reject(new Error('aborted'));
+            return;
+          }
+          options.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        });
+      },
+    });
+    await flushAsync();
+    assertEqual(nativeFetchRequests.length, 1, 'startup begins the hung request');
+    const timeout = clock.active(app.HUB_AGENT_LINKS_FETCH_TIMEOUT_MS)[0];
+    assert(timeout, 'hung request has a bounded timeout');
+
+    clock.fire(timeout);
+    await flushAsync();
+    assert(firstSignal.aborted, 'timeout aborts the native fetch signal');
+    assert(timeout.cleared, 'fetch cleanup clears the timeout in finally');
+
+    now += app.HUB_AGENT_LINKS_REFRESH_MS;
+    await window.dispatchEvent({ type: 'focus' });
+    await flushAsync();
+    assertEqual(nativeFetchRequests.length, 2, 'later refresh starts after timed-out single-flight clears');
+  });
+
   await run('sidebar search fetches server results', async () => {
     let requested = '';
     const { elements, state } = createHarness({
+      setTimeout(fn) { fn(); return 1; },
       fetch: async (url) => {
         requested = String(url);
         return new Response(JSON.stringify({ sessions: [{ id: 's1', short_title: 'Linux', snippet: 'match' }] }), {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -210,6 +210,7 @@
               </svg>
               <span>Back to Hub</span>
             </a>
+            <nav class="hub-agent-links hidden" id="hubAgentLinks" aria-label="Hub agents"></nav>
           </div>
           <div class="sidebar-search-wrap">
             <input class="sidebar-search-input" id="sidebarSearchInput" type="search" placeholder="Search chats" autocomplete="off" aria-label="Search chats">


### PR DESCRIPTION
## Summary

- show one compact link per reachable Hub agent beneath **Back to Hub** in the proxied node Web UI
- keep ordering deterministic by agent name and ID
- resume the Hub-selected active/recent session, falling back to a new chat when no session exists
- mark agents with active sessions using a small accessible green indicator
- refresh Hub state on startup and foregrounding with a throttled, bounded request

## Design

The sidebar uses the Hub's existing `GET /api/nodes` response as the single authority for reachability, session selection, and active state. Requests only run in same-origin proxied Hub mode and use the Hub auth cookie via native `fetch`; cross-origin `--hub-url` contexts do not attempt an unauthenticated request.

Hub paths are resolved independently of the node UI's rebased `<base>`, and link targets are restricted to root-relative paths. A 10-second timeout prevents a stalled Hub from wedging refresh. Transient failures retain the last valid list; authoritative 4xx responses clear it.

## Tests

- `node internal/serveui/static/app_sidebar_test.js`
- `TERM_LLM_APP_SESSIONS_TEST_SHARD=0 node internal/serveui/static/app_sessions_test.js`
- `TERM_LLM_APP_SESSIONS_TEST_SHARD=1 node internal/serveui/static/app_sessions_test.js`
- `go test ./internal/serveui`
- `go test ./cmd -run Hub`
- isolated-home `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

The normal-home broad test run hit existing environment-dependent skill-discovery assertions; the same suite passes with an isolated HOME/XDG config.
