### PR TITLE
fix: Scheduled run insertion is not atomic with schedule advancement

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -1283,33 +1283,46 @@ func (m *jobsV2Manager) countActiveRuns(jobID string) (int, error) {
 	return active, nil
 }
 
-func (m *jobsV2Manager) enqueueRunWithConcurrencyLimit(job jobsV2Job, trigger string, scheduledFor time.Time, onLimit func() error, afterInsert func(string) error) (string, int, bool, error) {
+func (m *jobsV2Manager) enqueueRunWithConcurrencyLimit(job jobsV2Job, trigger string, scheduledFor time.Time, onLimit func(*sql.Tx) error, afterInsert func(*sql.Tx, string) error) (string, int, bool, error) {
 	m.enqueueMu.Lock()
 	defer m.enqueueMu.Unlock()
 
-	active, err := m.countActiveRuns(job.ID)
+	tx, err := m.db.Begin()
+	if err != nil {
+		return "", 0, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var active int
+	err = tx.QueryRow(`SELECT COUNT(1) FROM job_runs_v2 WHERE job_id = ? AND status IN (?, ?, ?)`, job.ID, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning).Scan(&active)
 	if err != nil {
 		return "", 0, false, err
 	}
 	limit := jobsV2ConcurrencyLimit(job)
 	if active >= limit {
 		if onLimit != nil {
-			if err := onLimit(); err != nil {
+			if err := onLimit(tx); err != nil {
 				return "", 0, false, err
 			}
+		}
+		if err := tx.Commit(); err != nil {
+			return "", 0, false, err
 		}
 		return "", active, false, nil
 	}
 
 	runID := "run_" + randomSuffix()
-	_, err = m.db.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, runID, job.ID, trigger, scheduledFor.UTC(), jobsV2RunQueued)
+	_, err = tx.Exec(`INSERT INTO job_runs_v2 (id, job_id, attempt, trigger, scheduled_for, status, created_at, updated_at) VALUES (?, ?, 1, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, runID, job.ID, trigger, scheduledFor.UTC(), jobsV2RunQueued)
 	if err != nil {
 		return "", 0, false, err
 	}
 	if afterInsert != nil {
-		if err := afterInsert(runID); err != nil {
+		if err := afterInsert(tx, runID); err != nil {
 			return "", 0, false, err
 		}
+	}
+	if err := tx.Commit(); err != nil {
+		return "", 0, false, err
 	}
 	return runID, active + 1, true, nil
 }
@@ -1320,15 +1333,15 @@ func (m *jobsV2Manager) scheduleOne(job jobsV2Job, now time.Time) error {
 		return err
 	}
 
-	runID, _, queued, err := m.enqueueRunWithConcurrencyLimit(job, "schedule", now, func() error {
-		_, err := m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
+	runID, _, queued, err := m.enqueueRunWithConcurrencyLimit(job, "schedule", now, func(tx *sql.Tx) error {
+		_, err := tx.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
 		return err
-	}, func(string) error {
+	}, func(tx *sql.Tx, _ string) error {
 		if job.TriggerType == jobsV2TriggerOnce {
-			_, err := m.db.Exec(`UPDATE jobs_v2 SET enabled = 0, next_run_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, job.ID)
+			_, err := tx.Exec(`UPDATE jobs_v2 SET enabled = 0, next_run_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, job.ID)
 			return err
 		}
-		_, err := m.db.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
+		_, err := tx.Exec(`UPDATE jobs_v2 SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, next, job.ID)
 		return err
 	})
 	if err != nil {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -1616,7 +1616,7 @@ func TestJobsV2EnqueueRunWithConcurrencyLimitSerializesConcurrentEnqueues(t *tes
 	var firstErr error
 	go func() {
 		defer close(firstDone)
-		firstRunID, _, firstQueued, firstErr = mgr.enqueueRunWithConcurrencyLimit(job, "manual", time.Now().UTC(), nil, func(string) error {
+		firstRunID, _, firstQueued, firstErr = mgr.enqueueRunWithConcurrencyLimit(job, "manual", time.Now().UTC(), nil, func(*sql.Tx, string) error {
 			close(started)
 			<-release
 			return nil
@@ -1689,6 +1689,90 @@ func TestJobsV2EnqueueRunWithConcurrencyLimitSerializesConcurrentEnqueues(t *tes
 	}
 	if active != 1 {
 		t.Fatalf("active runs = %d, want 1", active)
+	}
+}
+
+func TestJobsV2ScheduledEnqueueRollsBackWhenScheduleAdvancementFails(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "jobs_v2.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := execJobsV2Schema(db); err != nil {
+		_ = db.Close()
+		t.Fatalf("execJobsV2Schema failed: %v", err)
+	}
+
+	mgr := &jobsV2Manager{db: db}
+	runAt := time.Now().UTC().Add(-time.Minute)
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:              "atomic-scheduled-enqueue",
+		Enabled:           true,
+		RunnerType:        jobsV2RunnerProgram,
+		RunnerConfig:      json.RawMessage(`{"command":"true"}`),
+		TriggerType:       jobsV2TriggerOnce,
+		TriggerConfig:     json.RawMessage(`{"run_at":"` + runAt.Format(time.RFC3339Nano) + `"}`),
+		ConcurrencyPolicy: "forbid",
+		MaxConcurrentRuns: 1,
+		MisfirePolicy:     jobsV2MisfireRun,
+		TimeoutSeconds:    30,
+	})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	advanceErr := errors.New("injected schedule advancement failure")
+	_, _, _, err = mgr.enqueueRunWithConcurrencyLimit(job, "schedule", runAt, nil, func(*sql.Tx, string) error {
+		return advanceErr
+	})
+	if !errors.Is(err, advanceErr) {
+		_ = db.Close()
+		t.Fatalf("enqueue error = %v, want %v", err, advanceErr)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close database after failed enqueue: %v", err)
+	}
+
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	mgr = &jobsV2Manager{db: db}
+
+	var runs int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM job_runs_v2 WHERE job_id = ?`, job.ID).Scan(&runs); err != nil {
+		t.Fatalf("count runs after reopen: %v", err)
+	}
+	if runs != 0 {
+		t.Fatalf("runs after rolled-back enqueue = %d, want 0", runs)
+	}
+	job, err = mgr.GetJob(job.ID)
+	if err != nil {
+		t.Fatalf("GetJob after reopen: %v", err)
+	}
+	if !job.Enabled || job.NextRunAt == nil {
+		t.Fatalf("job after rolled-back enqueue = enabled:%t next_run_at:%v, want still due", job.Enabled, job.NextRunAt)
+	}
+
+	if err := mgr.scheduleOne(job, time.Now().UTC()); err != nil {
+		t.Fatalf("scheduleOne after rollback: %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM job_runs_v2 WHERE job_id = ?`, job.ID).Scan(&runs); err != nil {
+		t.Fatalf("count runs after scheduleOne: %v", err)
+	}
+	if runs != 1 {
+		t.Fatalf("runs after scheduleOne = %d, want 1", runs)
+	}
+	job, err = mgr.GetJob(job.ID)
+	if err != nil {
+		t.Fatalf("GetJob after scheduleOne: %v", err)
+	}
+	if job.Enabled || job.NextRunAt != nil {
+		t.Fatalf("job after scheduleOne = enabled:%t next_run_at:%v, want disabled", job.Enabled, job.NextRunAt)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Run the concurrency count, queued-run insert, and schedule bookkeeping inside one SQLite transaction.
- Pass that transaction to the limit and post-insert callbacks, committing only after the once-job disable or cron advancement succeeds.
- Keep `enqueueMu` to preserve same-process admission ordering.
- Add a regression test that injects a schedule-advancement failure after the run insert, reopens the database, and verifies the insert rolled back before a later schedule pass queues exactly one run and disables the once job.

## Why this is high-value

Scheduled jobs are a daily Jarvis path and can execute user-visible notifications, agent work, programs, and token-consuming provider calls. Previously, a crash or database error after the run insert but before schedule advancement could leave both a durable queued run and a still-due job, allowing one-shot or cron side effects to run twice. Making those writes crash-atomic removes that duplicate-execution window with a narrowly scoped transaction.

## Validation

- `go test ./cmd -run '^(TestJobsV2ScheduledEnqueueRollsBackWhenScheduleAdvancementFails|TestJobsV2EnqueueRunWithConcurrencyLimitSerializesConcurrentEnqueues|TestJobsV2ScheduleOneRespectsMaxConcurrentRuns)$' -count=1`
- `go build ./...`
- `HOME="$TMPHOME" XDG_CONFIG_HOME="$TMPHOME/.config" GOMODCACHE=/home/agent/go/pkg/mod GOCACHE=/home/agent/.cache/go-build go test ./...`
- `git diff --check`

The regression test failed before the fix with one committed run after the injected advancement error. An initial unisolated `go test ./...` encountered two unrelated skill-discovery tests affected by the host's global skill catalog; both those tests and the full suite pass with an isolated home/config environment.
