### PR TITLE
fix(ollama): use runtime context for compaction

### DIFF
--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -782,13 +782,37 @@ func (e *Engine) SetContextTracking(inputLimit int) {
 // Both inputLimit and compactionConfig are set atomically under a single lock.
 func (e *Engine) ConfigureContextManagement(provider Provider, providerName, modelName string, autoCompact bool) {
 	limit := 0
+	var err error
 	var compactionConfig *CompactionConfig
 
 	if provider != nil && !provider.Capabilities().ManagesOwnContext {
-		limit = InputLimitForProviderModel(providerName, modelName)
-		if limit == 0 {
-			refreshDynamicModelLimitsForContext(provider, providerName, modelName)
+		runtimeProvider := provider
+		if retry, ok := provider.(*RetryProvider); ok {
+			runtimeProvider = retry.inner
+		}
+		if limiter, ok := runtimeProvider.(interface {
+			effectiveInputLimit(context.Context, string) (int, error)
+		}); ok {
+			// Runtime-aware providers must win over canonical model-prefix tables.
+			// Ollama's GGUF metadata can advertise a much larger architectural
+			// context than the live Modelfile allocates.
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			limit, err = limiter.effectiveInputLimit(ctx, modelName)
+			cancel()
+			if err != nil {
+				slog.Debug("failed to inspect provider runtime context limit", "provider", providerName, "model", modelName, "error", err)
+				limit = InputLimitForProviderModel(providerName, modelName)
+				if limit == 0 {
+					refreshDynamicModelLimitsForContext(provider, providerName, modelName)
+					limit = InputLimitForProviderModel(providerName, modelName)
+				}
+			}
+		} else {
 			limit = InputLimitForProviderModel(providerName, modelName)
+			if limit == 0 {
+				refreshDynamicModelLimitsForContext(provider, providerName, modelName)
+				limit = InputLimitForProviderModel(providerName, modelName)
+			}
 		}
 		if limit > 0 && autoCompact {
 			cfg := DefaultCompactionConfig()

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -6393,5 +6395,49 @@ func TestSelfAssertedProviderControlToolCannotEscapeAllowlist(t *testing.T) {
 	}
 	if len(messages) != 1 || len(messages[0].Parts) != 1 || messages[0].Parts[0].ToolResult == nil || !strings.Contains(messages[0].Parts[0].ToolResult.Content, "allowed-tools") {
 		t.Fatalf("denied execution result = %#v", messages)
+	}
+}
+
+func TestConfigureContextManagementUsesOllamaRuntimeWindow(t *testing.T) {
+	var showRequests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/show" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var req struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		showRequests = append(showRequests, req.Model)
+		if req.Model == "qwen3.8:27b-thinking-low" {
+			http.Error(w, "model not found", http.StatusNotFound)
+			return
+		}
+		if req.Model != "qwen3.8:27b-thinking" {
+			http.Error(w, "unexpected model", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"capabilities":["completion","thinking","tools"],"parameters":"num_ctx 65536\nnum_predict 16384\n","model_info":{"qwen35.context_length":262144}}`)
+	}))
+	defer srv.Close()
+
+	provider := NewOllamaChatProvider(srv.URL, "qwen3.8:27b-thinking", OllamaOptions{})
+	wrapped := WrapWithRetry(provider, RetryConfig{MaxAttempts: 1})
+	engine := NewEngine(wrapped, nil)
+	engine.ConfigureContextManagement(wrapped, "chatgpt", "qwen3.8:27b-thinking-low", true)
+
+	if got := engine.InputLimit(); got != 49152 {
+		t.Fatalf("InputLimit() = %d, want 49152 (65536 num_ctx - 16384 num_predict)", got)
+	}
+	soft, hard, enabled := engine.CompactionThresholds()
+	if !enabled || soft != 44236 || hard != 46694 {
+		t.Fatalf("CompactionThresholds() = (%d, %d, %v), want (44236, 46694, true)", soft, hard, enabled)
+	}
+	if len(showRequests) < 2 || showRequests[0] != "qwen3.8:27b-thinking-low" {
+		t.Fatalf("show requests = %v, want exact effort variant checked before base model", showRequests)
 	}
 }

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -354,10 +354,10 @@ func ollamaShowContextLength(show ollamaShowResponse) int {
 	return 0
 }
 
-func ollamaShowNumCtx(show ollamaShowResponse) int {
+func ollamaShowParameterInt(show ollamaShowResponse, name string) int {
 	for _, line := range strings.Split(show.Parameters, "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 2 || fields[0] != "num_ctx" {
+		if len(fields) < 2 || fields[0] != name {
 			continue
 		}
 		if parsed, err := strconv.Atoi(strings.Trim(fields[1], `"`)); err == nil && parsed > 0 {
@@ -365,6 +365,36 @@ func ollamaShowNumCtx(show ollamaShowResponse) int {
 		}
 	}
 	return 0
+}
+
+func ollamaShowNumCtx(show ollamaShowResponse) int {
+	return ollamaShowParameterInt(show, "num_ctx")
+}
+
+// effectiveInputLimit returns the request input budget for the model as it is
+// actually configured on this Ollama endpoint. GGUF metadata can advertise a
+// much larger architectural context than the Modelfile allocates; using that
+// number prevents auto-compaction from ever firing on the live runner. Reserve
+// num_predict from the configured window because Ollama shares that window
+// between prompt and generation.
+func (p *OllamaProvider) effectiveInputLimit(ctx context.Context, model string) (int, error) {
+	resolved, _, err := p.resolveReasoningSuffix(ctx, model)
+	if err != nil {
+		return 0, err
+	}
+	show, err := p.showModel(ctx, resolved)
+	if err != nil {
+		return 0, err
+	}
+
+	limit := ollamaShowContextLength(show)
+	if configured := ollamaShowNumCtx(show); configured > 0 && (limit == 0 || configured < limit) {
+		limit = configured
+	}
+	if reserve := ollamaShowParameterInt(show, "num_predict"); reserve > 0 && reserve < limit {
+		limit -= reserve
+	}
+	return limit, nil
 }
 
 func (p *OllamaProvider) showModel(ctx context.Context, model string) (ollamaShowResponse, error) {
@@ -402,6 +432,13 @@ func (p *OllamaProvider) rememberThinkingSupport(model string, supported bool) {
 	p.capabilitiesMu.Unlock()
 }
 
+func (p *OllamaProvider) knownThinkingSupport(model string) (bool, bool) {
+	p.capabilitiesMu.RLock()
+	supported, ok := p.thinkingByModel[model]
+	p.capabilitiesMu.RUnlock()
+	return supported, ok
+}
+
 func (p *OllamaProvider) supportsThinking(ctx context.Context, model string) (bool, error) {
 	p.capabilitiesMu.RLock()
 	supported, ok := p.thinkingByModel[model]
@@ -430,6 +467,7 @@ func splitOllamaReasoningSuffix(model string) (string, string) {
 func (p *OllamaProvider) resolveReasoningSuffix(ctx context.Context, model string) (string, string, error) {
 	for _, info := range GetCachedOllamaModelInfos(p.baseURL) {
 		if strings.EqualFold(strings.TrimSpace(info.ID), strings.TrimSpace(model)) {
+			p.rememberThinkingSupport(model, len(info.ReasoningEfforts) > 0)
 			return model, "", nil
 		}
 	}
@@ -505,6 +543,14 @@ func (p *OllamaProvider) Stream(ctx context.Context, req Request) (Stream, error
 			return nil, fmt.Errorf("Ollama model %q does not advertise thinking support", model)
 		}
 		think = thinkLevel
+	} else if p.opts.Think == nil {
+		// Explicitly disable thinking when live discovery has already established
+		// that this is a non-thinking model. Do not add a blocking /api/show call
+		// on the ordinary stream path: offline/custom Ollama-compatible servers
+		// may not implement it, and unknown models retain legacy nil semantics.
+		if supported, known := p.knownThinkingSupport(model); known && !supported {
+			think = false
+		}
 	}
 
 	messages := buildOllamaMessages(req.Messages)

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -218,6 +218,44 @@ func TestOllamaProviderStreamThinkFalse(t *testing.T) {
 	}
 }
 
+func TestOllamaProviderStreamDefaultsNonThinkingModelToFalse(t *testing.T) {
+	var capturedThink any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"capabilities":["completion","tools"]}`)
+		case "/api/chat":
+			var req ollamaChatRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			capturedThink = req.Think
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			fmt.Fprintln(w, `{"model":"direct:7b","message":{"role":"assistant","content":"ok"},"done":true}`)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewOllamaChatProvider(srv.URL, "direct:7b", OllamaOptions{})
+	p.rememberThinkingSupport("direct:7b", false)
+	stream, err := p.Stream(context.Background(), Request{Messages: []Message{UserText("hello")}})
+	if err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+	defer stream.Close()
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+	if capturedThink != false {
+		t.Fatalf("think = %#v, want false from non-thinking model capabilities", capturedThink)
+	}
+}
+
 func TestOllamaProviderStreamThinkLevel(t *testing.T) {
 	var capturedThink any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -356,8 +394,8 @@ func TestOllamaProviderStreamPreservesExactModelEndingInEffort(t *testing.T) {
 			break
 		}
 	}
-	if captured.Model != "natural-high" || captured.Think != nil {
-		t.Fatalf("chat request model/think = %q/%#v, want exact model with no inferred effort", captured.Model, captured.Think)
+	if captured.Model != "natural-high" || captured.Think != false {
+		t.Fatalf("chat request model/think = %q/%#v, want exact non-thinking model with think=false", captured.Model, captured.Think)
 	}
 }
 


### PR DESCRIPTION
## Summary

- derive native Ollama prompt limits from the live `/api/show` configuration instead of GGUF architectural metadata
- inspect through the factory-added `RetryProvider` wrapper so context management sees Ollama's runtime window
- resolve reasoning-effort suffixes to the installed model before inspecting its runtime settings
- explicitly send `think: false` for models already discovered to be non-thinking, while preserving legacy behavior for unknown/custom endpoints

## Context-window arithmetic

For the deployed Qwen3.8 thinking profile:

```text
num_ctx      65,536
num_predict  16,384
input limit  49,152  (65,536 - 16,384)
soft compact 44,236  (90%)
hard compact 46,694  (95%)
```

The GGUF metadata advertises a 262,144-token architectural context, but the live Modelfile only allocates 65,536. Using the architectural value prevented compaction from firing before the actual runtime limit.

## Live verification

Before the fix, a native Ollama session reached roughly 65K input tokens with `compaction_count = 0`.

After the fix, the same session emitted the summarize/resume compaction phases, persisted `compaction_count = 1`, and the next request used 13,061 input tokens while retaining the relevant task context.

## Tests

- `go test ./internal/llm`
- `go build ./...`
- `git diff --check`
- live native-Ollama compaction and post-compaction continuity
- live non-thinking instruct output without leaked thinking

A prior `go test ./...` run reached unrelated environment-sensitive failures in two `cmd` skill working-directory tests. The changed `internal/llm` package and full build pass.
