### PR TITLE
Add inline diff instructions

### DIFF
--- a/cmd/serve_diff_comments_test.go
+++ b/cmd/serve_diff_comments_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func testDiffComment() *llm.DiffComment {
+	return &llm.DiffComment{
+		ID:            "diff-comment-1",
+		Path:          "internal/example.go",
+		Side:          "old",
+		Line:          17,
+		FileChangeSeq: 42,
+		LineText:      "return obsolete",
+		ContextBefore: []llm.DiffCommentContextLine{{Side: "old", Line: 16, Text: "if stale {"}},
+		ContextAfter:  []llm.DiffCommentContextLine{{Side: "old", Line: 18, Text: "}"}},
+		Instruction:   "Keep the compatibility fallback.",
+	}
+}
+
+func TestParseUserMessageContentAcceptsDiffCommentMetadata(t *testing.T) {
+	comment := testDiffComment()
+	content, err := json.Marshal([]any{
+		map[string]any{"type": "diff_comment", "diff_comment": comment},
+		map[string]any{"type": "input_text", "text": "provider-facing anchored instruction"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parseUserMessageContent: %v", err)
+	}
+	if len(message.Parts) != 2 || message.Parts[0].Type != llm.PartDiffComment || message.Parts[0].DiffComment == nil {
+		t.Fatalf("parts = %#v", message.Parts)
+	}
+	if got := message.Parts[0].DiffComment; got.Path != comment.Path || got.Side != "old" || got.Line != 17 || got.FileChangeSeq != 42 {
+		t.Fatalf("diff comment = %#v", got)
+	}
+}
+
+func TestParseUserMessageContentRejectsInvalidDiffCommentMetadata(t *testing.T) {
+	content := json.RawMessage(`[
+		{"type":"diff_comment","diff_comment":{"id":"bad","path":"x.go","side":"middle","line":1,"file_change_seq":2,"instruction":"fix"}},
+		{"type":"input_text","text":"provider text"}
+	]`)
+	if _, err := parseUserMessageContent(content); err == nil || !strings.Contains(err.Error(), "side must be old or new") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestParseUserMessageContentRejectsOversizedDiffCommentPayloads(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*llm.DiffComment)
+		wantErr string
+	}{
+		{
+			name: "anchor line",
+			mutate: func(comment *llm.DiffComment) {
+				comment.LineText = strings.Repeat("x", diffCommentMaxLineBytes+1)
+			},
+			wantErr: "line_text",
+		},
+		{
+			name: "context line",
+			mutate: func(comment *llm.DiffComment) {
+				comment.ContextBefore = []llm.DiffCommentContextLine{{Side: "old", Line: 1, Text: strings.Repeat("x", diffCommentMaxLineBytes+1)}}
+			},
+			wantErr: "context line text",
+		},
+		{
+			name: "total text",
+			mutate: func(comment *llm.DiffComment) {
+				comment.LineText = strings.Repeat("a", diffCommentMaxLineBytes)
+				comment.Instruction = strings.Repeat("b", diffCommentMaxInstructionBytes)
+				comment.ContextBefore = make([]llm.DiffCommentContextLine, 4)
+				comment.ContextAfter = make([]llm.DiffCommentContextLine, 4)
+				for i := range comment.ContextBefore {
+					comment.ContextBefore[i] = llm.DiffCommentContextLine{Side: "old", Line: i + 1, Text: strings.Repeat("c", 2200)}
+					comment.ContextAfter[i] = llm.DiffCommentContextLine{Side: "new", Line: i + 1, Text: strings.Repeat("d", 2200)}
+				}
+			},
+			wantErr: "text payload",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comment := testDiffComment()
+			tt.mutate(comment)
+			raw, err := json.Marshal(comment)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := parseDiffCommentPart(raw); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandleSessionInterruptAcceptsTypedDiffComment(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 10, nil)
+	defer manager.Close()
+	engine := llm.NewEngine(llm.NewMockProvider("mock"), nil)
+	runtime := &serveRuntime{engine: engine, providerKey: "mock"}
+	active := &runtimeInterruptState{cancel: func() {}, done: make(chan struct{})}
+	runtime.setActiveInterrupt(active)
+	defer runtime.clearActiveInterrupt(active)
+	putTestSession(manager, "session-interrupt-comment", runtime)
+
+	comment := testDiffComment()
+	content, err := json.Marshal([]any{
+		map[string]any{"type": "diff_comment", "diff_comment": comment},
+		map[string]any{"type": "input_text", "text": "provider-facing anchored instruction"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"message":           "provider-facing anchored instruction",
+		"content":           json.RawMessage(content),
+		"interjection_id":   "interrupt-comment-1",
+		"client_message_id": "interrupt-comment-1",
+		"delivery":          "steer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/session-interrupt-comment/interrupt", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	(&serveServer{sessionMgr: manager}).handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	pending := engine.ListPendingInterjections()
+	if len(pending) != 1 || len(pending[0].Message.Parts) != 2 || pending[0].Message.Parts[0].Type != llm.PartDiffComment {
+		t.Fatalf("pending interjections = %#v", pending)
+	}
+}
+
+func TestDiffCommentMetadataIsStrippedFromProviderMessages(t *testing.T) {
+	comment := testDiffComment()
+	stored := session.NewMessage("session-comments", llm.Message{Role: llm.RoleUser, Parts: []llm.Part{
+		{Type: llm.PartDiffComment, DiffComment: comment},
+		{Type: llm.PartText, Text: "provider-facing anchored instruction"},
+	}}, -1)
+	providerMessage := stored.ToLLMMessage()
+	if len(providerMessage.Parts) != 1 || providerMessage.Parts[0].Type != llm.PartText {
+		t.Fatalf("provider parts = %#v", providerMessage.Parts)
+	}
+}
+
+func TestHandleSessionDiffCommentsScansTypedTranscriptParts(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const sessionID = "session-comments"
+	if err := store.Create(ctx, &session.Session{ID: sessionID, Provider: "test", Model: "test", Mode: session.ModeChat}); err != nil {
+		t.Fatal(err)
+	}
+	message := session.NewMessage(sessionID, llm.Message{Role: llm.RoleUser, ClientMessageID: "client-comment-1", Parts: []llm.Part{
+		{Type: llm.PartDiffComment, DiffComment: testDiffComment()},
+		{Type: llm.PartText, Text: "provider-facing anchored instruction"},
+	}}, -1)
+	if err := store.AddMessage(ctx, sessionID, message); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddMessage(ctx, sessionID, session.NewMessage(sessionID, llm.UserText("prose mentioning diff_comment must not count"), -1)); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &serveServer{store: store}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sessionID+"/diff-comments", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var payload struct {
+		Comments      []sessionDiffCommentEntry `json:"comments"`
+		TranscriptRev int64                     `json:"transcript_rev"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Comments) != 1 || payload.Comments[0].Comment == nil || payload.TranscriptRev <= 0 {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if got := payload.Comments[0]; got.ClientMessageID != "client-comment-1" || got.Comment.Instruction != "Keep the compatibility fallback." {
+		t.Fatalf("comment = %#v", got)
+	}
+
+	entries := srv.sessionMessageEntries([]session.Message{*message})
+	if len(entries) != 1 || len(entries[0].Parts) != 2 || entries[0].Parts[0].Type != "diff_comment" {
+		t.Fatalf("transcript projection = %#v", entries)
+	}
+}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -898,6 +898,7 @@ type sessionMessagePartEntry struct {
 	Text            string                         `json:"text,omitempty"`
 	SkillActivation *llm.SkillActivationProvenance `json:"skill_activation,omitempty"`
 	PathNote        *llm.PathNoteProvenance        `json:"path_note,omitempty"`
+	DiffComment     *llm.DiffComment               `json:"diff_comment,omitempty"`
 	ToolName        string                         `json:"tool_name,omitempty"`
 	ToolInfo        string                         `json:"tool_info,omitempty"`
 	ToolArgs        string                         `json:"tool_arguments,omitempty"`
@@ -925,6 +926,66 @@ type sessionMessageEntry struct {
 	AssistantSegmentOrdinal *int                      `json:"assistant_segment_ordinal,omitempty"`
 	SegmentStartSequence    int64                     `json:"segment_start_sequence,omitempty"`
 	SegmentEndSequence      int64                     `json:"segment_end_sequence,omitempty"`
+}
+
+type sessionDiffCommentEntry struct {
+	MessageID       int64            `json:"message_id"`
+	ClientMessageID string           `json:"client_message_id,omitempty"`
+	CreatedAt       int64            `json:"created_at"`
+	Comment         *llm.DiffComment `json:"diff_comment"`
+}
+
+func (s *serveServer) handleSessionDiffComments(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if s.store == nil {
+		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session history is unavailable")
+		return
+	}
+	sess, err := s.store.Get(r.Context(), sessionID)
+	if err != nil || sess == nil {
+		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
+		return
+	}
+	lister, ok := s.store.(session.DiffCommentMessageLister)
+	if !ok {
+		writeOpenAIError(w, http.StatusNotImplemented, "server_error", "session history does not support inline comment lookup")
+		return
+	}
+	revision := int64(-1)
+	if reader, ok := s.store.(interface {
+		TranscriptRev(context.Context, string) (int64, error)
+	}); ok {
+		revision, err = reader.TranscriptRev(r.Context(), sessionID)
+		if err != nil {
+			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to get diff comment revision")
+			return
+		}
+	}
+	messages, err := lister.GetDiffCommentMessages(r.Context(), sessionID)
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to get diff comments")
+		return
+	}
+	comments := make([]sessionDiffCommentEntry, 0)
+	for _, message := range messages {
+		for _, part := range message.Parts {
+			if part.Type != llm.PartDiffComment || part.DiffComment == nil {
+				continue
+			}
+			comment := *part.DiffComment
+			comment.ContextBefore = append([]llm.DiffCommentContextLine(nil), part.DiffComment.ContextBefore...)
+			comment.ContextAfter = append([]llm.DiffCommentContextLine(nil), part.DiffComment.ContextAfter...)
+			comments = append(comments, sessionDiffCommentEntry{
+				MessageID:       message.ID,
+				ClientMessageID: message.ClientMessageID,
+				CreatedAt:       message.CreatedAt.UnixMilli(),
+				Comment:         &comment,
+			})
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"comments":       comments,
+		"transcript_rev": revision,
+	})
 }
 
 type sessionMessagesResponse struct {
@@ -1535,6 +1596,13 @@ func (s *serveServer) sessionMessageEntries(msgs []session.Message) []sessionMes
 		embeddedFiles := make(map[string]bool)
 		for _, p := range msg.Parts {
 			switch p.Type {
+			case llm.PartDiffComment:
+				if p.DiffComment != nil {
+					copyComment := *p.DiffComment
+					copyComment.ContextBefore = append([]llm.DiffCommentContextLine(nil), p.DiffComment.ContextBefore...)
+					copyComment.ContextAfter = append([]llm.DiffCommentContextLine(nil), p.DiffComment.ContextAfter...)
+					entry.Parts = append(entry.Parts, sessionMessagePartEntry{Type: "diff_comment", DiffComment: &copyComment})
+				}
 			case llm.PartText:
 				text := p.Text
 				if msg.Role == llm.RoleUser {
@@ -1847,6 +1915,16 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 		s.handleSessionMCP(w, r, sessionID)
+		return
+	}
+
+	if suffix == "diff-comments" {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		s.handleSessionDiffComments(w, r, sessionID)
 		return
 	}
 

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -456,6 +456,69 @@ func tiffOrientation(tiff []byte) int {
 	return 0
 }
 
+const (
+	diffCommentMaxPathBytes        = 1024
+	diffCommentMaxLineBytes        = 8 * 1024
+	diffCommentMaxInstructionBytes = 8 * 1024
+	diffCommentMaxPayloadBytes     = 32 * 1024
+)
+
+func parseDiffCommentPart(raw json.RawMessage) (*llm.DiffComment, error) {
+	var comment llm.DiffComment
+	if err := json.Unmarshal(raw, &comment); err != nil {
+		return nil, fmt.Errorf("invalid diff_comment metadata: %w", err)
+	}
+	comment.ID = strings.TrimSpace(comment.ID)
+	comment.ParentID = strings.TrimSpace(comment.ParentID)
+	comment.Path = strings.TrimSpace(comment.Path)
+	comment.Side = strings.ToLower(strings.TrimSpace(comment.Side))
+	comment.Instruction = strings.TrimSpace(comment.Instruction)
+	if comment.ID == "" || len(comment.ID) > 200 {
+		return nil, fmt.Errorf("diff_comment.id is required and must be at most 200 characters")
+	}
+	if len(comment.ParentID) > 200 {
+		return nil, fmt.Errorf("diff_comment.parent_id must be at most 200 characters")
+	}
+	if comment.Path == "" || len(comment.Path) > diffCommentMaxPathBytes {
+		return nil, fmt.Errorf("diff_comment.path is required and must be at most %d bytes", diffCommentMaxPathBytes)
+	}
+	if comment.Side != "old" && comment.Side != "new" {
+		return nil, fmt.Errorf("diff_comment.side must be old or new")
+	}
+	if comment.Line <= 0 {
+		return nil, fmt.Errorf("diff_comment.line must be positive")
+	}
+	if comment.FileChangeSeq <= 0 {
+		return nil, fmt.Errorf("diff_comment.file_change_seq must be positive")
+	}
+	if len(comment.LineText) > diffCommentMaxLineBytes {
+		return nil, fmt.Errorf("diff_comment.line_text must be at most %d bytes", diffCommentMaxLineBytes)
+	}
+	if comment.Instruction == "" || len(comment.Instruction) > diffCommentMaxInstructionBytes {
+		return nil, fmt.Errorf("diff_comment.instruction is required and must be at most %d bytes", diffCommentMaxInstructionBytes)
+	}
+	if len(comment.ContextBefore) > 4 || len(comment.ContextAfter) > 4 {
+		return nil, fmt.Errorf("diff_comment context is limited to four lines on each side")
+	}
+	totalBytes := len(comment.ID) + len(comment.ParentID) + len(comment.Path) + len(comment.Side) + len(comment.LineText) + len(comment.Instruction)
+	for _, contextLines := range [][]llm.DiffCommentContextLine{comment.ContextBefore, comment.ContextAfter} {
+		for i := range contextLines {
+			contextLines[i].Side = strings.ToLower(strings.TrimSpace(contextLines[i].Side))
+			if contextLines[i].Side != "old" && contextLines[i].Side != "new" || contextLines[i].Line <= 0 {
+				return nil, fmt.Errorf("diff_comment context lines require an old/new side and positive line")
+			}
+			if len(contextLines[i].Text) > diffCommentMaxLineBytes {
+				return nil, fmt.Errorf("diff_comment context line text must be at most %d bytes", diffCommentMaxLineBytes)
+			}
+			totalBytes += len(contextLines[i].Side) + len(contextLines[i].Text)
+		}
+	}
+	if totalBytes > diffCommentMaxPayloadBytes {
+		return nil, fmt.Errorf("diff_comment text payload must be at most %d bytes", diffCommentMaxPayloadBytes)
+	}
+	return &comment, nil
+}
+
 // parseUserMessageContent builds a user llm.Message from a content field
 // that may be a plain string or an array of content parts (input_text, input_image, input_file).
 // Chat Completions-style text/image_url parts are also accepted.
@@ -475,6 +538,12 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 		for _, part := range parts {
 			partType := strings.ToLower(strings.TrimSpace(jsonString(part["type"])))
 			switch partType {
+			case "diff_comment":
+				comment, err := parseDiffCommentPart(part["diff_comment"])
+				if err != nil {
+					return llm.Message{}, err
+				}
+				llmParts = append(llmParts, llm.Part{Type: llm.PartDiffComment, DiffComment: comment})
 			case "input_text", "text", "output_text":
 				text := jsonString(part["text"])
 				if text != "" {
@@ -594,6 +663,15 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 			}
 		}
 		if len(llmParts) > 0 {
+			hasDiffComment := false
+			hasProviderContent := false
+			for _, part := range llmParts {
+				hasDiffComment = hasDiffComment || part.Type == llm.PartDiffComment
+				hasProviderContent = hasProviderContent || ((part.Type == llm.PartText || part.Type == llm.PartFile) && strings.TrimSpace(part.Text) != "") || part.Type == llm.PartImage
+			}
+			if hasDiffComment && !hasProviderContent {
+				return llm.Message{}, fmt.Errorf("diff_comment requires adjacent provider-facing content")
+			}
 			return llm.Message{Role: llm.RoleUser, Parts: llmParts}, nil
 		}
 	}

--- a/internal/llm/agent_mention_test.go
+++ b/internal/llm/agent_mention_test.go
@@ -31,3 +31,17 @@ func TestPrepareProviderRequestConvertsOnlyTypedAgentMentionContext(t *testing.T
 		t.Fatalf("human message text included typed provider context: %q", got)
 	}
 }
+
+func TestPrepareProviderRequestStripsDiffCommentMetadata(t *testing.T) {
+	original := []Message{{Role: RoleUser, Parts: []Part{
+		{Type: PartDiffComment, DiffComment: &DiffComment{ID: "comment-1", Path: "main.go", Side: "new", Line: 3, FileChangeSeq: 7, Instruction: "rename this"}},
+		{Type: PartText, Text: "provider-facing anchored instruction"},
+	}}}
+	prepared := NewEngine(NewMockProvider("mock"), nil).prepareProviderRequest(Request{Messages: original})
+	if len(prepared.Messages) != 1 || len(prepared.Messages[0].Parts) != 1 || prepared.Messages[0].Parts[0].Type != PartText {
+		t.Fatalf("prepared messages = %#v", prepared.Messages)
+	}
+	if original[0].Parts[0].Type != PartDiffComment || original[0].Parts[0].DiffComment == nil {
+		t.Fatalf("provider preparation mutated stored metadata: %#v", original)
+	}
+}

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -1490,7 +1490,7 @@ func providerSafeRequestMessages(messages []Message) []Message {
 	for index, message := range messages {
 		needsRewrite := false
 		for _, part := range message.Parts {
-			if part.Type == PartSkillActivation || part.Type == PartAgentMention {
+			if part.Type == PartSkillActivation || part.Type == PartAgentMention || part.Type == PartDiffComment {
 				needsRewrite = true
 				break
 			}
@@ -1509,7 +1509,7 @@ func providerSafeRequestMessages(messages []Message) []Message {
 		copyMessage.Parts = make([]Part, 0, len(message.Parts))
 		for _, part := range message.Parts {
 			switch part.Type {
-			case PartSkillActivation:
+			case PartSkillActivation, PartDiffComment:
 				continue
 			case PartAgentMention:
 				part.Type = PartText

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -261,6 +261,7 @@ const (
 	PartSkillActivation PartType = "skill_activation" // Persisted direct-activation provenance; never sent to providers.
 	PartAgentMention    PartType = "agent_mention"    // Provider-visible delegation instruction; excluded from human-visible text surfaces.
 	PartPathNote        PartType = "path_note"        // Persisted branch-context provenance; adjacent text is sent as developer context.
+	PartDiffComment     PartType = "diff_comment"     // Persisted inline-diff anchor metadata; never sent to providers.
 )
 
 // Message holds a role with structured parts.
@@ -378,6 +379,31 @@ type Part struct {
 	DiscoveryOutput           *ToolDiscoveryOutput       // Planner-selected trusted schemas paired to a discovery call.
 	SkillActivation           *SkillActivationProvenance // Direct user activation metadata; persisted but not provider content.
 	PathNote                  *PathNoteProvenance        // Branch-context metadata; persisted but not sent to providers.
+	DiffComment               *DiffComment               // Inline-diff comment anchor; persisted but not sent to providers.
+}
+
+// DiffCommentContextLine preserves one exact nearby line from the diff that the
+// user saw when submitting an inline instruction.
+type DiffCommentContextLine struct {
+	Side string `json:"side"`
+	Line int    `json:"line"`
+	Text string `json:"text"`
+}
+
+// DiffComment is durable, display-only metadata for an instruction anchored to
+// a particular retained file-change snapshot. The adjacent text part carries
+// the actual provider-facing instruction.
+type DiffComment struct {
+	ID            string                   `json:"id"`
+	ParentID      string                   `json:"parent_id,omitempty"`
+	Path          string                   `json:"path"`
+	Side          string                   `json:"side"`
+	Line          int                      `json:"line"`
+	FileChangeSeq int64                    `json:"file_change_seq"`
+	LineText      string                   `json:"line_text"`
+	ContextBefore []DiffCommentContextLine `json:"context_before,omitempty"`
+	ContextAfter  []DiffCommentContextLine `json:"context_after,omitempty"`
+	Instruction   string                   `json:"instruction"`
 }
 
 // PathNoteProvenance identifies generated context carried from the suffix that

--- a/internal/serveui/embed.go
+++ b/internal/serveui/embed.go
@@ -16,7 +16,7 @@ import (
 //go:embed static/index.html static/manifest.webmanifest static/icon-512.png static/sw.js
 //go:embed static/app.css
 //go:embed static/app-core.js static/toast.js static/app-network.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-path-notes.js static/app-branching.js static/app-branch-commands.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
-//go:embed static/app-attachments.js static/app-stream.js static/app-response-effects.js static/app-send.js static/app-runtime.js static/app-interject.js static/app-modals.js static/app-composer.js static/app-skills.js static/side-question.js static/app-webrtc.js static/app-diffs.js static/app-worktrees.js
+//go:embed static/app-attachments.js static/app-stream.js static/app-response-effects.js static/app-send.js static/app-runtime.js static/app-interject.js static/app-modals.js static/app-composer.js static/app-skills.js static/side-question.js static/app-webrtc.js static/app-diff-comments.js static/app-diffs.js static/app-worktrees.js
 //go:embed static/decoration.js static/markdown-setup.js static/markdown-streaming.js static/transcript-window.js static/active-response.js static/conversation.js
 //go:embed static/vendor
 var staticFiles embed.FS
@@ -120,6 +120,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`href="app-message-convert.js"`, `href="` + versioned("app-message-convert.js") + `"`},
 		{`href="intent-storage.js"`, `href="` + versioned("intent-storage.js") + `"`},
 		{`href="app-session-admin.js"`, `href="` + versioned("app-session-admin.js") + `"`},
+		{`href="app-diff-comments.js"`, `href="` + versioned("app-diff-comments.js") + `"`},
 		{`href="app-diffs.js"`, `href="` + versioned("app-diffs.js") + `"`},
 		{`href="app-worktrees.js"`, `href="` + versioned("app-worktrees.js") + `"`},
 		{`src="markdown-setup.js"`, `src="` + versioned("markdown-setup.js") + `"`},
@@ -155,6 +156,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`src="app-message-convert.js"`, `src="` + versioned("app-message-convert.js") + `"`},
 		{`src="intent-storage.js"`, `src="` + versioned("intent-storage.js") + `"`},
 		{`src="app-session-admin.js"`, `src="` + versioned("app-session-admin.js") + `"`},
+		{`src="app-diff-comments.js"`, `src="` + versioned("app-diff-comments.js") + `"`},
 		{`src="app-diffs.js"`, `src="` + versioned("app-diffs.js") + `"`},
 		{`src="app-worktrees.js"`, `src="` + versioned("app-worktrees.js") + `"`},
 	}
@@ -244,6 +246,7 @@ func renderServiceWorkerBytes(opts RenderOptions) []byte {
 		{"'./app-message-convert.js'", "'./" + versioned("app-message-convert.js") + "'"},
 		{"'./intent-storage.js'", "'./" + versioned("intent-storage.js") + "'"},
 		{"'./app-session-admin.js'", "'./" + versioned("app-session-admin.js") + "'"},
+		{"'./app-diff-comments.js'", "'./" + versioned("app-diff-comments.js") + "'"},
 		{"'./app-diffs.js'", "'./" + versioned("app-diffs.js") + "'"},
 		{"'./app-worktrees.js'", "'./" + versioned("app-worktrees.js") + "'"},
 	}

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -54,6 +54,7 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	completionLines := 0
 	branchingLines := 0
 	branchCommandLines := 0
+	diffLines := map[string]int{}
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".js") || strings.HasSuffix(name, "_test.js") {
@@ -72,12 +73,14 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 			branchingLines = lineCount
 		} else if name == "app-branch-commands.js" {
 			branchCommandLines = lineCount
+		} else if name == "app-diffs.js" || name == "app-diff-comments.js" {
+			diffLines[name] = lineCount
 		} else {
 			legacyProductionLines += lineCount
 		}
 	}
-	// Keep focused transport/completion/branching boundaries from weakening the
-	// pre-existing ratchet: legacy production code must still decrease, while each
+	// Keep focused transport/completion/branching/diff boundaries from weakening
+	// the pre-existing ratchet: legacy production code must still decrease, while each
 	// extracted module gets a narrow independent ceiling.
 	if legacyProductionLines >= 20729 {
 		t.Fatalf("legacy first-party production JS=%d lines, must decrease from 20729", legacyProductionLines)
@@ -93,6 +96,9 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	}
 	if branchCommandLines == 0 || branchCommandLines > 100 {
 		t.Fatalf("conversation branch command controller=%d lines, budget=100", branchCommandLines)
+	}
+	if diffLines["app-diffs.js"] == 0 || diffLines["app-diff-comments.js"] == 0 || diffLines["app-diffs.js"]+diffLines["app-diff-comments.js"] > 1950 {
+		t.Fatalf("diff controllers grew beyond focused budget: %v", diffLines)
 	}
 
 	for _, name := range []string{"active-response.js", "conversation.js", "transcript-window.js"} {
@@ -1006,6 +1012,23 @@ func TestStaticAssetsSupportCurrentPlanSurface(t *testing.T) {
 	}
 }
 
+func TestAppDiffCommentsJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found in PATH, skipping JS app-diff-comments tests")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "static", "app_diff_comments_test.js")
+	out, err := exec.Command(node, script).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("app_diff_comments_test.js failed: %v", err)
+	}
+}
+
 func TestAppDiffsJS(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
@@ -1039,6 +1062,7 @@ func TestStaticAssetsSupportDiffSidebar(t *testing.T) {
 		`id="diffToggleBtn"`,
 		`id="diffFileList"`,
 		`id="diffResizeHandle"`,
+		`src="app-diff-comments.js"`,
 		`src="app-diffs.js"`,
 	} {
 		if !strings.Contains(indexSrc, want) {
@@ -1102,17 +1126,23 @@ func TestStaticAssetsSupportDiffSidebar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StaticAsset(sw.js): %v", err)
 	}
-	if !strings.Contains(string(swJS), "'./app-diffs.js'") {
-		t.Fatal("sw.js SHELL_ASSETS missing app-diffs.js")
+	for _, asset := range []string{"app-diff-comments.js", "app-diffs.js"} {
+		if !strings.Contains(string(swJS), "'./"+asset+"'") {
+			t.Fatalf("sw.js SHELL_ASSETS missing %s", asset)
+		}
 	}
 
 	rendered := RenderIndexHTML("/ui", "", RenderOptions{})
-	if !strings.Contains(string(rendered), `src="app-diffs.js?v=`) {
-		t.Fatal("RenderIndexHTML does not version app-diffs.js")
+	for _, asset := range []string{"app-diff-comments.js", "app-diffs.js"} {
+		if !strings.Contains(string(rendered), `src="`+asset+`?v=`) {
+			t.Fatalf("RenderIndexHTML does not version %s", asset)
+		}
 	}
 	renderedSW := RenderServiceWorker(RenderOptions{})
-	if !strings.Contains(string(renderedSW), "'./app-diffs.js?v=") {
-		t.Fatal("RenderServiceWorker does not version app-diffs.js")
+	for _, asset := range []string{"app-diff-comments.js", "app-diffs.js"} {
+		if !strings.Contains(string(renderedSW), "'./"+asset+"?v=") {
+			t.Fatalf("RenderServiceWorker does not version %s", asset)
+		}
 	}
 }
 

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -2097,6 +2097,8 @@ const sanitizeMessage = (msg) => {
         const askUserCallId = String(msg.askUserCallId || msg.ask_user_call_id || '').trim();
         if (askUserCallId) base.askUserCallId = askUserCallId;
       }
+      const diffComment = msg.diffComment || msg.diff_comment;
+      if (diffComment && typeof diffComment === 'object') { try { base.diffComment = JSON.parse(JSON.stringify(diffComment)); } catch {} }
       if (Array.isArray(msg.attachments) && msg.attachments.length > 0) {
         base.attachments = msg.attachments.map(a => ({
           name: String(a.name || 'file'),
@@ -2311,6 +2313,7 @@ const saveSessions = () => {
   for (const removed of sessionsBeforePrune) {
     if (!retainedSessionIDs.has(removed.id)) removed.transcript?.destroy?.();
   }
+  app.pruneDiffCommentState?.(retainedSessionIDs);
   evictStaleSessionMessages();
   const nextActiveId = state.activeSessionId || '';
   const nextDraftActive = state.draftSessionActive ? '1' : '0';

--- a/internal/serveui/static/app-diff-comments.js
+++ b/internal/serveui/static/app-diff-comments.js
@@ -1,0 +1,497 @@
+(() => {
+'use strict';
+
+const app = window.TermLLMApp || (window.TermLLMApp = {});
+const { UI_PREFIX, state } = app;
+const CONTEXT_RADIUS = 2;
+const COMMENT_REFRESH_MS = 15_000;
+const commentStateBySession = new Map();
+
+const liveSessionIDs = () => new Set((state.sessions || []).map((session) => String(session?.id || '').trim()).filter(Boolean));
+const pruneDiffCommentState = (retainedIDs = liveSessionIDs()) => {
+  const retained = retainedIDs instanceof Set ? retainedIDs : new Set(retainedIDs || []);
+  for (const sessionId of commentStateBySession.keys()) {
+    if (!retained.has(sessionId)) commentStateBySession.delete(sessionId);
+  }
+};
+
+const sessionCommentState = (sessionId) => {
+  let value = commentStateBySession.get(sessionId);
+  if (!value) {
+    value = {
+      comments: [], loaded: false, inflight: null, lastLoadedAt: 0, serverRevision: -1,
+      revisionsByPath: new Map(), editorDrafts: new Map(), openPanel: null
+    };
+    commentStateBySession.set(sessionId, value);
+  }
+  return value;
+};
+
+const normalizeComment = (entry) => {
+  const raw = entry?.diff_comment || entry;
+  if (!raw || typeof raw !== 'object') return null;
+  const side = String(raw.side || '').toLowerCase();
+  const line = Number(raw.line) || 0;
+  const seq = Number(raw.file_change_seq) || 0;
+  const id = String(raw.id || '').trim();
+  const path = String(raw.path || '');
+  const instruction = String(raw.instruction || '').trim();
+  if (!id || !path || !instruction || (side !== 'old' && side !== 'new') || line <= 0 || seq <= 0) return null;
+  return {
+    id,
+    parent_id: String(raw.parent_id || ''),
+    path,
+    side,
+    line,
+    file_change_seq: seq,
+    line_text: String(raw.line_text ?? ''),
+    context_before: Array.isArray(raw.context_before) ? raw.context_before : [],
+    context_after: Array.isArray(raw.context_after) ? raw.context_after : [],
+    instruction,
+    client_message_id: String(entry?.client_message_id || raw.client_message_id || ''),
+    created_at: Number(entry?.created_at || raw.created_at) || Date.now(),
+    optimistic: Boolean(raw.optimistic)
+  };
+};
+
+const anchorKey = (comment) => `${String(comment?.path || '')}\u0000${String(comment?.side || '')}\u0000${Number(comment?.line) || 0}`;
+const commentsForAnchor = (sessionId, anchor) => sessionCommentState(sessionId).comments
+  .filter((comment) => anchorKey(comment) === anchorKey(anchor))
+  .sort((a, b) => (a.created_at - b.created_at) || a.id.localeCompare(b.id));
+
+const pathFingerprint = (comments, path) => JSON.stringify(comments
+  .filter((comment) => comment.path === path)
+  .map((comment) => [comment.id, comment.parent_id, comment.side, comment.line, comment.file_change_seq, comment.instruction, comment.optimistic])
+  .sort((a, b) => String(a[0]).localeCompare(String(b[0]))));
+
+const bumpChangedPathRevisions = (cs, before, after) => {
+  const paths = new Set([...before.map((comment) => comment.path), ...after.map((comment) => comment.path)]);
+  for (const path of paths) {
+    if (pathFingerprint(before, path) === pathFingerprint(after, path)) continue;
+    cs.revisionsByPath.set(path, (cs.revisionsByPath.get(path) || 0) + 1);
+  }
+};
+
+const localCommentStillPending = (sessionId, comment) => {
+  const identities = new Set([comment.id, comment.client_message_id].filter(Boolean));
+  for (const collection of [state.pendingInterjections, state.pendingInterruptCommits, state.queuedInterrupts]) {
+    if ((collection || []).some((entry) => entry?.sessionId === sessionId && identities.has(String(entry?.messageId || '')))) return true;
+  }
+  const session = (state.sessions || []).find((entry) => String(entry?.id || '') === sessionId);
+  const messages = window.TermLLMConversation?.sessionMessages?.(session) || session?.messages || [];
+  return messages.some((message) => {
+    const identity = String(message?.clientMessageId || message?.id || '');
+    return message?.role === 'user' && identities.has(identity) && !Number.isFinite(Number(message?.serverSeq));
+  });
+};
+
+const replaceComments = (sessionId, incoming, serverRevision = -1) => {
+  const cs = sessionCommentState(sessionId);
+  const before = cs.comments;
+  const merged = new Map();
+  for (const comment of before) {
+    if (comment.optimistic && localCommentStillPending(sessionId, comment)) merged.set(comment.id, comment);
+  }
+  for (const entry of Array.isArray(incoming) ? incoming : []) {
+    const comment = normalizeComment(entry);
+    if (comment) merged.set(comment.id, { ...comment, optimistic: false });
+  }
+  cs.comments = Array.from(merged.values());
+  cs.loaded = true;
+  cs.lastLoadedAt = Date.now();
+  if (Number.isFinite(Number(serverRevision)) && Number(serverRevision) >= 0) cs.serverRevision = Number(serverRevision);
+  bumpChangedPathRevisions(cs, before, cs.comments);
+};
+
+const currentSessionRevision = (sessionId) => {
+  const session = (state.sessions || []).find((entry) => String(entry?.id || '') === String(sessionId));
+  const revisions = [Number(session?.transcriptRev), Number(session?.transcript?.rev)].filter((value) => Number.isFinite(value) && value >= 0);
+  return revisions.length > 0 ? Math.max(...revisions) : -1;
+};
+
+const hydrateDiffComments = (sessionId, options = {}) => {
+  const id = String(sessionId || '').trim();
+  if (!id) return Promise.resolve([]);
+  pruneDiffCommentState(new Set([...liveSessionIDs(), id]));
+  const cs = sessionCommentState(id);
+  const expectedRevision = Number.isFinite(Number(options.revision)) ? Number(options.revision) : currentSessionRevision(id);
+  const revisionAhead = expectedRevision >= 0 && expectedRevision > cs.serverRevision;
+  const freshByTime = Date.now() - cs.lastLoadedAt < COMMENT_REFRESH_MS;
+  if (!options.force && cs.loaded && freshByTime && !revisionAhead) return Promise.resolve(cs.comments);
+  if (cs.inflight) return cs.inflight;
+  const headers = typeof app.requestHeaders === 'function' ? app.requestHeaders(id) : (state.token ? { Authorization: `Bearer ${state.token}` } : {});
+  cs.inflight = app.apiFetch(`${UI_PREFIX}/v1/sessions/${encodeURIComponent(id)}/diff-comments`, { headers })
+    .then(async (response) => {
+      if (!response.ok) throw new Error(`Unable to load inline comments (${response.status})`);
+      const payload = await response.json();
+      replaceComments(id, payload?.comments, payload?.transcript_rev);
+      if (id === state.activeSessionId) app.renderDiffSidebar?.(id);
+      return cs.comments;
+    })
+    .catch(() => cs.comments)
+    .finally(() => { cs.inflight = null; });
+  return cs.inflight;
+};
+
+const invalidateDiffComments = (sessionId) => {
+  const cs = commentStateBySession.get(String(sessionId || '').trim());
+  if (!cs) return;
+  cs.lastLoadedAt = 0;
+  cs.serverRevision = -1;
+};
+
+const diffCommentRevision = (sessionId, path) => commentStateBySession.get(sessionId)?.revisionsByPath.get(path) || 0;
+
+const rowAnchor = (path, row, fileChangeSeq) => {
+  const side = row?.type === 'del' ? 'old' : (row?.newNo ? 'new' : 'old');
+  return {
+    path,
+    side,
+    line: Number(side === 'old' ? row?.oldNo : row?.newNo) || 0,
+    file_change_seq: Number(fileChangeSeq) || 0,
+    line_text: String(row?.text ?? '')
+  };
+};
+
+const contextLine = (row) => {
+  if (!row || row.type === 'hunk') return null;
+  const side = row.type === 'del' ? 'old' : (row.newNo ? 'new' : 'old');
+  const line = Number(side === 'old' ? row.oldNo : row.newNo) || 0;
+  return line > 0 ? { side, line, text: String(row.text ?? '') } : null;
+};
+
+const captureContext = (rows, rowIndex) => {
+  const before = [], after = [];
+  for (let index = rowIndex - 1; index >= 0 && before.length < CONTEXT_RADIUS; index -= 1) {
+    if (rows[index]?.type === 'hunk') break;
+    const line = contextLine(rows[index]);
+    if (line) before.unshift(line);
+  }
+  for (let index = rowIndex + 1; index < rows.length && after.length < CONTEXT_RADIUS; index += 1) {
+    if (rows[index]?.type === 'hunk') break;
+    const line = contextLine(rows[index]);
+    if (line) after.push(line);
+  }
+  return { before, after };
+};
+
+const formatContextLine = (line) => `${line.side} ${line.line} | ${line.text}`;
+const formatAgentInstruction = (comment) => {
+  const lines = [
+    '[Inline diff instruction]',
+    `Path: ${comment.path}`,
+    `Side: ${comment.side}`,
+    `Line: ${comment.line}`,
+    `Captured file-change seq: ${comment.file_change_seq}`,
+    '',
+    'Captured context:'
+  ];
+  for (const line of comment.context_before) lines.push(`  ${formatContextLine(line)}`);
+  lines.push(`> ${comment.side} ${comment.line} | ${comment.line_text}`);
+  for (const line of comment.context_after) lines.push(`  ${formatContextLine(line)}`);
+  lines.push('', 'Instruction:', comment.instruction);
+  return lines.join('\n');
+};
+
+const makeID = () => {
+  try {
+    if (globalThis.crypto?.randomUUID) return `diff_comment_${globalThis.crypto.randomUUID()}`;
+  } catch {}
+  return `diff_comment_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+};
+
+const addOptimisticComment = (sessionId, comment) => {
+  const cs = sessionCommentState(sessionId);
+  const before = cs.comments;
+  if (!before.some((existing) => existing.id === comment.id)) {
+    cs.comments = [...before, { ...comment, client_message_id: comment.id, created_at: Date.now(), optimistic: true }];
+    bumpChangedPathRevisions(cs, before, cs.comments);
+  }
+  app.renderDiffSidebar?.(sessionId);
+};
+
+const removeOptimisticComment = (sessionId, commentId) => {
+  const cs = sessionCommentState(sessionId);
+  const before = cs.comments;
+  cs.comments = before.filter((comment) => !(comment.id === commentId && comment.optimistic));
+  if (cs.comments.length !== before.length) {
+    bumpChangedPathRevisions(cs, before, cs.comments);
+    app.renderDiffSidebar?.(sessionId);
+  }
+};
+
+const makeButton = (className, label, text) => {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = className;
+  button.setAttribute('aria-label', label);
+  button.title = label;
+  button.textContent = text;
+  return button;
+};
+
+const panelIDForAnchor = (sessionId, anchor) => {
+  const source = `${sessionId}\u0000${anchorKey(anchor)}`;
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index += 1) hash = Math.imul(hash ^ source.charCodeAt(index), 16777619);
+  return `diff-comment-panel-${(hash >>> 0).toString(36)}`;
+};
+
+const closePanel = (panel, focusTarget, options = {}) => {
+  const sessionId = String(options.sessionId || panel?._diffCommentSessionId || '');
+  const key = String(options.key || panel?._diffCommentKey || '');
+  const cs = commentStateBySession.get(sessionId);
+  if (options.clearDraft && cs && key) cs.editorDrafts.delete(key);
+  if (cs?.openPanel?.key === key) cs.openPanel = null;
+  const trigger = focusTarget || panel?._diffCommentTrigger;
+  trigger?.setAttribute?.('aria-expanded', 'false');
+  panel?.remove?.();
+  trigger?.focus?.();
+};
+
+const showEditor = (panel, sessionId, anchor, rows, rowIndex, trigger, prior) => {
+  const existingEditor = panel.querySelector?.('.diff-comment-editor');
+  if (existingEditor) {
+    existingEditor.querySelector?.('textarea')?.focus?.();
+    return;
+  }
+  const cs = sessionCommentState(sessionId);
+  const key = anchorKey(anchor);
+  if (cs.openPanel?.key === key) cs.openPanel.editing = true;
+  const editor = document.createElement('div');
+  editor.className = 'diff-comment-editor';
+  const textarea = document.createElement('textarea');
+  textarea.rows = 2;
+  textarea.placeholder = prior.length > 0 ? 'Add a follow-up instruction…' : 'Instruction for this line…';
+  textarea.setAttribute('aria-label', 'Inline diff instruction');
+  textarea.value = cs.editorDrafts.get(key) || '';
+  const actions = document.createElement('div');
+  actions.className = 'diff-comment-editor-actions';
+  const cancel = makeButton('diff-comment-cancel', 'Cancel inline comment', 'Cancel');
+  const send = makeButton('diff-comment-send', 'Send inline comment now', 'Send now');
+  actions.append(cancel, send);
+  editor.append(textarea, actions);
+  panel.appendChild(editor);
+
+  const submit = async () => {
+    const instruction = String(textarea.value || '').trim();
+    if (!instruction || send.disabled) return;
+    cs.editorDrafts.set(key, textarea.value);
+    if (!state.connected) {
+      app.openAuthModal?.('Connect before sending an inline instruction.', true);
+      return;
+    }
+    if (state.branchContextQueuedSend) {
+      app.showToast?.('A message is already queued for this conversation path.', { id: 'diff-comment-send', tone: 'warning' });
+      return;
+    }
+    const context = captureContext(rows, rowIndex);
+    const comment = normalizeComment({
+      ...anchor,
+      id: makeID(),
+      parent_id: prior.length > 0 ? prior[prior.length - 1].id : '',
+      context_before: context.before,
+      context_after: context.after,
+      instruction,
+      optimistic: true
+    });
+    if (!comment) return;
+    send.disabled = true;
+    textarea.disabled = true;
+    closePanel(panel);
+    addOptimisticComment(sessionId, comment);
+    let transportStarted = false;
+    let transportFailed = false;
+    try {
+      await app.sendMessage?.({
+        prompt: formatAgentInstruction(comment),
+        displayPrompt: comment.instruction,
+        contentParts: [{ type: 'diff_comment', diff_comment: {
+          id: comment.id,
+          ...(comment.parent_id ? { parent_id: comment.parent_id } : {}),
+          path: comment.path,
+          side: comment.side,
+          line: comment.line,
+          file_change_seq: comment.file_change_seq,
+          line_text: comment.line_text,
+          context_before: comment.context_before,
+          context_after: comment.context_after,
+          instruction: comment.instruction
+        }}],
+        diffComment: comment,
+        attachments: [],
+        preserveComposer: true,
+        reuseMessageId: comment.id,
+        _onTransportStarted() { transportStarted = true; },
+        _onTransportFailed() { transportFailed = true; }
+      });
+    } catch {
+      transportFailed = true;
+    }
+    if (!transportStarted || transportFailed) {
+      removeOptimisticComment(sessionId, comment.id);
+      app.showToast?.('Inline instruction was not sent. Your draft is still available.', { id: 'diff-comment-send', tone: 'error' });
+      return;
+    }
+    cs.editorDrafts.delete(key);
+    void hydrateDiffComments(sessionId, { force: true });
+  };
+  textarea.addEventListener('input', () => cs.editorDrafts.set(key, textarea.value));
+  cancel.addEventListener('click', () => closePanel(panel, trigger, { clearDraft: true, sessionId, key }));
+  send.addEventListener('click', submit);
+  textarea.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault?.();
+      closePanel(panel, trigger, { sessionId, key });
+    } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault?.();
+      void submit();
+    }
+  });
+  textarea.focus?.();
+};
+
+const openCommentPanel = (sessionId, anchor, rows, rowIndex, rowElement, trigger, options = {}) => {
+  const cs = sessionCommentState(sessionId);
+  const key = anchorKey(anchor);
+  const current = rowElement.parentNode?.querySelector?.('.diff-comment-panel');
+  if (current) current.remove?.();
+  const panel = document.createElement('div');
+  panel.className = 'diff-comment-panel';
+  panel.id = panelIDForAnchor(sessionId, anchor);
+  panel.setAttribute('role', 'region');
+  panel.setAttribute('aria-label', `Inline instructions for ${anchor.side} line ${anchor.line}`);
+  panel._diffCommentTrigger = trigger;
+  panel._diffCommentSessionId = sessionId;
+  panel._diffCommentKey = key;
+  trigger?.setAttribute?.('aria-controls', panel.id);
+  trigger?.setAttribute?.('aria-expanded', 'true');
+  rowElement.parentNode?.insertBefore?.(panel, rowElement.nextSibling || null);
+  const prior = commentsForAnchor(sessionId, anchor);
+  const wasEditing = options.restore && cs.openPanel?.key === key ? Boolean(cs.openPanel.editing) : prior.length === 0;
+  cs.openPanel = { key, path: anchor.path, side: anchor.side, line: anchor.line, editing: wasEditing };
+  if (prior.length > 0) {
+    const heading = document.createElement('div');
+    heading.className = 'diff-comment-heading';
+    heading.textContent = `Line ${anchor.line} · ${anchor.side === 'old' ? 'original' : 'current'} version`;
+    panel.appendChild(heading);
+    for (const comment of prior) {
+      const item = document.createElement('div');
+      item.className = 'diff-comment-history-item';
+      const text = document.createElement('div');
+      text.className = 'diff-comment-history-text';
+      text.textContent = comment.instruction;
+      const meta = document.createElement('div');
+      meta.className = 'diff-comment-history-meta';
+      meta.textContent = comment.file_change_seq === anchor.file_change_seq
+        ? (comment.optimistic ? 'Sending…' : 'Sent')
+        : `File changed after this instruction${comment.optimistic ? ' · sending…' : ''}`;
+      item.append(text, meta);
+      panel.appendChild(item);
+    }
+    const followUp = makeButton('diff-comment-follow-up', 'Add follow-up inline instruction', 'Add follow-up');
+    followUp.addEventListener('click', () => showEditor(panel, sessionId, anchor, rows, rowIndex, trigger, prior));
+    panel.appendChild(followUp);
+  }
+  if (wasEditing) showEditor(panel, sessionId, anchor, rows, rowIndex, trigger, prior);
+};
+
+const focusAdjacentCommentRow = (rowElement, direction) => {
+  const rows = Array.from(rowElement.parentNode?.querySelectorAll?.('.diff-row[data-commentable="true"]') || []);
+  const index = rows.indexOf(rowElement);
+  if (index < 0 || rows.length === 0) return;
+  const next = rows[(index + direction + rows.length) % rows.length];
+  rowElement.tabIndex = -1;
+  next.tabIndex = 0;
+  next.focus?.();
+};
+
+const decorateDiffCommentRow = ({ sessionId, path, row, rows, rowIndex, rowElement, fileChangeSeq }) => {
+  if (!rowElement || !row || row.type === 'hunk') return null;
+  const anchor = rowAnchor(path, row, fileChangeSeq);
+  if (!anchor.line || !anchor.file_change_seq) return null;
+  const prior = commentsForAnchor(sessionId, anchor);
+  const hasComments = prior.length > 0;
+  const label = hasComments ? `Show ${prior.length} inline instruction${prior.length === 1 ? '' : 's'} for ${anchor.side} line ${anchor.line}` : `Comment on ${anchor.side} line ${anchor.line}`;
+  const button = makeButton(`diff-comment-affordance${hasComments ? ' has-comments' : ''}`, label, hasComments ? '' : '+');
+  button.tabIndex = -1;
+  button.setAttribute('aria-expanded', 'false');
+  button.setAttribute('aria-controls', panelIDForAnchor(sessionId, anchor));
+  if (hasComments && prior.some((comment) => comment.file_change_seq !== anchor.file_change_seq)) {
+    button.classList.add('stale');
+    button.title = `${label} (one or more anchors are outdated)`;
+  }
+  const open = (event) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    const expanded = button.getAttribute?.('aria-expanded') === 'true';
+    const panel = rowElement.parentNode?.querySelector?.(`#${panelIDForAnchor(sessionId, anchor)}`);
+    if (expanded && panel) {
+      closePanel(panel, button, { sessionId, key: anchorKey(anchor) });
+      return;
+    }
+    openCommentPanel(sessionId, anchor, rows, rowIndex, rowElement, button);
+  };
+  button.addEventListener('click', open);
+  rowElement.dataset.commentable = 'true';
+  rowElement.tabIndex = rows.slice(0, rowIndex).some((candidate) => candidate?.type !== 'hunk' && contextLine(candidate)) ? -1 : 0;
+  rowElement.setAttribute?.('aria-label', `${anchor.side} line ${anchor.line}. ${label}`);
+  rowElement.addEventListener?.('keydown', (event) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault?.();
+      focusAdjacentCommentRow(rowElement, event.key === 'ArrowDown' ? 1 : -1);
+    } else if (event.key === 'Enter' || String(event.key || '').toLowerCase() === 'c') {
+      event.preventDefault?.();
+      open(event);
+    }
+  });
+  rowElement.appendChild(button);
+  const shouldRestore = sessionCommentState(sessionId).openPanel?.key === anchorKey(anchor);
+  return shouldRestore ? () => openCommentPanel(sessionId, anchor, rows, rowIndex, rowElement, button, { restore: true }) : null;
+};
+
+const createDiffCommentMessageNode = (message, createMetaNode) => {
+  const comment = normalizeComment(message.diffComment) || { path: '', side: '', line: 0, line_text: '', instruction: String(message.content || '') };
+  const article = document.createElement('article');
+  article.className = 'message user diff-comment-message';
+  article.dataset.messageId = message.id;
+  const body = document.createElement('div');
+  body.className = 'message-body diff-comment-message-body';
+  const heading = document.createElement('div');
+  heading.className = 'diff-comment-message-heading';
+  heading.textContent = `Inline comment · ${comment.path}:${comment.line} (${comment.side})`;
+  const instruction = document.createElement('div');
+  instruction.className = 'diff-comment-message-instruction';
+  instruction.textContent = comment.instruction;
+  const exact = document.createElement('code');
+  exact.className = 'diff-comment-message-line';
+  exact.textContent = `${comment.side} ${comment.line} | ${comment.line_text}`;
+  body.append(heading, instruction, exact);
+  article.appendChild(body);
+  if (typeof createMetaNode === 'function') article.appendChild(createMetaNode(message.created, message));
+  return article;
+};
+
+window.addEventListener?.('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  const focused = document.activeElement;
+  const panel = focused?.closest?.('.diff-comment-panel');
+  if (!panel || !panel.contains?.(focused)) return;
+  event.preventDefault?.();
+  event.stopImmediatePropagation?.();
+  closePanel(panel, panel._diffCommentTrigger);
+});
+
+Object.assign(app, {
+  anchorKey,
+  captureDiffCommentContext: captureContext,
+  formatDiffCommentInstruction: formatAgentInstruction,
+  normalizeDiffComment: normalizeComment,
+  hydrateDiffComments,
+  invalidateDiffComments,
+  pruneDiffCommentState,
+  diffCommentRevision,
+  decorateDiffCommentRow,
+  createDiffCommentMessageNode
+});
+})();

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -247,14 +247,20 @@ const handleFileChangeEvent = (session, payload) => {
   // Replayed events (stream reconnect) arrive with stale sequence numbers.
   if (existing && seq && existing.lastSeq && seq <= existing.lastSeq) return;
 
-  ds.files.set(path, {
+  const incoming = {
     path,
     kind: normalizeDiffKind(payload.kind),
     adds: Number(payload.adds) || 0,
     dels: Number(payload.dels) || 0,
     truncated: Boolean(payload.truncated),
     lastSeq: seq
-  });
+  };
+  // Tool events describe only the latest before→after operation, while this
+  // panel shows the cumulative session-baseline diff. Once canonical metadata
+  // exists, retain it until the scheduled server refresh replaces it. Otherwise
+  // a second write to a newly-created file briefly relabels the whole file as a
+  // modification and flashes every added row green.
+  ds.files.set(path, existing ? { ...existing, lastSeq: seq } : incoming);
   ds.dirtyPaths.add(path);
 
   // Live follow: keep only the file being edited open. The previously

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -740,7 +740,7 @@ const renderDiffFileBody = (sessionId, ds, path) => {
   if (lang) requestDiffHighlight();
 
   const table = createEl('div', `diff-rows diff-rows-kind-${normalizeDiffKind(ds.files.get(path)?.kind)}`);
-  visibleRows.forEach((row) => {
+  visibleRows.forEach((row, rowIndex) => {
     const rowEl = createEl('div', `diff-row ${row.type}`);
     if (row.type === 'hunk') {
       rowEl.appendChild(createEl('span', 'diff-hunk-sep', '⋯'));
@@ -748,6 +748,18 @@ const renderDiffFileBody = (sessionId, ds, path) => {
       rowEl.appendChild(createEl('span', 'diff-ln old', row.oldNo ? String(row.oldNo) : ''));
       rowEl.appendChild(createEl('span', 'diff-ln new', row.newNo ? String(row.newNo) : ''));
       rowEl.appendChild(renderDiffCode(row.type, row.text, lang, row.emph));
+      const restoreCommentPanel = app.decorateDiffCommentRow?.({
+        sessionId,
+        path,
+        row,
+        rows,
+        rowIndex,
+        rowElement: rowEl,
+        fileChangeSeq: Number(ds.files.get(path)?.lastSeq) || Number(cached.seq) || 0
+      });
+      table.appendChild(rowEl);
+      restoreCommentPanel?.();
+      return;
     }
     table.appendChild(rowEl);
   });
@@ -900,7 +912,8 @@ const syncDiffFileBlock = (sessionId, ds, path) => {
     cached ? cached.rev : 'none',
     ds.rowLimits.get(path) || 0,
     ds.fetchErrors.has(path) ? 1 : 0,
-    typeof window.hljs !== 'undefined' ? 1 : 0
+    typeof window.hljs !== 'undefined' ? 1 : 0,
+    app.diffCommentRevision?.(sessionId, path) || 0
   ].join('|');
   if (!block.body || block.bodyKey !== bodyKey) {
     block.body = renderDiffFileBody(sessionId, ds, path);
@@ -995,6 +1008,8 @@ const renderDiffSidebarContent = (sessionId, ds) => {
 
 const renderDiffSidebar = (sessionId) => {
   if (sessionId !== state.activeSessionId) return;
+  const session = state.sessions?.find?.((item) => String(item?.id || '') === String(sessionId));
+  void app.hydrateDiffComments?.(sessionId, { revision: Math.max(Number(session?.transcriptRev) || 0, Number(session?.transcript?.rev) || 0) });
   const ds = sessionDiffState(sessionId);
   applyDiffSidebarVisibility(ds);
   updateDiffBulkToggle(ds);
@@ -1163,8 +1178,9 @@ const activateDiffSidebar = (sessionId) => {
     return;
   }
   const ds = sessionDiffState(sessionId);
+  const session = state.sessions?.find?.((item) => String(item?.id || '').trim() === String(sessionId));
+  void app.hydrateDiffComments?.(sessionId, { revision: Math.max(Number(session?.transcriptRev) || 0, Number(session?.transcript?.rev) || 0) });
   if (!ds.summaryKnown) {
-    const session = state.sessions?.find?.((item) => String(item?.id || '').trim() === String(sessionId));
     if (session?.fileChangeSummary) applySessionDiffSummary(sessionId, session.fileChangeSummary);
   }
   if (elements.diffFilterInput) elements.diffFilterInput.value = ds.filter || '';

--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -11,7 +11,7 @@ const {
   requestHeaders, normalizeError, isSessionVisible, sendMessage
 } = app;
 
-const queueInterruptFollowUp = (sessionId, prompt, messageId, attachments = []) => {
+const queueInterruptFollowUp = (sessionId, prompt, messageId, attachments = [], sendOptions = {}) => {
   const normalizedSessionId = String(sessionId || '').trim();
   if (!normalizedSessionId) return;
   const normalizedMessageId = String(messageId || '').trim();
@@ -20,12 +20,28 @@ const queueInterruptFollowUp = (sessionId, prompt, messageId, attachments = []) 
   ))) {
     return;
   }
-  state.queuedInterrupts.push({ sessionId: normalizedSessionId, prompt, messageId, attachments: Array.isArray(attachments) ? attachments : [] });
+  state.queuedInterrupts.push({
+    sessionId: normalizedSessionId,
+    prompt,
+    messageId,
+    attachments: Array.isArray(attachments) ? attachments : [],
+    contentParts: Array.isArray(sendOptions.contentParts) ? sendOptions.contentParts : [],
+    diffComment: sendOptions.diffComment || null,
+    displayPrompt: String(sendOptions.displayPrompt || '')
+  });
 };
 
-const trackPendingInterruptCommit = (sessionId, prompt, messageId, attachments = []) => {
+const trackPendingInterruptCommit = (sessionId, prompt, messageId, attachments = [], sendOptions = {}) => {
   state.pendingInterruptCommits = state.pendingInterruptCommits.filter(entry => entry.messageId !== messageId);
-  state.pendingInterruptCommits.push({ sessionId, prompt, messageId, attachments: Array.isArray(attachments) ? attachments : [] });
+  state.pendingInterruptCommits.push({
+    sessionId,
+    prompt,
+    messageId,
+    attachments: Array.isArray(attachments) ? attachments : [],
+    contentParts: Array.isArray(sendOptions.contentParts) ? sendOptions.contentParts : [],
+    diffComment: sendOptions.diffComment || null,
+    displayPrompt: String(sendOptions.displayPrompt || '')
+  });
 };
 
 const resolvePendingInterruptCommitById = (messageId) => {
@@ -83,7 +99,11 @@ const requeueUncommittedInterrupts = (session) => {
       continue;
     }
     if (cancelled.has(entry.messageId)) continue;
-    queueInterruptFollowUp(session.id, entry.prompt, entry.messageId, entry.attachments);
+    queueInterruptFollowUp(session.id, entry.prompt, entry.messageId, entry.attachments, {
+      contentParts: entry.contentParts,
+      diffComment: entry.diffComment,
+      displayPrompt: entry.displayPrompt
+    });
   }
   state.pendingInterruptCommits = remaining;
 };
@@ -165,6 +185,7 @@ const materializeCommittedInterjection = (session, messageId, committedMessage =
   const committedAttachments = Array.isArray(committedMessage?.attachments) ? committedMessage.attachments : [], localAttachments = Array.isArray(pending?.attachments) ? pending.attachments : [];
   const attachments = mergeCommittedInterjectionAttachments(localAttachments, committedAttachments);
   if (attachments.length > 0) message.attachments = attachments;
+  if (pending?.diffComment) message.diffComment = pending.diffComment;
   return app.trackPendingIntent?.(session, message) || message;
 };
 
@@ -243,15 +264,21 @@ const refreshPendingInterjectionBanner = () => {
   banner.scrollTop = banner.scrollHeight;
 };
 
-const trackPendingInterjection = (sessionId, prompt, messageId, action, attachments = []) => {
+const trackPendingInterjection = (sessionId, prompt, messageId, action, attachments = [], sendOptions = {}) => {
   if (!sessionId || !messageId) return;
   const existing = state.pendingInterjections.find(entry => entry.messageId === messageId);
+  const extra = {
+    contentParts: Array.isArray(sendOptions.contentParts) ? sendOptions.contentParts : [],
+    diffComment: sendOptions.diffComment || null,
+    displayPrompt: String(sendOptions.displayPrompt || '')
+  };
   if (existing) {
     existing.prompt = prompt;
     existing.action = action;
     existing.attachments = Array.isArray(attachments) ? attachments : [];
+    Object.assign(existing, extra);
   } else {
-    state.pendingInterjections.push({ sessionId, prompt, messageId, action, attachments: Array.isArray(attachments) ? attachments : [] });
+    state.pendingInterjections.push({ sessionId, prompt, messageId, action, attachments: Array.isArray(attachments) ? attachments : [], ...extra });
   }
   refreshPendingInterjectionBanner();
 };
@@ -321,7 +348,11 @@ const requeuePendingInterjections = (session) => {
     if (entry.sessionId !== session.id || entry.cancelRequested) continue;
     entry.action = 'queue';
     discardPendingInterruptCommit(entry.messageId);
-    queueInterruptFollowUp(session.id, entry.prompt, entry.messageId, entry.attachments);
+    queueInterruptFollowUp(session.id, entry.prompt, entry.messageId, entry.attachments, {
+      contentParts: entry.contentParts,
+      diffComment: entry.diffComment,
+      displayPrompt: entry.displayPrompt
+    });
   }
   refreshPendingInterjectionBanner();
 };
@@ -372,7 +403,11 @@ const interruptActiveRunNow = async (session, prompt, messageId, contentParts = 
   }
 
   if (action === 'cancel' || action === 'queue') {
-    queueInterruptFollowUp(session.id, prompt, messageId, attachments);
+    queueInterruptFollowUp(session.id, prompt, messageId, attachments, {
+      contentParts: pendingEntry?.contentParts,
+      diffComment: pendingEntry?.diffComment,
+      displayPrompt: pendingEntry?.displayPrompt
+    });
   }
   if (action === 'cancel') {
     state.expectCanceledRun = true;

--- a/internal/serveui/static/app-message-convert.js
+++ b/internal/serveui/static/app-message-convert.js
@@ -424,8 +424,11 @@ const convertServerMessages = (serverMessages, options = {}) => {
 
       const attachments = [];
       const textParts = [];
+      let diffComment = null;
       for (const part of parts) {
-        if (part.type === 'image' && part.image_url) {
+        if (part.type === 'diff_comment' && part.diff_comment) {
+          diffComment = part.diff_comment;
+        } else if (part.type === 'image' && part.image_url) {
           const width = Number(part.width), height = Number(part.height), validDimensions = Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0;
           attachments.push({ name: 'image', type: part.mime_type || 'image/*', dataURL: rebaseMessageAssetURL(part.image_url), ...(validDimensions ? { width: Math.round(width), height: Math.round(height) } : {}) });
         } else if (part.type === 'file' && part.text) {
@@ -460,7 +463,8 @@ const convertServerMessages = (serverMessages, options = {}) => {
         content,
         created,
         ...(seq !== null ? { serverSeq: seq } : {}),
-        ...(attachments.length > 0 ? { attachments } : {})
+        ...(attachments.length > 0 ? { attachments } : {}),
+        ...(diffComment ? { diffComment } : {})
       }, msg));
       continue;
     }

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1699,6 +1699,7 @@ const applyAttachmentImageDimensions = (img, attachment) => {
 };
 
 const createMessageNode = (message) => {
+  if (message.diffComment && typeof app.createDiffCommentMessageNode === 'function') return app.createDiffCommentMessageNode(message, createMetaNode);
   if (message.role === 'transcript-gap') return createTranscriptGapNode(message);
   if (message.role === 'skill-run') return createSkillRunNode(message);
   if (message.role === 'tool') return createToolCard(message);

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -110,6 +110,8 @@ const restoreQueuedFollowUps = (entries, sessionId) => {
   }
 };
 const sendMessage = async (options = {}) => {
+  const preserveComposer = Boolean(options.preserveComposer);
+  const customContentParts = Array.isArray(options.contentParts) ? options.contentParts.filter(Boolean) : [];
   let followUps = Array.isArray(options.followUps)
     ? options.followUps.filter((entry) => entry && String(entry.messageId || '').trim()) : [];
   const cancellableFollowUpIDs = new Set(state.pendingInterjections
@@ -118,6 +120,7 @@ const sendMessage = async (options = {}) => {
   const promptSource = batchingFollowUps ? followUps[followUps.length - 1].prompt
     : (typeof options.prompt === 'string' ? options.prompt : elements.promptInput.value);
   const prompt = String(promptSource || '').trim();
+  const displayPrompt = String(typeof options.displayPrompt === 'string' ? options.displayPrompt : prompt).trim();
   const pendingAttachments = batchingFollowUps ? []
     : (Array.isArray(options.attachments) ? [...options.attachments] : [...state.attachments]);
 
@@ -193,6 +196,8 @@ const sendMessage = async (options = {}) => {
         reason: operation
       });
       await app.syncActiveSessionFromServer?.(session, false, { skipMessagesFetch: true });
+      app.invalidateDiffComments?.(session.id);
+      await app.hydrateDiffComments?.(session.id, { force: true, revision: Number(payload?.rev) || -1 });
       const sameActiveSession = !state.draftSessionActive
         && state.activeSessionId === session.id
         && getActiveSession() === session;
@@ -288,14 +293,22 @@ const sendMessage = async (options = {}) => {
     state.branchContextQueuedSend = {
       sessionId: state.activeSessionId,
       prompt,
-      attachments: pendingAttachments.map((attachment) => cloneAttachmentForMessage(attachment))
+      attachments: pendingAttachments.map((attachment) => cloneAttachmentForMessage(attachment)),
+      contentParts: customContentParts,
+      diffComment: options.diffComment || null,
+      displayPrompt,
+      preserveComposer,
+      onTransportFailed: options._onTransportFailed
     };
-    elements.promptInput.value = '';
-    state.attachments = [];
-    renderAttachments();
-    app.autoGrowPrompt?.();
+    if (!preserveComposer) {
+      elements.promptInput.value = '';
+      state.attachments = [];
+      renderAttachments();
+      app.autoGrowPrompt?.();
+    }
     const active = getActiveSession();
     if (active?.branchContextStatus) active.branchContextStatus.queued = true;
+    options._onTransportStarted?.({ queued: true });
     app.renderMessages?.(false);
     return;
   }
@@ -339,7 +352,7 @@ const sendMessage = async (options = {}) => {
     return;
   }
   if (activeSessionBusy && !retryingHeartbeatPost) {
-    const pendingMessageId = generateId('msg');
+    const pendingMessageId = String(options.reuseMessageId || '').trim() || generateId('msg');
     let requestAttachmentParts = [];
     if (pendingAttachments.length > 0) {
       const controller = new AbortController();
@@ -351,21 +364,37 @@ const sendMessage = async (options = {}) => {
         return;
       }
     }
-    stageDraftMessage(prompt, session.id);
-    app.trackPendingInterruptCommit(session.id, prompt, pendingMessageId, pendingAttachments);
-    app.trackPendingInterjection(session.id, prompt || pendingAttachments[0]?.name || 'Attachment', pendingMessageId, 'interject', pendingAttachments);
+    requestAttachmentParts = customContentParts.concat(requestAttachmentParts);
+    if (!preserveComposer) stageDraftMessage(prompt, session.id);
+    app.trackPendingInterruptCommit(session.id, prompt, pendingMessageId, pendingAttachments, {
+      contentParts: customContentParts,
+      diffComment: options.diffComment,
+      displayPrompt
+    });
+    app.trackPendingInterjection(session.id, displayPrompt || pendingAttachments[0]?.name || 'Attachment', pendingMessageId, 'interject', pendingAttachments, {
+      contentParts: customContentParts,
+      diffComment: options.diffComment,
+      displayPrompt
+    });
     persistAndRefreshShell();
-    elements.promptInput.value = '';
-    state.attachments = [];
+    options._onTransportStarted?.({ interjection: true });
+    if (!preserveComposer) elements.promptInput.value = '';
+    state.attachments = preserveComposer ? state.attachments : [];
     renderAttachments();
     app.autoGrowPrompt();
     try {
       await app.interruptActiveRun(session, prompt, pendingMessageId, requestAttachmentParts, pendingAttachments);
-      clearDraftMessageForSession(session.id);
+      if (!preserveComposer) clearDraftMessageForSession(session.id);
     } catch (err) {
       if (err?.status && err.status !== 401) {
         try {
-          const recovered = await recoverInterruptFailure(session, prompt, pendingMessageId, pendingAttachments);
+          const recovered = await recoverInterruptFailure(session, prompt, pendingMessageId, pendingAttachments, {
+            contentParts: customContentParts,
+            diffComment: options.diffComment,
+            displayPrompt,
+            preserveComposer,
+            _onTransportFailed: options._onTransportFailed
+          });
           if (recovered) {
             return;
           }
@@ -375,15 +404,18 @@ const sendMessage = async (options = {}) => {
       }
       app.discardPendingInterruptCommit(pendingMessageId);
       app.setInterjectionPhase(session, pendingMessageId, 'failed');
+      options._onTransportFailed?.(err);
       const message = err?.message || 'Failed to interrupt active run.';
       addErrorMessage(message, session);
       if (err?.status === 401) {
         app.handleAuthFailure();
       }
-      elements.promptInput.value = prompt;
-      state.attachments = pendingAttachments;
-      renderAttachments();
-      app.autoGrowPrompt();
+      if (!preserveComposer) {
+        elements.promptInput.value = prompt;
+        state.attachments = pendingAttachments;
+        renderAttachments();
+        app.autoGrowPrompt();
+      }
       persistAndRefreshShell();
       scrollVisibleStreamToBottom(session, true);
     }
@@ -397,9 +429,11 @@ const sendMessage = async (options = {}) => {
     if (batchingFollowUps) {
       for (const entry of followUps) {
         const attachments = Array.isArray(entry.attachments) ? entry.attachments : [];
-        batchAttachmentParts.set(entry.messageId, attachments.length > 0
+        const attachmentParts = attachments.length > 0
           ? await buildAttachmentInputParts(attachments, controller.signal)
-          : []);
+          : [];
+        const entryContentParts = Array.isArray(entry.contentParts) ? entry.contentParts : [];
+        batchAttachmentParts.set(entry.messageId, entryContentParts.concat(attachmentParts));
       }
     } else if (pendingAttachments.length > 0) {
       requestAttachmentParts = await buildAttachmentInputParts(pendingAttachments, controller.signal);
@@ -413,6 +447,8 @@ const sendMessage = async (options = {}) => {
   if (batchingFollowUps) {
     followUps = followUps.filter((queued) => !cancellableFollowUpIDs.has(queued.messageId) || state.pendingInterjections.some((pending) => pending.messageId === queued.messageId && !pending.cancelRequested));
     if (followUps.length === 0) return;
+  } else if (customContentParts.length > 0) {
+    requestAttachmentParts = customContentParts.concat(requestAttachmentParts);
   }
   const wasDraftSessionSend = !session || state.draftSessionActive;
   if (!session) {
@@ -447,14 +483,17 @@ const sendMessage = async (options = {}) => {
     attachments: Array.isArray(entry.attachments) ? entry.attachments : [],
     messageId: String(entry.messageId || '').trim(),
     requestParts: batchAttachmentParts.get(entry.messageId) || [],
-  })) : [{ prompt, attachments: pendingAttachments, messageId: reuseMessageId, requestParts: requestAttachmentParts }];
+    contentParts: Array.isArray(entry.contentParts) ? entry.contentParts : [],
+    diffComment: entry.diffComment || null,
+    displayPrompt: String(entry.displayPrompt || '').trim(),
+  })) : [{ prompt, attachments: pendingAttachments, messageId: reuseMessageId, requestParts: requestAttachmentParts, contentParts: customContentParts, diffComment: options.diffComment || null, displayPrompt }];
   for (const spec of messageSpecs) {
     if (!spec.messageId) continue;
     app.removePendingInterjectionById?.(spec.messageId, batchingFollowUps ? { refresh: false } : undefined);
     app.discardPendingInterruptCommit?.(spec.messageId);
   }
   if (batchingFollowUps) app.refreshPendingInterjectionBanner?.();
-  if (!batchingFollowUps) stageDraftMessage(prompt, session.id);
+  if (!batchingFollowUps && !preserveComposer) stageDraftMessage(prompt, session.id);
   const userMessages = [];
   for (const spec of messageSpecs) {
     let message = spec.messageId ? window.TermLLMConversation.sessionMessages(session)
@@ -466,6 +505,7 @@ const sendMessage = async (options = {}) => {
       message.content = spec.prompt;
       delete message.interruptState;
     }
+    if (spec.diffComment) message.diffComment = spec.diffComment;
     message.clientMessageId = String(message.clientMessageId || message.id || '').trim();
     if (spec.attachments.length > 0) message.attachments = spec.attachments.map(cloneAttachmentForMessage);
     else delete message.attachments;
@@ -482,7 +522,11 @@ const sendMessage = async (options = {}) => {
     followUpBatchRestored = true;
     restoreQueuedFollowUps(followUps, session.id);
     for (const spec of messageSpecs) {
-      app.trackPendingInterjection?.(session.id, spec.prompt, spec.messageId, 'queue', spec.attachments);
+      app.trackPendingInterjection?.(session.id, spec.displayPrompt || spec.prompt, spec.messageId, 'queue', spec.attachments, {
+        contentParts: spec.contentParts,
+        diffComment: spec.diffComment,
+        displayPrompt: spec.displayPrompt
+      });
       app.retirePendingIntent?.(session, spec.messageId);
     }
     app.refreshSessionMessagesFromTranscript?.(session);
@@ -500,7 +544,7 @@ const sendMessage = async (options = {}) => {
   }
   setSessionOptimisticBusy(session, true);
   persistAndRefreshShell();
-  if (!batchingFollowUps) {
+  if (!batchingFollowUps && !preserveComposer) {
     elements.promptInput.value = '';
     app.hideSlashCommands?.();
     if (!Array.isArray(options.attachments)) {
@@ -655,7 +699,7 @@ const sendMessage = async (options = {}) => {
       updateURL(sessionSlug(session));
     }
     setConnectionState('', '');
-    clearDraftMessageForSession(session.id);
+    if (!preserveComposer) clearDraftMessageForSession(session.id);
     if (wasDraftSessionSend) {
       clearDraftMessageForSession('');
     }
@@ -718,7 +762,7 @@ const sendMessage = async (options = {}) => {
       app.refreshPendingInterjectionBanner?.();
       app.refreshSessionMessagesFromTranscript?.(session);
       if (isSessionVisible(session)) app.renderMessages?.();
-      clearDraftMessageForSession(session.id);
+      if (!preserveComposer) clearDraftMessageForSession(session.id);
       try {
         await app.syncActiveSessionFromServer?.(session, false);
       } catch {
@@ -847,11 +891,12 @@ const sendMessage = async (options = {}) => {
     app.refreshSidebarStatusPoll?.();
     restoreFollowUpBatch();
     const message = err?.message || 'Network error. Please try again.';
+    options._onTransportFailed?.(err);
     addErrorMessage(message, session);
     if (err?.status === 401) {
       app.handleAuthFailure();
     }
-    if (!batchingFollowUps && !String(elements.promptInput.value || '').trim()) {
+    if (!batchingFollowUps && !preserveComposer && !String(elements.promptInput.value || '').trim()) {
       elements.promptInput.value = prompt;
       app.autoGrowPrompt();
     }
@@ -898,6 +943,11 @@ const releaseBranchContextQueuedSend = (sessionId) => {
   void sendMessage({
     prompt: queued.prompt,
     attachments: queued.attachments,
+    contentParts: queued.contentParts,
+    diffComment: queued.diffComment,
+    displayPrompt: queued.displayPrompt,
+    preserveComposer: queued.preserveComposer,
+    _onTransportFailed: queued.onTransportFailed,
     _releaseBranchContextSend: true,
     _onTransportStarted() {
       elements.promptInput.value = newerDraft;
@@ -914,6 +964,7 @@ const restoreBranchContextQueuedSend = (sessionId) => {
   if (!queued || queued.sessionId !== sessionId) return false;
   state.branchContextQueuedSend = null;
   if (state.activeSessionId !== sessionId) return false;
+  if (queued.preserveComposer) return true;
   const current = String(elements.promptInput.value || '').trim();
   elements.promptInput.value = current ? `${queued.prompt}\n\n${current}` : queued.prompt;
   state.attachments = [...queued.attachments, ...state.attachments];

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1378,7 +1378,7 @@ const refreshSessionFromServerTruth = async (session, pollOnActive = false) => {
   return app.syncActiveSessionFromServer(session, pollOnActive);
 };
 
-const recoverInterruptFailure = async (session, prompt, messageId, attachments = []) => {
+const recoverInterruptFailure = async (session, prompt, messageId, attachments = [], sendOptions = {}) => {
   const pending = state.pendingInterjections.find((entry) => entry.messageId === messageId);
   if (pending?.cancelRequested) {
     app.removePendingInterjectionById(messageId);
@@ -1396,9 +1396,9 @@ const recoverInterruptFailure = async (session, prompt, messageId, attachments =
   if (app.runtimeHasActiveRun(runtimeState)) {
     app.discardPendingInterruptCommit(messageId);
     app.updatePendingInterjectionAction(messageId, 'queue');
-    app.queueInterruptFollowUp(session.id, prompt, messageId, attachments);
+    app.queueInterruptFollowUp(session.id, prompt, messageId, attachments, sendOptions);
     persistAndRefreshShell();
-    app.clearDraftMessageForSession(session.id);
+    if (!sendOptions.preserveComposer) app.clearDraftMessageForSession(session.id);
     return true;
   }
 
@@ -1407,6 +1407,7 @@ const recoverInterruptFailure = async (session, prompt, messageId, attachments =
   app.discardPendingInterruptCommit(messageId);
   app.removePendingInterjectionById(messageId);
   await app.sendMessage({
+    ...sendOptions,
     prompt,
     attachments,
     reuseMessageId: messageId,

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -614,6 +614,105 @@
       overflow-wrap: anywhere; /* break unbroken tokens so nothing scrolls off-screen */
     }
 
+    .diff-row[data-commentable="true"]:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
+    }
+
+    .diff-comment-affordance {
+      flex: none;
+      align-self: center;
+      width: 1.65rem;
+      height: 1.65rem;
+      margin: 0 0.2rem;
+      padding: 0;
+      border: 0;
+      border-radius: 5px;
+      background: transparent;
+      color: var(--text-muted);
+      font: 600 0.88rem/1 ui-sans-serif, system-ui, sans-serif;
+      opacity: 0;
+      cursor: pointer;
+    }
+
+    .diff-row:hover .diff-comment-affordance,
+    .diff-comment-affordance:focus-visible,
+    .diff-comment-affordance.has-comments {
+      opacity: 1;
+    }
+
+    .diff-comment-affordance:hover,
+    .diff-comment-affordance:focus-visible {
+      background: var(--surface-2);
+      color: var(--text);
+      outline: none;
+    }
+
+    .diff-comment-affordance.has-comments { position: relative; color: var(--text-muted); }
+    .diff-comment-affordance.has-comments::before {
+      content: "";
+      display: inline-block;
+      width: 0.72rem;
+      height: 0.52rem;
+      border: 1.5px solid currentColor;
+      border-radius: 3px;
+      vertical-align: 0.05rem;
+    }
+    .diff-comment-affordance.has-comments::after {
+      content: "";
+      position: absolute;
+      left: 0.57rem;
+      top: 1.02rem;
+      width: 0.25rem;
+      height: 0.25rem;
+      border-left: 1.5px solid currentColor;
+      transform: skewY(-35deg);
+    }
+    .diff-comment-affordance.stale { text-decoration: underline dotted; text-underline-offset: 2px; }
+
+    .diff-comment-panel {
+      margin: 0.25rem 0.4rem 0.55rem 6.25rem;
+      padding: 0.55rem;
+      border: 1px solid var(--border);
+      border-radius: 7px;
+      background: var(--surface);
+      color: var(--text);
+      white-space: normal;
+    }
+
+    .diff-comment-heading { margin-bottom: 0.4rem; color: var(--text-muted); font-size: 0.75rem; font-weight: 600; }
+    .diff-comment-history-item + .diff-comment-history-item { margin-top: 0.45rem; padding-top: 0.45rem; border-top: 1px solid var(--border); }
+    .diff-comment-history-text { white-space: pre-wrap; overflow-wrap: anywhere; font-size: 0.8rem; }
+    .diff-comment-history-meta { margin-top: 0.18rem; color: var(--text-muted); font-size: 0.68rem; }
+    .diff-comment-editor textarea {
+      box-sizing: border-box;
+      width: 100%;
+      min-height: 3.5rem;
+      resize: vertical;
+      padding: 0.45rem 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      background: var(--surface-strong);
+      color: var(--text);
+      font: inherit;
+    }
+    .diff-comment-editor-actions { display: flex; justify-content: flex-end; gap: 0.4rem; margin-top: 0.4rem; }
+    .diff-comment-cancel,
+    .diff-comment-send,
+    .diff-comment-follow-up { padding: 0.28rem 0.55rem; border: 1px solid var(--border); border-radius: 5px; background: var(--surface-2); color: var(--text); cursor: pointer; font-size: 0.75rem; }
+    .diff-comment-send { border-color: var(--accent); background: var(--accent); color: white; }
+    .diff-comment-follow-up { margin-top: 0.5rem; }
+
+    @media (hover: none), (pointer: coarse) {
+      .diff-comment-affordance { opacity: 1; min-width: 2rem; min-height: 2rem; }
+      .diff-comment-panel { margin-left: 0.4rem; }
+    }
+
+    .diff-comment-message-body { display: grid; gap: 0.38rem; }
+    .diff-comment-message-heading { color: var(--text-muted); font-size: 0.78rem; font-weight: 600; }
+    .diff-comment-message-instruction { white-space: pre-wrap; overflow-wrap: anywhere; }
+    .diff-comment-message-line { display: block; padding: 0.32rem 0.45rem; border-radius: 5px; background: var(--surface-2); color: var(--text-muted); white-space: pre-wrap; overflow-wrap: anywhere; }
+
     .diff-row.add .diff-code::before {
       content: "+";
       margin-right: 0.4em;

--- a/internal/serveui/static/app_diff_comments_test.js
+++ b/internal/serveui/static/app_diff_comments_test.js
@@ -1,0 +1,323 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(path.join(__dirname, 'app-diff-comments.js'), 'utf8');
+let failures = 0;
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+const run = async (name, fn) => {
+  try { await fn(); console.log(`PASS ${name}`); }
+  catch (error) { failures += 1; console.error(`FAIL ${name}: ${error.stack || error}`); }
+};
+
+const createDOM = () => {
+  const document = { activeElement: null };
+  const matches = (element, selector) => {
+    if (!element) return false;
+    if (selector.startsWith('#')) return element.id === selector.slice(1);
+    const dataMatch = selector.match(/^\.([\w-]+)\[data-commentable="true"\]$/);
+    if (dataMatch) return String(element.className).split(/\s+/).includes(dataMatch[1]) && element.dataset.commentable === 'true';
+    if (selector.startsWith('.')) return String(element.className).split(/\s+/).includes(selector.slice(1));
+    return element.tagName === selector.toUpperCase();
+  };
+  const descendants = (element) => element.children.flatMap((child) => [child, ...descendants(child)]);
+  document.createElement = (tagName) => {
+    const listeners = new Map();
+    const attrs = new Map();
+    const element = {
+      tagName: String(tagName || '').toUpperCase(),
+      children: [], dataset: {}, className: '', textContent: '', value: '', id: '', tabIndex: 0,
+      parentNode: null, removed: false, disabled: false,
+      classList: {
+        add(...names) {
+          const values = new Set(String(element.className).split(/\s+/).filter(Boolean));
+          names.forEach((name) => values.add(name));
+          element.className = Array.from(values).join(' ');
+        },
+        contains(name) { return String(element.className).split(/\s+/).includes(name); }
+      },
+      append(...nodes) { nodes.forEach((node) => this.appendChild(node)); },
+      appendChild(node) {
+        if (node.parentNode) node.remove();
+        node.parentNode = this; node.removed = false; this.children.push(node); return node;
+      },
+      insertBefore(node, reference) {
+        if (node.parentNode) node.remove();
+        const index = reference ? this.children.indexOf(reference) : -1;
+        node.parentNode = this; node.removed = false;
+        if (index < 0) this.children.push(node); else this.children.splice(index, 0, node);
+        return node;
+      },
+      setAttribute(name, value) {
+        attrs.set(name, String(value));
+        if (name === 'id') this.id = String(value);
+        if (name === 'tabindex') this.tabIndex = Number(value);
+      },
+      getAttribute(name) { return attrs.has(name) ? attrs.get(name) : null; },
+      addEventListener(type, listener) {
+        if (!listeners.has(type)) listeners.set(type, []);
+        listeners.get(type).push(listener);
+      },
+      async dispatch(type, init = {}) {
+        const event = {
+          type, target: this, key: '', metaKey: false, ctrlKey: false,
+          defaultPrevented: false, immediateStopped: false,
+          preventDefault() { this.defaultPrevented = true; },
+          stopPropagation() {}, stopImmediatePropagation() { this.immediateStopped = true; },
+          ...init
+        };
+        for (const listener of listeners.get(type) || []) {
+          await listener(event);
+          if (event.immediateStopped) break;
+        }
+        return event;
+      },
+      click() { return this.dispatch('click'); },
+      focus() { document.activeElement = this; },
+      remove() {
+        if (this.parentNode) {
+          const index = this.parentNode.children.indexOf(this);
+          if (index >= 0) this.parentNode.children.splice(index, 1);
+        }
+        this.parentNode = null; this.removed = true;
+      },
+      querySelector(selector) { return descendants(this).find((node) => matches(node, selector)) || null; },
+      querySelectorAll(selector) { return descendants(this).filter((node) => matches(node, selector)); },
+      contains(node) { return node === this || descendants(this).includes(node); },
+      closest(selector) {
+        let current = this;
+        while (current) { if (matches(current, selector)) return current; current = current.parentNode; }
+        return null;
+      }
+    };
+    Object.defineProperty(element, 'nextSibling', {
+      get() {
+        if (!this.parentNode) return null;
+        const index = this.parentNode.children.indexOf(this);
+        return this.parentNode.children[index + 1] || null;
+      }
+    });
+    return element;
+  };
+  document.querySelector = () => null;
+  return document;
+};
+
+const createHarness = (initialPayloads = {}) => {
+  const calls = [];
+  const payloads = { ...initialPayloads };
+  const document = createDOM();
+  const windowListeners = new Map();
+  const state = {
+    activeSessionId: 's1', token: '', connected: true, sessions: [{ id: 's1', transcriptRev: 1 }],
+    pendingInterjections: [], pendingInterruptCommits: [], queuedInterrupts: [], branchContextQueuedSend: null
+  };
+  const app = {
+    UI_PREFIX: '/ui', state,
+    requestHeaders: (id) => ({ 'X-Session': id }),
+    apiFetch: async (url) => {
+      calls.push(url);
+      const sessionId = decodeURIComponent(url.split('/sessions/')[1].split('/')[0]);
+      const value = typeof payloads[sessionId] === 'function' ? payloads[sessionId]() : payloads[sessionId];
+      const payload = Array.isArray(value) ? { comments: value, transcript_rev: 1 } : (value || { comments: [], transcript_rev: 1 });
+      return { ok: true, json: async () => payload };
+    },
+    renderDiffSidebar() {}, showToast() {}
+  };
+  const window = {
+    TermLLMApp: app,
+    addEventListener(type, listener) {
+      if (!windowListeners.has(type)) windowListeners.set(type, []);
+      windowListeners.get(type).push(listener);
+    },
+    async dispatch(type, init = {}) {
+      const event = {
+        type, key: '', defaultPrevented: false, immediateStopped: false,
+        preventDefault() { this.defaultPrevented = true; },
+        stopImmediatePropagation() { this.immediateStopped = true; },
+        ...init
+      };
+      for (const listener of windowListeners.get(type) || []) {
+        await listener(event);
+        if (event.immediateStopped) break;
+      }
+      return event;
+    }
+  };
+  const context = {
+    window, document, globalThis: {}, console, Date, Math, Promise,
+    encodeURIComponent, decodeURIComponent, setTimeout, clearTimeout
+  };
+  vm.runInNewContext(source, context, { filename: 'app-diff-comments.js' });
+  return { app, state, calls, payloads, document, window };
+};
+
+const commentEntry = (id, pathName, instruction, revision = 1) => ({ created_at: revision, client_message_id: id, diff_comment: {
+  id, path: pathName, side: 'new', line: 2, file_change_seq: revision,
+  line_text: 'x', instruction
+} });
+
+const decorateRow = (harness, options = {}) => {
+  const table = options.table || harness.document.createElement('div');
+  const rowElement = harness.document.createElement('div');
+  rowElement.className = 'diff-row add';
+  const row = options.row || { type: 'add', oldNo: 0, newNo: 2, text: 'x' };
+  const rows = options.rows || [row];
+  const restore = harness.app.decorateDiffCommentRow({
+    sessionId: options.sessionId || 's1', path: options.path || 'a.go', row, rows,
+    rowIndex: options.rowIndex || 0, rowElement, fileChangeSeq: options.fileChangeSeq || 1
+  });
+  table.appendChild(rowElement);
+  restore?.();
+  return { table, rowElement, button: rowElement.querySelector('.diff-comment-affordance') };
+};
+
+(async () => {
+  await run('captures deleted-line context without crossing hunks', () => {
+    const { app } = createHarness();
+    const rows = [
+      { type: 'ctx', oldNo: 10, newNo: 10, text: 'before two' },
+      { type: 'ctx', oldNo: 11, newNo: 11, text: 'before one' },
+      { type: 'del', oldNo: 12, newNo: 0, text: 'removed' },
+      { type: 'add', oldNo: 0, newNo: 12, text: 'replacement' },
+      { type: 'hunk' },
+      { type: 'ctx', oldNo: 30, newNo: 30, text: 'other hunk' }
+    ];
+    const context = app.captureDiffCommentContext(rows, 2);
+    assert(context.before.length === 2 && context.before[0].line === 10, 'missing before context');
+    assert(context.after.length === 1 && context.after[0].side === 'new' && context.after[0].line === 12, 'context crossed hunk or lost added line');
+  });
+
+  await run('agent instruction includes complete captured anchor and exact text', () => {
+    const { app } = createHarness();
+    const text = app.formatDiffCommentInstruction({
+      path: 'internal/a.go', side: 'old', line: 12, file_change_seq: 99, line_text: '<exact & old>',
+      context_before: [{ side: 'old', line: 11, text: 'before' }],
+      context_after: [{ side: 'new', line: 12, text: 'after' }], instruction: 'Keep this behavior.'
+    });
+    for (const expected of ['Path: internal/a.go', 'Side: old', 'Line: 12', 'Captured file-change seq: 99', '> old 12 | <exact & old>', 'Instruction:\nKeep this behavior.']) {
+      assert(text.includes(expected), `missing ${expected}`);
+    }
+  });
+
+  await run('hydrates by transcript revision and isolates per-path revisions', async () => {
+    const first = { comments: [commentEntry('a1', 'a.go', 'A'), commentEntry('b1', 'b.go', 'B')], transcript_rev: 1 };
+    const { app, state, calls, payloads } = createHarness({ s1: first, s2: { comments: [], transcript_rev: 1 } });
+    state.sessions.push({ id: 's2', transcriptRev: 1 });
+    await app.hydrateDiffComments('s1', { revision: 1 });
+    const aRevision = app.diffCommentRevision('s1', 'a.go');
+    const bRevision = app.diffCommentRevision('s1', 'b.go');
+    await app.hydrateDiffComments('s1', { revision: 1 });
+    payloads.s1 = { comments: [commentEntry('a1', 'a.go', 'A changed', 2), commentEntry('b1', 'b.go', 'B')], transcript_rev: 2 };
+    await app.hydrateDiffComments('s1', { revision: 2 });
+    await app.hydrateDiffComments('s2', { revision: 1 });
+    assert(calls.length === 3, `expected revision-aware requests, got ${calls.length}`);
+    assert(app.diffCommentRevision('s1', 'a.go') > aRevision, 'file A revision did not advance');
+    assert(app.diffCommentRevision('s1', 'b.go') === bRevision, 'file A update rebuilt file B');
+    assert(app.diffCommentRevision('s2', 'a.go') === 0, 'comments leaked between sessions');
+    app.pruneDiffCommentState(new Set(['s2']));
+    assert(app.diffCommentRevision('s1', 'a.go') === 0, 'evicted session retained comment state');
+  });
+
+  await run('open editor draft survives a diff body rebuild', async () => {
+    const harness = createHarness();
+    const first = decorateRow(harness);
+    await first.button.click();
+    const textarea = first.table.querySelector('textarea');
+    textarea.value = 'typed but not sent';
+    await textarea.dispatch('input');
+    first.table.remove();
+
+    const second = decorateRow(harness);
+    const restored = second.table.querySelector('textarea');
+    assert(restored?.value === 'typed but not sent', 'rerender discarded open editor draft');
+    assert(second.button.getAttribute('aria-expanded') === 'true', 'restored trigger lost expanded state');
+  });
+
+  await run('early send return removes optimistic instruction and keeps retry draft', async () => {
+    const harness = createHarness();
+    harness.app.sendMessage = async () => undefined;
+    const first = decorateRow(harness);
+    await first.button.click();
+    const textarea = first.table.querySelector('textarea');
+    textarea.value = 'retry me';
+    await textarea.dispatch('input');
+    await first.table.querySelector('.diff-comment-send').click();
+
+    const second = decorateRow(harness);
+    assert(!second.button.classList.contains('has-comments'), 'unsent optimistic instruction remained visible forever');
+    await second.button.click();
+    assert(second.table.querySelector('textarea')?.value === 'retry me', 'failed send discarded retry draft');
+  });
+
+  await run('server hydration reconciles an accepted optimistic instruction', async () => {
+    const harness = createHarness();
+    let submittedID = '';
+    harness.app.sendMessage = async (options) => {
+      submittedID = options.diffComment.id;
+      options._onTransportStarted();
+      harness.payloads.s1 = { comments: [commentEntry(submittedID, 'a.go', 'accepted')], transcript_rev: 2 };
+    };
+    const first = decorateRow(harness);
+    await first.button.click();
+    const textarea = first.table.querySelector('textarea');
+    textarea.value = 'accepted';
+    await textarea.dispatch('input');
+    await first.table.querySelector('.diff-comment-send').click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const second = decorateRow(harness, { fileChangeSeq: 2 });
+    assert(second.button.classList.contains('has-comments'), 'accepted server comment disappeared during reconciliation');
+    await second.button.click();
+    const history = second.table.querySelector('.diff-comment-history-text');
+    assert(history?.textContent === 'accepted', 'server entry did not replace optimistic instruction');
+  });
+
+  await run('Escape only closes a focused comment panel', async () => {
+    const harness = createHarness();
+    const decorated = decorateRow(harness);
+    await decorated.button.click();
+    const panel = decorated.table.querySelector('.diff-comment-panel');
+    const outside = harness.document.createElement('button');
+    outside.focus();
+    const drawerEscape = await harness.window.dispatch('keydown', { key: 'Escape' });
+    assert(!drawerEscape.defaultPrevented && !panel.removed, 'comment handler swallowed drawer Escape');
+    panel.querySelector('textarea').focus();
+    const panelEscape = await harness.window.dispatch('keydown', { key: 'Escape' });
+    assert(panelEscape.defaultPrevented && panel.removed, 'focused comment panel did not handle Escape');
+  });
+
+  await run('diff rows provide one keyboard entry point with panel semantics', async () => {
+    const harness = createHarness();
+    const table = harness.document.createElement('div');
+    const rows = [
+      { type: 'add', oldNo: 0, newNo: 1, text: 'one' },
+      { type: 'add', oldNo: 0, newNo: 2, text: 'two' }
+    ];
+    const first = decorateRow(harness, { table, rows, row: rows[0], rowIndex: 0 });
+    const second = decorateRow(harness, { table, rows, row: rows[1], rowIndex: 1 });
+    assert(first.rowElement.tabIndex === 0 && second.rowElement.tabIndex === -1, 'rows did not use roving tabindex');
+    assert(first.button.tabIndex === -1, 'hidden affordance remained a tab stop');
+    assert(Boolean(first.button.getAttribute('aria-controls')) && first.button.getAttribute('aria-expanded') === 'false', 'trigger lacks disclosure semantics');
+    await first.rowElement.dispatch('keydown', { key: 'Enter' });
+    const panel = table.querySelector('.diff-comment-panel');
+    assert(panel?.getAttribute('role') === 'region' && first.button.getAttribute('aria-expanded') === 'true', 'keyboard entry did not open a semantic panel');
+  });
+
+  await run('transcript projection writes untrusted values through textContent', () => {
+    const { app } = createHarness();
+    const node = app.createDiffCommentMessageNode({
+      id: 'm1', role: 'user', created: 1,
+      diffComment: { id: 'c1', path: '<img src=x>', side: 'new', line: 4, file_change_seq: 8, line_text: '<script>x</script>', instruction: '<b>do not parse</b>' }
+    });
+    const body = node.children[0];
+    assert(body.children[0].textContent.includes('<img src=x>'), 'path was not kept as text');
+    assert(body.children[1].textContent === '<b>do not parse</b>', 'instruction was not kept as text');
+    assert(body.children[2].textContent.includes('<script>x</script>'), 'line was not kept as text');
+  });
+
+  if (failures > 0) process.exit(1);
+  console.log('All app-diff-comments tests passed');
+})();

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -398,6 +398,17 @@ async function run(name, fn) {
     assertEqual(counts.textContent, '+5', 'older replayed event did not overwrite newer state');
   });
 
+  await run('live operation metadata does not replace cumulative file metadata before refresh', () => {
+    const { app, elements } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/new.txt', kind: 'create', adds: 20, dels: 0, seq: 1 });
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/new.txt', kind: 'modify', adds: 1, dels: 1, seq: 2 });
+
+    assertEqual(elements.diffFileList.querySelector('.diff-kind-badge').textContent, 'A', 'incremental modify did not relabel a cumulative create');
+    assertEqual(elements.diffFileList.querySelector('.diff-count-add').textContent, '+20', 'incremental counts did not replace cumulative additions');
+    assert(!elements.diffFileList.querySelector('.diff-count-del'), 'incremental deletion count did not flash before canonical refresh');
+  });
+
   await run('events for inactive sessions update data without DOM', () => {
     const { app, elements } = createHarness();
     app.handleFileChangeEvent({ id: 'other' }, { path: '/b', kind: 'create', adds: 1, dels: 0, seq: 1 });
@@ -1061,29 +1072,6 @@ async function run(name, fn) {
     await elements.diffResizeHandle.dispatchEvent({ type: 'dblclick' });
     assertEqual(localStorage.getItem('term_llm_diff_sidebar_width'), null, 'stored width cleared');
     assertEqual(elements.appShell.style.getPropertyValue('--diff-sidebar-user-width'), '', 'width override removed');
-  });
-
-  await run('live count updates patch the existing header instead of rebuilding', async () => {
-    const { app, elements, flushTimers } = createHarness();
-    app.toggleDiffSidebar();
-    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
-    await flushTimers();
-
-    const before = elements.diffFileList.querySelectorAll('.diff-file-row')[0];
-    let listRebuilds = 0;
-    const original = elements.diffFileList.replaceChildren.bind(elements.diffFileList);
-    elements.diffFileList.replaceChildren = (...nodes) => {
-      listRebuilds += 1;
-      return original(...nodes);
-    };
-
-    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 7, dels: 2, seq: 2 });
-    await flushTimers();
-
-    const after = elements.diffFileList.querySelectorAll('.diff-file-row')[0];
-    assert(before === after, 'header node identity preserved across live updates');
-    assertEqual(listRebuilds, 0, 'list container not rebuilt for an in-place update');
-    assertEqual(elements.diffFileList.querySelector('.diff-count-add').textContent, '+7', 'counts updated in place');
   });
 
   await run('buildUnifiedDiff reconstructs a patch from cached hunks', () => {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -5571,6 +5571,29 @@ function testSanitizeMessagePreservesSkillRunState() {
   });
 }
 
+function testSanitizeMessagePreservesDiffComment() {
+  const name = 'sanitizeMessage preserves typed inline diff comment metadata';
+  return createSessionsHarness().then(({ app }) => {
+    const sanitized = app.sanitizeMessage({
+      id: 'diff-message', role: 'user', content: 'provider prompt', created: 1,
+      diffComment: {
+        id: 'comment-1', parent_id: 'comment-0', path: 'internal/a.go', side: 'old', line: 7,
+        file_change_seq: 12, line_text: 'old()', instruction: 'Keep this.',
+        context_before: [{ side: 'old', line: 6, text: 'before' }],
+        context_after: [{ side: 'new', line: 7, text: 'after' }],
+      },
+    });
+    if (sanitized?.diffComment?.id !== 'comment-1'
+        || sanitized.diffComment.parent_id !== 'comment-0'
+        || sanitized.diffComment.context_before?.[0]?.text !== 'before'
+        || sanitized.diffComment.context_after?.[0]?.side !== 'new') {
+      fail(name, 'diff comment metadata was discarded', JSON.stringify(sanitized));
+      return;
+    }
+    pass(name);
+  });
+}
+
 function testSanitizeMessagePreservesAskUserCallIdentity() {
   const name = 'sanitizeMessage preserves ask_user call identity';
   return createSessionsHarness().then(({ app }) => {
@@ -7608,6 +7631,28 @@ async function testMarkedPathNoteConvertsToVisibleArtifact() {
   pass(name);
 }
 
+async function testDiffCommentConvertsToReadableTypedUserMessage() {
+  const name = 'typed diff comment survives transcript conversion without parsing provider prose';
+  const { app } = await createSessionsHarness();
+  const converted = app.convertServerMessages([{
+    id: 71,
+    sequence: 9,
+    role: 'user',
+    client_message_id: 'comment-client-1',
+    created_at: 1000,
+    parts: [
+      { type: 'diff_comment', diff_comment: { id: 'dc1', path: 'a.go', side: 'old', line: 4, file_change_seq: 8, line_text: 'old()', instruction: 'Keep it.' } },
+      { type: 'text', text: '[Inline diff instruction]\nprovider detail' }
+    ]
+  }]);
+  const message = converted[0];
+  if (converted.length !== 1 || message?.diffComment?.instruction !== 'Keep it.' || message?.diffComment?.side !== 'old' || message?.content.indexOf('provider detail') < 0) {
+    fail(name, 'typed diff comment was not projected', JSON.stringify(converted));
+    return;
+  }
+  pass(name);
+}
+
 const appSessionsShardValue = process.env.TERM_LLM_APP_SESSIONS_TEST_SHARD;
 const appSessionsShard = appSessionsShardValue === undefined ? null : Number(appSessionsShardValue);
 let appSessionsTestIndex = 0;
@@ -7623,7 +7668,9 @@ const runAppSessionsTest = async (testCase) => {
   await runAppSessionsTest(testBranchShortcutCommandsUseSafeActiveBoundaryAndSkipEmptySend);
   await runAppSessionsTest(testPendingBranchProjectionHidesVirtualTranscriptGaps);
   await runAppSessionsTest(testMarkedPathNoteConvertsToVisibleArtifact);
+  await runAppSessionsTest(testDiffCommentConvertsToReadableTypedUserMessage);
   await runAppSessionsTest(testSanitizeMessagePreservesSkillRunState);
+  await runAppSessionsTest(testSanitizeMessagePreservesDiffComment);
   await runAppSessionsTest(testSanitizeMessagePreservesAskUserCallIdentity);
   await runAppSessionsTest(testSanitizeMessagePreservesPlanExecutionEvidence);
   await runAppSessionsTest(testSkillProvenanceEventConvertsToLinkedRunBlock);

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -8444,6 +8444,111 @@ const runAppStreamTest = async (testCase) => {
   if (appStreamShard === null || index % 2 === appStreamShard) await testCase();
 };
 
+async function testInlineSendPreservesUnrelatedComposerForIdleAndActiveRuns() {
+  const name = 'inline send preserves unrelated composer and carries typed metadata when idle or active';
+  const metadata = { type: 'diff_comment', diff_comment: {
+    id: 'dc1', path: 'main.go', side: 'old', line: 7, file_change_seq: 11,
+    line_text: 'old()', instruction: 'Keep this call.'
+  }};
+
+  const idle = createHarness();
+  const idleSession = { id: 'session_inline_idle', title: 'Inline', messages: [], activeResponseId: '', lastResponseId: 'resp_prior', lastSequenceNumber: 0 };
+  idle.state.sessions.push(idleSession);
+  idle.state.activeSessionId = idleSession.id;
+  idle.state.draftSessionActive = false;
+  idle.elements.promptInput.value = 'unrelated idle draft';
+  idle.state.attachments = [{ name: 'unrelated.txt', type: 'text/plain' }];
+  await idle.app.sendMessage({ prompt: 'provider anchored prompt', displayPrompt: 'Keep this call.', contentParts: [metadata], attachments: [], preserveComposer: true });
+  const post = idle.fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const postBody = post?.body ? JSON.parse(post.body) : null;
+  if (idle.elements.promptInput.value !== 'unrelated idle draft'
+      || idle.state.attachments.length !== 1
+      || postBody?.input?.[0]?.content?.length !== 2
+      || postBody?.input?.[0]?.content?.[0]?.type !== 'diff_comment'
+      || postBody?.input?.[0]?.content?.[1]?.text !== 'provider anchored prompt') {
+    fail(name, 'idle inline send consumed composer or lost metadata', JSON.stringify({ composer: idle.elements.promptInput.value, postBody }));
+    await idle.cleanup();
+    return;
+  }
+  await idle.cleanup();
+
+  const active = createHarness({ interruptPayload: { action: 'interject' } });
+  const activeSession = { id: 'session_inline_active', title: 'Inline active', messages: [], activeResponseId: 'resp_active', lastSequenceNumber: 0 };
+  active.state.sessions.push(activeSession);
+  active.state.activeSessionId = activeSession.id;
+  active.state.draftSessionActive = false;
+  active.elements.promptInput.value = 'unrelated active draft';
+  active.state.attachments = [{ name: 'unrelated.txt', type: 'text/plain' }];
+  await active.app.sendMessage({ prompt: 'provider anchored prompt', displayPrompt: 'Keep this call.', contentParts: [metadata], attachments: [], preserveComposer: true });
+  const interrupt = active.fetchCalls.find((call) => call.url.endsWith('/interrupt'));
+  const interruptBody = interrupt?.body ? JSON.parse(interrupt.body) : null;
+  if (active.elements.promptInput.value !== 'unrelated active draft'
+      || active.state.attachments.length !== 1
+      || interruptBody?.content?.length !== 2
+      || interruptBody?.content?.[0]?.type !== 'diff_comment'
+      || interruptBody?.content?.[1]?.text !== 'provider anchored prompt') {
+    fail(name, 'active inline send consumed composer or lost metadata', JSON.stringify({ composer: active.elements.promptInput.value, interruptBody }));
+    await active.cleanup();
+    return;
+  }
+  await active.cleanup();
+  pass(name);
+}
+
+async function testUncommittedInlineInterjectionRetainsProviderAnchorAsFollowUp() {
+  const name = 'uncommitted inline interjection keeps full provider anchor when drained as a follow-up';
+  const harness = createHarness({ interruptPayload: { action: 'interject' } });
+  const { app, state, fetchCalls, cleanup } = harness;
+  const session = { id: 'session_inline_orphan', title: 'Inline orphan', messages: [], activeResponseId: 'resp_active', lastResponseId: 'resp_prior', lastSequenceNumber: 0 };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.draftSessionActive = false;
+  const fullPrompt = '[Inline diff instruction]\nPath: internal/a.go\nSide: old\nLine: 7\n\nCaptured context:\n> old 7 | old()\n\nInstruction:\nKeep this call.';
+  const metadata = { type: 'diff_comment', diff_comment: {
+    id: 'dc-orphan', path: 'internal/a.go', side: 'old', line: 7, file_change_seq: 11,
+    line_text: 'old()', context_before: [{ side: 'old', line: 6, text: 'before()' }],
+    context_after: [{ side: 'new', line: 7, text: 'after()' }], instruction: 'Keep this call.'
+  }};
+
+  await app.sendMessage({
+    prompt: fullPrompt,
+    displayPrompt: 'Keep this call.',
+    contentParts: [metadata],
+    diffComment: metadata.diff_comment,
+    attachments: [],
+    preserveComposer: true
+  });
+  const pending = state.pendingInterruptCommits.find((entry) => entry.messageId);
+  if (!pending || pending.prompt !== fullPrompt || pending.displayPrompt !== 'Keep this call.') {
+    fail(name, 'pending commit replaced the provider prompt with display text', JSON.stringify(pending));
+    await cleanup();
+    return;
+  }
+
+  session.activeResponseId = '';
+  app.requeueUncommittedInterrupts(session);
+  const queued = state.queuedInterrupts.find((entry) => entry.messageId === pending.messageId);
+  if (!queued || queued.prompt !== fullPrompt || queued.contentParts?.[0]?.diff_comment?.context_before?.[0]?.text !== 'before()') {
+    fail(name, 'orphan requeue lost the full anchor or captured context', JSON.stringify(queued));
+    await cleanup();
+    return;
+  }
+
+  await app.sendMessage({ followUps: [queued] });
+  const post = fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
+  const body = post?.body ? JSON.parse(post.body) : null;
+  const content = body?.input?.[0]?.content;
+  if (!Array.isArray(content)
+      || content[0]?.diff_comment?.context_after?.[0]?.text !== 'after()'
+      || content[content.length - 1]?.text !== fullPrompt) {
+    fail(name, 'follow-up transport lost provider-facing anchor/context', JSON.stringify(body));
+    await cleanup();
+    return;
+  }
+  await cleanup();
+  pass(name);
+}
+
 (async () => {
   await runAppStreamTest(testStaleSnapshotCannotReclaimOwnershipAfterRapidResponseSwitch);
   await runAppStreamTest(testUnknownSlashTextRemainsNormalMessage);
@@ -8480,6 +8585,8 @@ const runAppStreamTest = async (testCase) => {
   await runAppStreamTest(testSendMessageDoesNotResumeAfterStalePostStream);
   await runAppStreamTest(testSendMessageUsesLocalContinuationIdWithoutPreflightSync);
   await runAppStreamTest(testSendMessageIncludesServerToolsForFirstPartyUI);
+  await runAppStreamTest(testInlineSendPreservesUnrelatedComposerForIdleAndActiveRuns);
+  await runAppStreamTest(testUncommittedInlineInterjectionRetainsProviderAnchorAsFollowUp);
   await runAppStreamTest(testSendMessageBranchesAndTransfersStreamOwnership);
   await runAppStreamTest(testBranchContextQueuesSendUntilReady);
   await runAppStreamTest(testBranchShortcutSlashCommandsPreserveOptionalInstruction);

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -152,6 +152,7 @@
   <link rel="preload" as="script" href="app-message-convert.js">
   <link rel="preload" as="script" href="intent-storage.js">
   <link rel="preload" as="script" href="app-session-admin.js">
+  <link rel="preload" as="script" href="app-diff-comments.js">
   <link rel="preload" as="script" href="app-diffs.js">
   <link rel="preload" as="script" href="app-worktrees.js">
 </head>
@@ -701,6 +702,7 @@
   <script src="app-branching.js"></script>
   <script src="app-branch-commands.js"></script>
   <script src="app-session-events.js"></script>
+  <script src="app-diff-comments.js"></script>
   <script src="app-diffs.js"></script>
   <script src="app-worktrees.js"></script>
   <!-- term-llm:webrtc-script -->

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -36,6 +36,7 @@ const SHELL_ASSETS = [
   './app-message-convert.js',
   './intent-storage.js',
   './app-session-admin.js',
+  './app-diff-comments.js',
   './app-diffs.js',
   './app-worktrees.js',
   // term-llm:webrtc-shell-asset

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -294,6 +294,19 @@ func (s *LoggingStore) GetLatestVisibleMessageID(ctx context.Context, sessionID 
 	return 0, nil
 }
 
+// GetDiffCommentMessages delegates the targeted typed inline-comment lookup.
+func (s *LoggingStore) GetDiffCommentMessages(ctx context.Context, sessionID string) ([]Message, error) {
+	lister, ok := s.Store.(DiffCommentMessageLister)
+	if !ok {
+		return nil, ErrNotFound
+	}
+	messages, err := lister.GetDiffCommentMessages(ctx, sessionID)
+	if err != nil {
+		s.logOnce("GetDiffCommentMessages", err)
+	}
+	return messages, err
+}
+
 // GetMessagesPageDescending returns a reverse-ordered page of messages. It
 // delegates when the wrapped store supports efficient paging; otherwise it falls
 // back to in-memory paging over GetMessages.

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -4476,6 +4476,23 @@ func (s *SQLiteStore) GetMessages(ctx context.Context, sessionID string, limit, 
 	return scanMessageRows(rows)
 }
 
+// GetDiffCommentMessages retrieves only messages whose serialized parts can
+// contain typed inline-diff comment metadata. The final typed-part check remains
+// with the caller; LIKE is used only as a conservative SQLite row prefilter.
+func (s *SQLiteStore) GetDiffCommentMessages(ctx context.Context, sessionID string) ([]Message, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+s.messageSelectCols()+`
+		FROM messages
+		WHERE session_id = ? AND parts LIKE ?
+		ORDER BY sequence ASC`, sessionID, `%"Type":"diff_comment"%`)
+	if err != nil {
+		return nil, fmt.Errorf("query diff comment messages: %w", err)
+	}
+	defer rows.Close()
+
+	return scanMessageRows(rows)
+}
+
 // SetCurrent marks a session as the current one.
 func (s *SQLiteStore) SetCurrent(ctx context.Context, sessionID string) error {
 	_, err := s.db.ExecContext(ctx, `

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -540,6 +540,13 @@ type SessionSummaryTranscriptRevisionReporter interface {
 	SessionSummariesIncludeTranscriptRev() bool
 }
 
+// DiffCommentMessageLister is an optional targeted lookup capability for stores
+// that can select only messages carrying typed inline-diff comment metadata.
+// Web comment hydration uses it to avoid loading and decoding an entire session.
+type DiffCommentMessageLister interface {
+	GetDiffCommentMessages(ctx context.Context, sessionID string) ([]Message, error)
+}
+
 // MessagesDescendingPager is an optional Store capability for efficient reverse
 // pagination over session messages. Implementations return messages ordered by
 // descending sequence and, when beforeSeq > 0, only rows with sequence < beforeSeq.

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -319,14 +319,14 @@ func (m *Message) ToLLMMessage() llm.Message {
 
 func providerMessageParts(parts []llm.Part) []llm.Part {
 	for i, part := range parts {
-		if part.Type != llm.PartSkillActivation && part.Type != llm.PartAgentMention && part.Type != llm.PartPathNote {
+		if part.Type != llm.PartSkillActivation && part.Type != llm.PartAgentMention && part.Type != llm.PartPathNote && part.Type != llm.PartDiffComment {
 			continue
 		}
 		converted := make([]llm.Part, 0, len(parts))
 		converted = append(converted, parts[:i]...)
 		for _, candidate := range parts[i:] {
 			switch candidate.Type {
-			case llm.PartSkillActivation, llm.PartPathNote:
+			case llm.PartSkillActivation, llm.PartPathNote, llm.PartDiffComment:
 				continue
 			case llm.PartAgentMention:
 				candidate.Type = llm.PartText


### PR DESCRIPTION
## Summary

- add an immediate inline instruction affordance to changed diff rows
- send anchored instructions through the existing response/interjection path without disturbing the composer draft
- persist typed `diff_comment` metadata in the transcript so subtle grey markers survive rerenders, session switches, and reloads
- let users reopen a marker to recall prior instructions or add a follow-up

## Agent context

Each instruction sends the model the file path, old/new side, line number, captured file-change sequence, exact line, nearby context, and user instruction. The metadata part is retained for UI reconstruction but stripped before provider calls; the adjacent text block is the provider-facing payload.

## Reliability

- idle and active-run delivery share existing retry/idempotency behavior
- deferred interjections retain the full anchored prompt
- unrelated composer text and attachments remain untouched
- editor drafts survive live diff rerenders
- optimistic markers reconcile with persisted transcript entries or roll back on failed delivery
- stale anchors are labelled without silently relocating them
- comment hydration uses a targeted transcript query rather than local storage or prose parsing

## UX

- hover/focus reveals the line affordance; touch keeps it available
- Escape cancels a focused editor; Cmd/Ctrl+Enter sends
- one roving keyboard entry point avoids hundreds of invisible tab stops
- sent markers and history use restrained grey styling

## Verification

- `HOME=<isolated> XDG_CONFIG_HOME=<isolated> XDG_DATA_HOME=<isolated> go test ./...`
- all direct `internal/serveui/static/*_test.js` scripts
- `go build ./...`
- `go vet ./...`
- `git diff --check`
- live Chromium flow: create a 20-line file, comment on line 11, agent updates the anchored line, marker persists, history/follow-up reopens

## Review

Claude Fable reviewed the product architecture before implementation. Claude Opus reviewed the implementation; the follow-up patch addressed its delivery, optimistic-state, refresh, performance, payload-bound, Escape, and accessibility findings.
