### PR TITLE
feat(web): clarify Hub agent navigation

### DIFF
--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -240,7 +240,7 @@ const hubAgentLinksContext = () => {
 
 const clearHubAgentLinks = () => {
   elements.hubAgentLinks?.replaceChildren();
-  elements.hubAgentLinks?.classList.add('hidden');
+  elements.hubAgentLinks?.classList.add('hidden'); hubAgentAttention.clear();
 };
 
 const renderHubAgentLinks = (nodes, context) => {
@@ -279,7 +279,7 @@ const renderHubAgentLinks = (nodes, context) => {
       const dot = createEl('span', 'hub-agent-attention');
       dot.title = 'Needs attention'; dot.setAttribute('aria-hidden', 'true'); link.appendChild(dot); link.appendChild(createEl('span', 'visually-hidden', 'Needs attention'));
     }
-    link.addEventListener('click', () => hubAgentAttention.set(id, { active, attention: false })); return link;
+    ['click', 'auxclick'].forEach((type) => link.addEventListener(type, () => { hubAgentAttention.set(id, { active, attention: false }); link.querySelector('.hub-agent-attention')?.remove(); link.querySelector('.visually-hidden')?.remove(); })); return link;
   });
 
   elements.hubAgentLinks.replaceChildren(...rows);

--- a/internal/serveui/static/app-sidebar.js
+++ b/internal/serveui/static/app-sidebar.js
@@ -178,6 +178,7 @@ let hubAgentLinksLastFetchAt = null;
 let hubAgentLinksFetchPromise = null;
 let hubAgentLinksRefreshTimer = null;
 let hubAgentLinksHasValidRender = false;
