### PR TITLE
feat: support OpenCode Go proxy base URLs

### DIFF
--- a/cmd/models.go
+++ b/cmd/models.go
@@ -192,7 +192,7 @@ func runModels(cmd *cobra.Command, args []string) error {
 		}
 		// The Go model and metadata endpoints are public; a key is required only
 		// when the returned provider is used for inference.
-		lister = llm.NewOpenCodeGoProvider(apiKey, providerCfg.Model)
+		lister = llm.NewOpenCodeGoProviderWithBaseURL(apiKey, providerCfg.Model, providerCfg.BaseURL)
 	case config.ProviderTypeXAI:
 		apiKey := providerCfg.ResolvedAPIKey
 		if apiKey == "" {

--- a/docs-site/content/reference/providers-and-models.md
+++ b/docs-site/content/reference/providers-and-models.md
@@ -64,6 +64,17 @@ term-llm ask --provider opencode-go:glm-5.2 "question"
 
 OpenCode Go's model set changes frequently. term-llm merges the live Go `/models` availability list with OpenCode's model catalog for protocol, limits, pricing, and reasoning metadata, then caches the result for five minutes. Models marked for `@ai-sdk/openai-compatible`, `@ai-sdk/openai`, and `@ai-sdk/anthropic` are sent to the Go Chat Completions, Responses, and Messages endpoints respectively. Effort-based models expose their advertised suffixes, while budget-based Anthropic-compatible models such as `qwen3.8-max` expose `-high` and `-max` reasoning variants. A newly available model without catalog metadata falls back to Chat Completions until its metadata arrives.
 
+A compatible gateway can be configured under a custom provider name. `base_url` replaces the standard OpenCode Go `/v1` base while preserving dynamic protocol routing:
+
+```yaml
+providers:
+  private-go:
+    type: opencode-go
+    base_url: https://gateway.example.com/v1
+    api_key: ${PRIVATE_GO_API_KEY}
+    model: muse-spark-1.2-contributor
+```
+
 Examples:
 
 ```bash

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -481,14 +481,14 @@ func createProviderFromConfig(name string, cfg *config.ProviderConfig) (Provider
 		return NewZenProvider(cfg.ResolvedAPIKey, cfg.Model), nil
 
 	case config.ProviderTypeOpenCodeGo:
-		if strings.TrimSpace(cfg.BaseURL) != "" || strings.TrimSpace(cfg.URL) != "" {
-			return nil, fmt.Errorf("provider %q does not support base_url or url overrides", name)
+		if strings.TrimSpace(cfg.URL) != "" {
+			return nil, fmt.Errorf("provider %q does not support url overrides; use base_url", name)
 		}
 		apiKey := strings.TrimSpace(cfg.ResolvedAPIKey)
 		if apiKey == "" {
 			return nil, fmt.Errorf("provider %q requires OPENCODE_API_KEY or explicit config", name)
 		}
-		return NewOpenCodeGoProvider(apiKey, cfg.Model), nil
+		return NewOpenCodeGoProviderWithBaseURL(apiKey, cfg.Model, cfg.BaseURL), nil
 
 	case config.ProviderTypeXAI:
 		apiKey := cfg.ResolvedAPIKey

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -201,14 +201,33 @@ func TestCreateProviderFromConfigOpenCodeGo(t *testing.T) {
 	}
 }
 
-func TestCreateProviderFromConfigOpenCodeGoRejectsURLOverrides(t *testing.T) {
+func TestCreateProviderFromConfigOpenCodeGoUsesBaseURLOverride(t *testing.T) {
+	provider, err := createProviderFromConfig("opencode-go", &config.ProviderConfig{
+		Type:           config.ProviderTypeOpenCodeGo,
+		ResolvedAPIKey: "test-key",
+		Model:          "muse-spark-1.2-contributor",
+		BaseURL:        "https://example.test/muse/v1/",
+	})
+	if err != nil {
+		t.Fatalf("createProviderFromConfig: %v", err)
+	}
+	openCodeGo, ok := provider.(*OpenCodeGoProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *OpenCodeGoProvider", provider)
+	}
+	if openCodeGo.baseURL != "https://example.test/muse/v1" {
+		t.Fatalf("baseURL = %q", openCodeGo.baseURL)
+	}
+}
+
+func TestCreateProviderFromConfigOpenCodeGoRejectsURLOverride(t *testing.T) {
 	_, err := createProviderFromConfig("opencode-go", &config.ProviderConfig{
 		Type:           config.ProviderTypeOpenCodeGo,
 		ResolvedAPIKey: "test-key",
-		BaseURL:        "https://example.test/v1",
+		URL:            "https://example.test/responses",
 	})
-	if err == nil || !strings.Contains(err.Error(), "does not support base_url or url overrides") {
-		t.Fatalf("error = %v, want URL override guidance", err)
+	if err == nil || !strings.Contains(err.Error(), "use base_url") {
+		t.Fatalf("error = %v, want base_url guidance", err)
 	}
 }
 

--- a/internal/llm/opencode_go.go
+++ b/internal/llm/opencode_go.go
@@ -57,7 +57,16 @@ func latestOpenCodeGoCatalog() *opencodeGoModelCatalog {
 }
 
 func NewOpenCodeGoProvider(apiKey, model string) *OpenCodeGoProvider {
-	return newOpenCodeGoProvider(apiKey, model, opencodeGoBaseURL, opencodeGoCatalogURL, defaultHTTPClient)
+	return NewOpenCodeGoProviderWithBaseURL(apiKey, model, "")
+}
+
+// NewOpenCodeGoProviderWithBaseURL creates an OpenCode Go provider using an
+// optional compatible proxy base URL.
+func NewOpenCodeGoProviderWithBaseURL(apiKey, model, baseURL string) *OpenCodeGoProvider {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = opencodeGoBaseURL
+	}
+	return newOpenCodeGoProvider(apiKey, model, baseURL, opencodeGoCatalogURL, defaultHTTPClient)
 }
 
 func newOpenCodeGoProvider(apiKey, model, baseURL, catalogURL string, client *http.Client) *OpenCodeGoProvider {


### PR DESCRIPTION
## What changed

- allow configured `type: opencode-go` providers to override the compatible API base with `base_url`
- use the override for both inference and `term-llm models`
- continue rejecting ambiguous full `url` overrides
- document custom OpenCode Go gateways

The provider still reads OpenCode's public metadata catalog for protocol, limits, pricing, and reasoning variants, while availability and inference go through the configured gateway.

## Live verification

Configured a private provider against an OpenAI-style gateway:

```yaml
providers:
  muse:
    type: opencode-go
    base_url: https://wasnotwas.com/muse/v1
    model: muse-spark-1.2-contributor-low
```

Using the branch binary:

- `term-llm models --provider muse` listed Muse Spark 1.2 Contributor and all advertised effort variants
- a completion returned exactly `TERM_MUSE_PROXY_OK`
- an `@developer` tool loop wrote exactly `TERM_MUSE_TOOL_OK`

## Tests

- `go test ./internal/llm -run 'TestCreateProviderFromConfigOpenCodeGo|TestOpenCodeGo'`
- isolated `go test -short ./...`
- `go build ./...`
