### PR TITLE
fix: Every stateful response run decodes all historical transcript bodies before provider start

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -2590,24 +2590,38 @@ func (s *serveServer) configureResponseRunRevision(run *responseRun, sessionID s
 		return
 	}
 	startedCtx, startedCancel := context.WithTimeout(context.Background(), responseRunRevisionReadTimeout)
-	if indexer, ok := s.transcriptIndexerForWeb(); ok {
-		if snapshot, err := indexer.GetTranscriptSnapshot(startedCtx, sessionID); err == nil {
-			run.startedRev = snapshot.Rev
-			run.startedCompactionSeq = snapshot.CompactionSeq
-			run.startedCompactionCount = snapshot.CompactionCount
-			for i := len(snapshot.Items) - 1; i >= 0; i-- {
-				item := snapshot.Items[i]
-				if item.ID <= 0 || item.Flags&session.TranscriptFlagCompactionTail != 0 {
-					continue
-				}
-				switch llm.Role(item.Role) {
-				case llm.RoleUser, llm.RoleAssistant, llm.RoleTool:
-					run.setInitialDurableBoundary(item.ID)
+	configured := false
+	if reader, ok := s.store.(session.ResponseRunStartStateReader); ok {
+		if state, err := reader.GetResponseRunStartState(startedCtx, sessionID); err == nil {
+			run.startedRev = state.Rev
+			run.startedCompactionSeq = state.CompactionSeq
+			run.startedCompactionCount = state.CompactionCount
+			if state.DurableBoundaryID > 0 {
+				run.setInitialDurableBoundary(state.DurableBoundaryID)
+			}
+			configured = true
+		}
+	}
+	if !configured {
+		if indexer, ok := s.transcriptIndexerForWeb(); ok {
+			if snapshot, err := indexer.GetTranscriptSnapshot(startedCtx, sessionID); err == nil {
+				run.startedRev = snapshot.Rev
+				run.startedCompactionSeq = snapshot.CompactionSeq
+				run.startedCompactionCount = snapshot.CompactionCount
+				for i := len(snapshot.Items) - 1; i >= 0; i-- {
+					item := snapshot.Items[i]
+					if item.ID <= 0 || item.Flags&session.TranscriptFlagCompactionTail != 0 {
+						continue
+					}
+					switch llm.Role(item.Role) {
+					case llm.RoleUser, llm.RoleAssistant, llm.RoleTool:
+						run.setInitialDurableBoundary(item.ID)
+						break
+					default:
+						continue
+					}
 					break
-				default:
-					continue
 				}
-				break
 			}
 		}
 	}

--- a/cmd/serve_response_runs_bench_test.go
+++ b/cmd/serve_response_runs_bench_test.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
 )
 
 func BenchmarkResponseRunAppendTextDeltaRetainedReplay(b *testing.B) {
@@ -13,5 +20,62 @@ func BenchmarkResponseRunAppendTextDeltaRetainedReplay(b *testing.B) {
 		if err := run.appendTextDeltaSegmentEvent(0, 0, ""); err != nil {
 			b.Fatalf("appendTextDeltaSegmentEvent failed: %v", err)
 		}
+	}
+}
+
+func BenchmarkConfigureResponseRunRevisionLargeBodies(b *testing.B) {
+	for _, rowCount := range []int{1, 256} {
+		b.Run(fmt.Sprintf("rows=%d", rowCount), func(b *testing.B) {
+			ctx := context.Background()
+			rawStore, err := session.NewSQLiteStore(session.Config{
+				Enabled: true,
+				Path:    filepath.Join(b.TempDir(), "sessions.db"),
+			})
+			if err != nil {
+				b.Fatalf("NewSQLiteStore: %v", err)
+			}
+			b.Cleanup(func() { _ = rawStore.Close() })
+			sess := &session.Session{ID: fmt.Sprintf("sess-bench-%d", rowCount), Provider: "test", Model: "test", Mode: session.ModeChat}
+			if err := rawStore.Create(ctx, sess); err != nil {
+				b.Fatalf("Create: %v", err)
+			}
+			payload := strings.Repeat("a", 32<<10)
+			for i := 0; i < rowCount; i++ {
+				var message llm.Message
+				if i%2 == 0 {
+					message = llm.Message{Role: llm.RoleTool, Parts: []llm.Part{{
+						Type:       llm.PartToolResult,
+						ToolResult: &llm.ToolResult{ID: fmt.Sprintf("call-%d", i), Name: "shell", Content: payload},
+					}}}
+				} else {
+					message = llm.Message{Role: llm.RoleUser, Parts: []llm.Part{{
+						Type:      llm.PartImage,
+						ImageData: &llm.ToolImageData{MediaType: "image/png", Base64: payload},
+					}}}
+				}
+				if err := rawStore.AddMessage(ctx, sess.ID, session.NewMessage(sess.ID, message, -1)); err != nil {
+					b.Fatalf("AddMessage %d: %v", i, err)
+				}
+			}
+			server := &serveServer{store: session.NewLoggingStore(rawStore, nil)}
+
+			b.Run("compact-start-state", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					run := newResponseRun("resp-bench", sess.ID, "", "test", time.Now().Unix(), nil)
+					server.configureResponseRunRevision(run, sess.ID)
+				}
+			})
+			b.Run("full-snapshot-reference", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := rawStore.GetTranscriptSnapshot(ctx, sess.ID); err != nil {
+						b.Fatalf("GetTranscriptSnapshot: %v", err)
+					}
+				}
+			})
+		})
 	}
 }

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -242,6 +242,51 @@ func TestResponseRunCarriesStartedAndFinalTranscriptRevisions(t *testing.T) {
 	}
 }
 
