### PR TITLE
fix: Server ping heartbeats cannot keep Responses WebSocket streams alive

### DIFF
--- a/internal/llm/responses_websocket.go
+++ b/internal/llm/responses_websocket.go
@@ -157,6 +157,15 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 		if idleTimeout == 0 {
 			idleTimeout = 5 * time.Minute
 		}
+		if !reused {
+			pingHandler := conn.PingHandler()
+			conn.SetPingHandler(func(appData string) error {
+				if err := conn.SetReadDeadline(time.Now().Add(idleTimeout)); err != nil {
+					return err
+				}
+				return pingHandler(appData)
+			})
+		}
 		conn.SetPongHandler(func(string) error {
 			return conn.SetReadDeadline(time.Now().Add(idleTimeout))
 		})

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -533,6 +533,95 @@ func TestResponsesClientStreamWebSocket(t *testing.T) {
 	}
 }
 
+func TestResponsesClientWebSocketServerPingsKeepStreamAlive(t *testing.T) {
+	const (
+		idleTimeout  = 100 * time.Millisecond
+		pingInterval = 20 * time.Millisecond
+		pingCount    = 15
+	)
+
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read request: %v", err)
+			return
+		}
+		if err := conn.WriteJSON(map[string]any{"type": "response.created", "response": map[string]any{"id": "resp_1"}}); err != nil {
+			t.Errorf("write response.created: %v", err)
+			return
+		}
+		if err := conn.WriteJSON(map[string]any{"type": "response.output_text.delta", "delta": "started"}); err != nil {
+			t.Errorf("write initial delta: %v", err)
+			return
+		}
+
+		pongs := make(chan struct{}, 1)
+		conn.SetPongHandler(func(string) error {
+			pongs <- struct{}{}
+			return nil
+		})
+		go func() {
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}()
+		for i := 0; i < pingCount; i++ {
+			time.Sleep(pingInterval)
+			if err := conn.WriteControl(websocket.PingMessage, []byte("heartbeat"), time.Now().Add(time.Second)); err != nil {
+				return
+			}
+			select {
+			case <-pongs:
+			case <-time.After(time.Second):
+				t.Errorf("timed out waiting for pong %d", i)
+				return
+			}
+		}
+		_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_1"}})
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	client := &ResponsesClient{
+		BaseURL:              server.URL,
+		UseWebSocket:         true,
+		WebSocketIdleTimeout: idleTimeout,
+	}
+	stream, err := client.Stream(ctx, ResponsesRequest{
+		Model:          "gpt-test",
+		Input:          []ResponsesInputItem{{Type: "message", Role: "user", Content: "hi"}},
+		Stream:         true,
+		ForceWebSocket: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close()
+
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		switch event.Type {
+		case EventDone:
+			return
+		case EventError:
+			t.Fatalf("stream error: %v", event.Err)
+		}
+	}
+}
+
 func TestResponsesClientWebSocketAuthRetryUsesFreshHeaderAndTimeout(t *testing.T) {
 	var attempts atomic.Int32
 	upgrader := websocket.Upgrader{}


### PR DESCRIPTION
## What changed

- Wrap the Gorilla WebSocket connection's existing ping handler when a Responses socket is created.
- Refresh the stream read deadline for each server ping, then delegate to Gorilla's handler so the matching pong is still sent.
- Add an integration test that keeps a stream idle for three timeout periods using server ping frames before sending `response.completed`.

## Why this is high-value

ChatGPT enables Responses-over-WebSocket by default, and long reasoning pauses are normal in Sam/Jarvis's daily usage. Gorilla's default incoming-ping handler sends a pong but does not invoke the pong handler, so server heartbeats previously could not refresh term-llm's five-minute read deadline. A healthy, heartbeat-responsive stream could therefore be discarded at the idle boundary after partial output, where automatic HTTP fallback is unsafe.

This preserves the existing idle timeout for genuinely silent connections while allowing valid server heartbeats to keep active streams alive.

## Validation

- Regression reproduced before the fix: the new test failed at the 100 ms idle deadline with `Responses WebSocket closed before response.completed: ... i/o timeout`.
- `go test ./internal/llm -run '^(TestResponsesClientStreamWebSocket|TestResponsesClientWebSocketServerPingsKeepStreamAlive|TestResponsesClientWebSocketContextCancel)$' -count=5`
- `go test -race ./internal/llm -run '^TestResponsesClientWebSocketServerPingsKeepStreamAlive$' -count=1`
- `go build ./...`
- `go test ./...` ran all packages; the changed `internal/llm` package passed. The overall command remains red on two unrelated `cmd` tests (`TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`) because this agent's 31 configured skills exceed those tests' visible-skill budgets, omitting their temporary fixture skill.
- `git diff --check`
