### PR TITLE
fix: Responses WebSocket silently drops the requested priority service tier

### DIFF
--- a/internal/llm/responses_websocket.go
+++ b/internal/llm/responses_websocket.go
@@ -58,6 +58,7 @@ type responsesWSRequest struct {
 	Generate           *bool                        `json:"generate,omitempty"`
 	StreamOptions      *ResponsesStreamOptions      `json:"stream_options,omitempty"`
 	PreviousResponseID string                       `json:"previous_response_id,omitempty"`
+	ServiceTier        string                       `json:"service_tier,omitempty"`
 }
 
 func newResponsesWSRequest(req ResponsesRequest) responsesWSRequest {
@@ -81,6 +82,7 @@ func newResponsesWSRequest(req ResponsesRequest) responsesWSRequest {
 		Generate:           req.Generate,
 		StreamOptions:      req.StreamOptions,
 		PreviousResponseID: req.PreviousResponseID,
+		ServiceTier:        req.ServiceTier,
 	}
 }
 

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -125,6 +125,9 @@ func TestResponsesWebSocketRequestOmitsTransportFields(t *testing.T) {
 	if _, ok := decoded["stream"]; ok {
 		t.Fatalf("WebSocket response.create must not include stream: %s", body)
 	}
+	if _, ok := decoded["service_tier"]; ok {
+		t.Fatalf("empty service_tier must be omitted: %s", body)
+	}
 	if decoded["generate"] != false {
 		t.Fatalf("generate = %#v, want false", decoded["generate"])
 	}
@@ -485,10 +488,11 @@ func TestResponsesClientStreamWebSocket(t *testing.T) {
 		},
 	}
 	stream, err := client.Stream(context.Background(), ResponsesRequest{
-		Model:  "gpt-test",
-		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "hi"}},
-		Tools:  []any{ResponsesTool{Type: "function", Name: "tool", Parameters: map[string]any{"type": "object"}}},
-		Stream: true,
+		Model:       "gpt-test",
+		Input:       []ResponsesInputItem{{Type: "message", Role: "user", Content: "hi"}},
+		Tools:       []any{ResponsesTool{Type: "function", Name: "tool", Parameters: map[string]any{"type": "object"}}},
+		Stream:      true,
+		ServiceTier: ServiceTierFast,
 	}, false)
 	if err != nil {
 		t.Fatalf("Stream: %v", err)
@@ -519,6 +523,9 @@ func TestResponsesClientStreamWebSocket(t *testing.T) {
 			}
 			if gotReq["type"] != "response.create" || gotReq["model"] != "gpt-test" {
 				t.Fatalf("request fields = %#v", gotReq)
+			}
+			if gotReq["service_tier"] != ServiceTierFast {
+				t.Fatalf("service_tier = %#v, want %q", gotReq["service_tier"], ServiceTierFast)
 			}
 			if _, ok := gotReq["stream"]; ok {
 				t.Fatalf("WebSocket request must not include transport-only stream field: %#v", gotReq)


### PR DESCRIPTION
## What changed

- Added `service_tier` to the Responses WebSocket `response.create` wire request.
- Copied `ResponsesRequest.ServiceTier` into that wire request while retaining `omitempty` behavior for an explicitly cleared or unset tier.
- Added WebSocket-frame coverage for `service_tier: "priority"` and omission coverage for an empty tier.

## Why this is high-value

ChatGPT enables the Responses WebSocket transport by default. Provider defaults and TUI `/fast` requests already normalize fast mode to the API value `priority`, but the WebSocket conversion silently discarded that value. As a result, the backend used its default queue even while the UI and configuration reported fast mode.

Forwarding the requested tier lets ChatGPT actually provide the lower-queue-latency priority service selected by the user. The existing HTTP provider tests cover both request-level and provider-default tier selection; the new wire test covers the previously missing WebSocket serialization step.

## Validation

- Reproduced before the fix: `TestResponsesClientStreamWebSocket` decoded no `service_tier` from the first `response.create` frame.
- `go test ./internal/llm -run 'TestResponses(WebSocketRequestOmitsTransportFields|ClientStreamWebSocket)$' -count=1`
- `go build ./...`
- `go test ./...` (all packages, including `internal/llm`, passed except two unrelated `cmd` tests whose host skill-catalog truncation omitted their temporary test skill: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`)
- `git diff --check`