+type countingResponseRunStartStore struct {
+	*session.SQLiteStore
+	startStateCalls int
+	snapshotCalls   int
+}
+
+func (s *countingResponseRunStartStore) GetResponseRunStartState(ctx context.Context, sessionID string) (session.ResponseRunStartState, error) {
+	s.startStateCalls++
+	return s.SQLiteStore.GetResponseRunStartState(ctx, sessionID)
+}
+
+func (s *countingResponseRunStartStore) GetTranscriptSnapshot(ctx context.Context, sessionID string) (session.TranscriptSnapshot, error) {
+	s.snapshotCalls++
+	return s.SQLiteStore.GetTranscriptSnapshot(ctx, sessionID)
+}
+
+func TestConfigureResponseRunRevisionUsesCompactStartStateThroughLoggingStore(t *testing.T) {
+	base, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer base.Close()
+	ctx := context.Background()
+	sess := &session.Session{ID: "sess-compact-start-state", Provider: "test", Model: "test", Mode: session.ModeChat}
+	if err := base.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	user := session.NewMessage(sess.ID, llm.UserText("question"), -1)
+	if err := base.AddMessage(ctx, sess.ID, user); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	counting := &countingResponseRunStartStore{SQLiteStore: base}
+	store := session.NewLoggingStore(counting, t.Logf)
+	run := newResponseRun("resp-compact-start-state", sess.ID, "", "test", time.Now().Unix(), nil)
+
+	(&serveServer{store: store}).configureResponseRunRevision(run, sess.ID)
+
+	if counting.startStateCalls != 1 || counting.snapshotCalls != 0 {
+		t.Fatalf("start state calls = %d, snapshot calls = %d; want 1, 0", counting.startStateCalls, counting.snapshotCalls)
+	}
+	if run.startedRev != 1 || !run.anchorAvailable || run.anchorRowID != user.ID {
+		t.Fatalf("configured run = rev %d anchor (%d, %v), want rev 1 anchor %d", run.startedRev, run.anchorRowID, run.anchorAvailable, user.ID)
+	}
+}
+
 type deadlineTranscriptStore struct {
 	*serveRuntimeTestStore
 	deadlineSeen chan bool

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -357,6 +357,19 @@ func (s *LoggingStore) SessionSummariesIncludeTranscriptRev() bool {
 	return ok && reporter.SessionSummariesIncludeTranscriptRev()
 }
 
+// GetResponseRunStartState delegates compact response-run transcript reads.
+func (s *LoggingStore) GetResponseRunStartState(ctx context.Context, sessionID string) (ResponseRunStartState, error) {
+	reader, ok := s.Store.(ResponseRunStartStateReader)
+	if !ok {
+		return ResponseRunStartState{}, ErrTranscriptRevisionUnsupported
+	}
+	state, err := reader.GetResponseRunStartState(ctx, sessionID)
+	if !errors.Is(err, ErrTranscriptRevisionUnsupported) {
+		s.logOnce("GetResponseRunStartState", err)
+	}
+	return state, err
+}
+
 // GetTranscriptSnapshot delegates coherent transcript envelope reads.
 func (s *LoggingStore) GetTranscriptSnapshot(ctx context.Context, sessionID string) (TranscriptSnapshot, error) {
 	indexer, ok := s.Store.(TranscriptIndexer)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -3946,6 +3946,53 @@ func (s *SQLiteStore) transcriptReadDB() *sql.DB {
 	return s.db
 }
 
+// GetResponseRunStartState returns the response-run transcript envelope in one
+// indexed scalar query. It deliberately uses the primary connection so a new
+// provider run is not queued behind body materialization on the dedicated
+// transcript reader.
+func (s *SQLiteStore) GetResponseRunStartState(ctx context.Context, sessionID string) (ResponseRunStartState, error) {
+	if !s.hasTranscriptRev || !s.hasMessagesTable {
+		return ResponseRunStartState{}, ErrTranscriptRevisionUnsupported
+	}
+	compactionSeqExpr := "-1"
+	if s.hasCompactionSeq {
+		compactionSeqExpr = "COALESCE(compaction_seq, -1)"
+	}
+	compactionCountExpr := "0"
+	if s.hasCompactionCount {
+		compactionCountExpr = "COALESCE(compaction_count, 0)"
+	}
+	compactionTailFilter := ""
+	if s.hasMessageCompactionTail {
+		compactionTailFilter = "AND NOT COALESCE(compaction_tail, FALSE)"
+	}
+	state := ResponseRunStartState{CompactionSeq: -1}
+	err := s.db.QueryRowContext(ctx, `
+		SELECT transcript_rev, `+compactionSeqExpr+`, `+compactionCountExpr+`, COALESCE((
+			SELECT id
+			FROM messages
+			WHERE session_id = sessions.id
+				AND role IN ('user', 'assistant', 'tool')
+				`+compactionTailFilter+`
+			ORDER BY sequence DESC, id DESC
+			LIMIT 1
+		), 0)
+		FROM sessions
+		WHERE id = ?`, sessionID).Scan(
+		&state.Rev,
+		&state.CompactionSeq,
+		&state.CompactionCount,
+		&state.DurableBoundaryID,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ResponseRunStartState{}, ErrNotFound
+	}
+	if err != nil {
+		return ResponseRunStartState{}, fmt.Errorf("get response run start state: %w", err)
+	}
+	return state, nil
+}
+
 // GetTranscriptSnapshot returns the complete transcript envelope from one
 // SQLite read transaction.
 func (s *SQLiteStore) GetTranscriptSnapshot(ctx context.Context, sessionID string) (TranscriptSnapshot, error) {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -418,6 +418,22 @@ type TranscriptSnapshot struct {
 	Items           []TranscriptIndexItem
 }
 
+// ResponseRunStartState is the compact transcript envelope needed when a
+// stateful response run starts. DurableBoundaryID is the latest non-compaction
+// user, assistant, or tool row, or zero when no such row exists.
+type ResponseRunStartState struct {
+	Rev               int64
+	CompactionSeq     int
+	CompactionCount   int
+	DurableBoundaryID int64
+}
+
+// ResponseRunStartStateReader is an optional Store capability for reading the
+// response-run transcript envelope without materializing historical bodies.
+type ResponseRunStartStateReader interface {
+	GetResponseRunStartState(ctx context.Context, sessionID string) (ResponseRunStartState, error)
+}
+
 // TranscriptRange identifies one complete, contiguous UI transcript segment by
 // its inclusive durable ordering bounds. Sequence alone is not assumed unique,
 // so IDs disambiguate both endpoints.

--- a/internal/session/transcript_test.go
+++ b/internal/session/transcript_test.go
@@ -153,6 +153,75 @@ func TestSQLiteStoreTranscriptIndexAndBodiesUseDurableIdentity(t *testing.T) {
 	}
 }
 
+func TestSQLiteResponseRunStartStateMatchesTranscriptSnapshot(t *testing.T) {
+	store, sess := newTranscriptTestStore(t)
+	ctx := context.Background()
+	compacted := []Message{
+		*NewMessage(sess.ID, llm.UserText("[Context Compaction]\nsummary"), -1),
+		*NewMessage(sess.ID, llm.AssistantText("retained answer"), -1),
+	}
+	compacted[1].CompactionTail = true
+	if err := store.CompactMessages(ctx, sess.ID, compacted); err != nil {
+		t.Fatalf("CompactMessages: %v", err)
+	}
+	for _, message := range []*Message{
+		NewMessage(sess.ID, llm.Message{Role: llm.RoleEvent, Parts: []llm.Part{{Type: llm.PartText, Text: "visible event"}}}, -1),
+		NewMessage(sess.ID, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "provider context"}}}, -1),
+	} {
+		if err := store.AddMessage(ctx, sess.ID, message); err != nil {
+			t.Fatalf("AddMessage(%s): %v", message.Role, err)
+		}
+	}
+
+	assertMatchesSnapshot := func() ResponseRunStartState {
+		t.Helper()
+		snapshot, err := store.GetTranscriptSnapshot(ctx, sess.ID)
+		if err != nil {
+			t.Fatalf("GetTranscriptSnapshot: %v", err)
+		}
+		var wantBoundary int64
+		for i := len(snapshot.Items) - 1; i >= 0; i-- {
+			item := snapshot.Items[i]
+			if item.Flags&TranscriptFlagCompactionTail != 0 {
+				continue
+			}
+			switch llm.Role(item.Role) {
+			case llm.RoleUser, llm.RoleAssistant, llm.RoleTool:
+				wantBoundary = item.ID
+			}
+			if wantBoundary != 0 {
+				break
+			}
+		}
+		state, err := store.GetResponseRunStartState(ctx, sess.ID)
+		if err != nil {
+			t.Fatalf("GetResponseRunStartState: %v", err)
+		}
+		if state.Rev != snapshot.Rev ||
+			state.CompactionSeq != snapshot.CompactionSeq ||
+			state.CompactionCount != snapshot.CompactionCount ||
+			state.DurableBoundaryID != wantBoundary {
+			t.Fatalf("start state = %#v, snapshot = %#v, want boundary %d", state, snapshot, wantBoundary)
+		}
+		return state
+	}
+
+	compactedState := assertMatchesSnapshot()
+	if compactedState.CompactionSeq < 0 || compactedState.CompactionCount != 1 {
+		t.Fatalf("compaction state = %#v, want active first compaction", compactedState)
+	}
+	tool := NewMessage(sess.ID, llm.Message{Role: llm.RoleTool, Parts: []llm.Part{{
+		Type:       llm.PartToolResult,
+		ToolResult: &llm.ToolResult{ID: "call-latest", Name: "shell", Content: "done"},
+	}}}, -1)
+	if err := store.AddMessage(ctx, sess.ID, tool); err != nil {
+		t.Fatalf("AddMessage(tool): %v", err)
+	}
+	if state := assertMatchesSnapshot(); state.DurableBoundaryID != tool.ID {
+		t.Fatalf("boundary = %d, want latest tool row %d", state.DurableBoundaryID, tool.ID)
+	}
+}
+
 func TestSQLiteCompactionPreservesResponseIdentity(t *testing.T) {
 	store, sess := newTranscriptTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## What changed

- Added an optional response-run start-state reader for session stores.
- Implemented the SQLite reader as one coherent scalar query for `transcript_rev`, compaction sequence/count, and the latest eligible durable boundary row ID.
- Routed the capability through `LoggingStore` and made `configureResponseRunRevision` prefer it while retaining the existing full-snapshot path for custom, unversioned, or otherwise unsupported stores.
- Added parity coverage across compaction-tail and mixed-role rows, a serve-level test proving the logged SQLite path avoids `GetTranscriptSnapshot`, and a large-body benchmark.

## Why this is high-value

Every genuinely new stateful UI, skill, or queued-job continuation configures its response run before the provider starts and before `response.created` is emitted. The previous path selected every historical `parts` blob, decoded every blob into `[]llm.Part`, retained transcript-sized slices, and built display/tool-call state even though response startup only needs four scalar values.

The SQLite fast path now reads no historical body bytes and uses the existing session/sequence indexes to find the newest eligible boundary. It also uses the primary SQLite connection, so startup is not queued behind a long body materialization on the dedicated transcript reader. Custom stores preserve existing behavior through the snapshot fallback.

On an i9-14900K with alternating 32 KiB tool results and inline image payloads, the committed benchmark showed the compact configure path remaining about 20 microseconds and 3.5 KiB allocated from 1 to 256 rows. The full-snapshot reference grew from about 0.19 ms / 159 KiB / 85 allocations to 35–39 ms / 40.1 MiB / 7,016 allocations at 256 rows.

## Validation

- `go test ./internal/session -run 'TestSQLiteResponseRunStartStateMatchesTranscriptSnapshot' -count=1`
- `go test ./cmd -run 'TestConfigureResponseRunRevision(UsesCompactStartStateThroughLoggingStore|SkipsTrailingNonBranchableRows|BoundsStartedRevisionRead)$' -count=1`
- `go test ./cmd -run '^$' -bench '^BenchmarkConfigureResponseRunRevisionLargeBodies$' -benchmem -benchtime=300ms -count=3`
- `go build ./...`
- `go test ./...` with isolated `HOME`/XDG directories as documented in `AGENTS.md`
- `go vet ./...`
- `git diff --check`
