### PR TITLE
fix: Root checkout mutations can race with newly admitted or non-web agent runs

### DIFF
--- a/cmd/root_checkout_lease.go
+++ b/cmd/root_checkout_lease.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/samsaffron/term-llm/internal/worktree"
+)
+
+// rootCheckoutLeaseRegistry coordinates agent runs with operations that mutate
+// a repository's main checkout. Runs in linked worktrees use their own checkout
+// and intentionally do not participate.
+type rootCheckoutLeaseRegistry struct {
+	mu     sync.Mutex
+	leases map[string]*rootCheckoutLease
+}
+
+type rootCheckoutLease struct {
+	mu      sync.Mutex
+	readers int
+	writer  bool
+	changed chan struct{}
+}
+
+var processRootCheckoutLeases rootCheckoutLeaseRegistry
+
+func (r *rootCheckoutLeaseRegistry) acquireRun(ctx context.Context, dir string) (func(), error) {
+	dir, err := canonicalRootLeasePath(dir)
+	if err != nil {
+		return func() {}, nil
+	}
+
+	// Mutation admission registers its root before changing HEAD or the index.
+	// Consult registered roots first so a run cannot bypass the lease merely
+	// because Git inspection happens while that mutation is in progress.
+	if lease := r.knownRootLease(dir); lease != nil {
+		return lease.acquireRead(ctx)
+	}
+
+	mainRoot, err := worktree.MainRepoRoot(dir)
+	if err != nil {
+		// Non-Git working directories have no checkout to coordinate.
+		return func() {}, nil
+	}
+	mainRoot, err = canonicalRootLeasePath(mainRoot)
+	if err != nil || !pathWithinRoot(dir, mainRoot) {
+		// The directory belongs to a linked worktree, not the main checkout.
+		return func() {}, nil
+	}
+	return r.lease(mainRoot).acquireRead(ctx)
+}
+
+func (r *rootCheckoutLeaseRegistry) tryAcquireMutation(root string) (func(), bool, error) {
+	mainRoot, err := worktree.MainRepoRoot(root)
+	if err != nil {
+		return nil, false, err
+	}
+	mainRoot, err = canonicalRootLeasePath(mainRoot)
+	if err != nil {
+		return nil, false, err
+	}
+	release, ok := r.lease(mainRoot).tryAcquireWrite()
+	return release, ok, nil
+}
+
+func (r *rootCheckoutLeaseRegistry) knownRootLease(dir string) *rootCheckoutLease {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var match string
+	for root := range r.leases {
+		if pathWithinRoot(dir, root) && len(root) > len(match) {
+			match = root
+		}
+	}
+	return r.leases[match]
+}
+
+func (r *rootCheckoutLeaseRegistry) lease(root string) *rootCheckoutLease {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.leases == nil {
+		r.leases = make(map[string]*rootCheckoutLease)
+	}
+	lease := r.leases[root]
+	if lease == nil {
+		lease = &rootCheckoutLease{changed: make(chan struct{})}
+		r.leases[root] = lease
+	}
+	return lease
+}
+
+func (l *rootCheckoutLease) acquireRead(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		l.mu.Lock()
+		if !l.writer {
+			l.readers++
+			l.mu.Unlock()
+			var once sync.Once
+			return func() {
+				once.Do(func() {
+					l.mu.Lock()
+					l.readers--
+					l.mu.Unlock()
+				})
+			}, nil
+		}
+		changed := l.changed
+		l.mu.Unlock()
+
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (l *rootCheckoutLease) tryAcquireWrite() (func(), bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.writer || l.readers > 0 {
+		return nil, false
+	}
+	l.writer = true
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			l.mu.Lock()
+			l.writer = false
+			close(l.changed)
+			l.changed = make(chan struct{})
+			l.mu.Unlock()
+		})
+	}, true
+}
+
+func canonicalRootLeasePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		var err error
+		path, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+	return filepath.Clean(abs), nil
+}
+
+func pathWithinRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1196,6 +1196,7 @@ type serveServer struct {
 	worktreeRootErr          error
 	fileTrackStoreFn         func() *filetrack.Store // test seam; nil → process-wide store from config
 	worktreeRootFn           func() (string, error)  // test seam; nil → os.Getwd
+	rootMutationAdmitted     func()                  // test seam; called while the exclusive root lease is held
 }
 
 // fileTrackStore returns the file-change history store, or nil when file

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -1145,6 +1145,18 @@ func (rt *serveRuntime) applyRequestAllowedTools(req *llm.Request) func() {
 }
 
 func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHistory bool, inputMessages []llm.Message, req llm.Request, onStart func(), onEvent func(llm.Event) error) (serveRunResult, error) {
+	leaseDir := strings.TrimSpace(req.WorkingDir)
+	if rt.toolMgr != nil {
+		if baseDir := strings.TrimSpace(rt.toolMgr.BaseDir()); baseDir != "" {
+			leaseDir = baseDir
+		}
+	}
+	releaseRootLease, err := processRootCheckoutLeases.acquireRun(ctx, leaseDir)
+	if err != nil {
+		return serveRunResult{}, fmt.Errorf("wait for root checkout mutation: %w", err)
+	}
+	defer releaseRootLease()
+
 	if !rt.mu.TryLock() {
 		return serveRunResult{}, errServeSessionBusy
 	}

--- a/cmd/serve_worktrees.go
+++ b/cmd/serve_worktrees.go
@@ -245,10 +245,11 @@ func (s *serveServer) handleWorktreeMerge(w http.ResponseWriter, r *http.Request
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}
-	if activeRootSessions := s.activeRootRunsForWorktreeMerge(r.Context(), root); len(activeRootSessions) > 0 {
-		writeOpenAIError(w, http.StatusConflict, "conflict_error", fmt.Sprintf("root checkout has active session run(s): %s", strings.Join(activeRootSessions, ", ")))
+	releaseMutation, ok := s.acquireRootMutation(w, r.Context(), root)
+	if !ok {
 		return
 	}
+	defer releaseMutation()
 	opts := worktree.MergeOptions{Commit: req.Commit, Message: req.Message}
 	var res worktree.MergeResult
 	var cleanup worktree.CleanupResult
@@ -274,6 +275,31 @@ func (s *serveServer) handleWorktreeMerge(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"result": res, "cleanup": cleanup})
+}
+
+func (s *serveServer) acquireRootMutation(w http.ResponseWriter, ctx context.Context, root string) (func(), bool) {
+	release, admitted, err := processRootCheckoutLeases.tryAcquireMutation(root)
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", fmt.Sprintf("coordinate root checkout mutation: %v", err))
+		return nil, false
+	}
+	if !admitted {
+		message := "root checkout has an active agent run or worktree mutation"
+		if active := s.activeRootRunsForWorktreeMerge(ctx, root); len(active) > 0 {
+			message = fmt.Sprintf("root checkout has active session run(s): %s", strings.Join(active, ", "))
+		}
+		writeOpenAIError(w, http.StatusConflict, "conflict_error", message)
+		return nil, false
+	}
+	if active := s.activeRootRunsForWorktreeMerge(ctx, root); len(active) > 0 {
+		release()
+		writeOpenAIError(w, http.StatusConflict, "conflict_error", fmt.Sprintf("root checkout has active session run(s): %s", strings.Join(active, ", ")))
+		return nil, false
+	}
+	if s.rootMutationAdmitted != nil {
+		s.rootMutationAdmitted()
+	}
+	return release, true
 }
 
 func (s *serveServer) activeRootRunsForWorktreeMerge(ctx context.Context, root string) []string {
@@ -334,10 +360,11 @@ func (s *serveServer) handleWorktreePromote(w http.ResponseWriter, r *http.Reque
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}
-	if activeRootSessions := s.activeRootRunsForWorktreeMerge(r.Context(), root); len(activeRootSessions) > 0 {
-		writeOpenAIError(w, http.StatusConflict, "conflict_error", fmt.Sprintf("root checkout has active session run(s): %s", strings.Join(activeRootSessions, ", ")))
+	releaseMutation, ok := s.acquireRootMutation(w, r.Context(), root)
+	if !ok {
 		return
 	}
+	defer releaseMutation()
 	res, err := worktree.PromoteToRoot(r.Context(), wt.Dir, req.Branch, worktree.PromoteOptions{})
 	if errors.Is(err, worktree.ErrRootDirty) {
 		writeJSON(w, http.StatusConflict, map[string]any{"result": res, "error": "root_dirty", "message": err.Error()})

--- a/cmd/serve_worktrees_test.go
+++ b/cmd/serve_worktrees_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/worktree"
 )
@@ -324,6 +325,144 @@ func TestServeWorktreeMergeBlocksActiveRootRun(t *testing.T) {
 	}
 	if !strings.Contains(promoteRec.Body.String(), "root-active") {
 		t.Fatalf("promote body = %s, want active root session id", promoteRec.Body.String())
+	}
+}
+
+func TestServeWorktreeMutationsBlockNonWebRootRunLease(t *testing.T) {
+	repo := newGitRepoForBindingTest(t)
+	wt, err := worktree.Create(context.Background(), repo, worktree.CreateOptions{Name: "non-web-block"})
+	if err != nil {
+		t.Fatalf("Create worktree: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = worktree.Remove(context.Background(), wt.Dir, worktree.RemoveOptions{Force: true})
+	})
+
+	releaseRun, err := processRootCheckoutLeases.acquireRun(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("acquire root run lease: %v", err)
+	}
+	defer releaseRun()
+
+	srv := &serveServer{worktreeRootFn: worktreeRootForTest(repo)}
+	mergeReq := httptest.NewRequest(http.MethodPost, "/v1/worktrees/merge", bytes.NewBufferString(`{"dir":"`+wt.Dir+`","keep":true}`))
+	mergeRec := httptest.NewRecorder()
+	srv.handleWorktreeMerge(mergeRec, mergeReq)
+	if mergeRec.Code != http.StatusConflict {
+		t.Fatalf("merge status = %d body=%s", mergeRec.Code, mergeRec.Body.String())
+	}
+
+	promoteReq := httptest.NewRequest(http.MethodPost, "/v1/worktrees/promote", bytes.NewBufferString(`{"dir":"`+wt.Dir+`","branch":"blocked-non-web"}`))
+	promoteRec := httptest.NewRecorder()
+	srv.handleWorktreePromote(promoteRec, promoteReq)
+	if promoteRec.Code != http.StatusConflict {
+		t.Fatalf("promote status = %d body=%s", promoteRec.Code, promoteRec.Body.String())
+	}
+}
+
+func TestServeWorktreeMergeExclusiveLeaseBlocksNewRootRuns(t *testing.T) {
+	repo := newGitRepoForBindingTest(t)
+	wt, err := worktree.Create(context.Background(), repo, worktree.CreateOptions{Name: "merge-admission"})
+	if err != nil {
+		t.Fatalf("Create worktree: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = worktree.Remove(context.Background(), wt.Dir, worktree.RemoveOptions{Force: true})
+	})
+	if err := os.WriteFile(filepath.Join(wt.Dir, "lease.txt"), []byte("lease test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mutationAdmitted := make(chan struct{})
+	continueMutation := make(chan struct{})
+	defer func() {
+		select {
+		case <-continueMutation:
+		default:
+			close(continueMutation)
+		}
+	}()
+	srv := &serveServer{
+		worktreeRootFn: worktreeRootForTest(repo),
+		rootMutationAdmitted: func() {
+			close(mutationAdmitted)
+			<-continueMutation
+		},
+	}
+	requestBody, _ := json.Marshal(worktreeMergeRequest{Dir: wt.Dir, Keep: true})
+	mergeReq := httptest.NewRequest(http.MethodPost, "/v1/worktrees/merge", bytes.NewReader(requestBody))
+	mergeRec := httptest.NewRecorder()
+	mergeDone := make(chan struct{})
+	go func() {
+		defer close(mergeDone)
+		srv.handleWorktreeMerge(mergeRec, mergeReq)
+	}()
+
+	select {
+	case <-mutationAdmitted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("merge did not acquire the exclusive root lease")
+	}
+
+	platforms := []string{"web", "telegram", "jobs"}
+	started := make([]chan struct{}, len(platforms))
+	attempted := make([]chan struct{}, len(platforms))
+	runErrs := make(chan error, len(platforms))
+	for i, platform := range platforms {
+		started[i] = make(chan struct{})
+		attempted[i] = make(chan struct{})
+		provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+		runtime := &serveRuntime{
+			provider:     provider,
+			engine:       llm.NewEngine(provider, nil),
+			defaultModel: "mock-model",
+			platform:     platform,
+		}
+		go func(i int, rt *serveRuntime) {
+			close(attempted[i])
+			_, runErr := rt.RunWithEventsAndStart(
+				context.Background(),
+				false,
+				false,
+				[]llm.Message{llm.UserText("wait for merge")},
+				llm.Request{WorkingDir: repo},
+				func() { close(started[i]) },
+				nil,
+			)
+			runErrs <- runErr
+		}(i, runtime)
+	}
+	for i := range attempted {
+		<-attempted[i]
+	}
+	for i, platform := range platforms {
+		select {
+		case <-started[i]:
+			t.Fatalf("%s run became active while merge held the exclusive root lease", platform)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	close(continueMutation)
+	select {
+	case <-mergeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("merge did not complete")
+	}
+	if mergeRec.Code != http.StatusOK {
+		t.Fatalf("merge status = %d body=%s", mergeRec.Code, mergeRec.Body.String())
+	}
+	for i, platform := range platforms {
+		select {
+		case <-started[i]:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s run did not become active after merge released the lease", platform)
+		}
+	}
+	for range platforms {
+		if err := <-runErrs; err != nil {
+			t.Fatalf("root run failed: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added a process-wide, per-repository root checkout lease.
- Root-bound web, Telegram, jobs, and child-agent runs acquire a shared lease during admission and hold it through run completion.
- Linked-worktree runs remain independent and do not acquire the main checkout lease.
- Worktree merge and promote handlers atomically acquire an exclusive lease before checking legacy web runtime activity, and hold it through the Git operation and cleanup.
- Preserved HTTP 409 behavior when a root run or another root mutation is already active.

## Why this is high-value

Merge and promote mutate the shared root checkout's HEAD, index, and working files. Previously, their one-time web-session snapshot allowed a new web run to start after the check, and did not represent Telegram or jobs runs at all. That could make an agent read, edit, or commit while its checkout changed underneath it, mixing changes or placing commits on the wrong branch.

The shared admission lease closes both races while leaving worktree-bound agents concurrent with root mutation operations.

## Validation

- `go test -race ./cmd -run 'TestServeWorktree(MergeBlocksActiveRootRun|MutationsBlockNonWebRootRunLease|MergeExclusiveLeaseBlocksNewRootRuns)$'`
- `go build ./...`
- `HOME=<temp> XDG_CONFIG_HOME=<temp>/config XDG_DATA_HOME=<temp>/data XDG_CACHE_HOME=<temp>/cache go test ./...`
- `go vet ./...`
- `git diff --check`

Regression coverage verifies that:

- already-admitted non-web root runs make both merge and promote return HTTP 409;
- once merge has exclusive admission, web, Telegram, and jobs runtime admissions cannot become active until the Git operation releases the lease;
- the existing active web-runtime conflict behavior remains intact.
