### PR TITLE
fix: steer claude-bin with native interrupts

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -96,6 +96,15 @@ type ClaudeBinProvider struct {
 	tempFileTracker
 
 	activeStream atomic.Bool
+
+	// activeInput keeps Claude's stream-json stdin open for native control
+	// requests while a turn is running. RequestInlineFlush uses it to interrupt
+	// prose/model generation immediately instead of waiting for an MCP tool
+	// result boundary.
+	activeInputMu sync.Mutex
+	activeInput   *claudeStreamInput
+	interruptSeq  atomic.Uint64
+	interruptSent atomic.Bool
 }
 
 // ClaudeCommandError is retained as a compatibility alias for callers and tests.
@@ -342,11 +351,81 @@ func (p *ClaudeBinProvider) Capabilities() Capabilities {
 	}
 }
 
+type claudeStreamInput struct {
+	mu     sync.Mutex
+	writer io.WriteCloser
+	closed bool
+}
+
+func (in *claudeStreamInput) WriteLine(payload []byte) error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	if in.closed || in.writer == nil {
+		return io.ErrClosedPipe
+	}
+	if _, err := in.writer.Write(payload); err != nil {
+		return err
+	}
+	_, err := in.writer.Write([]byte{'\n'})
+	return err
+}
+
+func (in *claudeStreamInput) Close() error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	if in.closed || in.writer == nil {
+		return nil
+	}
+	in.closed = true
+	return in.writer.Close()
+}
+
+func (p *ClaudeBinProvider) activateStreamInput(in *claudeStreamInput) {
+	p.activeInputMu.Lock()
+	p.activeInput = in
+	p.activeInputMu.Unlock()
+}
+
+func (p *ClaudeBinProvider) deactivateStreamInput(in *claudeStreamInput) {
+	p.activeInputMu.Lock()
+	if p.activeInput == in {
+		p.activeInput = nil
+	}
+	p.activeInputMu.Unlock()
+}
+
+func (p *ClaudeBinProvider) sendNativeInterrupt() bool {
+	p.activeInputMu.Lock()
+	in := p.activeInput
+	p.activeInputMu.Unlock()
+	if in == nil {
+		return false
+	}
+	requestID := fmt.Sprintf("term_llm_interrupt_%d", p.interruptSeq.Add(1))
+	payload, err := json.Marshal(map[string]any{
+		"type":       "control_request",
+		"request_id": requestID,
+		"request": map[string]string{
+			"subtype": "interrupt",
+		},
+	})
+	p.interruptSent.Store(true)
+	if err != nil || in.WriteLine(payload) != nil {
+		p.interruptSent.Store(false)
+		return false
+	}
+	p.clearInlineFlush()
+	return true
+}
+
 func (p *ClaudeBinProvider) RequestInlineFlush() {
 	p.requestInlineFlush()
+	p.sendNativeInterrupt()
 }
 
 func (p *ClaudeBinProvider) SupportsInlineFlush() bool { return true }