+const hubAgentAttention = new Map();
 
 const compareCodeUnits = (left, right) => {
   if (left < right) return -1;
@@ -267,19 +268,18 @@ const renderHubAgentLinks = (nodes, context) => {
     const link = createEl('a', 'hub-agent-link');
     link.href = target;
     if (id && id === context.nodeId) link.setAttribute('aria-current', 'true');
-
-    const sessions = node.sessions;
-    const active = Number(sessions?.active_count) > 0
-      || (Array.isArray(sessions?.active) && sessions.active.length > 0);
-    if (active) {
-      const dot = createEl('span', 'hub-agent-active');
-      dot.title = 'Active session';
-      dot.setAttribute('aria-hidden', 'true');
-      link.appendChild(dot);
-      link.appendChild(createEl('span', 'visually-hidden', 'Active session'));
+    const icon = createEl('span', 'hub-agent-icon');
+    icon.setAttribute('aria-hidden', 'true'); link.appendChild(icon); link.appendChild(createEl('span', 'hub-agent-name', displayName));
+    const active = Number(node.sessions?.active_count) > 0
+      || (Array.isArray(node.sessions?.active) && node.sessions.active.length > 0);
+    const previous = hubAgentAttention.get(id); const attention = id !== context.nodeId
+      && Boolean(previous?.attention || (previous?.active && !active));
+    hubAgentAttention.set(id, { active, attention });
+    if (attention) {
+      const dot = createEl('span', 'hub-agent-attention');
+      dot.title = 'Needs attention'; dot.setAttribute('aria-hidden', 'true'); link.appendChild(dot); link.appendChild(createEl('span', 'visually-hidden', 'Needs attention'));
     }
-    link.appendChild(createEl('span', 'hub-agent-name', displayName));
-    return link;
+    link.addEventListener('click', () => hubAgentAttention.set(id, { active, attention: false })); return link;
   });
 
   elements.hubAgentLinks.replaceChildren(...rows);

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -1346,9 +1346,9 @@
     .hub-agent-links {
       display: flex;
       flex-direction: column;
-      gap: 0.1rem;
-      margin: -0.05rem 0 0.1rem;
-      padding: 0 0.35rem 0 1.65rem;
+      gap: 0.2rem;
+      margin: 0.15rem 0 0.1rem;
+      padding: 0;
     }
 
     .hub-agent-links.hidden {
@@ -1356,23 +1356,46 @@
     }
 
     .hub-agent-link {
+      width: 100%;
       min-width: 0;
-      border-radius: 7px;
-      color: var(--text-muted);
-      display: flex;
+      box-sizing: border-box;
+      border-radius: 10px;
+      border: 1px solid transparent;
+      color: var(--text);
+      display: grid;
+      grid-template-columns: 17px minmax(0, 1fr) 0.5rem;
       align-items: center;
-      gap: 0.38rem;
-      padding: 0.3rem 0.45rem;
-      font-size: 0.78rem;
+      column-gap: 0.55rem;
+      padding: 0.58rem 0.65rem;
+      font-size: 0.92rem;
       font-weight: 600;
-      line-height: 1.2;
+      line-height: 1.25;
       text-decoration: none;
+      transition: background 0.15s ease, border-color 0.15s ease;
     }
 
-    .hub-agent-link:hover,
+    .hub-agent-link:hover {
+      background: var(--surface-2);
+      border-color: var(--border);
+    }
+
+    .hub-agent-link:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
     .hub-agent-link[aria-current="true"] {
       background: var(--surface-2);
-      color: var(--text);
+    }
+
+    .hub-agent-icon {
+      width: 17px;
+      height: 17px;
+      display: block;
+      color: currentColor;
+      background: currentColor;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='7' width='16' height='13' rx='4'/%3E%3Cpath d='M12 7V3M9 12h.01M15 12h.01M8 17h8'/%3E%3C/svg%3E") center / contain no-repeat;
+      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='7' width='16' height='13' rx='4'/%3E%3Cpath d='M12 7V3M9 12h.01M15 12h.01M8 17h8'/%3E%3C/svg%3E") center / contain no-repeat;
     }
 
     .hub-agent-name {
@@ -1382,17 +1405,17 @@
       white-space: nowrap;
     }
 
-    .hub-agent-active {
-      width: 0.38rem;
-      height: 0.38rem;
-      flex: 0 0 0.38rem;
+    .hub-agent-attention {
+      width: 0.48rem;
+      height: 0.48rem;
+      justify-self: center;
       border-radius: 999px;
       background: #22c55e;
       box-shadow: 0 0 0 0.14rem rgba(34, 197, 94, 0.12);
     }
 
     .sidebar-search-wrap {
-      padding: 0 0.55rem 0.45rem;
+      padding: 0 0.55rem 0.55rem;
       flex-shrink: 0;
     }
 

--- a/internal/serveui/static/app_sidebar_test.js
+++ b/internal/serveui/static/app_sidebar_test.js
@@ -72,6 +72,12 @@ class Element {
     this.children = [];
     nodes.forEach((node) => { if (node) this.appendChild(node); });
   }
+  remove() {
+    if (!this.parentNode) return;
+    const idx = this.parentNode.children.indexOf(this);
+    if (idx !== -1) this.parentNode.children.splice(idx, 1);
+    this.parentNode = null;
+  }
   setAttribute(name, value) { this.attributes.set(name, String(value)); if (name === 'class') this.className = String(value); }
   getAttribute(name) { return this.attributes.get(name) || null; }
   addEventListener(type, listener) {
@@ -466,6 +472,23 @@ function createFakeTimers() {
     assertEqual(dot.title, 'Needs attention', 'attention dot has an explicit title');
     assertEqual(dot.getAttribute('aria-hidden'), 'true', 'visual dot is hidden from assistive technology');
     assertEqual(worker.querySelector('.visually-hidden').textContent, 'Needs attention', 'attention is announced once');
+
+    now += 60000;
+    await window.dispatchEvent({ type: 'focus' });
+    await flushAsync();
+    const latchedWorker = elements.hubAgentLinks.querySelectorAll('.hub-agent-link')
+      .find((link) => link.querySelector('.hub-agent-name').textContent === 'Worker');
+    assert(latchedWorker.querySelector('.hub-agent-attention'), 'attention remains latched while the agent stays idle');
+
+    await latchedWorker.dispatchEvent({ type: 'click' });
+    assertEqual(latchedWorker.querySelector('.hub-agent-attention'), null, 'click clears the visible dot immediately');
+    assertEqual(latchedWorker.querySelector('.visually-hidden'), null, 'click clears accessible attention immediately');
+    now += 60000;
+    await window.dispatchEvent({ type: 'focus' });
+    await flushAsync();
+    const visitedWorker = elements.hubAgentLinks.querySelectorAll('.hub-agent-link')
+      .find((link) => link.querySelector('.hub-agent-name').textContent === 'Worker');
+    assertEqual(visitedWorker.querySelector('.hub-agent-attention'), null, 'visiting the agent clears attention');
   });
 
   await run('initial Hub 401 hides and clears agent links', async () => {

--- a/internal/serveui/static/app_sidebar_test.js
+++ b/internal/serveui/static/app_sidebar_test.js
@@ -353,6 +353,9 @@ function createFakeTimers() {
       '/hub/node/beta/?new=1',
     ].join(','), 'agents sort by folded display name, raw name, then ID');
     assert(!elements.hubAgentLinks.classList.contains('hidden'), 'valid agent list is visible');
+    const icons = elements.hubAgentLinks.querySelectorAll('.hub-agent-icon');
+    assertEqual(icons.length, 4, 'every agent row renders one robot icon');
+    icons.forEach((icon) => assertEqual(icon.getAttribute('aria-hidden'), 'true', 'robot icon is decorative'));
   });
 
   await run('hidden Hub startup waits for visibility before fetching', async () => {
@@ -432,30 +435,37 @@ function createFakeTimers() {
     assert(!targetsByName.has('Unsafe backslash'), 'backslash authority escapes are skipped');
   });
 
-  await run('Hub agent activity dots and current-node state are accessible', async () => {
-    const { elements } = createHarness({
-      hub: { url: '/', nodeId: 'array-active' },
+  await run('Hub agent attention appears after a background run finishes', async () => {
+    let now = 1000;
+    let running = true;
+    const { elements, window } = createHarness({
+      now: () => now,
+      hub: { url: '/', nodeId: 'current' },
       nativeFetch: async () => nodesResponse([
-        { id: 'count-active', name: 'Count active', status: { reachable: true }, sessions: { active_count: '2' }, new_session_path: '/node/count/' },
-        { id: 'array-active', name: 'Array active', status: { reachable: true }, sessions: { active: [{ resume_path: '/node/array/session' }] }, new_session_path: '/node/array/' },
-        { id: 'idle', name: 'Idle', status: { reachable: true }, sessions: { active_count: 0, active: [] }, new_session_path: '/node/idle/' },
+        { id: 'current', name: 'Current', status: { reachable: true }, sessions: { active_count: running ? 1 : 0 }, new_session_path: '/node/current/' },
+        { id: 'worker', name: 'Worker', status: { reachable: true }, sessions: { active_count: running ? 1 : 0 }, new_session_path: '/node/worker/' },
       ]),
     });
     await flushAsync();
+    assertEqual(elements.hubAgentLinks.querySelectorAll('.hub-agent-attention').length, 0, 'running agents do not ask for attention');
+
+    running = false;
+    now += 60000;
+    await window.dispatchEvent({ type: 'focus' });
+    await flushAsync();
 
     const links = elements.hubAgentLinks.querySelectorAll('.hub-agent-link');
-    const current = links.find((link) => link.querySelector('.hub-agent-name').textContent === 'Array active');
-    assertEqual(current.getAttribute('aria-current'), 'true', 'current node is marked without claiming the current page');
-    const dots = elements.hubAgentLinks.querySelectorAll('.hub-agent-active');
-    assertEqual(dots.length, 2, 'active count and compatibility active array each render a dot');
-    dots.forEach((dot) => {
-      assertEqual(dot.title, 'Active session', 'active dot has a title');
-      assertEqual(dot.getAttribute('aria-hidden'), 'true', 'active dot is hidden from assistive technology');
-      assertEqual(dot.getAttribute('aria-label'), null, 'generic active dot has no aria-label');
-    });
-    const activeText = elements.hubAgentLinks.querySelectorAll('.visually-hidden');
-    assertEqual(activeText.length, 2, 'each active link contains accessible status text');
-    activeText.forEach((text) => assertEqual(text.textContent, 'Active session', 'active status text is explicit'));
+    const current = links.find((link) => link.querySelector('.hub-agent-name').textContent === 'Current');
+    const worker = links.find((link) => link.querySelector('.hub-agent-name').textContent === 'Worker');
+    assertEqual(current.getAttribute('aria-current'), 'true', 'current node keeps selected state');
+    assertEqual(current.querySelector('.hub-agent-attention'), null, 'current node never duplicates session attention');
+    assertEqual(worker.children[0].className, 'hub-agent-icon', 'robot icon owns the aligned leading column');
+    assertEqual(worker.children[1].className, 'hub-agent-name', 'agent name follows the icon');
+    assertEqual(worker.children[2].className, 'hub-agent-attention', 'attention dot owns the trailing column');
+    const dot = worker.querySelector('.hub-agent-attention');
+    assertEqual(dot.title, 'Needs attention', 'attention dot has an explicit title');
+    assertEqual(dot.getAttribute('aria-hidden'), 'true', 'visual dot is hidden from assistive technology');
+    assertEqual(worker.querySelector('.visually-hidden').textContent, 'Needs attention', 'attention is announced once');
   });
 
   await run('initial Hub 401 hides and clears agent links', async () => {

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -186,6 +186,9 @@
           </div>
         </div>
         <div class="sidebar-content" id="sidebarContent">
+          <div class="sidebar-search-wrap">
+            <input class="sidebar-search-input" id="sidebarSearchInput" type="search" placeholder="Search chats" autocomplete="off" aria-label="Search chats">
+          </div>
           <div class="sidebar-actions">
             <button class="new-chat-btn" id="newChatBtn" type="button">
               <svg class="sidebar-action-icon" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -211,9 +214,6 @@
               <span>Back to Hub</span>
             </a>
             <nav class="hub-agent-links hidden" id="hubAgentLinks" aria-label="Hub agents"></nav>
-          </div>
-          <div class="sidebar-search-wrap">
-            <input class="sidebar-search-input" id="sidebarSearchInput" type="search" placeholder="Search chats" autocomplete="off" aria-label="Search chats">
           </div>
           <div class="session-groups" id="sessionGroups"></div>
         </div>


### PR DESCRIPTION
## Summary

- move chat search to the top of the sidebar
- promote Hub agents to full-width, full-size navigation rows with aligned robot icons
- reserve a fixed trailing column for attention dots so dotted and undotted rows never shift
- show attention only after a non-current agent transitions from running to finished during the page lifetime
- keep selected-agent styling separate from attention state

## Behavior

The green dot is not an online or selected indicator. It appears when a background agent had an active run and that run finishes, remains latched across Hub refreshes, and clears when the agent row is visited.

## Validation

- `node internal/serveui/static/app_sidebar_test.js`
- `go test ./internal/serveui/...`
- `go test ./...` *(all changed/relevant packages pass; two unrelated `cmd` tests fail because the global injected skill budget hides temporary test skills: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`)*
- built the binary and exercised the real sidebar in system Chromium with mocked Hub transitions: 4 rows, 4 robot icons, exactly 1 post-completion attention dot
- two `claude-bin:opus-max` review rounds; first caught active-vs-attention semantics, second found no blockers after correction
