### PR TITLE
fix: Concurrent worktree merges can erase a successful merge

### DIFF
--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -231,7 +231,16 @@ var (
 	ErrConflict           = errors.New("merge back has conflicts")
 	ErrRootDirty          = errors.New("root checkout has uncommitted changes")
 	ErrMergeCleanupFailed = errors.New("merge succeeded but worktree cleanup failed")
+	rootMutationLocks     sync.Map
 )
+
+func lockRootMutation(root string) func() {
+	key, _ := samePathKey(root)
+	value, _ := rootMutationLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
 
 func (o *CreateOptions) progress(msg string) {
 	if o == nil {
@@ -1148,6 +1157,8 @@ func PromoteToRoot(ctx context.Context, dir, branch string, opts PromoteOptions)
 		return res, fmt.Errorf("branch is required")
 	}
 	root := wt.RepoRoot
+	unlockRoot := lockRootMutation(root)
+	defer unlockRoot()
 	worktreeHead := strings.TrimSpace(wt.HeadSHA)
 	if worktreeHead == "" {
 		worktreeHead, _ = revParseFull(wt.Dir, "HEAD")
@@ -1255,6 +1266,8 @@ func StartAssistedMerge(ctx context.Context, dir string, opts AssistedMergeOptio
 		return AssistedMergeResult{}, err
 	}
 	root := wt.RepoRoot
+	unlockRoot := lockRootMutation(root)
+	defer unlockRoot()
 	base := strings.TrimSpace(wt.Base)
 	if base == "" {
 		base = "HEAD"
@@ -1353,6 +1366,11 @@ func MergeBack(ctx context.Context, dir string, opts MergeOptions) (MergeResult,
 		return MergeResult{}, err
 	}
 	root := wt.RepoRoot
+	if mergeBackTestHook != nil {
+		mergeBackTestHook("before-lock")
+	}
+	unlockRoot := lockRootMutation(root)
+	defer unlockRoot()
 	base := strings.TrimSpace(wt.Base)
 	if base == "" {
 		base = "HEAD"
@@ -1373,6 +1391,9 @@ func MergeBack(ctx context.Context, dir string, opts MergeOptions) (MergeResult,
 	}
 	if !opts.AllowDirty && strings.TrimSpace(res.RootStatus) != "" {
 		return res, ErrRootDirty
+	}
+	if mergeBackTestHook != nil {
+		mergeBackTestHook("root-clean")
 	}
 	msg := strings.TrimSpace(opts.Message)
 	if msg == "" {
@@ -1415,6 +1436,8 @@ func MergeBack(ctx context.Context, dir string, opts MergeOptions) (MergeResult,
 	}
 	return res, nil
 }
+
+var mergeBackTestHook func(stage string)
 
 // MergeBackAndCleanup merges a worktree into root and removes it when no other
 // sessions are bound to it. The excluded session is normally the caller's own
@@ -1641,6 +1664,9 @@ func boundedLines(out string, max int) []string {
 }
 
 func cleanupCherryPickState(root string) error {
+	if !cherryPickStateExists(root) && len(conflictFiles(root)) == 0 {
+		return nil
+	}
 	var errs []string
 	if out, err := runGit(root, "reset", "--merge"); err != nil {
 		errs = append(errs, fmt.Sprintf("git reset --merge: %v: %s", err, strings.TrimSpace(out)))

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -733,6 +733,114 @@ func TestMergeBackRefusesDirtyRootByDefault(t *testing.T) {
 	}
 }
 
+func TestConcurrentMergeBackSerializesRootMutation(t *testing.T) {
+	repo := newGitRepoForWorktreeTest(t)
+	firstWorktree, err := Create(context.Background(), repo, CreateOptions{Name: "concurrent-first"})
+	if err != nil {
+		t.Fatalf("Create first worktree: %v", err)
+	}
+	cleanupWorktreeTest(t, firstWorktree.Dir)
+	secondWorktree, err := Create(context.Background(), repo, CreateOptions{Name: "concurrent-second"})
+	if err != nil {
+		t.Fatalf("Create second worktree: %v", err)
+	}
+	cleanupWorktreeTest(t, secondWorktree.Dir)
+
+	if err := os.WriteFile(filepath.Join(firstWorktree.Dir, "file.txt"), []byte("first merge\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile first worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secondWorktree.Dir, "file.txt"), []byte("second merge\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile second worktree: %v", err)
+	}
+
+	firstRootClean := make(chan struct{})
+	secondAttempted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	t.Cleanup(release)
+	var hookMu sync.Mutex
+	beforeLockCalls := 0
+	rootCleanCalls := 0
+	mergeBackTestHook = func(stage string) {
+		hookMu.Lock()
+		switch stage {
+		case "before-lock":
+			beforeLockCalls++
+			if beforeLockCalls == 2 {
+				close(secondAttempted)
+			}
+			hookMu.Unlock()
+		case "root-clean":
+			rootCleanCalls++
+			first := rootCleanCalls == 1
+			if first {
+				close(firstRootClean)
+			}
+			hookMu.Unlock()
+			if first {
+				<-releaseFirst
+			}
+		default:
+			hookMu.Unlock()
+		}
+	}
+	t.Cleanup(func() { mergeBackTestHook = nil })
+
+	type mergeCall struct {
+		result MergeResult
+		err    error
+	}
+	firstDone := make(chan mergeCall, 1)
+	go func() {
+		result, err := MergeBack(context.Background(), firstWorktree.Dir, MergeOptions{})
+		firstDone <- mergeCall{result: result, err: err}
+	}()
+	<-firstRootClean
+
+	secondDone := make(chan mergeCall, 1)
+	go func() {
+		result, err := MergeBack(context.Background(), secondWorktree.Dir, MergeOptions{})
+		secondDone <- mergeCall{result: result, err: err}
+	}()
+	<-secondAttempted
+
+	var earlySecond *mergeCall
+	select {
+	case call := <-secondDone:
+		earlySecond = &call
+	case <-time.After(200 * time.Millisecond):
+	}
+	release()
+
+	first := <-firstDone
+	var second mergeCall
+	if earlySecond != nil {
+		second = *earlySecond
+	} else {
+		second = <-secondDone
+	}
+	if earlySecond != nil {
+		t.Fatalf("second merge completed while first root mutation was in flight: result=%+v err=%v", second.result, second.err)
+	}
+	if first.err != nil || !first.result.Applied {
+		t.Fatalf("first MergeBack result=%+v err=%v, want applied", first.result, first.err)
+	}
+	if !errors.Is(second.err, ErrRootDirty) {
+		t.Fatalf("second MergeBack result=%+v err=%v, want ErrRootDirty", second.result, second.err)
+	}
+	if got := runGitForWorktreeTest(t, repo, "status", "--porcelain"); !strings.Contains(got, "M  file.txt") {
+		t.Fatalf("root status = %q, want successful merge staged", got)
+	}
+	data, err := os.ReadFile(filepath.Join(repo, "file.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile root file: %v", err)
+	}
+	if got := string(data); got != "first merge\n" {
+		t.Fatalf("root file = %q, want successful merge content", got)
+	}
+}
+
 func TestMergeBackConflictCleansCherryPickState(t *testing.T) {
 	repo := newGitRepoForWorktreeTest(t)
 	wt, err := Create(context.Background(), repo, CreateOptions{Name: "conflict-test"})
@@ -776,6 +884,29 @@ func TestMergeBackConflictCleansCherryPickState(t *testing.T) {
 	}
 	if got := string(data); got != "root changed\n" {
 		t.Fatalf("root file = %q, want original root change", got)
+	}
+}
+
+func TestCleanupCherryPickStatePreservesChangesWithoutCherryPick(t *testing.T) {
+	repo := newGitRepoForWorktreeTest(t)
+	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("unrelated staged change\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile root: %v", err)
+	}
+	runGitForWorktreeTest(t, repo, "add", "file.txt")
+	before := runGitForWorktreeTest(t, repo, "status", "--porcelain")
+
+	if err := cleanupCherryPickState(repo); err != nil {
+		t.Fatalf("cleanupCherryPickState: %v", err)
+	}
+	if after := runGitForWorktreeTest(t, repo, "status", "--porcelain"); after != before {
+		t.Fatalf("root status changed from %q to %q without cherry-pick state", before, after)
+	}
+	data, err := os.ReadFile(filepath.Join(repo, "file.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile root: %v", err)
+	}
+	if got := string(data); got != "unrelated staged change\n" {
+		t.Fatalf("root file = %q, want unrelated staged change preserved", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a canonical per-repository-root mutation lock shared by merge-back, promote-to-root, and assisted-merge operations. The lock covers the root cleanliness check through apply, commit, conflict cleanup, or promotion rollback.
- Made cherry-pick cleanup skip `git reset --merge` unless Git has either cherry-pick metadata or unmerged index entries, so cleanup cannot reset unrelated staged changes when the failed command established no cherry-pick state.
- Added regression coverage for overlapping conflicting merge-back requests and for preserving staged changes when no cherry-pick state exists.

## Why this is high-value

Two overlapping web merge/promote requests could both observe a clean root. One request could apply successfully, then the other could conflict and unconditionally reset the first request's staged result while the first client still received `Applied=true`. A double submission or requests from multiple browser tabs could therefore silently erase a successful merge. Per-root serialization makes the later request observe the staged root and return `ErrRootDirty` instead.

## Validation

- `gofmt -w internal/worktree/worktree.go internal/worktree/worktree_test.go`
- `go test ./internal/worktree`
- `go test -race ./internal/worktree`
- `go build ./...`
- `go test ./...` with a clean `HOME`/`XDG_CONFIG_HOME` (passes; the host-configured run independently failed two existing skill-discovery tests because the host's 31 skills exceeded their visible-skill budget)
- `git diff --check`
