### PR TITLE
fix: One unread reverse response can wedge every request on the node tunnel

### DIFF
--- a/cmd/serve_hub_reverse.go
+++ b/cmd/serve_hub_reverse.go
@@ -39,6 +39,8 @@ const (
 	hubReverseFrameResponseEnd   = "response_end"
 )
 
+var errHubReverseSlowConsumer = errors.New("reverse response consumer is too slow")
+
 type hubReverseRequest struct {
 	Type   string      `json:"type,omitempty"`
 	ID     string      `json:"id"`
@@ -138,20 +140,20 @@ func (p *hubReversePending) abort(err error) {
 	}
 }
 
-func (p *hubReversePending) enqueue(resp hubReverseResponse) bool {
+func (p *hubReversePending) enqueue(resp hubReverseResponse) (queued, full bool) {
 	if p == nil {
-		return false
+		return false, false
 	}
-	// Apply per-request backpressure instead of dropping body frames for a
-	// slower downstream consumer. Because one websocket reader multiplexes all
-	// requests for a node, a full per-request queue can temporarily stall sibling
-	// requests on the same reverse connection until this request drains or is
-	// canceled.
+	// Never block the sole websocket reader behind one request. A full queue
+	// means this consumer has stopped draining; the caller can isolate it while
+	// continuing to dispatch sibling responses and process control frames.
 	select {
 	case p.ch <- resp:
-		return true
+		return true, false
 	case <-p.done:
-		return false
+		return false, false
+	default:
+		return false, true
 	}
 }
 
@@ -287,7 +289,11 @@ func (c *hubReverseConnection) readLoop(done func()) {
 		terminal := hubReverseResponseFrameTerminal(resp)
 		c.pendingMu.Unlock()
 		if pending != nil {
-			if !pending.enqueue(resp) {
+			queued, full := pending.enqueue(resp)
+			if full {
+				c.abortPending(resp.ID, pending, errHubReverseSlowConsumer, true)
+			}
+			if !queued {
 				continue
 			}
 			if terminal {

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -255,7 +255,7 @@ func TestHubReverseResponseCancellation(t *testing.T) {
 	}
 }
 
-func TestHubReverseReadLoopBackpressuresSlowConsumerInsteadOfCanceling(t *testing.T) {
+func TestHubReverseReadLoopIsolatesUnreadResponseOverflow(t *testing.T) {
 	node := hub.Node{ID: "artist", Name: "Artist", Connection: "reverse", BasePath: "/chat", Token: "node-token"}
 	s := newHubServer(hub.NewRegistry(fakeHubResolver{nodes: []hub.Node{node}}), nil)
 	hubTS := httptest.NewServer(s.handler())
@@ -272,26 +272,24 @@ func TestHubReverseReadLoopBackpressuresSlowConsumerInsteadOfCanceling(t *testin
 	defer conn.Close()
 	waitForReverseNode(t, s, "artist")
 
-	requests := make(chan hubReverseRequest, 16)
+	frames := make(chan hubReverseRequest, 32)
 	go func() {
 		for {
 			var frame hubReverseRequest
 			if err := conn.ReadJSON(&frame); err != nil {
 				return
 			}
-			if frame.Type == hubReverseFrameRequest {
-				requests <- frame
-			}
+			frames <- frame
 		}
 	}()
 
 	firstResult := make(chan reverseDoResult, 1)
 	go func() {
-		req := httptest.NewRequest(http.MethodGet, "http://reverse.local/chat/slow-stream", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://reverse.local/chat/unread-stream", nil)
 		resp, err := s.reverse.do(context.Background(), node, req)
 		firstResult <- reverseDoResult{resp: resp, err: err}
 	}()
-	firstReq := waitForReverseRequest(t, requests, "/chat/slow-stream")
+	firstReq := waitForReverseRequest(t, frames, "/chat/unread-stream")
 	if err := conn.WriteJSON(hubReverseResponse{Type: hubReverseFrameResponseStart, ID: firstReq.ID, Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"text/plain"}}}); err != nil {
 		t.Fatalf("write first response_start: %v", err)
 	}
@@ -301,37 +299,58 @@ func TestHubReverseReadLoopBackpressuresSlowConsumerInsteadOfCanceling(t *testin
 	}
 	defer first.resp.Body.Close()
 
-	const chunk = "chunk"
-	const chunkCount = hubReversePendingBuffer + 4
-	writerDone := make(chan error, 1)
-	go func() {
-		for i := 0; i < chunkCount; i++ {
-			if err := conn.WriteJSON(hubReverseResponse{Type: hubReverseFrameResponseBody, ID: firstReq.ID, Body: []byte(chunk)}); err != nil {
-				writerDone <- err
-				return
+	// Leave the first body unread and overflow only its bounded response queue.
+	// The hub must cancel that request without blocking the tunnel's sole reader.
+	for i := 0; i < hubReversePendingBuffer+2; i++ {
+		if err := conn.WriteJSON(hubReverseResponse{Type: hubReverseFrameResponseBody, ID: firstReq.ID, Body: []byte("chunk")}); err != nil {
+			t.Fatalf("write unread response body frame %d: %v", i, err)
+		}
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case frame := <-frames:
+			if frame.Type == hubReverseFrameCancel && frame.ID == firstReq.ID {
+				goto canceled
 			}
+		case <-deadline:
+			t.Fatal("timed out waiting for unread reverse response cancellation")
 		}
-		writerDone <- conn.WriteJSON(hubReverseResponse{Type: hubReverseFrameResponseEnd, ID: firstReq.ID})
+	}
+
+canceled:
+	secondCtx, cancelSecond := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelSecond()
+	secondResult := make(chan reverseDoResult, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "http://reverse.local/chat/healthz", nil).WithContext(secondCtx)
+		resp, err := s.reverse.do(secondCtx, node, req)
+		secondResult <- reverseDoResult{resp: resp, err: err}
 	}()
-
-	// Leave the response body unread long enough for the per-request queue to fill.
-	// The stream must apply backpressure instead of being canceled as "slow".
-	time.Sleep(100 * time.Millisecond)
-
-	body, err := io.ReadAll(first.resp.Body)
+	secondReq := waitForReverseRequest(t, frames, "/chat/healthz")
+	if err := conn.WriteJSON(hubReverseResponse{ID: secondReq.ID, Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"text/plain"}}, Body: []byte("ok")}); err != nil {
+		t.Fatalf("write second response: %v", err)
+	}
+	second := waitForReverseDoResult(t, secondResult)
+	if second.err != nil {
+		t.Fatalf("second reverse do after unread stream overflow: %v", second.err)
+	}
+	defer second.resp.Body.Close()
+	body, err := io.ReadAll(second.resp.Body)
 	if err != nil {
-		t.Fatalf("read slow body: %v", err)
+		t.Fatalf("read second body: %v", err)
 	}
-	if string(body) != strings.Repeat(chunk, chunkCount) {
-		t.Fatalf("slow body len=%d, want len=%d", len(body), len(strings.Repeat(chunk, chunkCount)))
+	if string(body) != "ok" {
+		t.Fatalf("second body = %q", body)
 	}
-	select {
-	case err := <-writerDone:
-		if err != nil {
-			t.Fatalf("write slow response: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for reverse writer")
+	if !s.reverse.isConnected("artist") {
+		t.Fatal("reverse tunnel disconnected after isolating unread response")
+	}
+
+	_, err = io.ReadAll(first.resp.Body)
+	if !errors.Is(err, errHubReverseSlowConsumer) {
+		t.Fatalf("first body error = %v, want %v", err, errHubReverseSlowConsumer)
 	}
 }
 
@@ -384,12 +403,12 @@ func TestHubReverseReadLoopSurvivesCanceledUndrainedStream(t *testing.T) {
 	}
 	defer first.resp.Body.Close()
 
-	// Fill the first request's response queue until the websocket reader is
-	// backpressured behind an undrained body. Canceling the request must unblock
-	// that path so later multiplexed requests on the same websocket still work.
+	// Queue several frames behind the unread body without overflowing its buffer.
+	// Explicit cancellation must still release that request so later multiplexed
+	// requests on the same websocket continue to work.
 	writerDone := make(chan error, 1)
 	go func() {
-		for i := 0; i < hubReversePendingBuffer+4; i++ {
+		for i := 0; i < hubReversePendingBuffer/2; i++ {
 			if err := conn.WriteJSON(hubReverseResponse{Type: hubReverseFrameResponseBody, ID: firstReq.ID, Body: []byte("chunk")}); err != nil {
 				writerDone <- err
 				return
@@ -404,10 +423,10 @@ func TestHubReverseReadLoopSurvivesCanceledUndrainedStream(t *testing.T) {
 	select {
 	case err := <-writerDone:
 		if err != nil {
-			t.Fatalf("write blocked body frames: %v", err)
+			t.Fatalf("write queued body frames: %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for blocked reverse writer to unblock after cancel")
+		t.Fatal("timed out waiting for reverse writer")
 	}
 
 	secondCtx, cancelSecond := context.WithTimeout(context.Background(), 2*time.Second)
@@ -458,6 +477,9 @@ func waitForReverseRequest(t *testing.T, ch <-chan hubReverseRequest, wantPath s
 	for {
 		select {
 		case req := <-ch:
+			if req.Type != hubReverseFrameRequest {
+				continue
+			}
 			if req.Path == wantPath {
 				return req
 			}


### PR DESCRIPTION
## What changed

- Made reverse-response delivery to each request queue nonblocking so the tunnel's sole WebSocket reader cannot wait behind one unread response.
- When a request's 16-frame queue is full, remove and abort only that pending request with a slow-consumer error and asynchronously send its cancel frame to the node.
- Replaced the old node-wide backpressure expectation with an integration test that overflows an unread response, verifies a sibling request completes on the same tunnel, and checks that the unread body receives the overflow error.

## Why this is high-value

Every multiplexed request for a reverse-connected node shares one WebSocket reader. Previously, one suspended or abandoned consumer could fill its 16-frame queue (about 512 KiB with 32 KiB body chunks) and block that reader indefinitely. That prevented sibling web, health, streaming, and delegation responses from being dispatched, and also prevented pong processing until the whole node appeared offline.

Bounding the failure to the request that stopped draining preserves service for every other request and keeps the healthy reverse tunnel connected.

## Validation

- Reproduced the failure with the new integration test before the implementation: it timed out waiting for cancellation because the shared reader was wedged.
- `gofmt -w cmd/serve_hub_reverse.go cmd/serve_hub_reverse_test.go`
- `go build ./...`
- `go test ./cmd -run 'TestHubReverse' -count=1`
- `go test -race ./cmd -run '^TestHubReverse(ReadLoopIsolatesUnreadResponseOverflow|ReadLoopSurvivesCanceledUndrainedStream|ResponseCancellation)$' -count=1`
- `go test ./...` *(all non-`cmd` packages passed; `cmd` has two unrelated ambient-skill-discovery failures because the host's visible-skill budget omits temporary test skills: `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`)*
- `git diff --stat`
- `git diff --check`