+
+func (p *ClaudeBinProvider) SupportsImmediateInterruption() bool { return true }
 
 func (p *ClaudeBinProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
@@ -399,29 +478,17 @@ func (p *ClaudeBinProvider) Stream(ctx context.Context, req Request) (Stream, er
 			streamJSONSessionID = p.sessionID
 		}
 
-		// Build the conversation prompt from messages to send.
-		// Use stream-json format when images are present so the model can vision-analyze them.
-		useStreamJson := hasImages(messagesToSend)
-		if useStreamJson && strings.TrimSpace(p.buildStreamJsonInput(messagesToSend, streamJSONSessionID)) == "" {
-			slog.Warn("claude-bin stream-json input was empty despite image detection; falling back to text prompt")
-			useStreamJson = false
-		}
-		// buildPrompt produces the full stdin payload for a set of messages.
-		// For text mode the system prompt is passed via --system-prompt above,
-		// not embedded in stdin as a fake "System:" transcript line. Claude Code
-		// treats stdin as user conversation text; putting the system prompt there
-		// makes it vulnerable to being interpreted or narrated as prompt content.
-		// For stream-json mode the system prompt also goes on argv.
+		// Keep every Claude turn on stream-json input. Besides carrying images,
+		// this leaves a bidirectional stdin channel available for Claude Code's
+		// native interrupt control request while model output is in flight.
 		buildPrompt := func(msgs []Message) string {
-			if useStreamJson {
-				return p.buildStreamJsonInput(msgs, streamJSONSessionID)
-			}
-			return p.buildConversationPrompt(msgs)
-		}
-		if useStreamJson {
-			args = append(args, "--input-format", "stream-json")
+			return p.buildStreamJsonInput(msgs, streamJSONSessionID)
 		}
 		userPrompt := buildPrompt(messagesToSend)
+		if strings.TrimSpace(userPrompt) == "" {
+			return fmt.Errorf("claude-bin stream-json input is empty")
+		}
+		args = append(args, "--input-format", "stream-json")
 
 		debug := req.Debug || req.DebugRaw
 
@@ -780,6 +847,24 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		return fmt.Errorf("failed to start claude: %w", err)
 	}
 
+	p.interruptSent.Store(false)
+	streamInput := &claudeStreamInput{writer: stdin}
+	if err := streamInput.WriteLine([]byte(userPrompt)); err != nil {
+		_ = streamInput.Close()
+		return fmt.Errorf("write claude stream-json input: %w", err)
+	}
+	p.activateStreamInput(streamInput)
+	defer func() {
+		p.deactivateStreamInput(streamInput)
+		_ = streamInput.Close()
+		p.interruptSent.Store(false)
+	}()
+	// An interjection can race process startup. The shared flush marker records
+	// it until stdin is live, at which point the native interrupt can be sent.
+	if p.inlineFlushRequested() {
+		p.sendNativeInterrupt()
+	}
+
 	bridge := &claudeTurnBridge{
 		toolReqCh: make(chan claudeToolRequest, 64),
 		done:      make(chan struct{}),
@@ -829,12 +914,6 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		}
 	}()
 
