### PR TITLE
feat(ollama): support named thinking levels

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -472,7 +472,7 @@ func resolveBenchmarkTargets(ctx context.Context, cfg *config.Config, providerFl
 			reasoningExpected = modelEffort != ""
 			targetCapabilities.SupportsReasoningEffort = len(llm.ReasoningEffortsForProviderModel(string(providerType), selectedModel)) > 0
 		}
-		if providerCfg.Think != nil && *providerCfg.Think {
+		if (providerCfg.Think != nil && *providerCfg.Think) || strings.TrimSpace(providerCfg.ThinkLevel) != "" {
 			reasoningExpected = true
 		}
 		reportedNumCtx := 0

--- a/docs-site/content/reference/providers-and-models.md
+++ b/docs-site/content/reference/providers-and-models.md
@@ -160,6 +160,21 @@ providers:
 
 The provider uses `https://cloud-api.near.ai/v1`, supports tool calls, and has a curated fallback list of TEE-hosted text models. `term-llm models --provider nearai` queries NEAR AI Cloud's public `/model/list` catalog and filters it to chat-capable models, with token prices shown per 1M tokens when available.
 
+## Ollama thinking levels
+
+Ollama's native chat API accepts either a boolean `think` switch or a named thinking level. Use `think` for binary on/off models, or `think_level` when the model supports `low`, `medium`, `high`, or `max`:
+
+```yaml
+providers:
+  local_qwen:
+    type: ollama
+    base_url: http://127.0.0.1:11434
+    model: qwen3:30b
+    think_level: low
+```
+
+`think_level` takes precedence when both settings are present. Named levels are useful when binary thinking produces unnecessarily long traces; support still depends on the selected Ollama model.
+
 ## vLLM reasoning providers
 
 For vLLM servers running reasoning models, prefer `type: vllm` instead of generic `openai_compatible`. The vLLM provider still uses the OpenAI-compatible `/v1/chat/completions` API, but maps term-llm reasoning effort suffixes into model-family-specific vLLM request fields and replays prior assistant reasoning with vLLM's current `reasoning` message field.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,7 +191,8 @@ type ProviderConfig struct {
 	ModelMap     map[string]string `mapstructure:"model_map"`         // Friendly name -> Bedrock model ID/ARN
 
 	// Ollama-native sampling options (type: ollama only)
-	Think           *bool    `mapstructure:"think"`            // Enable extended thinking / reasoning
+	Think           *bool    `mapstructure:"think"`            // Enable or disable extended thinking
+	ThinkLevel      string   `mapstructure:"think_level"`      // Thinking level: low, medium, high, or max
 	TopK            *int     `mapstructure:"top_k"`            // Top-K sampling
 	MinP            *float64 `mapstructure:"min_p"`            // Min-P sampling
 	PresencePenalty *float64 `mapstructure:"presence_penalty"` // Presence penalty

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -419,6 +419,7 @@ var providerFieldSpecs = []ProviderFieldSpec{
 	{Path: "session_token", Sensitive: true},
 	{Path: "model_map", Placeholder: map[string]any{}},
 	{Path: "think", Placeholder: false},
+	{Path: "think_level", Placeholder: "low"},
 	{Path: "top_k", Placeholder: 0},
 	{Path: "min_p", Placeholder: 0.0},
 	{Path: "presence_penalty", Placeholder: 0.0},

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -567,8 +567,13 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 		return NewAgyBinProvider(cfg.Model, cfg.Env), nil
 
 	case config.ProviderTypeOllama:
+		thinkLevel, err := normalizeOllamaThinkLevel(cfg.ThinkLevel)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", name, err)
+		}
 		opts := OllamaOptions{
 			Think:           cfg.Think,
+			ThinkLevel:      thinkLevel,
 			TopK:            cfg.TopK,
 			MinP:            cfg.MinP,
 			PresencePenalty: cfg.PresencePenalty,

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestCreateProviderFromConfigRejectsInvalidOllamaThinkLevel(t *testing.T) {
+	_, err := createProviderFromConfig("local", &config.ProviderConfig{
+		Type:       config.ProviderTypeOllama,
+		Model:      "qwen3:14b",
+		ThinkLevel: "extreme",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid Ollama think_level") {
+		t.Fatalf("error = %v, want invalid think_level guidance", err)
+	}
+}
+
 func TestCreateProviderFromConfigGrokBin(t *testing.T) {
 	provider, err := createProviderFromConfig("grok-bin", &config.ProviderConfig{
 		Type:  config.ProviderTypeGrokBin,

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -24,6 +24,7 @@ var (
 // in the shared Request struct.
 type OllamaOptions struct {
 	Think           *bool
+	ThinkLevel      string
 	TopK            *int
 	MinP            *float64
 	PresencePenalty *float64
@@ -38,6 +39,16 @@ type OllamaProvider struct {
 	baseURL string
 	model   string
 	opts    OllamaOptions
+}
+
+func normalizeOllamaThinkLevel(level string) (string, error) {
+	level = strings.ToLower(strings.TrimSpace(level))
+	switch level {
+	case "", "low", "medium", "high", "max":
+		return level, nil
+	default:
+		return "", fmt.Errorf("invalid Ollama think_level %q: expected low, medium, high, or max", level)
+	}
 }
 
 // NewOllamaChatProvider creates a native Ollama chat provider.
@@ -88,7 +99,7 @@ type ollamaChatRequest struct {
 	Messages []ollamaChatMsg `json:"messages"`
 	Tools    []ollamaTool    `json:"tools,omitempty"`
 	Stream   bool            `json:"stream"`
-	Think    *bool           `json:"think,omitempty"`
+	Think    any             `json:"think,omitempty"`
 	Options  *ollamaChatOpts `json:"options,omitempty"`
 }
 
@@ -298,11 +309,22 @@ func buildOllamaTools(specs []ToolSpec) ([]ollamaTool, error) {
 func (p *OllamaProvider) Stream(ctx context.Context, req Request) (Stream, error) {
 	// Strip a -think suffix from the model name and enable thinking automatically.
 	model := chooseModel(req.Model, p.model)
-	think := p.opts.Think
+	var think any
+	if p.opts.Think != nil {
+		think = *p.opts.Think
+	}
+	thinkLevel, err := normalizeOllamaThinkLevel(p.opts.ThinkLevel)
+	if err != nil {
+		return nil, err
+	}
+	if thinkLevel != "" {
+		think = thinkLevel
+	}
 	if strings.HasSuffix(model, "-think") {
 		model = strings.TrimSuffix(model, "-think")
-		t := true
-		think = &t
+		if thinkLevel == "" {
+			think = true
+		}
 	}
 
 	messages := buildOllamaMessages(req.Messages)
@@ -356,8 +378,8 @@ func (p *OllamaProvider) Stream(ctx context.Context, req Request) (Stream, error
 		fmt.Fprintf(os.Stderr, "Model: %s\n", model)
 		fmt.Fprintf(os.Stderr, "Messages: %d\n", len(messages))
 		fmt.Fprintf(os.Stderr, "Tools: %d\n", len(tools))
-		if think != nil && *think {
-			fmt.Fprintf(os.Stderr, "Think: enabled\n")
+		if think != nil {
+			fmt.Fprintf(os.Stderr, "Think: %v\n", think)
 		}
 		fmt.Fprintln(os.Stderr, "====================================")
 	}

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -128,8 +128,8 @@ func TestOllamaProviderStreamThink(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollamaChatRequest
 		json.NewDecoder(r.Body).Decode(&req)
-		if req.Think == nil || !*req.Think {
-			t.Error("expected think=true in request")
+		if value, ok := req.Think.(bool); !ok || !value {
+			t.Errorf("expected think=true in request, got %#v", req.Think)
 		}
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		for _, chunk := range []string{
@@ -178,6 +178,88 @@ func TestOllamaProviderStreamThink(t *testing.T) {
 		if kind != ReasoningKindRaw {
 			t.Fatalf("thinking kind = %q, want raw", kind)
 		}
+	}
+}
+
+func TestOllamaProviderStreamThinkFalse(t *testing.T) {
+	var capturedThink any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		capturedThink = req.Think
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"model":"qwen3:14b","message":{"role":"assistant","content":"ok"},"done":true}`)
+	}))
+	defer srv.Close()
+
+	think := false
+	p := NewOllamaChatProvider(srv.URL, "qwen3:14b", OllamaOptions{Think: &think})
+	stream, err := p.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	if capturedThink != false {
+		t.Fatalf("think = %#v, want false", capturedThink)
+	}
+}
+
+func TestOllamaProviderStreamThinkLevel(t *testing.T) {
+	var capturedThink any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		capturedThink = req.Think
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"model":"qwen3:14b","message":{"role":"assistant","content":"ok"},"done":false}`)
+		fmt.Fprintln(w, `{"model":"qwen3:14b","message":{"role":"assistant","content":""},"done":true}`)
+	}))
+	defer srv.Close()
+
+	p := NewOllamaChatProvider(srv.URL, "qwen3:14b", OllamaOptions{ThinkLevel: "low"})
+	stream, err := p.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	if capturedThink != "low" {
+		t.Fatalf("think = %#v, want low", capturedThink)
+	}
+}
+
+func TestNormalizeOllamaThinkLevel(t *testing.T) {
+	for _, level := range []string{"low", "medium", "high", "max"} {
+		got, err := normalizeOllamaThinkLevel(level)
+		if err != nil || got != level {
+			t.Fatalf("normalizeOllamaThinkLevel(%q) = %q, %v", level, got, err)
+		}
+	}
+	if _, err := normalizeOllamaThinkLevel("extreme"); err == nil {
+		t.Fatal("expected invalid think level error")
+	}
+}
+
+func TestOllamaProviderStreamRejectsInvalidThinkLevel(t *testing.T) {
+	p := NewOllamaChatProvider("http://127.0.0.1:1", "qwen3:14b", OllamaOptions{ThinkLevel: "extreme"})
+	_, err := p.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}})
+	if err == nil || !strings.Contains(err.Error(), "invalid Ollama think_level") {
+		t.Fatalf("error = %v, want invalid think_level guidance", err)
 	}
 }
 
@@ -274,7 +356,7 @@ func TestOllamaProviderStreamSuppressesLeadingReasoningWhitespaceArtifact(t *tes
 
 func TestOllamaProviderStreamThinkSuffix(t *testing.T) {
 	var capturedModel string
-	var capturedThink *bool
+	var capturedThink any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollamaChatRequest
 		json.NewDecoder(r.Body).Decode(&req)
@@ -304,8 +386,8 @@ func TestOllamaProviderStreamThinkSuffix(t *testing.T) {
 	if capturedModel != "qwen3:14b" {
 		t.Errorf("expected model 'qwen3:14b' (suffix stripped), got %q", capturedModel)
 	}
-	if capturedThink == nil || !*capturedThink {
-		t.Error("expected think=true when -think suffix used")
+	if value, ok := capturedThink.(bool); !ok || !value {
+		t.Fatalf("expected think=true when -think suffix used, got %#v", capturedThink)
 	}
 }
 


### PR DESCRIPTION
## Summary

- allow Ollama's native `think` request field to carry named levels as well as booleans
- add `think_level: low|medium|high|max` for `type: ollama` providers
- preserve existing `think: true|false` and `-think` behavior, with `think_level` taking precedence
- validate unsupported levels and include named thinking in benchmark capability reporting
- document the configuration and cover boolean, level, precedence, suffix, and invalid-value paths

## Why

Newer Ollama models support graded reasoning through the native `/api/chat` field:

```json
{"think":"high"}
```

term-llm currently models that field as `*bool`, so local models can only toggle reasoning rather than select an effort level.

## Verification

- `go test ./internal/llm ./internal/config`
- `go test ./cmd -run 'TestResolveBenchmarkTargets' -count=1`
- `HOME=<clean> XDG_CONFIG_HOME=<clean> go test ./...`
- live local Ollama smoke against `hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q5_K_XL`:
  - `think_level: high` logged `Think: high` and completed successfully
  - `think: false` logged `Think: false` and completed successfully
