### PR TITLE
fix: route uncatalogued Muse models via Responses

### DIFF
--- a/internal/llm/opencode_go_models.go
+++ b/internal/llm/opencode_go_models.go
@@ -251,10 +251,16 @@ func (c *opencodeGoModelCatalog) model(ctx context.Context, client *http.Client,
 }
 
 func unknownOpenCodeGoModel(id string) opencodeGoModel {
+	id = strings.TrimSpace(id)
 	// The availability endpoint can lead the metadata catalog. Its provider-level
 	// default is OpenAI-compatible chat, which the Go gateway translates to the
-	// selected upstream protocol.
-	return opencodeGoModel{ModelInfo: ModelInfo{ID: strings.TrimSpace(id), InputPrice: -1, OutputPrice: -1}, Protocol: opencodeGoProtocolChat}
+	// selected upstream protocol. Muse Spark is the exception: OpenCode Go exposes
+	// preview IDs before their catalog metadata and serves them on Responses.
+	protocol := opencodeGoProtocolChat
+	if strings.HasPrefix(strings.ToLower(id), "muse-spark-") {
+		protocol = opencodeGoProtocolResponses
+	}
+	return opencodeGoModel{ModelInfo: ModelInfo{ID: id, InputPrice: -1, OutputPrice: -1}, Protocol: protocol}
 }
 
 func fetchOpenCodeGoModels(ctx context.Context, client *http.Client, apiKey, baseURL, catalogURL string) (opencodeGoFetchResult, error) {

--- a/internal/llm/opencode_go_test.go
+++ b/internal/llm/opencode_go_test.go
@@ -27,8 +27,8 @@ func TestOpenCodeGoListModelsMergesLiveCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
 	}
-	if len(models) != 5 { // deprecated-model is intentionally hidden
-		t.Fatalf("models = %#v, want five active models", models)
+	if len(models) != 6 { // deprecated-model is intentionally hidden
+		t.Fatalf("models = %#v, want six active models", models)
 	}
 	byID := make(map[string]ModelInfo)
 	for _, model := range models {
@@ -46,7 +46,7 @@ func TestOpenCodeGoListModelsMergesLiveCatalog(t *testing.T) {
 	if got := byID["unknown-preview"].DisplayName; got != "" {
 		t.Fatalf("unknown preview display name = %q, want empty fallback metadata", got)
 	}
-	if ids := GetCachedOpenCodeGoModels(); strings.Join(ids, ",") != "chat-model,messages-model,qwen3.8-max,responses-model,unknown-preview" {
+	if ids := GetCachedOpenCodeGoModels(); strings.Join(ids, ",") != "chat-model,messages-model,muse-spark-1.2,qwen3.8-max,responses-model,unknown-preview" {
 		t.Fatalf("cached IDs = %v", ids)
 	}
 	cachedInfos, fresh, err := CachedOpenCodeGoModels()
@@ -180,7 +180,7 @@ func TestOpenCodeGoCatalogFailureUsesAvailabilityThenStaleMetadata(t *testing.T)
 	recorder.setCatalogFailure(true)
 	fallbackProvider := newOpenCodeGoProvider("test-key", "responses-model", server.URL, server.URL+"/catalog", server.Client())
 	models, fresh, err := fallbackProvider.ListModelsWithFreshness(context.Background())
-	if err != nil || len(models) != 6 || fresh {
+	if err != nil || len(models) != 7 || fresh {
 		t.Fatalf("availability-only ListModels = %d, fresh %v, %v", len(models), fresh, err)
 	}
 	requestsBeforeStream := recorder.metadataRequestCount()
@@ -352,6 +352,7 @@ func TestOpenCodeGoRoutesProtocolsAuthLimitsAndDeprecatedModel(t *testing.T) {
 		{model: "qwen3.8-max", wantPath: "/v1/messages", wantHeader: "x-api-key", wantValue: "test-key", wantBaseModel: "qwen3.8-max"},
 		{model: "qwen3.8-max-high", wantPath: "/v1/messages", wantHeader: "x-api-key", wantValue: "test-key", wantThinking: true, wantBaseModel: "qwen3.8-max"},
 		{model: "responses-model", wantPath: "/responses", wantHeader: "Authorization", wantValue: "Bearer test-key"},
+		{model: "muse-spark-1.2", wantPath: "/responses", wantHeader: "Authorization", wantValue: "Bearer test-key"},
 		{model: "responses-model", reasoning: "none", wantPath: "/responses", wantHeader: "Authorization", wantValue: "Bearer test-key"},
 		{model: "responses-model-high", wantPath: "/responses", wantHeader: "Authorization", wantValue: "Bearer test-key", wantBaseModel: "responses-model"},
 		{model: "responses-model", wantPath: "/responses", wantHeader: "Authorization", wantValue: "Bearer test-key", maxOutput: 1000, wantMaxOutput: 100},
@@ -571,7 +572,7 @@ func newOpenCodeGoTestServer(t *testing.T) (*httptest.Server, *openCodeGoTestRec
 		switch r.URL.Path {
 		case "/models":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"object":"list","data":[{"id":"chat-model"},{"id":"messages-model"},{"id":"qwen3.8-max"},{"id":"responses-model"},{"id":"deprecated-model"},{"id":"unknown-preview"}]}`)
+			fmt.Fprint(w, `{"object":"list","data":[{"id":"chat-model"},{"id":"messages-model"},{"id":"muse-spark-1.2"},{"id":"qwen3.8-max"},{"id":"responses-model"},{"id":"deprecated-model"},{"id":"unknown-preview"}]}`)
 		case "/catalog":
 			if recorder.catalogFailure() {
 				http.Error(w, "catalog unavailable", http.StatusServiceUnavailable)


### PR DESCRIPTION
## What changed

- route live OpenCode Go `muse-spark-*` IDs through the Responses API when they appear before `models.opencode.ai` has metadata for them
- keep the generic Chat Completions fallback for other uncatalogued models
- cover the real `muse-spark-1.2` availability-without-catalog case in the protocol routing tests

OpenCode Go currently advertises `muse-spark-1.2` from `/models`, but the metadata catalog only describes `muse-spark-1.2-contributor`. That made term-llm send the bare model to `/chat/completions` instead of `/responses`.

## Verification

With the same valid OpenCode Go key and isolated empty homes so no model cache was shared:

- current `v0.0.399`: `opencode-go:muse-spark-1.2` repeatedly retries, then fails with `OpenCode Go SSE closed before [DONE]`
- patched binary: the same prompt returns exactly `MUSE_OK`
- patched binary + `@developer`: successfully calls tools and writes/verifies a 12-byte `MUSE_TOOL_OK` file with no trailing newline

The contributor model was tested separately. It already routes through Responses on current term-llm, but OpenCode Go returns `403 RegionError: This model is not available in your country.` from this Australian environment. The non-contributor `muse-spark-1.2` works here after this routing fix.

Local checks:

- `go test ./internal/llm`
- `GOMODCACHE="$(go env GOMODCACHE)" HOME="$(mktemp -d)" go test -short ./...`
- `go build ./...`