-	// Write prompt to stdin and close
-	go func() {
-		defer stdin.Close()
-		stdin.Write([]byte(userPrompt))
-	}()
-
 	lineCh := make(chan string, 256)
 	scanErrCh := make(chan error, 1)
 	var (
@@ -848,6 +927,12 @@ func (p *ClaudeBinProvider) runClaudeCommand(
 		for scanner.Scan() {
 			line := scanner.Text()
 			recordCLITailLine(&stdoutMu, &stdoutTail, line, claudeStdoutTailMaxLines)
+			if claudeStreamLineType(line) == "result" {
+				// Streaming input keeps Claude alive for more user turns. term-llm
+				// resumes those as separate provider turns, so EOF after this
+				// terminal frame lets the current subprocess exit cleanly.
+				_ = streamInput.Close()
+			}
 			if line != "" {
 				select {
 				case lineCh <- line:
@@ -1013,6 +1098,16 @@ drained:
 	return lastUsage, toolsExecuted, handledTerminalResult, nil
 }
 
+func claudeStreamLineType(line string) string {
+	var message struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal([]byte(line), &message) != nil {
+		return ""
+	}
+	return message.Type
+}
+
 func (p *ClaudeBinProvider) handleClaudeLine(
 	ctx context.Context,
 	line string,
@@ -1095,6 +1190,10 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 		var resultMsg claudeResultMessage
 		if err := json.Unmarshal([]byte(line), &resultMsg); err == nil {
 			permissionDenied := resultMsg.hasPermissionDenial()
+			nativeInterrupted := resultMsg.Subtype == claudeResultSubtypeInterrupted && p.interruptSent.Swap(false)
+			if nativeInterrupted && handledTerminalResult != nil {
+				*handledTerminalResult = true
+			}
 			// Claude Code owns the tool loop, so exhausting its turn budget ends
 			// the run here rather than in the engine. Warn like the engine's own
 			// budget does and let the turn complete: the work already streamed is
@@ -1112,7 +1211,7 @@ func (p *ClaudeBinProvider) handleClaudeLine(
 			// Check for API errors (rate limits, auth issues, etc.). Claude Code
 			// reports permission denials as terminal result errors too; surface
 			// those as model-visible text so the conversation can fail gracefully.
-			if resultMsg.IsError && resultMsg.Result != "" && !permissionDenied && !maxTurnsReached {
+			if resultMsg.IsError && resultMsg.Result != "" && !permissionDenied && !maxTurnsReached && !nativeInterrupted {
 				return fmt.Errorf("claude API error: %s", resultMsg.Result)
 			}
 
@@ -1176,6 +1275,10 @@ const defaultClaudeBinMaxTurns = 200
 // claudeResultSubtypeMaxTurns is the terminal result subtype Claude Code reports
 // when the inline tool loop exhausts --max-turns.
 const claudeResultSubtypeMaxTurns = "error_max_turns"
+
+// claudeResultSubtypeInterrupted is emitted after a successful native interrupt
+// control request. It is an expected provider-turn boundary, not an API error.
+const claudeResultSubtypeInterrupted = "error_during_execution"
 
 // claudeMaxTurns returns the turn budget handed to Claude Code for one provider
 // turn. Requests without tools cannot loop, so they stay pinned at a single turn.

--- a/internal/llm/claude_bin_continuation_test.go
+++ b/internal/llm/claude_bin_continuation_test.go
@@ -58,6 +58,20 @@ func (h *claudeContinuationHarness) resumed() bool {
 	return false
 }
 
+func (h *claudeContinuationHarness) inputText(t *testing.T) string {
+	t.Helper()
+	messages := parseSDKUserMessages(t, h.stdin)
+	var parts []string
+	for _, message := range messages {
+		for _, block := range message.Message.Content {
+			if block.Type == "text" {
+				parts = append(parts, block.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 func assistantToolCall(id, name, args string) Message {
 	return Message{
 		Role: RoleAssistant,
@@ -82,8 +96,8 @@ func TestClaudeBinResumeSendsOnlyNewUserTurns(t *testing.T) {
 	if h.resumed() {
 		t.Fatalf("first turn used --resume: %q", strings.Join(h.args, " "))
 	}
-	if got, want := h.stdin, "User: turn one"; got != want {
-		t.Fatalf("first turn stdin = %q, want %q", got, want)
+	if got, want := h.inputText(t), "turn one"; got != want {
+		t.Fatalf("first turn stdin text = %q, want %q", got, want)
 	}
 
 	replyOne := AssistantText("answer one")
@@ -92,8 +106,8 @@ func TestClaudeBinResumeSendsOnlyNewUserTurns(t *testing.T) {
 	if !h.resumed() {
 		t.Fatalf("second turn did not resume: %q", strings.Join(h.args, " "))
 	}
-	if got, want := h.stdin, "User: turn two"; got != want {
-		t.Fatalf("second turn stdin = %q, want only the new user turn %q", got, want)
+	if got, want := h.inputText(t), "turn two"; got != want {
+		t.Fatalf("second turn stdin text = %q, want only the new user turn %q", got, want)
 	}
 
 	toolCall := assistantToolCall("call-1", "glob", `{"pattern":"*.md"}`)
@@ -104,8 +118,8 @@ func TestClaudeBinResumeSendsOnlyNewUserTurns(t *testing.T) {
 	if !h.resumed() {
 		t.Fatalf("third turn did not resume: %q", strings.Join(h.args, " "))
 	}
-	if got, want := h.stdin, "User: turn three"; got != want {
-		t.Fatalf("third turn stdin = %q, want only the new user turn %q", got, want)
+	if got, want := h.inputText(t), "turn three"; got != want {
+		t.Fatalf("third turn stdin text = %q, want only the new user turn %q", got, want)
 	}
 	for _, banned := range []string{"<conversation_history>", "Assistant called tool:", "Tool result (", "answer one", "answer two"} {
 		if strings.Contains(h.stdin, banned) {
@@ -171,8 +185,8 @@ func TestClaudeBinImportedStateWithoutDigestStillResumes(t *testing.T) {
 	if !h.resumed() {
 		t.Fatalf("legacy state did not resume: %q", strings.Join(h.args, " "))
 	}
-	if got, want := h.stdin, "User: turn two"; got != want {
-		t.Fatalf("legacy resume stdin = %q, want %q", got, want)
+	if got, want := h.inputText(t), "turn two"; got != want {
+		t.Fatalf("legacy resume stdin text = %q, want %q", got, want)
 	}
 	if h.provider.transcriptDigest == "" {
 		t.Fatal("completed turn did not start fingerprinting the transcript")

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -38,6 +38,10 @@ func TestClaudeBinProvider_ImplementsInlineFlusher(t *testing.T) {
 	if !flusher.SupportsInlineFlush() {
 		t.Fatal("retry wrapper does not report claude-bin inline flush support")
 	}
+	interrupter, ok := wrapped.(ImmediateInterrupter)
+	if !ok || !interrupter.SupportsImmediateInterruption() {
+		t.Fatal("retry wrapper does not report claude-bin immediate interruption support")
+	}
 	flusher.RequestInlineFlush()
 	if !provider.inlineFlushRequested() {
 		t.Fatal("RequestInlineFlush did not mark the tool-result boundary")
@@ -45,6 +49,88 @@ func TestClaudeBinProvider_ImplementsInlineFlusher(t *testing.T) {
 	formatted := provider.formatToolOutputForClaude(TextOutput("tool ok"))
 	if !strings.Contains(formatted, strings.TrimSpace(inlineFlushToolNotice)) {
 		t.Fatalf("formatToolOutputForClaude = %q, want flush notice", formatted)
+	}
+}
+
+func TestClaudeBinProvider_NativeInterruptEndsActiveProseTurn(t *testing.T) {
+	binDir := t.TempDir()
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	script := `#!/usr/bin/env python3
+import json, os, sys
+first = json.loads(sys.stdin.readline())
+if first.get("type") != "user":
+    sys.exit(2)
+open(os.environ["CLAUDE_INTERRUPT_READY"], "w").close()
+control = json.loads(sys.stdin.readline())
+if control.get("type") != "control_request" or control.get("request", {}).get("subtype") != "interrupt":
+    sys.exit(3)
+print(json.dumps({"type":"control_response","response":{"subtype":"success","request_id":control.get("request_id"),"response":{"still_queued":[]}}}), flush=True)
+print(json.dumps({"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"partial"}}}), flush=True)
+print(json.dumps({"type":"result","subtype":"error_during_execution","is_error":True,"result":"interrupted by user","usage":{}}), flush=True)
+sys.exit(1)
+`
+	claudePath := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(claudePath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CLAUDE_INTERRUPT_READY", readyFile)
+
+	provider := NewClaudeBinProvider("haiku", nil)
+	stream, err := provider.Stream(context.Background(), Request{Messages: []Message{UserText("long answer")}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+
+	type streamResult struct {
+		text string
+		err  error
+	}
+	done := make(chan streamResult, 1)
+	go func() {
+		var text strings.Builder
+		for {
+			event, recvErr := stream.Recv()
+			if recvErr == io.EOF {
+				done <- streamResult{text: text.String()}
+				return
+			}
+			if recvErr != nil {
+				done <- streamResult{err: recvErr}
+				return
+			}
+			if event.Type == EventTextDelta {
+				text.WriteString(event.Text)
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, statErr := os.Stat(readyFile); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fake Claude did not receive initial stream-json user message")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	provider.RequestInlineFlush()
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("interrupted stream failed: %v", result.err)
+		}
+		if result.text != "partial" {
+			t.Fatalf("stream text = %q, want partial output preserved", result.text)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("native interrupt did not end Claude stream")
+	}
+	if provider.inlineFlushRequested() {
+		t.Fatal("successful native interrupt retained tool-boundary fallback")
 	}
 }
 

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -195,6 +195,14 @@ type InlineFlusher interface {
 	SupportsInlineFlush() bool
 }
 
+// ImmediateInterrupter reports that a provider can end an in-flight model turn
+// without waiting for a tool boundary. Engines use the normal agentic loop for
+// these providers even when no tools are exposed so queued interjections have a
+// continuation boundary to consume.
+type ImmediateInterrupter interface {
+	SupportsImmediateInterruption() bool
+}
+
 // inlineFlushResetter clears a flush request at an engine-controlled provider
 // turn boundary. Keeping this outside provider Stream implementations preserves
 // a request while RetryProvider re-enters the same logical turn.
@@ -460,6 +468,11 @@ func (e *Engine) requestInlineFlush() {
 func (e *Engine) providerSupportsInlineFlush() bool {
 	flusher, ok := e.provider.(InlineFlusher)
 	return ok && flusher.SupportsInlineFlush()
+}
+
+func (e *Engine) providerSupportsImmediateInterruption() bool {
+	interrupter, ok := e.provider.(ImmediateInterrupter)
+	return ok && interrupter.SupportsImmediateInterruption()
 }
 
 func (e *Engine) clearInlineFlush() {
@@ -1846,7 +1859,10 @@ func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 	// 2. Decide if we use the agentic loop
 	// We use it if request has tools, or this request opted into a discovery
 	// planner that may add authorised MCP tools, and the provider supports calls.
-	useLoop := caps.ToolCalls && (len(req.Tools) > 0 || planner != nil)
+	// Providers with a true mid-generation interrupt also need the loop when no
+	// tools are exposed: the next provider turn is where the queued steer is
+	// committed and delivered after the interrupted turn.
+	useLoop := caps.ToolCalls && (len(req.Tools) > 0 || planner != nil || e.providerSupportsImmediateInterruption())
 
 	if useLoop {
 		e.beginInterjectionRun(getMaxTurns(req) > 1)

--- a/internal/llm/engine_orchestration_test.go
+++ b/internal/llm/engine_orchestration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
@@ -1000,6 +1001,91 @@ func TestEngineOrchestration_ExternalSearchMixedCalls(t *testing.T) {
 	}
 	if !foundUnregistered {
 		t.Errorf("Expected suggest_something tool call to be present")
+	}
+}
+
+type immediateInterruptionProvider struct {
+	calls       int
+	interrupted chan struct{}
+	once        sync.Once
+}
+
+func (p *immediateInterruptionProvider) Name() string       { return "immediate-interruption-test" }
+func (p *immediateInterruptionProvider) Credential() string { return "test" }
+func (p *immediateInterruptionProvider) Capabilities() Capabilities {
+	return Capabilities{ToolCalls: true, InlineToolLoop: true, OrderedInlineToolEvents: true}
+}
+func (p *immediateInterruptionProvider) SupportsInlineFlush() bool { return true }
+func (p *immediateInterruptionProvider) SupportsImmediateInterruption() bool {
+	return true
+}
+func (p *immediateInterruptionProvider) RequestInlineFlush() {
+	p.once.Do(func() { close(p.interrupted) })
+}
+func (p *immediateInterruptionProvider) Stream(ctx context.Context, _ Request) (Stream, error) {
+	p.calls++
+	call := p.calls
+	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
+		if call == 1 {
+			if err := send.Send(Event{Type: EventTextDelta, Text: "partial"}); err != nil {
+				return err
+			}
+			select {
+			case <-p.interrupted:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		} else {
+			if err := send.Send(Event{Type: EventTextDelta, Text: "steered"}); err != nil {
+				return err
+			}
+		}
+		return send.Send(Event{Type: EventDone})
+	}), nil
+}
+
+func TestImmediateInterruptionEnablesInterjectionWithoutTools(t *testing.T) {
+	provider := &immediateInterruptionProvider{interrupted: make(chan struct{})}
+	engine := NewEngine(provider, nil)
+	stream, err := engine.Stream(context.Background(), Request{Messages: []Message{UserText("start")}, MaxTurns: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	var text strings.Builder
+	committed := false
+	queued := false
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatal(recvErr)
+		}
+		if event.Type == EventTextDelta {
+			text.WriteString(event.Text)
+			if !queued {
+				_, status := engine.QueueInterjectionWithStatus(QueuedInterjection{ID: "no-tools-steer", Message: UserText("steer")})
+				if status != InterjectionQueueQueued {
+					t.Fatalf("queue status = %q", status)
+				}
+				queued = true
+			}
+		}
+		if event.Type == EventInterjection && event.InterjectionID == "no-tools-steer" {
+			committed = true
+		}
+	}
+	if provider.calls != 2 {
+		t.Fatalf("provider calls = %d, want interrupted turn plus resumed steer", provider.calls)
+	}
+	if !committed {
+		t.Fatal("queued interjection was not committed")
+	}
+	if got := text.String(); got != "partialsteered" {
+		t.Fatalf("text = %q", got)
 	}
 }
 

--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -187,6 +187,13 @@ func (r *RetryProvider) SupportsInlineFlush() bool {
 	return ok && flusher.SupportsInlineFlush()
 }
 
+// SupportsImmediateInterruption reports whether the wrapped provider can end
+// model generation immediately rather than waiting for a tool result.
+func (r *RetryProvider) SupportsImmediateInterruption() bool {
+	interrupter, ok := r.inner.(ImmediateInterrupter)
+	return ok && interrupter.SupportsImmediateInterruption()
+}
+
 // clearInlineFlush forwards logical provider-turn resets without clearing a
 // request between RetryProvider attempts of that same turn.
 func (r *RetryProvider) clearInlineFlush() {


### PR DESCRIPTION
## Summary

- keep `claude-bin` stdin open in stream-json mode for every turn
- use Claude Code's native `control_request` / `interrupt` protocol when an interjection requests an inline flush
- treat the resulting `error_during_execution` as an expected turn boundary, then deliver the queued steer through the existing resumed provider-turn path
- retain the MCP tool-result flush notice as a fallback when native control is unavailable or races startup
- let providers with immediate interruption enter the engine loop even without tools, so prose-only Claude turns can be steered

## Why

The previous `claude-bin` interjection path could only append a stop notice to the next MCP tool result. A long prose or reasoning response with no later tool boundary therefore completed before the queued interjection was delivered.

Claude Code 2.1.231 accepts a native interrupt over bidirectional stream-json stdin. A plain second user frame only queues; the control request immediately ends the active model turn.

## Verification

- `go test ./internal/llm`
- `go test -race ./internal/llm`
- focused interruption/resume tests repeated 20 times
- `go build ./...`
- live authenticated Haiku test, with **no tools exposed**:
  - asked Haiku to print integers 1 through 1000
  - queued the steer after more than 20 bytes had streamed
  - Claude stopped after `20`, committed the interjection, resumed, and returned `STEERED`
  - completed in 4.45s; observed tail: `...17\n18\n19\n20STEERED`
  - original response did not reach `1000`
- live authenticated Haiku tool-loop test:
  - asked Haiku to sleep for one second, say `HELLO`, sleep for another second, then say `DONE`
  - queued the steer 200ms into the second sleep tool call
  - the already-running tool completed normally, then Claude committed the interjection and returned `STEERED` without saying `DONE`
  - observed output: `I'll follow that sequence exactly.HELLOSTEERED`

`go test ./...` was otherwise green except two existing `cmd` tests whose request-directory skills were omitted because the local global skill metadata budget was exhausted (`TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`). The changed `internal/llm` package passes normally and under the race detector.
