### PR TITLE
Expand inline diff review workflow

### DIFF
--- a/cmd/serve_diff_comments_test.go
+++ b/cmd/serve_diff_comments_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -46,6 +47,59 @@ func TestParseUserMessageContentAcceptsDiffCommentMetadata(t *testing.T) {
 	}
 	if got := message.Parts[0].DiffComment; got.Path != comment.Path || got.Side != "old" || got.Line != 17 || got.FileChangeSeq != 42 {
 		t.Fatalf("diff comment = %#v", got)
+	}
+}
+
+func TestParseUserMessageContentAcceptsDiffCommentBatchAndEnforcesCap(t *testing.T) {
+	parts := make([]any, 0, diffCommentMaxPartsPerMessage+1)
+	for i := 0; i < diffCommentMaxPartsPerMessage; i++ {
+		comment := *testDiffComment()
+		comment.ID = fmt.Sprintf("diff-comment-%d", i)
+		parts = append(parts, map[string]any{"type": "diff_comment", "diff_comment": &comment})
+	}
+	parts = append(parts, map[string]any{"type": "input_text", "text": "one provider-facing batch"})
+	content, err := json.Marshal(parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, err := parseUserMessageContent(content)
+	if err != nil {
+		t.Fatalf("parse batch at cap: %v", err)
+	}
+	if len(message.Parts) != diffCommentMaxPartsPerMessage+1 {
+		t.Fatalf("parts = %d, want %d", len(message.Parts), diffCommentMaxPartsPerMessage+1)
+	}
+
+	extra := *testDiffComment()
+	extra.ID = "diff-comment-over-cap"
+	parts = append(parts[:len(parts)-1], map[string]any{"type": "diff_comment", "diff_comment": &extra}, parts[len(parts)-1])
+	content, err = json.Marshal(parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseUserMessageContent(content); err == nil || !strings.Contains(err.Error(), "too many diff_comment parts (max 25)") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestParseUserMessageContentRejectsDiffCommentAggregatePayloadOverCap(t *testing.T) {
+	parts := make([]any, 0, 12)
+	for i := 0; i < 11; i++ {
+		comment := *testDiffComment()
+		comment.ID = fmt.Sprintf("large-diff-comment-%d", i)
+		comment.LineText = strings.Repeat("a", diffCommentMaxLineBytes)
+		comment.Instruction = strings.Repeat("b", diffCommentMaxInstructionBytes)
+		comment.ContextBefore = []llm.DiffCommentContextLine{{Side: "old", Line: 16, Text: strings.Repeat("c", diffCommentMaxLineBytes)}}
+		comment.ContextAfter = nil
+		parts = append(parts, map[string]any{"type": "diff_comment", "diff_comment": &comment})
+	}
+	parts = append(parts, map[string]any{"type": "input_text", "text": "provider-facing batch"})
+	content, err := json.Marshal(parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseUserMessageContent(content); err == nil || !strings.Contains(err.Error(), "aggregate payload limit (262144 bytes)") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -457,10 +457,12 @@ func tiffOrientation(tiff []byte) int {
 }
 
 const (
-	diffCommentMaxPathBytes        = 1024
-	diffCommentMaxLineBytes        = 8 * 1024
-	diffCommentMaxInstructionBytes = 8 * 1024
-	diffCommentMaxPayloadBytes     = 32 * 1024
+	diffCommentMaxPathBytes             = 1024
+	diffCommentMaxLineBytes             = 8 * 1024
+	diffCommentMaxInstructionBytes      = 8 * 1024
+	diffCommentMaxPayloadBytes          = 32 * 1024
+	diffCommentMaxPartsPerMessage       = 25
+	diffCommentMaxAggregatePayloadBytes = 256 * 1024
 )
 
 func parseDiffCommentPart(raw json.RawMessage) (*llm.DiffComment, error) {
@@ -535,10 +537,20 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 	if err := json.Unmarshal(content, &parts); err == nil && len(parts) > 0 {
 		var llmParts []llm.Part
 		fileCount := 0
+		diffCommentCount := 0
+		diffCommentAggregateBytes := 0
 		for _, part := range parts {
 			partType := strings.ToLower(strings.TrimSpace(jsonString(part["type"])))
 			switch partType {
 			case "diff_comment":
+				diffCommentCount++
+				if diffCommentCount > diffCommentMaxPartsPerMessage {
+					return llm.Message{}, fmt.Errorf("too many diff_comment parts (max %d)", diffCommentMaxPartsPerMessage)
+				}
+				diffCommentAggregateBytes += len(part["diff_comment"])
+				if diffCommentAggregateBytes > diffCommentMaxAggregatePayloadBytes {
+					return llm.Message{}, fmt.Errorf("diff_comment parts exceed aggregate payload limit (%d bytes)", diffCommentMaxAggregatePayloadBytes)
+				}
 				comment, err := parseDiffCommentPart(part["diff_comment"])
 				if err != nil {
 					return llm.Message{}, err

--- a/internal/serveui/embed.go
+++ b/internal/serveui/embed.go
@@ -16,7 +16,7 @@ import (
 //go:embed static/index.html static/manifest.webmanifest static/icon-512.png static/sw.js
 //go:embed static/app.css
 //go:embed static/app-core.js static/toast.js static/app-network.js static/app-plan.js static/slash-commands.js static/app-render.js static/app-sessions.js static/app-path-notes.js static/app-branching.js static/app-branch-commands.js static/app-session-events.js static/app-mcp.js static/app-goals-location.js static/app-message-convert.js static/intent-storage.js static/app-session-admin.js static/app-sidebar.js
-//go:embed static/app-attachments.js static/app-stream.js static/app-response-effects.js static/app-send.js static/app-runtime.js static/app-interject.js static/app-modals.js static/app-composer.js static/app-skills.js static/side-question.js static/app-webrtc.js static/app-diff-comments.js static/app-diffs.js static/app-worktrees.js
+//go:embed static/app-attachments.js static/app-stream.js static/app-response-effects.js static/app-send.js static/app-runtime.js static/app-interject.js static/app-modals.js static/app-composer.js static/app-skills.js static/side-question.js static/app-webrtc.js static/app-diff-comments.js static/app-diff-queue.js static/app-diffs.js static/app-worktrees.js
 //go:embed static/decoration.js static/markdown-setup.js static/markdown-streaming.js static/transcript-window.js static/active-response.js static/conversation.js
 //go:embed static/vendor
 var staticFiles embed.FS
@@ -121,6 +121,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`href="intent-storage.js"`, `href="` + versioned("intent-storage.js") + `"`},
 		{`href="app-session-admin.js"`, `href="` + versioned("app-session-admin.js") + `"`},
 		{`href="app-diff-comments.js"`, `href="` + versioned("app-diff-comments.js") + `"`},
+		{`href="app-diff-queue.js"`, `href="` + versioned("app-diff-queue.js") + `"`},
 		{`href="app-diffs.js"`, `href="` + versioned("app-diffs.js") + `"`},
 		{`href="app-worktrees.js"`, `href="` + versioned("app-worktrees.js") + `"`},
 		{`src="markdown-setup.js"`, `src="` + versioned("markdown-setup.js") + `"`},
@@ -157,6 +158,7 @@ func RenderIndexHTML(basePath, headSnippet string, opts RenderOptions) []byte {
 		{`src="intent-storage.js"`, `src="` + versioned("intent-storage.js") + `"`},
 		{`src="app-session-admin.js"`, `src="` + versioned("app-session-admin.js") + `"`},
 		{`src="app-diff-comments.js"`, `src="` + versioned("app-diff-comments.js") + `"`},
+		{`src="app-diff-queue.js"`, `src="` + versioned("app-diff-queue.js") + `"`},
 		{`src="app-diffs.js"`, `src="` + versioned("app-diffs.js") + `"`},
 		{`src="app-worktrees.js"`, `src="` + versioned("app-worktrees.js") + `"`},
 	}
@@ -247,6 +249,7 @@ func renderServiceWorkerBytes(opts RenderOptions) []byte {
 		{"'./intent-storage.js'", "'./" + versioned("intent-storage.js") + "'"},
 		{"'./app-session-admin.js'", "'./" + versioned("app-session-admin.js") + "'"},
 		{"'./app-diff-comments.js'", "'./" + versioned("app-diff-comments.js") + "'"},
+		{"'./app-diff-queue.js'", "'./" + versioned("app-diff-queue.js") + "'"},
 		{"'./app-diffs.js'", "'./" + versioned("app-diffs.js") + "'"},
 		{"'./app-worktrees.js'", "'./" + versioned("app-worktrees.js") + "'"},
 	}

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -73,7 +73,7 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 			branchingLines = lineCount
 		} else if name == "app-branch-commands.js" {
 			branchCommandLines = lineCount
-		} else if name == "app-diffs.js" || name == "app-diff-comments.js" {
+		} else if name == "app-diffs.js" || name == "app-diff-comments.js" || name == "app-diff-queue.js" {
 			diffLines[name] = lineCount
 		} else {
 			legacyProductionLines += lineCount
@@ -97,8 +97,9 @@ func TestConversationLifecycleSizeAndPurityBudgets(t *testing.T) {
 	if branchCommandLines == 0 || branchCommandLines > 100 {
 		t.Fatalf("conversation branch command controller=%d lines, budget=100", branchCommandLines)
 	}
-	if diffLines["app-diffs.js"] == 0 || diffLines["app-diff-comments.js"] == 0 || diffLines["app-diffs.js"]+diffLines["app-diff-comments.js"] > 1950 {
-		t.Fatalf("diff controllers grew beyond focused budget: %v", diffLines)
+	diffControllerLines := diffLines["app-diffs.js"] + diffLines["app-diff-comments.js"] + diffLines["app-diff-queue.js"]
+	if diffLines["app-diffs.js"] == 0 || diffLines["app-diff-comments.js"] == 0 || diffLines["app-diff-queue.js"] == 0 || diffControllerLines > 2650 {
+		t.Fatalf("diff sidebar, comments, and queue controllers grew beyond focused budget: %v", diffLines)
 	}
 
 	for _, name := range []string{"active-response.js", "conversation.js", "transcript-window.js"} {
@@ -1029,6 +1030,23 @@ func TestAppDiffCommentsJS(t *testing.T) {
 	}
 }
 
+func TestAppDiffQueueJS(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found in PATH, skipping JS app-diff-queue tests")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "static", "app_diff_queue_test.js")
+	out, err := exec.Command(node, script).CombinedOutput()
+	t.Log(string(out))
+	if err != nil {
+		t.Fatalf("app_diff_queue_test.js failed: %v", err)
+	}
+}
+
 func TestAppDiffsJS(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
@@ -1062,7 +1080,11 @@ func TestStaticAssetsSupportDiffSidebar(t *testing.T) {
 		`id="diffToggleBtn"`,
 		`id="diffFileList"`,
 		`id="diffResizeHandle"`,
+		`id="diffMaximizeBtn"`,
+		`id="diffQueueBar"`,
+		`id="diffQueueStatus"`,
 		`src="app-diff-comments.js"`,
+		`src="app-diff-queue.js"`,
 		`src="app-diffs.js"`,
 	} {
 		if !strings.Contains(indexSrc, want) {
@@ -1093,6 +1115,11 @@ func TestStaticAssetsSupportDiffSidebar(t *testing.T) {
 		".diff-sidebar.open",
 		".diff-resize-handle",
 		".app.diff-resizing",
+		".diff-sidebar.maximized",
+		".app.diff-maximized",
+		".diff-queue-bar",
+		".diff-comment-send-split",
+		".diff-toggle.has-queued",
 		"--diff-sidebar-user-width",
 		".diff-toggle[hidden]",
 		"pre-wrap",
@@ -1126,20 +1153,20 @@ func TestStaticAssetsSupportDiffSidebar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StaticAsset(sw.js): %v", err)
 	}
-	for _, asset := range []string{"app-diff-comments.js", "app-diffs.js"} {
+	for _, asset := range []string{"app-diff-comments.js", "app-diff-queue.js", "app-diffs.js"} {
 		if !strings.Contains(string(swJS), "'./"+asset+"'") {
 			t.Fatalf("sw.js SHELL_ASSETS missing %s", asset)
 		}
 	}
 
 	rendered := RenderIndexHTML("/ui", "", RenderOptions{})
-	for _, asset := range []string{"app-diff-comments.js", "app-diffs.js"} {
+	for _, asset := range []string{"app-diff-comments.js", "app-diff-queue.js", "app-diffs.js"} {
 		if !strings.Contains(string(rendered), `src="`+asset+`?v=`) {
 			t.Fatalf("RenderIndexHTML does not version %s", asset)
 		}
 	}
 	renderedSW := RenderServiceWorker(RenderOptions{})
-	for _, asset := range []string{"app-diff-comments.js", "app-diffs.js"} {
+	for _, asset := range []string{"app-diff-comments.js", "app-diff-queue.js", "app-diffs.js"} {
 		if !strings.Contains(string(renderedSW), "'./"+asset+"?v=") {
 			t.Fatalf("RenderServiceWorker does not version %s", asset)
 		}

--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -28,6 +28,7 @@ const STORAGE_BASE_KEYS = {
   lastNotifiedResponseId: 'term_llm_last_notified_response_id',
   draftMessages: 'term_llm_draft_messages',
   pendingIntents: 'term_llm_pending_intent',
+  diffCommentQueue: 'term_llm_diff_comment_queue',
   optimisticTranscript: 'term_llm_optimistic_transcript'
 };
 
@@ -2097,8 +2098,8 @@ const sanitizeMessage = (msg) => {
         const askUserCallId = String(msg.askUserCallId || msg.ask_user_call_id || '').trim();
         if (askUserCallId) base.askUserCallId = askUserCallId;
       }
-      const diffComment = msg.diffComment || msg.diff_comment;
-      if (diffComment && typeof diffComment === 'object') { try { base.diffComment = JSON.parse(JSON.stringify(diffComment)); } catch {} }
+      const diffComments = [].concat(Array.isArray(msg.diffComments) && msg.diffComments.length > 0 ? msg.diffComments : (msg.diffComment || msg.diff_comment || [])).filter((entry) => entry && typeof entry === 'object');
+      if (diffComments.length > 0) { try { base.diffComments = JSON.parse(JSON.stringify(diffComments)); } catch {} }
       if (Array.isArray(msg.attachments) && msg.attachments.length > 0) {
         base.attachments = msg.attachments.map(a => ({
           name: String(a.name || 'file'),

--- a/internal/serveui/static/app-diff-comments.js
+++ b/internal/serveui/static/app-diff-comments.js
@@ -13,6 +13,7 @@ const pruneDiffCommentState = (retainedIDs = liveSessionIDs()) => {
   for (const sessionId of commentStateBySession.keys()) {
     if (!retained.has(sessionId)) commentStateBySession.delete(sessionId);
   }
+  app.pruneDiffCommentQueues?.(retained);
 };
 
 const sessionCommentState = (sessionId) => {
@@ -20,7 +21,7 @@ const sessionCommentState = (sessionId) => {
   if (!value) {
     value = {
       comments: [], loaded: false, inflight: null, lastLoadedAt: 0, serverRevision: -1,
-      revisionsByPath: new Map(), editorDrafts: new Map(), openPanel: null
+      revisionsByPath: new Map(), editorDrafts: new Map(), retryIDs: new Map(), openPanel: null, pendingFocusKey: ''
     };
     commentStateBySession.set(sessionId, value);
   }
@@ -141,6 +142,23 @@ const invalidateDiffComments = (sessionId) => {
 };
 
 const diffCommentRevision = (sessionId, path) => commentStateBySession.get(sessionId)?.revisionsByPath.get(path) || 0;
+const bumpDiffCommentPathRevision = (sessionId, path) => {
+  const revisions = sessionCommentState(sessionId).revisionsByPath;
+  revisions.set(path, (revisions.get(path) || 0) + 1);
+};
+const diffCommentPanelOpen = (sessionId) => Boolean(commentStateBySession.get(String(sessionId || ''))?.openPanel);
+const clearDiffCommentPanel = (sessionId, path = '') => {
+  const cs = commentStateBySession.get(String(sessionId || ''));
+  if (!cs?.openPanel || (path && cs.openPanel.path !== path)) return false;
+  cs.openPanel = null;
+  return true;
+};
+const reconcileDiffCommentPanel = (sessionId, retainedPaths) => {
+  const cs = commentStateBySession.get(String(sessionId || ''));
+  if (!cs?.openPanel) return false;
+  const retained = retainedPaths instanceof Set ? retainedPaths : new Set(retainedPaths || []);
+  return retained.has(cs.openPanel.path) ? false : clearDiffCommentPanel(sessionId);
+};
 
 const rowAnchor = (path, row, fileChangeSeq) => {
   const side = row?.type === 'del' ? 'old' : (row?.newNo ? 'new' : 'old');
@@ -204,7 +222,7 @@ const addOptimisticComment = (sessionId, comment) => {
   const cs = sessionCommentState(sessionId);
   const before = cs.comments;
   if (!before.some((existing) => existing.id === comment.id)) {
-    cs.comments = [...before, { ...comment, client_message_id: comment.id, created_at: Date.now(), optimistic: true }];
+    cs.comments = [...before, { ...comment, client_message_id: comment.client_message_id || comment.id, created_at: Date.now(), optimistic: true }];
     bumpChangedPathRevisions(cs, before, cs.comments);
   }
   app.renderDiffSidebar?.(sessionId);
@@ -241,7 +259,10 @@ const closePanel = (panel, focusTarget, options = {}) => {
   const sessionId = String(options.sessionId || panel?._diffCommentSessionId || '');
   const key = String(options.key || panel?._diffCommentKey || '');
   const cs = commentStateBySession.get(sessionId);
-  if (options.clearDraft && cs && key) cs.editorDrafts.delete(key);
+  if (options.clearDraft && cs && key) {
+    cs.editorDrafts.delete(key);
+    cs.retryIDs.delete(key);
+  }
   if (cs?.openPanel?.key === key) cs.openPanel = null;
   const trigger = focusTarget || panel?._diffCommentTrigger;
   trigger?.setAttribute?.('aria-expanded', 'false');
@@ -249,10 +270,10 @@ const closePanel = (panel, focusTarget, options = {}) => {
   trigger?.focus?.();
 };
 
-const showEditor = (panel, sessionId, anchor, rows, rowIndex, trigger, prior) => {
+const showEditor = (panel, sessionId, anchor, rows, rowIndex, trigger, prior, options = {}) => {
   const existingEditor = panel.querySelector?.('.diff-comment-editor');
   if (existingEditor) {
-    existingEditor.querySelector?.('textarea')?.focus?.();
+    if (options.focus !== false) existingEditor.querySelector?.('textarea')?.focus?.();
     return;
   }
   const cs = sessionCommentState(sessionId);
@@ -268,40 +289,107 @@ const showEditor = (panel, sessionId, anchor, rows, rowIndex, trigger, prior) =>
   const actions = document.createElement('div');
   actions.className = 'diff-comment-editor-actions';
   const cancel = makeButton('diff-comment-cancel', 'Cancel inline comment', 'Cancel');
-  const send = makeButton('diff-comment-send', 'Send inline comment now', 'Send now');
-  actions.append(cancel, send);
+  const split = document.createElement('div');
+  split.className = 'diff-comment-send-split';
+  const send = makeButton('diff-comment-send', 'Send now', 'Send now');
+  const more = makeButton('diff-comment-send-more', 'More send options', '▾');
+  more.setAttribute('aria-haspopup', 'menu');
+  more.setAttribute('aria-expanded', 'false');
+  const menu = document.createElement('div');
+  menu.className = 'diff-comment-send-menu';
+  menu.id = `${panel.id}-send-menu`;
+  menu.setAttribute('role', 'menu');
+  menu.hidden = true;
+  more.setAttribute('aria-controls', menu.id);
+  const sendNowOption = makeButton('diff-comment-send-option', 'Send now', 'Send now');
+  sendNowOption.setAttribute('role', 'menuitem');
+  sendNowOption.tabIndex = -1;
+  const queueOption = makeButton('diff-comment-send-option', 'Queue comment — Deliver later as one batch', 'Queue comment');
+  queueOption.setAttribute('role', 'menuitem');
+  queueOption.tabIndex = -1;
+  const queueDescription = document.createElement('small');
+  queueDescription.textContent = 'Deliver later as one batch';
+  queueOption.appendChild(queueDescription);
+  menu.append(sendNowOption, queueOption);
+  split.append(send, more, menu);
+  actions.append(cancel, split);
   editor.append(textarea, actions);
   panel.appendChild(editor);
 
-  const submit = async () => {
+  const menuItems = [sendNowOption, queueOption];
+  const setMenuOpen = (open, focusIndex = -1) => {
+    menu.hidden = !open;
+    if (open) menu.removeAttribute?.('hidden'); else menu.setAttribute?.('hidden', '');
+    more.setAttribute('aria-expanded', open ? 'true' : 'false');
+    if (open && focusIndex >= 0) menuItems[focusIndex]?.focus?.();
+  };
+  const moveMenuFocus = (direction) => {
+    const current = Math.max(0, menuItems.indexOf(document.activeElement));
+    menuItems[(current + direction + menuItems.length) % menuItems.length]?.focus?.();
+  };
+  const updatePrimary = () => {
+    const queueMode = app.diffCommentSendMode?.(sessionId) === 'queue';
+    const label = queueMode ? 'Queue comment' : 'Send now';
+    send.textContent = label;
+    send.setAttribute('aria-label', label);
+    send.title = `${label} (Ctrl/⌘+Enter)`;
+  };
+  const submit = async (requestedMode = app.diffCommentSendMode?.(sessionId) || 'send') => {
+    const mode = requestedMode === 'queue' ? 'queue' : 'send';
     const instruction = String(textarea.value || '').trim();
-    if (!instruction || send.disabled) return;
+    if (!instruction || send.disabled) return false;
     cs.editorDrafts.set(key, textarea.value);
-    if (!state.connected) {
+    if (mode === 'send' && !state.connected) {
       app.openAuthModal?.('Connect before sending an inline instruction.', true);
-      return;
+      return false;
     }
-    if (state.branchContextQueuedSend) {
+    if (mode === 'send' && state.branchContextQueuedSend) {
       app.showToast?.('A message is already queued for this conversation path.', { id: 'diff-comment-send', tone: 'warning' });
-      return;
+      return false;
+    }
+    if (mode === 'queue' && (app.queuedDiffComments?.(sessionId) || []).length >= (app.MAX_QUEUED_DIFF_COMMENTS || 20)) {
+      app.showToast?.('Queue is full (20). Send or discard queued comments first.', { id: 'diff-comment-queue-full', tone: 'warning' });
+      return false;
     }
     const context = captureContext(rows, rowIndex);
     const comment = normalizeComment({
       ...anchor,
-      id: makeID(),
+      id: cs.retryIDs.get(key) || makeID(),
       parent_id: prior.length > 0 ? prior[prior.length - 1].id : '',
       context_before: context.before,
       context_after: context.after,
       instruction,
-      optimistic: true
+      optimistic: mode === 'send'
     });
-    if (!comment) return;
+    if (!comment) return false;
+    app.pinDiffFileExpanded?.(sessionId, anchor.path);
+    cs.pendingFocusKey = key;
     send.disabled = true;
+    more.disabled = true;
     textarea.disabled = true;
     closePanel(panel);
+    if (mode === 'queue') {
+      if (!app.queueDiffComment?.(sessionId, comment)) {
+        cs.pendingFocusKey = '';
+        return false;
+      }
+      cs.editorDrafts.delete(key);
+      cs.retryIDs.delete(key);
+      return true;
+    }
     addOptimisticComment(sessionId, comment);
     let transportStarted = false;
+    let transportQueued = false;
     let transportFailed = false;
+    let failureHandled = false;
+    const keepRetryDraft = (tone = 'error') => {
+      if (failureHandled) return;
+      failureHandled = true;
+      transportFailed = true;
+      cs.retryIDs.set(key, comment.id);
+      removeOptimisticComment(sessionId, comment.id);
+      app.showToast?.('Inline instruction was not sent. Your draft is still available.', { id: 'diff-comment-send', tone });
+    };
     try {
       await app.sendMessage?.({
         prompt: formatAgentInstruction(comment),
@@ -322,23 +410,72 @@ const showEditor = (panel, sessionId, anchor, rows, rowIndex, trigger, prior) =>
         attachments: [],
         preserveComposer: true,
         reuseMessageId: comment.id,
-        _onTransportStarted() { transportStarted = true; },
-        _onTransportFailed() { transportFailed = true; }
+        _onTransportStarted(detail = {}) {
+          if (detail.queued) {
+            transportQueued = true;
+            return;
+          }
+          transportStarted = true;
+          cs.retryIDs.delete(key);
+          cs.editorDrafts.delete(key);
+          void Promise.resolve().then(() => hydrateDiffComments(sessionId, { force: true }));
+        },
+        _onTransportFailed() { keepRetryDraft(); },
+        _onTransportCanceled() { keepRetryDraft('warning'); }
       });
     } catch {
-      transportFailed = true;
+      keepRetryDraft();
     }
+    if (transportQueued && !transportStarted && !transportFailed) return true;
     if (!transportStarted || transportFailed) {
-      removeOptimisticComment(sessionId, comment.id);
-      app.showToast?.('Inline instruction was not sent. Your draft is still available.', { id: 'diff-comment-send', tone: 'error' });
-      return;
+      keepRetryDraft();
+      return false;
     }
-    cs.editorDrafts.delete(key);
-    void hydrateDiffComments(sessionId, { force: true });
+    return true;
+  };
+  const choose = async (mode) => {
+    app.setDiffCommentSendMode?.(sessionId, mode);
+    updatePrimary();
+    setMenuOpen(false);
+    if (!String(textarea.value || '').trim()) { textarea.focus?.(); return; }
+    await submit(mode);
   };
   textarea.addEventListener('input', () => cs.editorDrafts.set(key, textarea.value));
   cancel.addEventListener('click', () => closePanel(panel, trigger, { clearDraft: true, sessionId, key }));
-  send.addEventListener('click', submit);
+  send.addEventListener('click', () => submit());
+  more.addEventListener('click', (event) => {
+    event.stopPropagation?.();
+    const opening = menu.hidden;
+    setMenuOpen(opening, opening ? 0 : -1);
+  });
+  more.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'Escape') return;
+    event.preventDefault?.();
+    event.stopImmediatePropagation?.();
+    if (event.key === 'Escape') setMenuOpen(false);
+    else setMenuOpen(true, event.key === 'ArrowUp' ? menuItems.length - 1 : 0);
+  });
+  sendNowOption.addEventListener('click', () => choose('send'));
+  queueOption.addEventListener('click', () => choose('queue'));
+  menu.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault?.();
+      moveMenuFocus(event.key === 'ArrowDown' ? 1 : -1);
+      return;
+    }
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault?.();
+      menuItems[event.key === 'Home' ? 0 : menuItems.length - 1]?.focus?.();
+      return;
+    }
+    if (event.key !== 'Escape' && event.key !== 'Tab') return;
+    if (event.key === 'Escape') {
+      event.preventDefault?.();
+      event.stopImmediatePropagation?.();
+      more.focus?.();
+    }
+    setMenuOpen(false);
+  });
   textarea.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {
       event.preventDefault?.();
@@ -348,11 +485,13 @@ const showEditor = (panel, sessionId, anchor, rows, rowIndex, trigger, prior) =>
       void submit();
     }
   });
-  textarea.focus?.();
+  updatePrimary();
+  if (options.focus !== false) textarea.focus?.();
 };
 
 const openCommentPanel = (sessionId, anchor, rows, rowIndex, rowElement, trigger, options = {}) => {
   const cs = sessionCommentState(sessionId);
+  app.pinDiffFileExpanded?.(sessionId, anchor.path);
   const key = anchorKey(anchor);
   const current = rowElement.parentNode?.querySelector?.('.diff-comment-panel');
   if (current) current.remove?.();
@@ -367,33 +506,62 @@ const openCommentPanel = (sessionId, anchor, rows, rowIndex, rowElement, trigger
   trigger?.setAttribute?.('aria-controls', panel.id);
   trigger?.setAttribute?.('aria-expanded', 'true');
   rowElement.parentNode?.insertBefore?.(panel, rowElement.nextSibling || null);
-  const prior = commentsForAnchor(sessionId, anchor);
-  const wasEditing = options.restore && cs.openPanel?.key === key ? Boolean(cs.openPanel.editing) : prior.length === 0;
+  const queued = app.queuedDiffComments?.(sessionId, anchor) || [];
+  const queuedIDs = new Set(queued.map((comment) => comment.id));
+  const prior = commentsForAnchor(sessionId, anchor).filter((comment) => !queuedIDs.has(comment.id));
+  const history = [...prior, ...queued].sort((a, b) => (a.created_at - b.created_at) || a.id.localeCompare(b.id));
+  const wasEditing = options.restore && cs.openPanel?.key === key ? Boolean(cs.openPanel.editing) : history.length === 0;
   cs.openPanel = { key, path: anchor.path, side: anchor.side, line: anchor.line, editing: wasEditing };
-  if (prior.length > 0) {
+  if (history.length > 0) {
     const heading = document.createElement('div');
     heading.className = 'diff-comment-heading';
     heading.textContent = `Line ${anchor.line} · ${anchor.side === 'old' ? 'original' : 'current'} version`;
     panel.appendChild(heading);
-    for (const comment of prior) {
+    for (const comment of history) {
+      const isQueued = queued.some((entry) => entry.id === comment.id);
       const item = document.createElement('div');
-      item.className = 'diff-comment-history-item';
+      item.className = `diff-comment-history-item${isQueued ? ' queued' : ''}`;
       const text = document.createElement('div');
       text.className = 'diff-comment-history-text';
       text.textContent = comment.instruction;
       const meta = document.createElement('div');
       meta.className = 'diff-comment-history-meta';
-      meta.textContent = comment.file_change_seq === anchor.file_change_seq
-        ? (comment.optimistic ? 'Sending…' : 'Sent')
-        : `File changed after this instruction${comment.optimistic ? ' · sending…' : ''}`;
+      meta.textContent = isQueued
+        ? (comment.file_change_seq === anchor.file_change_seq ? 'Queued — not sent' : 'File changed after this was queued')
+        : (comment.file_change_seq === anchor.file_change_seq ? (comment.optimistic ? 'Sending…' : 'Sent') : `File changed after this instruction${comment.optimistic ? ' · sending…' : ''}`);
       item.append(text, meta);
+      if (isQueued) {
+        const itemActions = document.createElement('div');
+        itemActions.className = 'diff-comment-history-actions';
+        const edit = makeButton('diff-comment-history-edit', 'Edit queued inline instruction', 'Edit');
+        const remove = makeButton('diff-comment-history-remove', 'Remove queued inline instruction', 'Remove');
+        const queueSending = Boolean(app.diffCommentQueueSending?.(sessionId));
+        edit.disabled = queueSending;
+        remove.disabled = queueSending;
+        edit.addEventListener('click', () => {
+          if (app.diffCommentQueueSending?.(sessionId)) return;
+          const removed = app.removeQueuedDiffComment?.(sessionId, comment.id);
+          if (!removed) return;
+          cs.editorDrafts.set(key, comment.instruction);
+          cs.retryIDs.delete(key);
+          if (cs.openPanel?.key === key) cs.openPanel.editing = true;
+          app.pinDiffFileExpanded?.(sessionId, comment.path);
+          app.scrollDiffFileIntoView?.(comment.path);
+        });
+        remove.addEventListener('click', () => {
+          if (app.diffCommentQueueSending?.(sessionId)) return;
+          app.removeQueuedDiffComment?.(sessionId, comment.id);
+        });
+        itemActions.append(edit, remove);
+        item.appendChild(itemActions);
+      }
       panel.appendChild(item);
     }
     const followUp = makeButton('diff-comment-follow-up', 'Add follow-up inline instruction', 'Add follow-up');
-    followUp.addEventListener('click', () => showEditor(panel, sessionId, anchor, rows, rowIndex, trigger, prior));
+    followUp.addEventListener('click', () => showEditor(panel, sessionId, anchor, rows, rowIndex, trigger, history));
     panel.appendChild(followUp);
   }
-  if (wasEditing) showEditor(panel, sessionId, anchor, rows, rowIndex, trigger, prior);
+  if (wasEditing) showEditor(panel, sessionId, anchor, rows, rowIndex, trigger, history, { focus: options.focus !== false });
 };
 
 const focusAdjacentCommentRow = (rowElement, direction) => {
@@ -406,18 +574,22 @@ const focusAdjacentCommentRow = (rowElement, direction) => {
   next.focus?.();
 };
 
-const decorateDiffCommentRow = ({ sessionId, path, row, rows, rowIndex, rowElement, fileChangeSeq }) => {
+const decorateDiffCommentRow = ({ sessionId, path, row, rows, rowIndex, rowElement, fileChangeSeq, initialTabStop = rowIndex === 0 }) => {
   if (!rowElement || !row || row.type === 'hunk') return null;
   const anchor = rowAnchor(path, row, fileChangeSeq);
   if (!anchor.line || !anchor.file_change_seq) return null;
-  const prior = commentsForAnchor(sessionId, anchor);
-  const hasComments = prior.length > 0;
-  const label = hasComments ? `Show ${prior.length} inline instruction${prior.length === 1 ? '' : 's'} for ${anchor.side} line ${anchor.line}` : `Comment on ${anchor.side} line ${anchor.line}`;
-  const button = makeButton(`diff-comment-affordance${hasComments ? ' has-comments' : ''}`, label, hasComments ? '' : '+');
+  const queued = app.queuedDiffComments?.(sessionId, anchor) || [];
+  const queuedIDs = new Set(queued.map((comment) => comment.id));
+  const prior = commentsForAnchor(sessionId, anchor).filter((comment) => !queuedIDs.has(comment.id));
+  const total = prior.length + queued.length;
+  const hasComments = total > 0;
+  const queuedSuffix = queued.length > 0 ? ` (${queued.length} queued, not sent)` : '';
+  const label = hasComments ? `Show ${total} inline instruction${total === 1 ? '' : 's'} for ${anchor.side} line ${anchor.line}${queuedSuffix}` : `Comment on ${anchor.side} line ${anchor.line}`;
+  const button = makeButton(`diff-comment-affordance${hasComments ? ' has-comments' : ''}${queued.length > 0 ? ' queued' : ''}`, label, hasComments ? '' : '+');
   button.tabIndex = -1;
   button.setAttribute('aria-expanded', 'false');
   button.setAttribute('aria-controls', panelIDForAnchor(sessionId, anchor));
-  if (hasComments && prior.some((comment) => comment.file_change_seq !== anchor.file_change_seq)) {
+  if (hasComments && [...prior, ...queued].some((comment) => comment.file_change_seq !== anchor.file_change_seq)) {
     button.classList.add('stale');
     button.title = `${label} (one or more anchors are outdated)`;
   }
@@ -434,7 +606,7 @@ const decorateDiffCommentRow = ({ sessionId, path, row, rows, rowIndex, rowEleme
   };
   button.addEventListener('click', open);
   rowElement.dataset.commentable = 'true';
-  rowElement.tabIndex = rows.slice(0, rowIndex).some((candidate) => candidate?.type !== 'hunk' && contextLine(candidate)) ? -1 : 0;
+  rowElement.tabIndex = initialTabStop ? 0 : -1;
   rowElement.setAttribute?.('aria-label', `${anchor.side} line ${anchor.line}. ${label}`);
   rowElement.addEventListener?.('keydown', (event) => {
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
@@ -446,31 +618,77 @@ const decorateDiffCommentRow = ({ sessionId, path, row, rows, rowIndex, rowEleme
     }
   });
   rowElement.appendChild(button);
-  const shouldRestore = sessionCommentState(sessionId).openPanel?.key === anchorKey(anchor);
-  return shouldRestore ? () => openCommentPanel(sessionId, anchor, rows, rowIndex, rowElement, button, { restore: true }) : null;
+  const cs = sessionCommentState(sessionId);
+  const key = anchorKey(anchor);
+  button._diffCommentKey = key; rowElement._diffCommentKey = key;
+  const shouldRestorePanel = cs.openPanel?.key === key, shouldRestoreFocus = cs.pendingFocusKey === key;
+  return (options = {}) => {
+    const ownedFocus = options.commentFocus?.key === key ? options.commentFocus : null;
+    if (shouldRestorePanel) openCommentPanel(sessionId, anchor, rows, rowIndex, rowElement, button, { restore: true, focus: false });
+    const restoreFocus = () => {
+      // Explicit submission/queue focus takes precedence over preserving the old control.
+      if (shouldRestoreFocus) {
+        cs.pendingFocusKey = ''; button.focus?.(); return;
+      }
+      if (!ownedFocus) return;
+      if (ownedFocus.kind === 'marker') {
+        (ownedFocus.target === 'row' ? rowElement : button).focus?.(); return;
+      }
+      const panel = rowElement.parentNode?.querySelector?.(`#${panelIDForAnchor(sessionId, anchor)}`);
+      (panel?.querySelector?.('textarea') || button).focus?.();
+    };
+    if (options.deferFocus) return restoreFocus;
+    restoreFocus(); return null;
+  };
 };
 
 const createDiffCommentMessageNode = (message, createMetaNode) => {
-  const comment = normalizeComment(message.diffComment) || { path: '', side: '', line: 0, line_text: '', instruction: String(message.content || '') };
+  const raw = Array.isArray(message.diffComments) && message.diffComments.length > 0
+    ? message.diffComments
+    : [message.diffComment];
+  const comments = raw.map(normalizeComment).filter(Boolean);
+  if (comments.length === 0) comments.push({ path: '', side: '', line: 0, line_text: '', instruction: String(message.content || '') });
   const article = document.createElement('article');
   article.className = 'message user diff-comment-message';
   article.dataset.messageId = message.id;
   const body = document.createElement('div');
   body.className = 'message-body diff-comment-message-body';
-  const heading = document.createElement('div');
-  heading.className = 'diff-comment-message-heading';
-  heading.textContent = `Inline comment · ${comment.path}:${comment.line} (${comment.side})`;
-  const instruction = document.createElement('div');
-  instruction.className = 'diff-comment-message-instruction';
-  instruction.textContent = comment.instruction;
-  const exact = document.createElement('code');
-  exact.className = 'diff-comment-message-line';
-  exact.textContent = `${comment.side} ${comment.line} | ${comment.line_text}`;
-  body.append(heading, instruction, exact);
+  if (comments.length > 1) {
+    const summary = document.createElement('div');
+    summary.className = 'diff-comment-message-summary';
+    summary.textContent = `${comments.length} inline comments`;
+    body.appendChild(summary);
+  }
+  comments.forEach((comment) => {
+    const block = document.createElement('div');
+    block.className = 'diff-comment-message-block';
+    const heading = document.createElement('div');
+    heading.className = 'diff-comment-message-heading';
+    heading.textContent = `Inline comment · ${comment.path}:${comment.line} (${comment.side})`;
+    const instruction = document.createElement('div');
+    instruction.className = 'diff-comment-message-instruction';
+    instruction.textContent = comment.instruction;
+    const exact = document.createElement('code');
+    exact.className = 'diff-comment-message-line';
+    exact.textContent = `${comment.side} ${comment.line} | ${comment.line_text}`;
+    if (comments.length === 1) body.append(heading, instruction, exact);
+    else { block.append(heading, instruction, exact); body.appendChild(block); }
+  });
   article.appendChild(body);
   if (typeof createMetaNode === 'function') article.appendChild(createMetaNode(message.created, message));
   return article;
 };
+
+const closeOpenSendMenus = (event) => {
+  for (const menu of document.querySelectorAll?.('.diff-comment-send-menu') || []) {
+    if (!menu.hidden && !event.target?.closest?.('.diff-comment-send-split')) {
+      menu.hidden = true;
+      menu.setAttribute?.('hidden', '');
+      menu.parentNode?.querySelector?.('.diff-comment-send-more')?.setAttribute?.('aria-expanded', 'false');
+    }
+  }
+};
+document.addEventListener?.('pointerdown', closeOpenSendMenus);
 
 window.addEventListener?.('keydown', (event) => {
   if (event.key !== 'Escape') return;
@@ -491,6 +709,12 @@ Object.assign(app, {
   invalidateDiffComments,
   pruneDiffCommentState,
   diffCommentRevision,
+  bumpDiffCommentPathRevision,
+  diffCommentPanelOpen,
+  clearDiffCommentPanel,
+  reconcileDiffCommentPanel,
+  addOptimisticDiffComment: addOptimisticComment,
+  removeOptimisticDiffComment: removeOptimisticComment,
   decorateDiffCommentRow,
   createDiffCommentMessageNode
 });

--- a/internal/serveui/static/app-diff-queue.js
+++ b/internal/serveui/static/app-diff-queue.js
@@ -1,0 +1,391 @@
+(() => {
+'use strict';
+
+const app = window.TermLLMApp || (window.TermLLMApp = {});
+const { state, elements, STORAGE_KEYS } = app;
+Object.assign(elements, {
+  diffQueueBar: document.getElementById?.('diffQueueBar'),
+  diffQueueStatus: document.getElementById?.('diffQueueStatus')
+});
+const MAX_QUEUED_DIFF_COMMENTS = 20;
+const MAX_QUEUED_DIFF_COMMENT_BYTES = 32 * 1024;
+const queueBySession = new Map();
+
+const resolvedSessionID = (sessionId) => {
+  const id = String(sessionId || '').trim();
+  if (!id) return '';
+  if (typeof app.isSessionIdentityResolved === 'function' && !app.isSessionIdentityResolved(id)) return '';
+  return id;
+};
+
+const queueState = (sessionId) => {
+  const id = String(sessionId || '').trim();
+  let value = queueBySession.get(id);
+  if (!value) {
+    value = { mode: 'send', items: [], sending: false, discardArmedUntil: 0, discardTimer: null };
+    queueBySession.set(id, value);
+  }
+  return value;
+};
+
+const utf8ByteLength = (value) => {
+  const text = String(value || '');
+  let bytes = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code < 0x80) bytes += 1;
+    else if (code < 0x800) bytes += 2;
+    else if (code >= 0xd800 && code <= 0xdbff && index + 1 < text.length
+        && text.charCodeAt(index + 1) >= 0xdc00 && text.charCodeAt(index + 1) <= 0xdfff) {
+      bytes += 4;
+      index += 1;
+    } else bytes += 3;
+  }
+  return bytes;
+};
+const queuedCommentBytes = (comment) => {
+  try { return utf8ByteLength(JSON.stringify(comment)); } catch { return Infinity; }
+};
+
+const normalizeQueuedComment = (entry) => {
+  const comment = app.normalizeDiffComment?.(entry);
+  if (!comment) return null;
+  return { ...comment, optimistic: false, created_at: Number(entry?.created_at || comment.created_at) || Date.now() };
+};
+
+const storagePayload = (dropOldestCount = 0) => {
+  const sessions = {};
+  const omitted = new Set();
+  if (dropOldestCount > 0) {
+    const oldest = [];
+    queueBySession.forEach((queue, sessionId) => queue.items.forEach((item) => oldest.push({ sessionId, item })));
+    oldest.sort((a, b) => (a.item.created_at - b.item.created_at) || a.item.id.localeCompare(b.item.id));
+    oldest.slice(0, dropOldestCount).forEach(({ sessionId, item }) => omitted.add(`${sessionId}\u0000${item.id}`));
+  }
+  queueBySession.forEach((queue, sessionId) => {
+    const items = queue.items.filter((item) => !omitted.has(`${sessionId}\u0000${item.id}`));
+    if (items.length > 0 || queue.mode !== 'send') sessions[sessionId] = { mode: queue.mode, items };
+  });
+  return JSON.stringify({ v: 1, sessions });
+};
+
+const persistQueues = () => {
+  const key = STORAGE_KEYS?.diffCommentQueue;
+  if (!key) return false;
+  let dropped = 0;
+  let total = 0;
+  queueBySession.forEach((queue) => { total += queue.items.length; });
+  while (dropped <= total) {
+    try {
+      localStorage.setItem(key, storagePayload(dropped));
+      return true;
+    } catch {
+      dropped += 1;
+    }
+  }
+  return false;
+};
+
+const loadQueues = () => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS?.diffCommentQueue || '');
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (parsed?.v !== 1 || !parsed.sessions || typeof parsed.sessions !== 'object') return;
+    Object.entries(parsed.sessions).forEach(([sessionId, value]) => {
+      const items = (Array.isArray(value?.items) ? value.items : [])
+        .map(normalizeQueuedComment)
+        .filter((item) => item && queuedCommentBytes(item) <= MAX_QUEUED_DIFF_COMMENT_BYTES)
+        .slice(0, MAX_QUEUED_DIFF_COMMENTS);
+      queueBySession.set(sessionId, { mode: value?.mode === 'queue' ? 'queue' : 'send', items, sending: false, discardArmedUntil: 0, discardTimer: null });
+    });
+  } catch {}
+};
+
+const queuedDiffComments = (sessionId, anchor = null) => {
+  const items = queueBySession.get(String(sessionId || ''))?.items || [];
+  if (!anchor) return items.slice();
+  const key = app.anchorKey?.(anchor);
+  return items.filter((item) => app.anchorKey?.(item) === key);
+};
+
+const diffCommentSendMode = (sessionId) => queueBySession.get(String(sessionId || ''))?.mode || 'send';
+const setDiffCommentSendMode = (sessionId, mode) => {
+  const id = resolvedSessionID(sessionId);
+  if (!id) return 'send';
+  const queue = queueState(id);
+  queue.mode = mode === 'queue' ? 'queue' : 'send';
+  persistQueues();
+  return queue.mode;
+};
+
+const bumpPaths = (sessionId, items) => {
+  new Set((items || []).map((item) => item.path).filter(Boolean)).forEach((path) => app.bumpDiffCommentPathRevision?.(sessionId, path));
+};
+
+const refreshQueueUI = (sessionId, changedItems = []) => {
+  bumpPaths(sessionId, changedItems);
+  app.renderDiffSidebar?.(sessionId);
+  if (sessionId === state.activeSessionId) renderDiffCommentQueueBar(sessionId);
+};
+
+const queueDiffComment = (sessionId, entry) => {
+  const id = resolvedSessionID(sessionId);
+  const comment = normalizeQueuedComment(entry);
+  if (!id || !comment) return false;
+  if (queuedCommentBytes(comment) > MAX_QUEUED_DIFF_COMMENT_BYTES) {
+    app.showToast?.('This inline comment is too large to queue safely. Shorten it and try again.', { id: 'diff-comment-queue-size', tone: 'warning' });
+    return false;
+  }
+  const queue = queueState(id);
+  if (queue.items.length >= MAX_QUEUED_DIFF_COMMENTS) {
+    app.showToast?.('Queue is full (20). Send or discard queued comments first.', { id: 'diff-comment-queue-full', tone: 'warning' });
+    return false;
+  }
+  if (!queue.items.some((item) => item.id === comment.id)) queue.items.push(comment);
+  persistQueues();
+  refreshQueueUI(id, [comment]);
+  return true;
+};
+
+const removeQueuedDiffComment = (sessionId, commentId) => {
+  const id = resolvedSessionID(sessionId);
+  if (!id) return null;
+  const queue = queueState(id);
+  const index = queue.items.findIndex((item) => item.id === commentId);
+  if (index < 0 || queue.sending) return null;
+  const [removed] = queue.items.splice(index, 1);
+  persistQueues();
+  refreshQueueUI(id, [removed]);
+  return removed;
+};
+
+const pruneDiffCommentQueues = (retainedIDs) => {
+  const retained = retainedIDs instanceof Set ? retainedIDs : new Set(retainedIDs || []);
+  let changed = false;
+  for (const sessionId of queueBySession.keys()) {
+    if (!retained.has(sessionId)) {
+      const queue = queueBySession.get(sessionId);
+      if (queue?.discardTimer) clearTimeout(queue.discardTimer);
+      queueBySession.delete(sessionId);
+      changed = true;
+    }
+  }
+  if (changed) persistQueues();
+};
+
+const commentPayload = (comment) => ({
+  id: comment.id,
+  ...(comment.parent_id ? { parent_id: comment.parent_id } : {}),
+  path: comment.path,
+  side: comment.side,
+  line: comment.line,
+  file_change_seq: comment.file_change_seq,
+  line_text: comment.line_text,
+  context_before: comment.context_before,
+  context_after: comment.context_after,
+  instruction: comment.instruction
+});
+
+const makeBatchID = () => {
+  try { if (globalThis.crypto?.randomUUID) return `diff_comment_batch_${globalThis.crypto.randomUUID()}`; } catch {}
+  return `diff_comment_batch_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+};
+
+const buildBatchPrompt = (items) => {
+  const blocks = items.map((item) => app.formatDiffCommentInstruction?.(item) || item.instruction);
+  return items.length === 1 ? blocks[0] : `[Inline diff instructions] (${items.length} anchored comments)\n\n${blocks.join('\n\n')}`;
+};
+
+const diffCommentQueueSending = (sessionId) => Boolean(queueBySession.get(String(sessionId || ''))?.sending);
+const focusBeforeQueueBarHides = () => {
+  const bar = elements.diffQueueBar;
+  if (!bar?.contains?.(document.activeElement)) return;
+  elements.diffToggleBtn?.focus?.();
+};
+
+const restoreFailedQueue = (sessionId, snapshot, mode) => {
+  const queue = queueState(sessionId);
+  const present = new Set(queue.items.map((item) => item.id));
+  queue.items = [...snapshot.filter((item) => !present.has(item.id)), ...queue.items].slice(0, MAX_QUEUED_DIFF_COMMENTS);
+  queue.mode = mode;
+  queue.sending = false;
+  persistQueues();
+  refreshQueueUI(sessionId, snapshot);
+};
+
+const sendQueuedDiffComments = async (sessionId = state.activeSessionId) => {
+  const id = resolvedSessionID(sessionId);
+  if (!id) return false;
+  const queue = queueState(id);
+  if (queue.sending || queue.items.length === 0) return false;
+  if (!state.connected) {
+    app.openAuthModal?.('Connect before sending queued inline instructions.', true);
+    return false;
+  }
+  if (state.branchContextQueuedSend) {
+    app.showToast?.('A message is already queued for this conversation path.', { id: 'diff-comment-batch-send', tone: 'warning' });
+    return false;
+  }
+
+  const snapshot = queue.items.slice();
+  const previousMode = queue.mode;
+  const batchId = makeBatchID();
+  queue.sending = true;
+  renderDiffCommentQueueBar(id);
+  snapshot.forEach((item) => app.addOptimisticDiffComment?.(id, { ...item, client_message_id: batchId }));
+  let transportStarted = false;
+  let transportQueued = false;
+  let transportFailed = false;
+  let failureHandled = false;
+  const restoreBatch = (tone = 'error') => {
+    if (failureHandled) return;
+    failureHandled = true;
+    transportFailed = true;
+    snapshot.forEach((item) => app.removeOptimisticDiffComment?.(id, item.id));
+    restoreFailedQueue(id, snapshot, previousMode);
+    app.showToast?.('Queued comments were not sent. They are still queued.', { id: 'diff-comment-batch-send', tone });
+  };
+  const clearAcceptedQueue = (detail = {}) => {
+    if (detail.queued) {
+      transportQueued = true;
+      return;
+    }
+    if (transportStarted) return;
+    transportStarted = true;
+    const accepted = queue.items.filter((item) => snapshot.some((sent) => sent.id === item.id));
+    const remaining = queue.items.filter((item) => !snapshot.some((sent) => sent.id === item.id));
+    if (remaining.length === 0) focusBeforeQueueBarHides();
+    queue.items = remaining;
+    queue.mode = 'send';
+    queue.sending = false;
+    persistQueues();
+    refreshQueueUI(id, accepted);
+    void app.hydrateDiffComments?.(id, { force: true });
+  };
+  try {
+    await app.sendMessage?.({
+      prompt: buildBatchPrompt(snapshot),
+      displayPrompt: snapshot.length === 1 ? snapshot[0].instruction : `${snapshot.length} inline comments`,
+      contentParts: snapshot.map((item) => ({ type: 'diff_comment', diff_comment: commentPayload(item) })),
+      diffComment: snapshot.length === 1 ? snapshot[0] : null,
+      diffComments: snapshot,
+      attachments: [],
+      preserveComposer: true,
+      reuseMessageId: batchId,
+      _onTransportStarted: clearAcceptedQueue,
+      _onTransportFailed() { restoreBatch(); },
+      _onTransportCanceled() { restoreBatch('warning'); }
+    });
+  } catch {
+    restoreBatch();
+  }
+  if (transportQueued && !transportStarted && !transportFailed) return true;
+  if (!transportStarted || transportFailed) {
+    restoreBatch();
+    return false;
+  }
+  return true;
+};
+
+const discardQueuedDiffComments = (sessionId = state.activeSessionId, force = false) => {
+  const id = resolvedSessionID(sessionId);
+  if (!id) return false;
+  const queue = queueState(id);
+  if (queue.sending || queue.items.length === 0) return false;
+  const now = Date.now();
+  if (!force && queue.discardArmedUntil < now) {
+    queue.discardArmedUntil = now + 4000;
+    renderDiffCommentQueueBar(id);
+    if (queue.discardTimer) clearTimeout(queue.discardTimer);
+    queue.discardTimer = setTimeout(() => {
+      queue.discardTimer = null;
+      queue.discardArmedUntil = 0;
+      if (id === state.activeSessionId) renderDiffCommentQueueBar(id);
+    }, 4000);
+    return false;
+  }
+  focusBeforeQueueBarHides();
+  const removed = queue.items.splice(0);
+  queue.mode = 'send';
+  queue.discardArmedUntil = 0;
+  if (queue.discardTimer) clearTimeout(queue.discardTimer);
+  queue.discardTimer = null;
+  persistQueues();
+  refreshQueueUI(id, removed);
+  return true;
+};
+
+const queuedSummaryTitle = (items) => items.map((item) => {
+  const words = item.instruction.trim().split(/\s+/).slice(0, 8).join(' ');
+  return `${item.path}:${item.line} — ${words}`;
+}).join('\n');
+
+const renderToggleQueueAccent = (items) => {
+  const button = elements.diffToggleBtn;
+  if (!button) return;
+  const count = items.length;
+  button.classList?.toggle?.('has-queued', count > 0);
+  const suffixPattern = / · \d+ queued comments? not sent$/;
+  const baseTitle = String(button.title || '').replace(suffixPattern, '');
+  const baseAria = String(button.getAttribute?.('aria-label') || 'Toggle file changes').replace(suffixPattern, '');
+  const suffix = count > 0 ? ` · ${count} queued comment${count === 1 ? '' : 's'} not sent` : '';
+  button.title = `${baseTitle}${suffix}`;
+  button.setAttribute?.('aria-label', `${baseAria}${suffix}`);
+};
+
+const renderDiffCommentQueueBar = (sessionId = state.activeSessionId) => {
+  const id = String(sessionId || '');
+  const queue = queueBySession.get(id) || { items: [], sending: false, discardArmedUntil: 0 };
+  const items = queue.items;
+  renderToggleQueueAccent(items);
+  const status = elements.diffQueueStatus;
+  if (status) {
+    status.textContent = queue.sending
+      ? `Sending ${items.length} queued inline comment${items.length === 1 ? '' : 's'}…`
+      : (items.length > 0
+          ? `${items.length} inline comment${items.length === 1 ? '' : 's'} queued, not sent.`
+          : 'No inline comments queued.');
+  }
+  const bar = elements.diffQueueBar;
+  if (!bar) return;
+  bar.hidden = items.length === 0;
+  if (bar.hidden) { bar.setAttribute?.('hidden', ''); return; }
+  bar.removeAttribute?.('hidden');
+  const count = bar.querySelector?.('.diff-queue-count');
+  const send = bar.querySelector?.('.diff-queue-send');
+  const discard = bar.querySelector?.('.diff-queue-discard');
+  if (count) {
+    count.textContent = `${items.length} queued`;
+    count.title = queuedSummaryTitle(items);
+  }
+  if (send) {
+    send.disabled = queue.sending;
+    send.textContent = queue.sending ? 'Sending…' : `Send ${items.length} comment${items.length === 1 ? '' : 's'}`;
+  }
+  if (discard) {
+    discard.disabled = queue.sending;
+    discard.textContent = queue.discardArmedUntil >= Date.now() ? `Discard ${items.length}?` : 'Discard';
+  }
+};
+
+loadQueues();
+elements.diffQueueBar?.querySelector?.('.diff-queue-send')?.addEventListener?.('click', () => { void sendQueuedDiffComments(); });
+elements.diffQueueBar?.querySelector?.('.diff-queue-discard')?.addEventListener?.('click', () => { discardQueuedDiffComments(); });
+
+Object.assign(app, {
+  MAX_QUEUED_DIFF_COMMENTS,
+  MAX_QUEUED_DIFF_COMMENT_BYTES,
+  diffCommentSendMode,
+  diffCommentQueueSending,
+  setDiffCommentSendMode,
+  queuedDiffComments,
+  queueDiffComment,
+  removeQueuedDiffComment,
+  pruneDiffCommentQueues,
+  sendQueuedDiffComments,
+  discardQueuedDiffComments,
+  renderDiffCommentQueueBar,
+  buildDiffCommentBatchPrompt: buildBatchPrompt
+});
+})();

--- a/internal/serveui/static/app-diffs.js
+++ b/internal/serveui/static/app-diffs.js
@@ -38,6 +38,14 @@ const DIFF_FEEDBACK_MS = 700;
 // Per-session diff state lives here, NOT on session objects: sessions persist
 // to localStorage and this data is server-backed and rebuildable.
 const diffStateBySession = new Map();
+let diffMaximized = false;
+let diffMaximizeReturnFocus = null;
+
+Object.assign(elements, {
+  appMain: document.getElementById?.('appMain'),
+  diffMaximizeBtn: document.getElementById?.('diffMaximizeBtn'),
+  diffQueueBar: document.getElementById?.('diffQueueBar')
+});
 
 const sessionDiffState = (sessionId) => {
   let ds = diffStateBySession.get(sessionId);
@@ -91,7 +99,7 @@ const applySessionDiffSummary = (sessionId, value) => {
   if (summary.fileCount === 0) {
     ds.files.clear();
     ds.listLoaded = true;
-    reconcileDiffPathState(ds);
+    reconcileDiffPathState(owner, ds);
   } else if (ds.files.size === 0) {
     ds.listLoaded = false;
   }
@@ -113,6 +121,71 @@ const isDiffDrawerViewport = () => {
 };
 
 const currentDiffState = () => (state.activeSessionId ? diffStateBySession.get(state.activeSessionId) || null : null);
+
+// Opening or submitting a line comment is an explicit expand. Live-follow may
+// keep following newer files, but it must not collapse this anchor's file.
+const pinDiffFileExpanded = (sessionId, path) => {
+  const ds = sessionDiffState(sessionId);
+  if (!ds.files.has(path)) return false;
+  ds.expanded.add(path);
+  ds.userCollapsed.delete(path);
+  ds.userExpanded.add(path);
+  if (ds.dirtyPaths.has(path) || !ds.diffCache.has(path)) void fetchFileDiff(sessionId, path);
+  return true;
+};
+
+const setDiffBackgroundInert = (inert) => {
+  for (const element of [elements.sidebar, elements.appMain]) {
+    if (!element) continue;
+    element.inert = Boolean(inert);
+    if (inert) element.setAttribute?.('inert', '');
+    else element.removeAttribute?.('inert');
+  }
+};
+
+const captureDiffSpatialAnchor = () => {
+  const list = elements.diffFileList;
+  const scrollTop = Number(list?.scrollTop) || 0;
+  const panel = list?.querySelector?.('.diff-comment-panel');
+  if (panel) {
+    const path = panel.closest?.('.diff-file')?.querySelector?.('.diff-file-row')?.dataset?.path || '';
+    return { element: panel, path, scrollTop };
+  }
+  const listTop = Number(list?.getBoundingClientRect?.().top) || 0;
+  const rows = Array.from(list?.querySelectorAll?.('.diff-file-row') || []);
+  const row = rows.find((entry) => Number(entry.getBoundingClientRect?.().bottom) >= listTop) || rows[0];
+  return { path: row?.dataset?.path || '', scrollTop };
+};
+
+const setDiffMaximized = (on) => {
+  const next = Boolean(on) && !isDiffDrawerViewport();
+  if (next === diffMaximized) return false;
+  const spatial = captureDiffSpatialAnchor();
+  const active = document.activeElement;
+  if (next && (elements.sidebar?.contains?.(active) || elements.appMain?.contains?.(active))) {
+    diffMaximizeReturnFocus = active;
+  }
+  diffMaximized = next;
+  elements.appShell?.classList.toggle('diff-maximized', next);
+  elements.diffSidebar?.classList.toggle('maximized', next);
+  setDiffBackgroundInert(next);
+  const button = elements.diffMaximizeBtn;
+  if (button) {
+    button.setAttribute?.('aria-label', next ? 'Restore changes' : 'Maximize changes');
+    button.setAttribute?.('title', next ? 'Restore' : 'Maximize');
+    button.dataset.action = next ? 'restore' : 'maximize';
+  }
+  if (elements.diffFileList) elements.diffFileList.scrollTop = spatial.scrollTop;
+  if (spatial.element && spatial.element.isConnected !== false) spatial.element.scrollIntoView?.({ block: 'nearest' });
+  else if (spatial.path) scrollFileIntoView(spatial.path);
+  if (next && diffMaximizeReturnFocus) button?.focus?.();
+  if (!next) {
+    const returnFocus = diffMaximizeReturnFocus;
+    diffMaximizeReturnFocus = null;
+    if (returnFocus?.isConnected !== false) returnFocus?.focus?.();
+  }
+  return true;
+};
 
 // ===== Pure model building (node-tested) =====
 
@@ -321,7 +394,7 @@ const scheduleDiffRefresh = (sessionId) => {
 // server list replaced ds.files: live rows can carry non-canonical paths
 // (e.g. relative) that the replace renames, and without pruning their
 // expansion/cache/limit state both leaks and detaches live-follow.
-const reconcileDiffPathState = (ds) => {
+const reconcileDiffPathState = (sessionId, ds) => {
   const prune = (collection) => {
     collection.forEach((_, key) => {
       // Sets iterate as (value, value); Maps as (value, key) — key works for both.
@@ -354,6 +427,7 @@ const reconcileDiffPathState = (ds) => {
       }
     }
   }
+  app.reconcileDiffCommentPanel?.(sessionId, new Set(ds.files.keys()));
 };
 
 const fetchSessionFileChanges = async (sessionId) => {
@@ -401,7 +475,7 @@ const fetchSessionFileChanges = async (sessionId) => {
       ds.summary.adds += entry.adds;
       ds.summary.dels += entry.dels;
     });
-    reconcileDiffPathState(ds);
+    reconcileDiffPathState(sessionId, ds);
     // Cached diffs predating the authoritative seq are stale even though no
     // live event bumped them (the tab may have missed events while detached).
     ds.files.forEach((entry, path) => {
@@ -700,7 +774,16 @@ const renderImageDiff = (sessionId, path, data) => {
   return comparison;
 };
 
-const renderDiffFileBody = (sessionId, ds, path) => {
+const captureDiffCommentFocus = (body) => {
+  const focused = document.activeElement;
+  if (!focused || !body?.contains?.(focused)) return null;
+  const panel = focused.closest?.('.diff-comment-panel');
+  const key = panel?._diffCommentKey || focused._diffCommentKey;
+  if (!key) return null;
+  return panel ? { key, kind: 'editor' } : { key, kind: 'marker', target: focused.classList?.contains?.('diff-comment-affordance') ? 'button' : 'row' };
+};
+
+const renderDiffFileBody = (sessionId, ds, path, commentFocus = null) => {
   const body = createEl('div', 'diff-file-body');
   const cached = ds.diffCache.get(path);
   if (!cached) {
@@ -746,6 +829,8 @@ const renderDiffFileBody = (sessionId, ds, path) => {
   if (lang) requestDiffHighlight();
 
   const table = createEl('div', `diff-rows diff-rows-kind-${normalizeDiffKind(ds.files.get(path)?.kind)}`);
+  const postAttachCommentFocus = [];
+  const firstCommentableRowIndex = visibleRows.findIndex((row) => row.type !== 'hunk');
   visibleRows.forEach((row, rowIndex) => {
     const rowEl = createEl('div', `diff-row ${row.type}`);
     if (row.type === 'hunk') {
@@ -761,15 +846,19 @@ const renderDiffFileBody = (sessionId, ds, path) => {
         rows,
         rowIndex,
         rowElement: rowEl,
-        fileChangeSeq: Number(ds.files.get(path)?.lastSeq) || Number(cached.seq) || 0
+        fileChangeSeq: Number(ds.files.get(path)?.lastSeq) || Number(cached.seq) || 0,
+        initialTabStop: rowIndex === firstCommentableRowIndex
       });
       table.appendChild(rowEl);
-      restoreCommentPanel?.();
+      const restoreFocus = restoreCommentPanel?.({ deferFocus: true, commentFocus });
+      if (restoreFocus) postAttachCommentFocus.push(restoreFocus);
       return;
     }
     table.appendChild(rowEl);
   });
+  if (!table.querySelector?.('.diff-comment-panel')) app.clearDiffCommentPanel?.(sessionId, path);
   body.appendChild(table);
+  if (postAttachCommentFocus.length > 0) body._restoreDiffCommentFocus = () => postAttachCommentFocus.forEach((restoreFocus) => restoreFocus());
 
   if (hiddenCount > 0) {
     // Reveal in chunks: rendering thousands of rows in one synchronous pass
@@ -922,9 +1011,11 @@ const syncDiffFileBlock = (sessionId, ds, path) => {
     app.diffCommentRevision?.(sessionId, path) || 0
   ].join('|');
   if (!block.body || block.bodyKey !== bodyKey) {
-    block.body = renderDiffFileBody(sessionId, ds, path);
+    const commentFocus = captureDiffCommentFocus(block.body);
+    block.body = renderDiffFileBody(sessionId, ds, path, commentFocus);
     block.bodyKey = bodyKey;
     block.el.replaceChildren(block.header, block.body);
+    block.body._restoreDiffCommentFocus?.();
   }
   return block;
 };
@@ -953,17 +1044,18 @@ const renderDiffAccordion = (sessionId, ds) => {
   });
 
   const paths = sortDiffPaths(Array.from(ds.files.values())).filter((path) => diffFilterMatches(ds, path));
+  app.reconcileDiffCommentPanel?.(sessionId, new Set(paths));
   const desired = paths.map((path) => syncDiffFileBlock(sessionId, ds, path).el);
 
-  if (desired.length === 0 && ds.filter) {
-    list.replaceChildren(createEl('div', 'diff-note', 'No files match the filter.'));
-  } else {
-    // Only touch the list when membership or order actually changed; count
-    // updates and body swaps patch reused nodes above without any list-level
-    // DOM churn (preserving scroll position, text selection, and focus).
-    const current = list.children || [];
-    const unchanged = current.length === desired.length && desired.every((el, i) => current[i] === el);
-    if (!unchanged) list.replaceChildren(...desired);
+  const desiredChildren = desired.length === 0 && ds.filter
+    ? [createEl('div', 'diff-note', 'No files match the filter.')] : desired;
+  // Avoid list churn unless membership/order changed, preserving exact surviving focus across necessary replacements.
+  const current = list.children || [];
+  const unchanged = current.length === desiredChildren.length && desiredChildren.every((el, i) => current[i] === el);
+  if (!unchanged) {
+    const focused = list.contains?.(document.activeElement) ? document.activeElement : null;
+    list.replaceChildren(...desiredChildren);
+    if (focused && document.activeElement !== focused && focused.isConnected && list.contains?.(focused)) focused.focus?.();
   }
   list.scrollTop = keepScroll;
   updateDiffFilterVisibility(ds);
@@ -998,8 +1090,6 @@ const updateDiffBulkToggle = (ds) => {
   button.dataset.action = action;
   button.setAttribute('aria-label', `${label} files`);
   button.setAttribute('title', label);
-  const actionElement = button.querySelector?.('.diff-bulk-toggle-action');
-  if (actionElement) actionElement.textContent = collapse ? 'Collapse' : 'Expand';
 };
 
 const renderDiffSidebarContent = (sessionId, ds) => {
@@ -1007,9 +1097,10 @@ const renderDiffSidebarContent = (sessionId, ds) => {
   updateDiffBulkToggle(ds);
   renderDiffAccordion(sessionId, ds);
   if (ds.pendingScrollPath) {
-    scrollFileIntoView(ds.pendingScrollPath);
+    if (!app.diffCommentPanelOpen?.(sessionId)) scrollFileIntoView(ds.pendingScrollPath);
     ds.pendingScrollPath = '';
   }
+  app.renderDiffCommentQueueBar?.(sessionId);
 };
 
 const renderDiffSidebar = (sessionId) => {
@@ -1020,13 +1111,14 @@ const renderDiffSidebar = (sessionId) => {
   applyDiffSidebarVisibility(ds);
   updateDiffBulkToggle(ds);
   renderDiffTotals(ds);
+  app.renderDiffCommentQueueBar?.(sessionId);
   if (ds.files.size === 0) return;
   // Skip the accordion (and its lazy diff fetches) while hidden; it renders
   // on reveal.
   if (elements.diffSidebar?.hidden) return;
   renderDiffAccordion(sessionId, ds);
   if (ds.pendingScrollPath) {
-    scrollFileIntoView(ds.pendingScrollPath);
+    if (!app.diffCommentPanelOpen?.(sessionId)) scrollFileIntoView(ds.pendingScrollPath);
     ds.pendingScrollPath = '';
   }
 };
@@ -1037,6 +1129,7 @@ const toggleDiffFile = (sessionId, path) => {
   const ds = sessionDiffState(sessionId);
   if (ds.expanded.has(path)) {
     ds.expanded.delete(path);
+    app.clearDiffCommentPanel?.(sessionId, path);
     // Remember the explicit collapse so live changes stop re-opening it.
     ds.userCollapsed.add(path);
     ds.userExpanded.delete(path);
@@ -1070,6 +1163,7 @@ const collapseAllDiffFiles = () => {
   if (!sessionId) return;
   const ds = sessionDiffState(sessionId);
   ds.expanded.clear();
+  app.clearDiffCommentPanel?.(sessionId);
   ds.userExpanded.clear();
   ds.autoExpandedPath = '';
   // Live changes must not immediately re-open what the user just closed.
@@ -1098,6 +1192,7 @@ const setDiffFilter = (value) => {
 const setDiffSidebarHidden = (hidden) => {
   const sessionId = state.activeSessionId;
   if (!sessionId) return;
+  if (hidden) setDiffMaximized(false);
   const ds = sessionDiffState(sessionId);
   ds.hidden = Boolean(hidden);
   if (!ds.hidden && !ds.listLoaded && (ds.summaryKnown || ds.files.size === 0)) void fetchSessionFileChanges(sessionId);
@@ -1137,6 +1232,7 @@ const toggleDiffSidebar = () => {
 };
 
 const closeDiffDrawer = () => {
+  setDiffMaximized(false);
   setPanelOpen({
     panel: elements.diffSidebar,
     open: false,
@@ -1170,6 +1266,7 @@ const closeDiffSidebar = () => {
 // ===== Session lifecycle =====
 
 const activateDiffSidebar = (sessionId) => {
+  setDiffMaximized(false);
   if (!sessionId) {
     elements.appShell?.classList.remove('diff-open');
     if (elements.diffSidebar) {
@@ -1254,13 +1351,14 @@ const initDiffResize = () => {
   let draggedWidth = 0;
 
   handle.addEventListener('pointerdown', (event) => {
+    if (diffMaximized) return;
     event.preventDefault?.();
     handle.setPointerCapture?.(event.pointerId);
     elements.appShell?.classList.add('diff-resizing');
   });
 
   handle.addEventListener('pointermove', (event) => {
-    if (!elements.appShell?.classList.contains('diff-resizing')) return;
+    if (diffMaximized || !elements.appShell?.classList.contains('diff-resizing')) return;
     // The panel is anchored to the right edge in both grid and drawer modes.
     draggedWidth = clampDiffWidth(window.innerWidth - event.clientX, window.innerWidth);
     applyDiffSidebarWidth(draggedWidth);
@@ -1314,6 +1412,11 @@ const isEditableTarget = (target) => {
 
 const handleDiffGlobalKeydown = (event) => {
   if (event.key !== 'Escape') return;
+  if (diffMaximized) {
+    event.preventDefault?.();
+    setDiffMaximized(false);
+    return;
+  }
   const input = elements.diffFilterInput;
   if (input && event.target === input) {
     // First escape clears the filter, keeping the panel open.
@@ -1363,6 +1466,7 @@ if (state.activeSessionId && !state.draftSessionActive) {
 // ===== Wiring =====
 
 const handleDiffViewportChange = () => {
+  if (isDiffDrawerViewport()) setDiffMaximized(false);
   const ds = currentDiffState();
   if (!ds) {
     elements.appShell?.classList.remove('diff-open');
@@ -1405,6 +1509,7 @@ elements.diffSidebarCloseBtn?.addEventListener?.('click', () => {
   else setDiffSidebarHidden(true);
 });
 elements.diffBulkToggleBtn?.addEventListener?.('click', toggleAllDiffFiles);
+elements.diffMaximizeBtn?.addEventListener?.('click', () => setDiffMaximized(!diffMaximized));
 elements.diffFilterInput?.addEventListener?.('input', (event) => {
   setDiffFilter(event.target?.value ?? elements.diffFilterInput.value ?? '');
 });
@@ -1424,6 +1529,9 @@ Object.assign(app, {
   closeDiffSidebar,
   toggleDiffSidebar,
   toggleDiffFile,
+  pinDiffFileExpanded,
+  scrollDiffFileIntoView: scrollFileIntoView,
+  setDiffMaximized,
   fetchSessionFileChanges,
   renderDiffSidebar
 });

--- a/internal/serveui/static/app-interject.js
+++ b/internal/serveui/static/app-interject.js
@@ -27,6 +27,7 @@ const queueInterruptFollowUp = (sessionId, prompt, messageId, attachments = [], 
     attachments: Array.isArray(attachments) ? attachments : [],
     contentParts: Array.isArray(sendOptions.contentParts) ? sendOptions.contentParts : [],
     diffComment: sendOptions.diffComment || null,
+    diffComments: Array.isArray(sendOptions.diffComments) ? sendOptions.diffComments : [],
     displayPrompt: String(sendOptions.displayPrompt || '')
   });
 };
@@ -40,6 +41,7 @@ const trackPendingInterruptCommit = (sessionId, prompt, messageId, attachments =
     attachments: Array.isArray(attachments) ? attachments : [],
     contentParts: Array.isArray(sendOptions.contentParts) ? sendOptions.contentParts : [],
     diffComment: sendOptions.diffComment || null,
+    diffComments: Array.isArray(sendOptions.diffComments) ? sendOptions.diffComments : [],
     displayPrompt: String(sendOptions.displayPrompt || '')
   });
 };
@@ -102,6 +104,7 @@ const requeueUncommittedInterrupts = (session) => {
     queueInterruptFollowUp(session.id, entry.prompt, entry.messageId, entry.attachments, {
       contentParts: entry.contentParts,
       diffComment: entry.diffComment,
+      diffComments: entry.diffComments,
       displayPrompt: entry.displayPrompt
     });
   }
@@ -186,6 +189,7 @@ const materializeCommittedInterjection = (session, messageId, committedMessage =
   const attachments = mergeCommittedInterjectionAttachments(localAttachments, committedAttachments);
   if (attachments.length > 0) message.attachments = attachments;
   if (pending?.diffComment) message.diffComment = pending.diffComment;
+  if (pending?.diffComments?.length) message.diffComments = pending.diffComments;
   return app.trackPendingIntent?.(session, message) || message;
 };
 
@@ -270,6 +274,7 @@ const trackPendingInterjection = (sessionId, prompt, messageId, action, attachme
   const extra = {
     contentParts: Array.isArray(sendOptions.contentParts) ? sendOptions.contentParts : [],
     diffComment: sendOptions.diffComment || null,
+    diffComments: Array.isArray(sendOptions.diffComments) ? sendOptions.diffComments : [],
     displayPrompt: String(sendOptions.displayPrompt || '')
   };
   if (existing) {
@@ -351,6 +356,7 @@ const requeuePendingInterjections = (session) => {
     queueInterruptFollowUp(session.id, entry.prompt, entry.messageId, entry.attachments, {
       contentParts: entry.contentParts,
       diffComment: entry.diffComment,
+      diffComments: entry.diffComments,
       displayPrompt: entry.displayPrompt
     });
   }
@@ -406,6 +412,7 @@ const interruptActiveRunNow = async (session, prompt, messageId, contentParts = 
     queueInterruptFollowUp(session.id, prompt, messageId, attachments, {
       contentParts: pendingEntry?.contentParts,
       diffComment: pendingEntry?.diffComment,
+      diffComments: pendingEntry?.diffComments,
       displayPrompt: pendingEntry?.displayPrompt
     });
   }

--- a/internal/serveui/static/app-message-convert.js
+++ b/internal/serveui/static/app-message-convert.js
@@ -424,10 +424,10 @@ const convertServerMessages = (serverMessages, options = {}) => {
 
       const attachments = [];
       const textParts = [];
-      let diffComment = null;
+      const diffComments = [];
       for (const part of parts) {
         if (part.type === 'diff_comment' && part.diff_comment) {
-          diffComment = part.diff_comment;
+          diffComments.push(part.diff_comment);
         } else if (part.type === 'image' && part.image_url) {
           const width = Number(part.width), height = Number(part.height), validDimensions = Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0;
           attachments.push({ name: 'image', type: part.mime_type || 'image/*', dataURL: rebaseMessageAssetURL(part.image_url), ...(validDimensions ? { width: Math.round(width), height: Math.round(height) } : {}) });
@@ -464,7 +464,7 @@ const convertServerMessages = (serverMessages, options = {}) => {
         created,
         ...(seq !== null ? { serverSeq: seq } : {}),
         ...(attachments.length > 0 ? { attachments } : {}),
-        ...(diffComment ? { diffComment } : {})
+        ...(diffComments.length > 0 ? { diffComments } : {})
       }, msg));
       continue;
     }

--- a/internal/serveui/static/app-render.js
+++ b/internal/serveui/static/app-render.js
@@ -1699,7 +1699,7 @@ const applyAttachmentImageDimensions = (img, attachment) => {
 };
 
 const createMessageNode = (message) => {
-  if (message.diffComment && typeof app.createDiffCommentMessageNode === 'function') return app.createDiffCommentMessageNode(message, createMetaNode);
+  if ((message.diffComments?.length || message.diffComment) && typeof app.createDiffCommentMessageNode === 'function') return app.createDiffCommentMessageNode(message, createMetaNode);
   if (message.role === 'transcript-gap') return createTranscriptGapNode(message);
   if (message.role === 'skill-run') return createSkillRunNode(message);
   if (message.role === 'tool') return createToolCard(message);

--- a/internal/serveui/static/app-send.js
+++ b/internal/serveui/static/app-send.js
@@ -296,9 +296,12 @@ const sendMessage = async (options = {}) => {
       attachments: pendingAttachments.map((attachment) => cloneAttachmentForMessage(attachment)),
       contentParts: customContentParts,
       diffComment: options.diffComment || null,
+      diffComments: Array.isArray(options.diffComments) ? options.diffComments : [],
       displayPrompt,
       preserveComposer,
-      onTransportFailed: options._onTransportFailed
+      onTransportStarted: options._onTransportStarted,
+      onTransportFailed: options._onTransportFailed,
+      onTransportCanceled: options._onTransportCanceled
     };
     if (!preserveComposer) {
       elements.promptInput.value = '';
@@ -369,11 +372,13 @@ const sendMessage = async (options = {}) => {
     app.trackPendingInterruptCommit(session.id, prompt, pendingMessageId, pendingAttachments, {
       contentParts: customContentParts,
       diffComment: options.diffComment,
+      diffComments: options.diffComments,
       displayPrompt
     });
     app.trackPendingInterjection(session.id, displayPrompt || pendingAttachments[0]?.name || 'Attachment', pendingMessageId, 'interject', pendingAttachments, {
       contentParts: customContentParts,
       diffComment: options.diffComment,
+      diffComments: options.diffComments,
       displayPrompt
     });
     persistAndRefreshShell();
@@ -391,6 +396,7 @@ const sendMessage = async (options = {}) => {
           const recovered = await recoverInterruptFailure(session, prompt, pendingMessageId, pendingAttachments, {
             contentParts: customContentParts,
             diffComment: options.diffComment,
+            diffComments: options.diffComments,
             displayPrompt,
             preserveComposer,
             _onTransportFailed: options._onTransportFailed
@@ -485,8 +491,9 @@ const sendMessage = async (options = {}) => {
     requestParts: batchAttachmentParts.get(entry.messageId) || [],
     contentParts: Array.isArray(entry.contentParts) ? entry.contentParts : [],
     diffComment: entry.diffComment || null,
+    diffComments: Array.isArray(entry.diffComments) ? entry.diffComments : [],
     displayPrompt: String(entry.displayPrompt || '').trim(),
-  })) : [{ prompt, attachments: pendingAttachments, messageId: reuseMessageId, requestParts: requestAttachmentParts, contentParts: customContentParts, diffComment: options.diffComment || null, displayPrompt }];
+  })) : [{ prompt, attachments: pendingAttachments, messageId: reuseMessageId, requestParts: requestAttachmentParts, contentParts: customContentParts, diffComment: options.diffComment || null, diffComments: Array.isArray(options.diffComments) ? options.diffComments : [], displayPrompt }];
   for (const spec of messageSpecs) {
     if (!spec.messageId) continue;
     app.removePendingInterjectionById?.(spec.messageId, batchingFollowUps ? { refresh: false } : undefined);
@@ -506,6 +513,7 @@ const sendMessage = async (options = {}) => {
       delete message.interruptState;
     }
     if (spec.diffComment) message.diffComment = spec.diffComment;
+    if (spec.diffComments.length > 0) message.diffComments = spec.diffComments;
     message.clientMessageId = String(message.clientMessageId || message.id || '').trim();
     if (spec.attachments.length > 0) message.attachments = spec.attachments.map(cloneAttachmentForMessage);
     else delete message.attachments;
@@ -525,6 +533,7 @@ const sendMessage = async (options = {}) => {
       app.trackPendingInterjection?.(session.id, spec.displayPrompt || spec.prompt, spec.messageId, 'queue', spec.attachments, {
         contentParts: spec.contentParts,
         diffComment: spec.diffComment,
+        diffComments: spec.diffComments,
         displayPrompt: spec.displayPrompt
       });
       app.retirePendingIntent?.(session, spec.messageId);
@@ -945,11 +954,14 @@ const releaseBranchContextQueuedSend = (sessionId) => {
     attachments: queued.attachments,
     contentParts: queued.contentParts,
     diffComment: queued.diffComment,
+    diffComments: queued.diffComments,
     displayPrompt: queued.displayPrompt,
     preserveComposer: queued.preserveComposer,
     _onTransportFailed: queued.onTransportFailed,
+    _onTransportCanceled: queued.onTransportCanceled,
     _releaseBranchContextSend: true,
-    _onTransportStarted() {
+    _onTransportStarted(detail) {
+      queued.onTransportStarted?.(detail);
       elements.promptInput.value = newerDraft;
       state.attachments = newerAttachments;
       renderAttachments();
@@ -963,6 +975,7 @@ const restoreBranchContextQueuedSend = (sessionId) => {
   const queued = state.branchContextQueuedSend;
   if (!queued || queued.sessionId !== sessionId) return false;
   state.branchContextQueuedSend = null;
+  queued.onTransportCanceled?.({ queued: true, canceled: true });
   if (state.activeSessionId !== sessionId) return false;
   if (queued.preserveComposer) return true;
   const current = String(elements.promptInput.value || '').trim();

--- a/internal/serveui/static/app-stream.js
+++ b/internal/serveui/static/app-stream.js
@@ -1346,7 +1346,9 @@ const setStreaming = (streaming) => {
     flushStreamPersistence();
     const shouldRestoreFocus = state.restorePromptFocus;
     state.restorePromptFocus = false;
-    if (shouldRestoreFocus) {
+    // A completed run must not pull focus out of a control the user moved into.
+    const active = document.activeElement;
+    if (shouldRestoreFocus && (!active || active === document.body || active === elements.promptInput)) {
       elements.promptInput.focus();
     }
   }

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -333,47 +333,21 @@
       white-space: nowrap;
     }
 
-    .diff-bulk-toggle {
-      min-height: 34px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.35rem;
-      padding: 0 0.65rem;
-      border: 1px solid color-mix(in srgb, var(--link) 32%, var(--border));
-      border-radius: 999px;
-      background: color-mix(in srgb, var(--link) 8%, var(--surface-2));
-      color: var(--text);
-      font: inherit;
-      font-size: 0.78rem;
-      font-weight: 650;
-      line-height: 1;
-      white-space: nowrap;
-      cursor: pointer;
-      flex-shrink: 0;
-      transition: background 0.15s ease, border-color 0.15s ease;
-    }
-
-    .diff-bulk-toggle:hover {
-      border-color: color-mix(in srgb, var(--link) 48%, var(--border-strong));
-      background: color-mix(in srgb, var(--link) 13%, var(--surface-2));
-    }
-
-    .diff-bulk-toggle:focus-visible {
-      outline: 2px solid var(--accent);
-      outline-offset: 2px;
-    }
-
-    .diff-bulk-toggle svg {
+    .diff-bulk-toggle,
+    .diff-sidebar-maximize {
       flex: none;
+      border-radius: 50%;
     }
 
     .diff-bulk-collapse-icon,
-    .diff-bulk-toggle[data-action="collapse"] .diff-bulk-expand-icon {
+    .diff-bulk-toggle[data-action="collapse"] .diff-bulk-expand-icon,
+    .diff-restore-icon,
+    .diff-sidebar-maximize[data-action="restore"] .diff-maximize-icon {
       display: none;
     }
 
-    .diff-bulk-toggle[data-action="collapse"] .diff-bulk-collapse-icon {
+    .diff-bulk-toggle[data-action="collapse"] .diff-bulk-collapse-icon,
+    .diff-sidebar-maximize[data-action="restore"] .diff-restore-icon {
       display: inline;
     }
 
@@ -381,18 +355,25 @@
       border-radius: 50%;
     }
 
-    @media (max-width: 360px) {
-      .diff-sidebar-header {
-        gap: 0.35rem;
-      }
+    .diff-sidebar.maximized {
+      position: fixed;
+      top: var(--app-offset-top);
+      left: 0;
+      right: 0;
+      bottom: auto;
+      width: 100%;
+      height: var(--app-height);
+      z-index: 55;
+      border-left: 0;
+      box-shadow: none;
+      opacity: 1;
+      pointer-events: auto;
+      transform: none;
+      padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
+    }
 
-      .diff-bulk-toggle {
-        padding-inline: 0.5rem;
-      }
-
-      .diff-bulk-toggle-all {
-        display: none;
-      }
+    .app.diff-maximized .diff-resize-handle {
+      display: none;
     }
 
     .diff-file-list {
@@ -400,6 +381,36 @@
       min-height: 0;
       overflow-y: auto;
     }
+
+    .diff-queue-status {
+      flex: none;
+      min-height: 1.15rem;
+      padding: 0.25rem 0.75rem;
+      border-top: 1px solid var(--border);
+      color: var(--text-muted);
+      font-size: 0.72rem;
+    }
+
+    .diff-queue-bar {
+      flex: none;
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+      padding: 0.6rem 0.75rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      box-shadow: 0 -6px 16px color-mix(in srgb, black 8%, transparent);
+    }
+
+    .diff-queue-bar[hidden] { display: none; }
+    .diff-queue-count { flex: 1; color: var(--text-muted); font-size: 0.78rem; font-weight: 650; }
+    .diff-queue-send,
+    .diff-queue-discard { min-height: 34px; border-radius: 6px; cursor: pointer; font: inherit; font-size: 0.75rem; }
+    .diff-queue-send { padding: 0.35rem 0.65rem; border: 1px solid var(--accent); background: var(--accent); color: white; font-weight: 650; }
+    .diff-queue-discard { padding: 0.35rem 0.45rem; border: 0; background: transparent; color: var(--text-muted); }
+    .diff-queue-discard:hover { color: var(--text); }
+    .diff-queue-send:disabled,
+    .diff-queue-discard:disabled { opacity: 0.55; cursor: default; }
 
     .diff-file-row {
       position: sticky;
@@ -649,6 +660,8 @@
     }
 
     .diff-comment-affordance.has-comments { position: relative; color: var(--text-muted); }
+    .diff-comment-affordance.queued { color: var(--accent); }
+    .diff-comment-affordance.queued::before { border-style: dashed; }
     .diff-comment-affordance.has-comments::before {
       content: "";
       display: inline-block;
@@ -697,11 +710,28 @@
       font: inherit;
     }
     .diff-comment-editor-actions { display: flex; justify-content: flex-end; gap: 0.4rem; margin-top: 0.4rem; }
+    .diff-comment-send-split { position: relative; display: inline-flex; }
     .diff-comment-cancel,
     .diff-comment-send,
-    .diff-comment-follow-up { padding: 0.28rem 0.55rem; border: 1px solid var(--border); border-radius: 5px; background: var(--surface-2); color: var(--text); cursor: pointer; font-size: 0.75rem; }
-    .diff-comment-send { border-color: var(--accent); background: var(--accent); color: white; }
+    .diff-comment-send-more,
+    .diff-comment-follow-up { min-height: 34px; padding: 0.28rem 0.55rem; border: 1px solid var(--border); border-radius: 5px; background: var(--surface-2); color: var(--text); cursor: pointer; font-size: 0.75rem; }
+    .diff-comment-send { border-color: var(--accent); border-radius: 5px 0 0 5px; background: var(--accent); color: white; }
+    .diff-comment-send-more { min-width: 34px; padding-inline: 0.4rem; border-left: 1px solid color-mix(in srgb, white 35%, transparent); border-color: var(--accent); border-radius: 0 5px 5px 0; background: var(--accent); color: white; }
+    .diff-comment-send-menu { position: absolute; right: 0; bottom: calc(100% + 0.3rem); z-index: 5; min-width: 13rem; padding: 0.3rem; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-elevated, var(--surface)); box-shadow: var(--shadow-strong); }
+    .diff-comment-send-menu[hidden] { display: none; }
+    .diff-comment-send-option { display: grid; width: 100%; gap: 0.15rem; min-height: 34px; padding: 0.42rem 0.5rem; border: 0; border-radius: 5px; background: transparent; color: var(--text); text-align: left; cursor: pointer; }
+    .diff-comment-send-option:hover,
+    .diff-comment-send-option:focus-visible { background: var(--surface-2); }
+    .diff-comment-send-option small { color: var(--text-muted); font-size: 0.68rem; }
     .diff-comment-follow-up { margin-top: 0.5rem; }
+    .diff-comment-history-item.queued { border-left: 2px dashed var(--accent); padding-left: 0.45rem; }
+    .diff-comment-history-actions { display: flex; gap: 0.45rem; margin-top: 0.3rem; }
+    .diff-comment-history-edit,
+    .diff-comment-history-remove { min-height: 34px; padding: 0.2rem 0.35rem; border: 0; background: transparent; color: var(--text-muted); cursor: pointer; font: inherit; font-size: 0.7rem; text-decoration: underline; }
+    .diff-comment-history-edit:hover,
+    .diff-comment-history-remove:hover { color: var(--text); }
+    .diff-comment-history-edit:disabled,
+    .diff-comment-history-remove:disabled { color: var(--text-muted); cursor: default; opacity: 0.55; }
 
     @media (hover: none), (pointer: coarse) {
       .diff-comment-affordance { opacity: 1; min-width: 2rem; min-height: 2rem; }
@@ -709,6 +739,9 @@
     }
 
     .diff-comment-message-body { display: grid; gap: 0.38rem; }
+    .diff-comment-message-summary { font-weight: 700; }
+    .diff-comment-message-block { display: grid; gap: 0.38rem; }
+    .diff-comment-message-block + .diff-comment-message-block { margin-top: 0.45rem; padding-top: 0.55rem; border-top: 1px solid var(--border); }
     .diff-comment-message-heading { color: var(--text-muted); font-size: 0.78rem; font-weight: 600; }
     .diff-comment-message-instruction { white-space: pre-wrap; overflow-wrap: anywhere; }
     .diff-comment-message-line { display: block; padding: 0.32rem 0.45rem; border-radius: 5px; background: var(--surface-2); color: var(--text-muted); white-space: pre-wrap; overflow-wrap: anywhere; }
@@ -768,6 +801,18 @@
       margin-left: 0;
       font-variant-numeric: tabular-nums;
       white-space: nowrap;
+    }
+
+    .diff-toggle.has-queued .diff-toggle-badge::after {
+      content: "";
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 7px;
+      height: 7px;
+      border: 2px solid var(--surface);
+      border-radius: 50%;
+      background: var(--accent);
     }
 
     .diff-filter-row {
@@ -911,6 +956,10 @@
        so the diff panel becomes a right-side drawer opened via the toggle.
        No backdrop: the chat stays visible and interactive beside the drawer. */
     @media (max-width: 1099px) {
+      .diff-sidebar-maximize {
+        display: none;
+      }
+
       .app.diff-open,
       .app.sidebar-collapsed.diff-open {
         grid-template-columns: var(--sidebar-width) minmax(0, 1fr) 0px;

--- a/internal/serveui/static/app.css
+++ b/internal/serveui/static/app.css
@@ -619,6 +619,7 @@
     .diff-row.del .diff-ln { background: var(--diff-del-ln-bg); }
 
     .diff-code {
+      order: 2;
       flex: 1;
       min-width: 0;
       padding-left: 0.55em;
@@ -631,6 +632,7 @@
     }
 
     .diff-comment-affordance {
+      order: 1;
       flex: none;
       align-self: center;
       width: 1.65rem;

--- a/internal/serveui/static/app_diff_comments_test.js
+++ b/internal/serveui/static/app_diff_comments_test.js
@@ -55,7 +55,8 @@ const createDOM = () => {
         if (name === 'id') this.id = String(value);
         if (name === 'tabindex') this.tabIndex = Number(value);
       },
-      getAttribute(name) { return attrs.has(name) ? attrs.get(name) : null; },
+       getAttribute(name) { return attrs.has(name) ? attrs.get(name) : null; },
+       removeAttribute(name) { attrs.delete(name); },
       addEventListener(type, listener) {
         if (!listeners.has(type)) listeners.set(type, []);
         listeners.get(type).push(listener);
@@ -114,8 +115,30 @@ const createHarness = (initialPayloads = {}) => {
     activeSessionId: 's1', token: '', connected: true, sessions: [{ id: 's1', transcriptRev: 1 }],
     pendingInterjections: [], pendingInterruptCommits: [], queuedInterrupts: [], branchContextQueuedSend: null
   };
+  const pinCalls = [];
+  const scrollCalls = [];
+  const queued = [];
+  const modes = new Map();
+  let queueSending = false;
   const app = {
     UI_PREFIX: '/ui', state,
+    MAX_QUEUED_DIFF_COMMENTS: 20,
+    diffCommentSendMode: (id) => modes.get(id) || 'send',
+    diffCommentQueueSending: () => queueSending,
+    setDiffCommentSendMode(id, mode) { modes.set(id, mode); return mode; },
+    queuedDiffComments(id, anchor = null) {
+      const items = queued.filter((item) => item.sessionId === id).map((item) => item.comment);
+      if (!anchor) return items;
+      const key = `${anchor.path}\0${anchor.side}\0${anchor.line}`;
+      return items.filter((item) => `${item.path}\0${item.side}\0${item.line}` === key);
+    },
+    queueDiffComment(id, comment) { queued.push({ sessionId: id, comment }); return true; },
+    removeQueuedDiffComment(id, commentId) {
+      const index = queued.findIndex((item) => item.sessionId === id && item.comment.id === commentId);
+      return index >= 0 ? queued.splice(index, 1)[0].comment : null;
+    },
+    scrollDiffFileIntoView(pathName) { scrollCalls.push(pathName); },
+    pinDiffFileExpanded(sessionId, pathName) { pinCalls.push([sessionId, pathName]); },
     requestHeaders: (id) => ({ 'X-Session': id }),
     apiFetch: async (url) => {
       calls.push(url);
@@ -151,7 +174,10 @@ const createHarness = (initialPayloads = {}) => {
     encodeURIComponent, decodeURIComponent, setTimeout, clearTimeout
   };
   vm.runInNewContext(source, context, { filename: 'app-diff-comments.js' });
-  return { app, state, calls, payloads, document, window };
+  return {
+    app, state, calls, payloads, pinCalls, scrollCalls, queued, modes, document, window,
+    setQueueSending(value) { queueSending = Boolean(value); }
+  };
 };
 
 const commentEntry = (id, pathName, instruction, revision = 1) => ({ created_at: revision, client_message_id: id, diff_comment: {
@@ -236,6 +262,112 @@ const decorateRow = (harness, options = {}) => {
     assert(second.button.getAttribute('aria-expanded') === 'true', 'restored trigger lost expanded state');
   });
 
+  await run('opening and submitting pin the file and restore rebuilt marker focus', async () => {
+    const harness = createHarness();
+    harness.app.sendMessage = async (options) => { options._onTransportStarted(); };
+    const first = decorateRow(harness);
+    await first.button.click();
+    assert(harness.app.diffCommentPanelOpen('s1'), 'open panel state was not exposed');
+    assert(harness.pinCalls.some(([id, pathName]) => id === 's1' && pathName === 'a.go'), 'opening did not pin the anchor file');
+    const textarea = first.table.querySelector('textarea');
+    textarea.value = 'keep this pinned';
+    await textarea.dispatch('input');
+    await first.table.querySelector('.diff-comment-send').click();
+    const rebuilt = decorateRow(harness);
+    assert(harness.document.activeElement === rebuilt.button, 'submit did not restore focus to the rebuilt marker');
+    assert(harness.pinCalls.length >= 2, 'submit did not reaffirm the explicit expansion');
+  });
+
+  await run('split send mode switches without text and alternate selection acts immediately with text', async () => {
+    const harness = createHarness();
+    const first = decorateRow(harness);
+    await first.button.click();
+    const textarea = first.table.querySelector('textarea');
+    const more = first.table.querySelector('.diff-comment-send-more');
+    await more.click();
+    const options = first.table.querySelectorAll('.diff-comment-send-option');
+    await options[1].click();
+    assert(harness.app.diffCommentSendMode('s1') === 'queue', 'empty alternate selection did not switch default');
+    assert(harness.queued.length === 0 && harness.document.activeElement === textarea, 'empty selection acted or lost editor focus');
+    assert(first.table.querySelector('.diff-comment-send').textContent === 'Queue comment', 'visible primary did not follow mode');
+
+    textarea.value = 'queue this now';
+    await textarea.dispatch('input');
+    await more.click();
+    await options[1].click();
+    assert(harness.queued.length === 1 && harness.queued[0].comment.instruction === 'queue this now', 'non-empty alternate did not act immediately');
+    const rebuilt = decorateRow(harness);
+    assert(harness.document.activeElement === rebuilt.button, 'queue did not restore focus to rebuilt marker');
+    assert(rebuilt.button.classList.contains('queued') && rebuilt.button.getAttribute('aria-label').includes('queued, not sent'), 'queued marker is not visually/accessibly distinct');
+  });
+
+  await run('primary Queue comment shortcut follows visible mode and menu Escape closes only menu', async () => {
+    const harness = createHarness();
+    harness.app.setDiffCommentSendMode('s1', 'queue');
+    const decorated = decorateRow(harness);
+    await decorated.button.click();
+    const textarea = decorated.table.querySelector('textarea');
+    const send = decorated.table.querySelector('.diff-comment-send');
+    assert(send.textContent === 'Queue comment' && send.title === 'Queue comment (Ctrl/⌘+Enter)', 'queue primary copy/shortcut changed');
+    const more = decorated.table.querySelector('.diff-comment-send-more');
+    await more.click();
+    const menu = decorated.table.querySelector('.diff-comment-send-menu');
+    const options = decorated.table.querySelectorAll('.diff-comment-send-option');
+    assert(harness.document.activeElement === options[0], 'opening the menu did not focus its first item');
+    await menu.dispatch('keydown', { key: 'ArrowDown' });
+    assert(harness.document.activeElement === options[1], 'ArrowDown did not move menu focus');
+    await menu.dispatch('keydown', { key: 'ArrowUp' });
+    assert(harness.document.activeElement === options[0], 'ArrowUp did not wrap menu focus');
+    const escape = await menu.dispatch('keydown', { key: 'Escape' });
+    assert(menu.hidden && escape.immediateStopped && !decorated.table.querySelector('.diff-comment-panel').removed, 'menu Escape leaked to panel close');
+    textarea.value = 'keyboard queued';
+    await textarea.dispatch('keydown', { key: 'Enter', metaKey: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert(harness.queued.some((item) => item.comment.instruction === 'keyboard queued'), 'shortcut did not run visible queue primary');
+  });
+
+  await run('Send now sends only current comment when a queue already exists', async () => {
+    const harness = createHarness();
+    harness.app.queueDiffComment('s1', { ...commentEntry('queued', 'a.go', 'wait').diff_comment, created_at: 1 });
+    let sent;
+    harness.app.sendMessage = async (options) => { sent = options; options._onTransportStarted(); };
+    const decorated = decorateRow(harness);
+    await decorated.button.click();
+    await decorated.table.querySelector('.diff-comment-follow-up').click();
+    const textarea = decorated.table.querySelector('textarea');
+    textarea.value = 'jump the queue';
+    await textarea.dispatch('input');
+    await decorated.table.querySelector('.diff-comment-send').click();
+    assert(sent.contentParts.length === 1 && sent.contentParts[0].diff_comment.instruction === 'jump the queue', 'Send now auto-attached queued items');
+    assert(harness.queued.length === 1, 'Send now mutated unsent queue');
+  });
+
+  await run('queued history shows stale status and Edit pins, scrolls, removes, and prefills', async () => {
+    const harness = createHarness();
+    const queued = { ...commentEntry('queued', 'a.go', 'edit me', 1).diff_comment, created_at: 1 };
+    harness.app.queueDiffComment('s1', queued);
+    const decorated = decorateRow(harness, { fileChangeSeq: 2 });
+    await decorated.button.click();
+    assert(decorated.table.querySelector('.diff-comment-history-meta')?.textContent === 'File changed after this was queued', 'stale queued microcopy changed');
+    await decorated.table.querySelector('.diff-comment-history-edit').click();
+    assert(harness.queued.length === 0, 'Edit did not remove item from queue');
+    assert(harness.pinCalls.some(([, pathName]) => pathName === 'a.go') && harness.scrollCalls.includes('a.go'), 'Edit did not pin and restore spatial context');
+  });
+
+  await run('queued Edit and Remove remain locked throughout batch send', async () => {
+    const harness = createHarness();
+    harness.app.queueDiffComment('s1', { ...commentEntry('queued', 'a.go', 'do not mutate', 1).diff_comment, created_at: 1 });
+    harness.setQueueSending(true);
+    const decorated = decorateRow(harness);
+    await decorated.button.click();
+    const edit = decorated.table.querySelector('.diff-comment-history-edit');
+    const remove = decorated.table.querySelector('.diff-comment-history-remove');
+    assert(edit.disabled && remove.disabled, 'sending queue actions were not disabled');
+    await edit.click();
+    await remove.click();
+    assert(harness.queued.length === 1 && harness.pinCalls.length === 1 && harness.scrollCalls.length === 0, 'locked action mutated queue, draft, or spatial state');
+  });
+
   await run('early send return removes optimistic instruction and keeps retry draft', async () => {
     const harness = createHarness();
     harness.app.sendMessage = async () => undefined;
@@ -250,6 +382,34 @@ const decorateRow = (harness, options = {}) => {
     assert(!second.button.classList.contains('has-comments'), 'unsent optimistic instruction remained visible forever');
     await second.button.click();
     assert(second.table.querySelector('textarea')?.value === 'retry me', 'failed send discarded retry draft');
+  });
+
+  await run('branch-context cancellation retains a single draft and retry identity', async () => {
+    const harness = createHarness();
+    let parked;
+    harness.app.sendMessage = async (options) => {
+      parked = options;
+      options._onTransportStarted({ queued: true });
+    };
+    const first = decorateRow(harness);
+    await first.button.click();
+    const textarea = first.table.querySelector('textarea');
+    textarea.value = 'retry after branch cancellation';
+    await textarea.dispatch('input');
+    await first.table.querySelector('.diff-comment-send').click();
+    const originalID = parked.reuseMessageId;
+    parked._onTransportCanceled({ queued: true, canceled: true });
+
+    const second = decorateRow(harness);
+    await second.button.click();
+    const retry = second.table.querySelector('textarea');
+    assert(retry?.value === 'retry after branch cancellation', 'branch cancellation discarded the inline draft');
+    harness.app.sendMessage = async (options) => {
+      parked = options;
+      options._onTransportStarted();
+    };
+    await second.table.querySelector('.diff-comment-send').click();
+    assert(parked.reuseMessageId === originalID, 'retry created a duplicate failed transcript identity');
   });
 
   await run('server hydration reconciles an accepted optimistic instruction', async () => {
@@ -316,6 +476,22 @@ const decorateRow = (harness, options = {}) => {
     assert(body.children[0].textContent.includes('<img src=x>'), 'path was not kept as text');
     assert(body.children[1].textContent === '<b>do not parse</b>', 'instruction was not kept as text');
     assert(body.children[2].textContent.includes('<script>x</script>'), 'line was not kept as text');
+  });
+
+  await run('plural transcript projection renders one summary and every untrusted anchor as text', () => {
+    const { app } = createHarness();
+    const node = app.createDiffCommentMessageNode({
+      id: 'm2', role: 'user', created: 1,
+      diffComments: [
+        { id: 'c1', path: 'a.go', side: 'new', line: 4, file_change_seq: 8, line_text: '<one>', instruction: 'First' },
+        { id: 'c2', path: '<b.go>', side: 'old', line: 9, file_change_seq: 9, line_text: '<two>', instruction: '<Second>' }
+      ]
+    });
+    const body = node.children[0];
+    assert(body.children[0].textContent === '2 inline comments', 'plural summary missing');
+    assert(body.querySelectorAll('.diff-comment-message-block').length === 2, 'not every diff comment rendered');
+    assert(body.querySelectorAll('.diff-comment-message-heading')[1].textContent.includes('<b.go>'), 'plural path was not kept as text');
+    assert(body.querySelectorAll('.diff-comment-message-instruction')[1].textContent === '<Second>', 'plural instruction was not kept as text');
   });
 
   if (failures > 0) process.exit(1);

--- a/internal/serveui/static/app_diff_queue_test.js
+++ b/internal/serveui/static/app_diff_queue_test.js
@@ -1,0 +1,267 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const source = fs.readFileSync(path.join(__dirname, 'app-diff-queue.js'), 'utf8');
+const indexSource = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+let failures = 0;
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+const run = async (name, fn) => {
+  try { await fn(); console.log(`PASS ${name}`); }
+  catch (error) { failures += 1; console.error(`FAIL ${name}: ${error.stack || error}`); }
+};
+
+class ClassList {
+  constructor() { this.values = new Set(); }
+  add(...names) { names.forEach((name) => this.values.add(name)); }
+  remove(...names) { names.forEach((name) => this.values.delete(name)); }
+  contains(name) { return this.values.has(name); }
+  toggle(name, force) {
+    const on = force === undefined ? !this.values.has(name) : Boolean(force);
+    if (on) this.values.add(name); else this.values.delete(name);
+    return on;
+  }
+}
+
+const makeElement = (className = '') => {
+  const attrs = new Map();
+  const listeners = new Map();
+  return {
+    className, hidden: false, disabled: false, textContent: '', title: '', classList: new ClassList(), children: [], parentNode: null,
+    setAttribute(name, value) { attrs.set(name, String(value)); },
+    removeAttribute(name) { attrs.delete(name); },
+    getAttribute(name) { return attrs.has(name) ? attrs.get(name) : null; },
+    addEventListener(type, listener) { listeners.set(type, listener); },
+    async dispatch(type) { return listeners.get(type)?.({ type, target: this }); },
+    contains(node) { return node === this || this.children.some((child) => child.contains?.(node)); },
+    focus() { if (this.ownerDocument) this.ownerDocument.activeElement = this; }
+  };
+};
+
+const makeBar = () => {
+  const bar = makeElement('diff-queue-bar');
+  const count = makeElement('diff-queue-count');
+  const send = makeElement('diff-queue-send');
+  const discard = makeElement('diff-queue-discard');
+  const children = { '.diff-queue-count': count, '.diff-queue-send': send, '.diff-queue-discard': discard };
+  bar.children = [count, send, discard];
+  bar.children.forEach((child) => { child.parentNode = bar; });
+  bar.querySelector = (selector) => children[selector] || null;
+  return { bar, count, send, discard };
+};
+
+const makeComment = (id, instruction = `instruction ${id}`, pathName = 'a.go', line = 2, seq = 1) => ({
+  id, path: pathName, side: 'new', line, file_change_seq: seq, line_text: `line ${line}`,
+  context_before: [{ side: 'new', line: line - 1, text: 'before' }],
+  context_after: [{ side: 'new', line: line + 1, text: 'after' }], instruction, created_at: seq
+});
+
+const createHarness = (options = {}) => {
+  const storage = options.storage || new Map();
+  const storageAttempts = [];
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) {
+      const serialized = String(value);
+      storageAttempts.push(serialized);
+      if (options.storageLimit && serialized.length > options.storageLimit) throw new Error('quota');
+      storage.set(String(key), serialized);
+    },
+    removeItem(key) { storage.delete(key); }
+  };
+  const document = { activeElement: null };
+  const { bar, count, send, discard } = makeBar();
+  const status = makeElement('diff-queue-status');
+  const toggle = makeElement('diff-toggle');
+  for (const element of [bar, count, send, discard, status, toggle]) element.ownerDocument = document;
+  toggle.title = '2 changed files (+2)';
+  toggle.setAttribute('aria-label', 'Toggle file changes: 2 changed files (+2)');
+  const state = { activeSessionId: 's1', connected: true, branchContextQueuedSend: null };
+  const optimistic = [], removedOptimistic = [], sendCalls = [], toasts = [], revisions = [], renders = [];
+  const app = {
+    state,
+    elements: { diffToggleBtn: toggle },
+    STORAGE_KEYS: { diffCommentQueue: 'term_llm_diff_comment_queue', pendingIntents: 'term_llm_pending_intent' },
+    isSessionIdentityResolved: (id) => id.startsWith('s'),
+    normalizeDiffComment(entry) {
+      if (!entry?.id || !entry.path || !entry.instruction || !entry.line || !entry.file_change_seq) return null;
+      return { ...entry, created_at: Number(entry.created_at) || Date.now() };
+    },
+    anchorKey: (entry) => `${entry.path}\0${entry.side}\0${entry.line}`,
+    formatDiffCommentInstruction: (entry) => `FORMAT:${entry.id}:${entry.instruction}`,
+    bumpDiffCommentPathRevision(sessionId, pathName) { revisions.push([sessionId, pathName]); },
+    renderDiffSidebar(sessionId) { renders.push(sessionId); },
+    showToast(message, detail) { toasts.push([message, detail]); },
+    addOptimisticDiffComment(sessionId, comment) { optimistic.push([sessionId, comment]); },
+    removeOptimisticDiffComment(sessionId, id) { removedOptimistic.push([sessionId, id]); },
+    hydrateDiffComments() { return Promise.resolve([]); },
+    async sendMessage(spec) {
+      sendCalls.push(spec);
+      if (options.sendMessage) return options.sendMessage(spec);
+      spec._onTransportStarted?.();
+    }
+  };
+  const documentGetElementById = (id) => ({ diffQueueBar: bar, diffQueueStatus: status }[id] || null);
+  document.getElementById = documentGetElementById;
+  const context = {
+    window: { TermLLMApp: app }, document, localStorage, console, Date, Math, Promise,
+    setTimeout: options.setTimeout || setTimeout,
+    clearTimeout: options.clearTimeout || clearTimeout,
+    globalThis: { crypto: { randomUUID: () => `uuid-${sendCalls.length + 1}` } }
+  };
+  vm.runInNewContext(source, context, { filename: 'app-diff-queue.js' });
+  return { app, state, storage, storageAttempts, document, bar, count, status, send, discard, toggle, optimistic, removedOptimistic, sendCalls, toasts, revisions, renders };
+};
+
+(async () => {
+  await run('queue status is a persistent visible polite live region outside the hidden action bar', () => {
+    const statusIndex = indexSource.indexOf('id="diffQueueStatus"');
+    const barIndex = indexSource.indexOf('id="diffQueueBar"');
+    assert(statusIndex >= 0 && statusIndex < barIndex, 'persistent queue status is missing or nested in the hidden bar');
+    const statusTag = indexSource.slice(indexSource.lastIndexOf('<', statusIndex), indexSource.indexOf('>', statusIndex) + 1);
+    assert(statusTag.includes('role="status"') && statusTag.includes('aria-live="polite"') && !statusTag.includes('hidden'), 'queue status lacks persistent polite live semantics');
+  });
+
+  await run('queue state is per resolved session, persisted separately, editable, removable, and pruned', () => {
+    const first = createHarness();
+    assert(!first.app.queueDiffComment('123', makeComment('bad')), 'unresolved session accepted queue state');
+    first.app.setDiffCommentSendMode('s1', 'queue');
+    assert(first.app.queueDiffComment('s1', makeComment('a1')), 'first queue add failed');
+    assert(first.app.queueDiffComment('s2', makeComment('b1', 'second', 'b.go')), 'second session queue add failed');
+    assert(first.app.diffCommentSendMode('s1') === 'queue', 'mode did not persist in memory');
+    assert(first.app.queuedDiffComments('s1').length === 1 && first.app.queuedDiffComments('s2').length === 1, 'session queues leaked');
+    const persisted = JSON.parse(first.storage.get('term_llm_diff_comment_queue'));
+    assert(persisted.sessions.s1.items[0].id === 'a1', 'queue was not stored under dedicated key');
+    assert(!first.storage.has('term_llm_pending_intent'), 'unsent queue polluted sent-intent storage');
+
+    const reloaded = createHarness({ storage: first.storage });
+    assert(reloaded.app.diffCommentSendMode('s1') === 'queue' && reloaded.app.queuedDiffComments('s1')[0].id === 'a1', 'reload did not restore queue and mode');
+    assert(reloaded.app.removeQueuedDiffComment('s1', 'a1')?.instruction === 'instruction a1', 'remove did not return queued item for editing');
+    reloaded.app.pruneDiffCommentQueues(new Set(['s1']));
+    assert(reloaded.app.queuedDiffComments('s2').length === 0, 'prune retained an evicted session queue');
+  });
+
+  await run('queue cap is 20 with exact reassuring microcopy and draft-safe rejection', () => {
+    const harness = createHarness();
+    for (let i = 0; i < 20; i += 1) assert(harness.app.queueDiffComment('s1', makeComment(`c${i}`)), `item ${i} rejected`);
+    assert(!harness.app.queueDiffComment('s1', makeComment('overflow')), 'queue accepted item 21');
+    assert(harness.app.queuedDiffComments('s1').length === 20, 'cap mutation changed existing queue');
+    assert(harness.toasts.at(-1)?.[0] === 'Queue is full (20). Send or discard queued comments first.', 'cap microcopy changed');
+  });
+
+  await run('queue bar exposes calm labels, review title, and visible toggle accent', () => {
+    const harness = createHarness();
+    harness.app.queueDiffComment('s1', makeComment('a1', 'Keep the stable behavior here'));
+    harness.app.queueDiffComment('s1', makeComment('a2', 'Avoid rebuilding this node', 'b.go', 8));
+    harness.app.renderDiffCommentQueueBar('s1');
+    assert(!harness.bar.hidden && harness.count.textContent === '2 queued', 'queue count missing');
+    assert(harness.status.textContent === '2 inline comments queued, not sent.', 'persistent live status missing queued state');
+    assert(harness.send.textContent === 'Send 2 comments' && harness.discard.textContent === 'Discard', 'queue actions use wrong copy');
+    assert(harness.count.title.includes('a.go:2 — Keep the stable') && harness.count.title.includes('b.go:8 — Avoid rebuilding'), 'review title omitted anchors');
+    assert(harness.toggle.classList.contains('has-queued'), 'Changes toggle lacks visible queued accent');
+    assert(harness.toggle.getAttribute('aria-label').endsWith('· 2 queued comments not sent'), 'toggle queued state not announced');
+  });
+
+  await run('one batch sends one message with N parts, shared identity, and resets mode', async () => {
+    const harness = createHarness();
+    harness.document.activeElement = harness.send;
+    harness.app.setDiffCommentSendMode('s1', 'queue');
+    harness.app.queueDiffComment('s1', makeComment('a1', 'First'));
+    harness.app.queueDiffComment('s1', makeComment('a2', 'Second', 'b.go', 5, 2));
+    assert(await harness.app.sendQueuedDiffComments('s1'), 'batch send did not succeed');
+    assert(harness.sendCalls.length === 1, 'batch created multiple send calls');
+    const call = harness.sendCalls[0];
+    assert(call.contentParts.length === 2 && call.diffComments.length === 2, 'batch lost diff comment parts');
+    assert(call.displayPrompt === '2 inline comments' && call.prompt.startsWith('[Inline diff instructions] (2 anchored comments)'), 'plural batch prompt/display changed');
+    assert(harness.optimistic.length === 2 && harness.optimistic.every(([, item]) => item.client_message_id === call.reuseMessageId), 'optimistic entries did not share batch identity');
+    assert(harness.app.queuedDiffComments('s1').length === 0 && harness.app.diffCommentSendMode('s1') === 'send', 'successful batch did not clear/reset mode');
+    assert(harness.document.activeElement === harness.toggle, 'focus was left inside the hidden queue bar');
+    assert(harness.status.textContent === 'No inline comments queued.', 'persistent live status did not announce the empty queue');
+  });
+
+  await run('N=1 batch prompt and display are identical to direct send', async () => {
+    const harness = createHarness();
+    const comment = makeComment('only', 'Keep exactly this');
+    harness.app.queueDiffComment('s1', comment);
+    assert(harness.app.buildDiffCommentBatchPrompt([comment]) === harness.app.formatDiffCommentInstruction(comment), 'single batch added wrapper bytes');
+    await harness.app.sendQueuedDiffComments('s1');
+    const call = harness.sendCalls[0];
+    assert(call.displayPrompt === comment.instruction && call.contentParts.length === 1 && call.contentParts[0].diff_comment.instruction === comment.instruction, 'single batch display/content differs from direct send');
+  });
+
+  await run('failure after transport start keeps queue and removes optimistic markers', async () => {
+    const harness = createHarness({ sendMessage: async (spec) => { spec._onTransportStarted(); spec._onTransportFailed(new Error('no')); } });
+    harness.app.setDiffCommentSendMode('s1', 'queue');
+    harness.app.queueDiffComment('s1', makeComment('a1'));
+    assert(!await harness.app.sendQueuedDiffComments('s1'), 'failed transport reported success');
+    assert(harness.app.queuedDiffComments('s1').length === 1 && harness.app.diffCommentSendMode('s1') === 'queue', 'failure lost queue or mode');
+    assert(harness.removedOptimistic.some(([, id]) => id === 'a1'), 'failure left optimistic marker');
+    assert(harness.toasts.at(-1)?.[0] === 'Queued comments were not sent. They are still queued.', 'failure microcopy changed');
+  });
+
+  await run('branch-context parking and cancellation retain every queued comment', async () => {
+    const harness = createHarness({ sendMessage: async (spec) => { spec._onTransportStarted({ queued: true }); } });
+    harness.app.setDiffCommentSendMode('s1', 'queue');
+    harness.app.queueDiffComment('s1', makeComment('a1'));
+    harness.app.queueDiffComment('s1', makeComment('a2', 'second', 'b.go'));
+    assert(await harness.app.sendQueuedDiffComments('s1'), 'parked batch was treated as a transport failure');
+    assert(harness.app.queuedDiffComments('s1').length === 2 && harness.app.diffCommentQueueSending('s1'), 'parking cleared or unlocked the queued snapshot');
+    harness.sendCalls[0]._onTransportCanceled({ queued: true, canceled: true });
+    assert(harness.app.queuedDiffComments('s1').length === 2 && !harness.app.diffCommentQueueSending('s1'), 'branch cancellation lost queued comments or left mutation locked');
+    assert(harness.app.diffCommentSendMode('s1') === 'queue', 'branch cancellation lost the queued send mode');
+  });
+
+  await run('persistence retries with progressively smaller payloads and rejects oversized items', () => {
+    const harness = createHarness({ storageLimit: 500 });
+    assert(harness.app.queueDiffComment('s1', makeComment('a1', 'first')), 'first bounded item was rejected');
+    assert(harness.app.queueDiffComment('s1', makeComment('a2', 'second')), 'second bounded item was rejected');
+    const attemptsBeforeThird = harness.storageAttempts.length;
+    assert(harness.app.queueDiffComment('s1', makeComment('a3', 'third')), 'third bounded item was rejected');
+    assert(harness.storageAttempts.length - attemptsBeforeThird >= 3, 'quota persistence did not keep shrinking until storable');
+    const persisted = JSON.parse(harness.storage.get('term_llm_diff_comment_queue'));
+    assert(persisted.sessions.s1.items.length === 1, 'quota retry did not shrink the stored payload enough');
+    const huge = makeComment('huge', 'x'.repeat(harness.app.MAX_QUEUED_DIFF_COMMENT_BYTES + 1));
+    assert(!harness.app.queueDiffComment('s1', huge), 'oversized queued item bypassed the item bound');
+  });
+
+  await run('double activation is idempotent while a batch is in flight', async () => {
+    let release;
+    const harness = createHarness({ sendMessage: (spec) => { spec._onTransportStarted(); return new Promise((resolve) => { release = resolve; }); } });
+    harness.app.queueDiffComment('s1', makeComment('a1'));
+    const first = harness.app.sendQueuedDiffComments('s1');
+    const second = await harness.app.sendQueuedDiffComments('s1');
+    assert(second === false && harness.sendCalls.length === 1, 'double activation posted twice');
+    release();
+    assert(await first, 'first send did not finish');
+  });
+
+  await run('discard confirmation timers remain independent per session', () => {
+    let nextTimer = 0;
+    const canceled = [];
+    const harness = createHarness({
+      setTimeout() { nextTimer += 1; return nextTimer; },
+      clearTimeout(id) { canceled.push(id); }
+    });
+    harness.app.queueDiffComment('s1', makeComment('a1'));
+    harness.app.queueDiffComment('s2', makeComment('b1', 'second', 'b.go'));
+    harness.app.discardQueuedDiffComments('s1');
+    harness.app.discardQueuedDiffComments('s2');
+    assert(nextTimer === 2 && canceled.length === 0, 'arming one session canceled another session timer');
+  });
+
+  await run('discard is two-step and resets queue mode only after confirmation', () => {
+    const harness = createHarness();
+    harness.app.setDiffCommentSendMode('s1', 'queue');
+    harness.app.queueDiffComment('s1', makeComment('a1'));
+    assert(!harness.app.discardQueuedDiffComments('s1'), 'first discard removed items');
+    assert(harness.discard.textContent === 'Discard 1?', 'first discard did not arm exact confirmation');
+    harness.document.activeElement = harness.discard;
+    assert(harness.app.discardQueuedDiffComments('s1'), 'second discard did not confirm');
+    assert(harness.document.activeElement === harness.toggle, 'confirmed discard hid its focused control without moving focus');
+    assert(harness.app.queuedDiffComments('s1').length === 0 && harness.app.diffCommentSendMode('s1') === 'send', 'discard-all did not clear/reset mode');
+  });
+
+  if (failures > 0) process.exit(1);
+  console.log('All app-diff-queue tests passed');
+})();

--- a/internal/serveui/static/app_diffs_test.js
+++ b/internal/serveui/static/app_diffs_test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const vm = require('vm');
 
 const source = fs.readFileSync(path.join(__dirname, 'app-diffs.js'), 'utf8');
+const commentSource = fs.readFileSync(path.join(__dirname, 'app-diff-comments.js'), 'utf8');
 let failures = 0;
 
 function fail(name, message, details) {
@@ -65,7 +66,18 @@ class Element {
     this.title = '';
     this.hidden = false;
     this.scrollTop = 0;
+    this._connectedOverride = null;
+    this.focusCount = 0;
+    this.rect = { width: 320, height: 40, top: 0, left: 0, right: 320, bottom: 40 };
   }
+  get isConnected() {
+    if (this._connectedOverride === false) return false;
+    let root = this;
+    while (root.parentNode) root = root.parentNode;
+    return root.tagName === 'DOCUMENT';
+  }
+  set isConnected(value) { this._connectedOverride = value === false ? false : null; }
+  append(...nodes) { nodes.forEach((node) => this.appendChild(node)); }
   appendChild(child) {
     if (child.parentNode) {
       const idx = child.parentNode.children.indexOf(child);
@@ -75,7 +87,29 @@ class Element {
     this.children.push(child);
     return child;
   }
+  insertBefore(child, reference) {
+    if (child.parentNode) {
+      const idx = child.parentNode.children.indexOf(child);
+      if (idx !== -1) child.parentNode.children.splice(idx, 1);
+    }
+    const index = reference ? this.children.indexOf(reference) : -1;
+    child.parentNode = this;
+    if (index === -1) this.children.push(child); else this.children.splice(index, 0, child);
+    return child;
+  }
+  remove() {
+    if (!this.parentNode) return;
+    const document = this.ownerDocument;
+    if (document?.activeElement && this.contains(document.activeElement)) document.activeElement = document.body;
+    const index = this.parentNode.children.indexOf(this);
+    if (index !== -1) this.parentNode.children.splice(index, 1);
+    this.parentNode = null;
+  }
   replaceChildren(...nodes) {
+    const document = this.ownerDocument;
+    if (document?.activeElement && this.children.some((child) => child.contains(document.activeElement))) {
+      document.activeElement = document.body;
+    }
     this.children.forEach((child) => { child.parentNode = null; });
     this.children = [];
     nodes.forEach((node) => { if (node) this.appendChild(node); });
@@ -94,6 +128,7 @@ class Element {
     for (const listener of listeners) await listener(evt);
   }
   matches(selector) {
+    if (selector.startsWith('#')) return this.id === selector.slice(1);
     if (selector.startsWith('.')) return this.classList.contains(selector.slice(1));
     return this.tagName.toLowerCase() === selector.toLowerCase();
   }
@@ -109,7 +144,29 @@ class Element {
     return results;
   }
   querySelector(selector) { return this.querySelectorAll(selector)[0] || null; }
-  getBoundingClientRect() { return { width: 320, height: 600, top: 0, left: 0, right: 320, bottom: 600 }; }
+  closest(selector) {
+    let current = this;
+    while (current) {
+      if (current.matches?.(selector)) return current;
+      current = current.parentNode;
+    }
+    return null;
+  }
+  contains(node) {
+    if (node === this) return true;
+    return this.children.some((child) => child.contains(node));
+  }
+  get nextSibling() {
+    if (!this.parentNode) return null;
+    const index = this.parentNode.children.indexOf(this);
+    return this.parentNode.children[index + 1] || null;
+  }
+  focus() {
+    this.focusCount += 1;
+    if (this.ownerDocument && this.isConnected) this.ownerDocument.activeElement = this;
+  }
+  scrollIntoView(options) { this.lastScrollIntoView = options || {}; }
+  getBoundingClientRect() { return this.rect; }
   setPointerCapture() {}
   releasePointerCapture() {}
 }
@@ -117,6 +174,8 @@ class Element {
 function createHarness(options = {}) {
   const elements = {
     appShell: new Element('div'),
+    appMain: new Element('main'),
+    sidebar: new Element('aside'),
     diffSidebar: new Element('aside'),
     diffSidebarTotals: new Element('span'),
     diffSidebarCloseBtn: new Element('button'),
@@ -125,22 +184,24 @@ function createHarness(options = {}) {
     diffToggleBtn: new Element('button'),
     diffToggleBadge: new Element('span'),
     diffBulkToggleBtn: new Element('button'),
+    diffMaximizeBtn: new Element('button'),
+    diffQueueBar: new Element('div'),
     diffFilterRow: new Element('div'),
     diffFilterInput: new Element('input')
   };
   elements.diffSidebar.hidden = true;
   elements.diffToggleBtn.hidden = true;
   elements.diffFilterRow.hidden = true;
-  const diffBulkToggleLabel = new Element('span');
-  diffBulkToggleLabel.className = 'diff-bulk-toggle-label';
-  const diffBulkToggleAction = new Element('span');
-  diffBulkToggleAction.className = 'diff-bulk-toggle-action';
-  diffBulkToggleLabel.appendChild(diffBulkToggleAction);
-  elements.diffBulkToggleBtn.appendChild(diffBulkToggleLabel);
 
   const state = {
     token: '',
-    activeSessionId: 's1'
+    activeSessionId: 's1',
+    connected: true,
+    sessions: [{ id: 's1', transcriptRev: 1 }],
+    pendingInterjections: [],
+    pendingInterruptCommits: [],
+    queuedInterrupts: [],
+    branchContextQueuedSend: null
   };
 
   const storage = new Map();
@@ -182,6 +243,8 @@ function createHarness(options = {}) {
     mediaListeners.slice().forEach((listener) => listener({ matches: drawerMatches }));
   };
 
+  const queuedComments = [];
+  const commentSendModes = new Map();
   const app = {
     createEl(tag, className, text) {
       const element = document.createElement(tag);
@@ -195,6 +258,21 @@ function createHarness(options = {}) {
     elements,
     clipboardWrites: [],
     closeCurrentPlanSurface() { planCloseCalls += 1; },
+    diffCommentSendMode(sessionId) { return commentSendModes.get(sessionId) || 'send'; },
+    setDiffCommentSendMode(sessionId, mode) {
+      commentSendModes.set(sessionId, mode === 'queue' ? 'queue' : 'send');
+    },
+    queuedDiffComments(sessionId, anchor = null) {
+      const comments = queuedComments.filter((entry) => entry.sessionId === sessionId).map((entry) => entry.comment);
+      if (!anchor) return comments;
+      return comments.filter((comment) => comment.path === anchor.path && comment.side === anchor.side && comment.line === anchor.line);
+    },
+    queueDiffComment(sessionId, comment) {
+      queuedComments.push({ sessionId, comment });
+      this.bumpDiffCommentPathRevision?.(sessionId, comment.path);
+      this.renderDiffSidebar?.(sessionId);
+      return true;
+    },
     getClipboardWriter() {
       const writes = this.clipboardWrites;
       return { writeText: (text) => { writes.push(String(text)); return Promise.resolve(); } };
@@ -256,7 +334,36 @@ function createHarness(options = {}) {
   };
 
   const document = new Element('document');
-  document.createElement = (tag) => new Element(tag);
+  document.ownerDocument = document;
+  document.activeElement = null;
+  document.createElement = (tag) => {
+    const element = new Element(tag);
+    element.ownerDocument = document;
+    return element;
+  };
+  document.body = document.createElement('body');
+  document.appendChild(document.body);
+  document.body.appendChild(elements.appShell);
+  elements.appShell.append(elements.appMain, elements.sidebar, elements.diffSidebar);
+  elements.appMain.appendChild(elements.diffToggleBtn);
+  elements.diffSidebar.append(
+    elements.diffSidebarTotals,
+    elements.diffSidebarCloseBtn,
+    elements.diffResizeHandle,
+    elements.diffFileList,
+    elements.diffBulkToggleBtn,
+    elements.diffMaximizeBtn,
+    elements.diffQueueBar,
+    elements.diffFilterRow
+  );
+  elements.diffFilterRow.appendChild(elements.diffFilterInput);
+  const elementIDs = {
+    appMain: elements.appMain,
+    diffMaximizeBtn: elements.diffMaximizeBtn,
+    diffQueueBar: elements.diffQueueBar
+  };
+  document.getElementById = (id) => elementIDs[id] || null;
+  Object.values(elements).forEach((element) => { element.ownerDocument = document; });
 
   const context = {
     window: {
@@ -301,6 +408,7 @@ function createHarness(options = {}) {
   };
   context.globalThis = context;
   app.apiFetch = (...args) => context.fetch(...args);
+  if (options.diffComments) vm.runInNewContext(commentSource, context, { filename: 'app-diff-comments.js' });
   vm.runInNewContext(source, context, { filename: 'app-diffs.js' });
 
   const flushTimers = async () => {
@@ -312,7 +420,7 @@ function createHarness(options = {}) {
   };
 
   return {
-    app, elements, state, localStorage, storage, timers, fetchCalls, flushTimers, setDrawer, media, windowObj: context.window,
+    app, elements, state, document, localStorage, storage, timers, fetchCalls, queuedComments, flushTimers, setDrawer, media, windowObj: context.window,
     get planCloseCalls() { return planCloseCalls; }
   };
 }
@@ -375,6 +483,36 @@ async function run(name, fn) {
     assert(!elements.diffSidebar.hidden, 'explicit toggle reveals sidebar');
     assert(elements.appShell.classList.contains('diff-open'), 'explicit toggle opens third column');
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').length, 1, 'one file row rendered after toggle');
+  });
+
+  await run('collapsing or removing an anchor clears stale comment-panel state', async () => {
+    const harness = createHarness({ fetch: async (url) => ({
+      ok: true,
+      json: async () => (String(url).includes('/diff?')
+        ? { path: '/a', kind: 'modify', lang: 'go', truncated: false, hunks: [] }
+        : { file_changes: [] })
+    }) });
+    const { app } = harness;
+    let openPath = '/a';
+    const cleared = [];
+    app.diffCommentPanelOpen = () => Boolean(openPath);
+    app.clearDiffCommentPanel = (_sessionId, pathName = '') => {
+      if (pathName && pathName !== openPath) return false;
+      cleared.push(pathName || openPath);
+      openPath = '';
+      return true;
+    };
+    app.reconcileDiffCommentPanel = (_sessionId, retained) => {
+      if (openPath && !retained.has(openPath)) app.clearDiffCommentPanel(_sessionId);
+    };
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    app.toggleDiffSidebar();
+    app.toggleDiffFile('s1', '/a');
+    assert(cleared.includes('/a') && !app.diffCommentPanelOpen('s1'), 'explicit collapse retained stale openPanel state');
+
+    openPath = '/a';
+    await app.fetchSessionFileChanges('s1');
+    assert(!app.diffCommentPanelOpen('s1'), 'authoritative anchor removal retained stale openPanel state');
   });
 
   await run('opening Changes closes the Plan surface in wide and drawer modes', () => {
@@ -463,6 +601,177 @@ async function run(name, fn) {
     await flushTimers();
 
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 2, 'pinned file stays open while live-follow moves on');
+  });
+
+  await run('comment interaction pins a live-followed file while explicit collapse still wins', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+    assert(app.pinDiffFileExpanded('s1', '/a'), 'comment pin did not recognize the file');
+    app.renderDiffSidebar('s1');
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/b', kind: 'create', adds: 1, dels: 0, seq: 2 });
+    await flushTimers();
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 2, 'commented file collapsed when live-follow moved');
+    app.toggleDiffFile('s1', '/a');
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 2, dels: 0, seq: 3 });
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 1, 'live edit overrode explicit user collapse');
+  });
+
+  await run('open comment panel suppresses and consumes live-follow pending scroll', async () => {
+    const { app, elements, flushTimers } = createHarness();
+    app.diffCommentPanelOpen = () => true;
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+    const row = elements.diffFileList.querySelector('.diff-file-row');
+    assert(!row.lastScrollIntoView, 'live-follow scrolled away while a comment panel was open');
+    app.diffCommentPanelOpen = () => false;
+    app.renderDiffSidebar('s1');
+    assert(!row.lastScrollIntoView, 'suppressed pending scroll fired later');
+  });
+
+  await run('expanded diff refetch restores only focus owned by rebuilt inline comment UI', async () => {
+    const files = ['/shipping.rb', '/receipt.rb', '/loyalty.rb'];
+    const harness = createHarness({
+      diffComments: true,
+      fetch: async (url) => {
+        if (String(url).includes('/diff?')) {
+          const params = new URLSearchParams(String(url).split('?')[1] || '');
+          const pathName = params.get('path') || '/loyalty.rb';
+          return { ok: true, json: async () => ({
+            path: pathName, kind: 'modify', lang: 'ruby', truncated: false,
+            hunks: [{ old_start: 1, new_start: 1, lines: [{ t: 'add', s: `change in ${pathName}` }] }]
+          }) };
+        }
+        return { ok: true, json: async () => ({ file_changes: files.map((pathName, index) => ({
+          path: pathName, kind: 'modify', adds: 1, dels: 0, truncated: false, seq: index + 1
+        })) }) };
+      }
+    });
+    const { app, elements, document, flushTimers, queuedComments } = harness;
+    const event = (type, target) => ({
+      type, target, preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {}
+    });
+
+    app.toggleDiffSidebar();
+    files.forEach((pathName, index) => app.handleFileChangeEvent(
+      { id: 's1' },
+      { path: pathName, kind: 'modify', adds: 1, dels: 0, seq: index + 1 }
+    ));
+    await flushTimers();
+    await flushTimers();
+    await elements.diffBulkToggleBtn.dispatchEvent(event('click', elements.diffBulkToggleBtn));
+    await elements.diffMaximizeBtn.dispatchEvent(event('click', elements.diffMaximizeBtn));
+
+    const loyaltyFile = elements.diffFileList.querySelectorAll('.diff-file-row')
+      .find((row) => row.dataset.path === '/loyalty.rb')?.parentNode;
+    const marker = loyaltyFile?.querySelector('.diff-comment-affordance');
+    assert(marker, 'loyalty comment marker was not rendered');
+    await marker.dispatchEvent(event('click', marker));
+    const textarea = loyaltyFile.querySelector('textarea');
+    textarea.value = 'Double points during ';
+    await textarea.dispatchEvent(event('input', textarea));
+    assert(document.activeElement === textarea && textarea.isConnected, 'editor did not begin with real connected focus');
+
+    const oldBody = loyaltyFile.querySelector('.diff-file-body');
+    app.refreshFileChangesAfterRun({ id: 's1' });
+    await flushTimers();
+    await flushTimers();
+
+    const rebuiltLoyaltyFile = elements.diffFileList.querySelectorAll('.diff-file-row')
+      .find((row) => row.dataset.path === '/loyalty.rb')?.parentNode;
+    const restored = rebuiltLoyaltyFile?.querySelector('textarea');
+    assert(rebuiltLoyaltyFile?.querySelector('.diff-file-body') !== oldBody, 'test did not replace the loyalty body');
+    assert(rebuiltLoyaltyFile?.querySelectorAll('.diff-comment-panel').length === 1
+      && rebuiltLoyaltyFile.querySelectorAll('.diff-comment-editor').length === 1, 'rebuilt comment UI was duplicated or lost');
+    assert(restored?.value === 'Double points during ', 'rebuilt editor lost its draft');
+    assert(document.activeElement === restored && restored.isConnected, `rebuilt connected editor did not regain owned focus (active=${document.activeElement?.tagName}.${document.activeElement?.className}, restoredFocusCount=${restored?.focusCount}, connected=${restored?.isConnected})`);
+
+    const outside = document.createElement('button');
+    elements.appMain.appendChild(outside);
+    outside.focus();
+    app.bumpDiffCommentPathRevision('s1', '/loyalty.rb');
+    app.renderDiffSidebar('s1');
+    assert(document.activeElement === outside, 'open editor stole focus after the user moved elsewhere');
+
+    const currentEditor = rebuiltLoyaltyFile.querySelector('textarea');
+    currentEditor.value = 'Double points during holidays';
+    await currentEditor.dispatchEvent(event('input', currentEditor));
+    app.setDiffCommentSendMode('s1', 'queue');
+    const queueButton = rebuiltLoyaltyFile.querySelector('.diff-comment-send');
+    queueButton.focus();
+    await queueButton.dispatchEvent(event('click', queueButton));
+    const rebuiltMarker = rebuiltLoyaltyFile.querySelector('.diff-comment-affordance');
+    assert(queuedComments.length === 1, 'queue submission did not complete');
+    assert(document.activeElement === rebuiltMarker && rebuiltMarker.isConnected, 'queue submission did not focus the attached rebuilt marker');
+  });
+
+  await run('file-list reorder preserves exact focus and draft in an untouched third-file editor', async () => {
+    const initialFiles = [
+      { path: '/loyalty.rb', seq: 1 },
+      { path: '/shipping.rb', seq: 2 },
+      { path: '/receipt.rb', seq: 3 }
+    ];
+    const harness = createHarness({
+      diffComments: true,
+      fetch: async (url) => {
+        if (String(url).includes('/diff?')) {
+          const params = new URLSearchParams(String(url).split('?')[1] || '');
+          const pathName = params.get('path') || '/loyalty.rb';
+          return { ok: true, json: async () => ({
+            path: pathName, kind: 'modify', lang: 'ruby', truncated: false,
+            hunks: [{ old_start: 1, new_start: 1, lines: [{ t: 'add', s: `change in ${pathName}` }] }]
+          }) };
+        }
+        return { ok: true, json: async () => ({ file_changes: initialFiles.map((file) => ({
+          path: file.path, kind: 'modify', adds: 1, dels: 0, truncated: false, seq: file.seq
+        })) }) };
+      }
+    });
+    const { app, elements, document, flushTimers } = harness;
+    const event = (type, target) => ({
+      type, target, preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {}
+    });
+
+    app.toggleDiffSidebar();
+    initialFiles.forEach((file) => app.handleFileChangeEvent(
+      { id: 's1' },
+      { path: file.path, kind: 'modify', adds: 1, dels: 0, seq: file.seq }
+    ));
+    await flushTimers();
+    await flushTimers();
+
+    app.toggleDiffFile('s1', '/loyalty.rb');
+    await flushTimers();
+    await flushTimers();
+    const loyaltyFile = elements.diffFileList.querySelectorAll('.diff-file-row')
+      .find((row) => row.dataset.path === '/loyalty.rb')?.parentNode;
+    const marker = loyaltyFile?.querySelector('.diff-comment-affordance');
+    assert(marker, 'third-file loyalty comment marker was not rendered');
+    await marker.dispatchEvent(event('click', marker));
+    const textarea = loyaltyFile.querySelector('textarea');
+    textarea.value = 'Keep the exact focused draft';
+    await textarea.dispatchEvent(event('input', textarea));
+    assert(document.activeElement === textarea, 'loyalty editor did not own focus before reorder');
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').map((row) => row.dataset.path).join(','),
+      '/receipt.rb,/shipping.rb,/loyalty.rb', 'loyalty editor was not in the untouched third file');
+
+    app.handleFileChangeEvent(
+      { id: 's1' },
+      { path: '/shipping.rb', kind: 'modify', adds: 2, dels: 0, seq: 4 }
+    );
+    await flushTimers();
+
+    const reorderedLoyaltyFile = elements.diffFileList.querySelectorAll('.diff-file-row')
+      .find((row) => row.dataset.path === '/loyalty.rb')?.parentNode;
+    assertEqual(elements.diffFileList.querySelectorAll('.diff-file-row').map((row) => row.dataset.path).join(','),
+      '/shipping.rb,/receipt.rb,/loyalty.rb', 'agent edit did not change file sort order');
+    assert(reorderedLoyaltyFile === loyaltyFile, 'untouched loyalty block was rebuilt instead of reused');
+    assert(reorderedLoyaltyFile.querySelector('textarea') === textarea, 'reorder replaced the exact loyalty textarea');
+    assert(textarea.value === 'Keep the exact focused draft', 'reorder lost the loyalty draft');
+    assert(document.activeElement === textarea && textarea.isConnected,
+      `reorder did not restore exact connected textarea focus (active=${document.activeElement?.tagName})`);
   });
 
   await run('explicit collapse sticks while the agent keeps editing', async () => {
@@ -1021,26 +1330,25 @@ async function run(name, fn) {
 
   await run('adaptive bulk toggle expands, collapses, and sticks', async () => {
     const { app, elements, flushTimers } = createHarness();
-    const bulkLabel = () => `${elements.diffBulkToggleBtn.querySelector('.diff-bulk-toggle-action')?.textContent} all`;
     app.toggleDiffSidebar();
     for (let i = 1; i <= 3; i += 1) {
       app.handleFileChangeEvent({ id: 's1' }, { path: `/f${i}`, kind: 'modify', adds: 1, dels: 0, seq: i });
     }
     await flushTimers();
 
-    assertEqual(bulkLabel(), 'Expand all', 'mixed accordion offers to expand all');
+    assertEqual(elements.diffBulkToggleBtn.getAttribute('title'), 'Expand all', 'mixed accordion offers to expand all');
     assertEqual(elements.diffBulkToggleBtn.dataset.action, 'expand', 'expand icon state selected');
     assertEqual(elements.diffBulkToggleBtn.getAttribute('aria-label'), 'Expand all files', 'expand action announced');
 
     await elements.diffBulkToggleBtn.dispatchEvent({ type: 'click' });
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 3, 'first click opens every body');
-    assertEqual(bulkLabel(), 'Collapse all', 'fully expanded accordion offers to collapse all');
+    assertEqual(elements.diffBulkToggleBtn.getAttribute('title'), 'Collapse all', 'fully expanded accordion offers to collapse all');
     assertEqual(elements.diffBulkToggleBtn.dataset.action, 'collapse', 'collapse icon state selected');
     assertEqual(elements.diffBulkToggleBtn.getAttribute('aria-label'), 'Collapse all files', 'collapse action announced');
 
     await elements.diffBulkToggleBtn.dispatchEvent({ type: 'click' });
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 0, 'second click closes every body');
-    assertEqual(bulkLabel(), 'Expand all', 'collapsed accordion returns to expand action');
+    assertEqual(elements.diffBulkToggleBtn.getAttribute('title'), 'Expand all', 'collapsed accordion returns to expand action');
 
     app.handleFileChangeEvent({ id: 's1' }, { path: '/f1', kind: 'modify', adds: 2, dels: 0, seq: 4 });
     await flushTimers();
@@ -1048,6 +1356,78 @@ async function run(name, fn) {
 
     await elements.diffBulkToggleBtn.dispatchEvent({ type: 'click' });
     assertEqual(elements.diffFileList.querySelectorAll('.diff-file-body').length, 3, 'expand action remains available after live updates');
+  });
+
+  await run('desktop maximize preserves same DOM, draft focus, scroll anchor, and restores cleanly', async () => {
+    const { app, elements, document, flushTimers } = createHarness();
+    app.toggleDiffSidebar();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    await flushTimers();
+    const body = elements.diffFileList.querySelector('.diff-file-body');
+    const spatialRow = elements.diffFileList.querySelector('.diff-file-row');
+    const textarea = document.createElement('textarea');
+    textarea.value = 'draft survives';
+    body.appendChild(textarea);
+    textarea.focus();
+    elements.diffFileList.scrollTop = 77;
+    const beforeChildren = elements.diffFileList.children.slice();
+
+    await elements.diffMaximizeBtn.dispatchEvent({ type: 'click' });
+    assert(elements.diffSidebar.classList.contains('maximized') && elements.appShell.classList.contains('diff-maximized'), 'maximize classes missing');
+    assert(elements.sidebar.getAttribute('inert') === '' && elements.appMain.getAttribute('inert') === '', 'background was not inert');
+    assert(document.activeElement === textarea, 'focus inside Changes moved during maximize');
+    assert(textarea.value === 'draft survives' && elements.diffFileList.scrollTop === 77, 'draft or scroll state changed');
+    assert(spatialRow.lastScrollIntoView?.block === 'nearest', 'maximize did not restore a reflow-safe spatial anchor');
+    assert(beforeChildren.every((child, index) => elements.diffFileList.children[index] === child), 'maximize rebuilt or reparented the list DOM');
+    assertEqual(elements.diffMaximizeBtn.getAttribute('aria-label'), 'Restore changes', 'restore action not announced');
+    assert(!elements.diffMaximizeBtn.getAttribute('aria-pressed'), 'maximize incorrectly exposed aria-pressed');
+
+    await elements.diffMaximizeBtn.dispatchEvent({ type: 'click' });
+    assert(!elements.diffSidebar.classList.contains('maximized') && !elements.appShell.classList.contains('diff-maximized'), 'restore classes remained');
+    assert(elements.sidebar.getAttribute('inert') === null && elements.appMain.getAttribute('inert') === null, 'restore left background inert');
+    assert(document.activeElement === textarea, 'restore moved panel focus');
+  });
+
+  await run('maximize falls back to the captured file path when an open panel anchor disconnects', async () => {
+    const { app, elements, document, flushTimers } = createHarness();
+    app.handleFileChangeEvent({ id: 's1' }, { path: '/a', kind: 'modify', adds: 1, dels: 0, seq: 1 });
+    app.toggleDiffSidebar();
+    await flushTimers();
+    const body = elements.diffFileList.querySelector('.diff-file-body');
+    const row = elements.diffFileList.querySelector('.diff-file-row');
+    const panel = document.createElement('div');
+    panel.className = 'diff-comment-panel';
+    body.appendChild(panel);
+    panel.isConnected = false;
+    await elements.diffMaximizeBtn.dispatchEvent({ type: 'click' });
+    assert(row.lastScrollIntoView?.block === 'nearest', 'disconnected panel lost its file-path spatial fallback');
+  });
+
+  await run('maximize focus, Escape, viewport, session, and close cleanup are layered', async () => {
+    const { app, elements, state, document, windowObj, setDrawer } = createHarness();
+    app.toggleDiffSidebar();
+    const backgroundControl = document.createElement('button');
+    elements.appMain.appendChild(backgroundControl);
+    backgroundControl.focus();
+    await elements.diffMaximizeBtn.dispatchEvent({ type: 'click' });
+    assert(document.activeElement === elements.diffMaximizeBtn, 'focus in inerted background did not move to maximize control');
+    windowObj.dispatchEvent({ type: 'keydown', key: 'Escape', target: elements.diffMaximizeBtn, preventDefault() { this.defaultPrevented = true; } });
+    assert(!elements.diffSidebar.classList.contains('maximized') && document.activeElement === backgroundControl, 'Escape did not restore maximize and prior focus');
+
+    await elements.diffMaximizeBtn.dispatchEvent({ type: 'click' });
+    setDrawer(true);
+    assert(!elements.diffSidebar.classList.contains('maximized') && elements.appMain.getAttribute('inert') === null, 'drawer breakpoint left maximize residue');
+    setDrawer(false);
+    app.toggleDiffSidebar();
+    await elements.diffMaximizeBtn.dispatchEvent({ type: 'click' });
+    app.activateDiffSidebar('s2');
+    assert(!elements.diffSidebar.classList.contains('maximized') && elements.sidebar.getAttribute('inert') === null, 'session activation left inert residue');
+    state.activeSessionId = 's1';
+    app.activateDiffSidebar('s1');
+    app.toggleDiffSidebar();
+    await elements.diffMaximizeBtn.dispatchEvent({ type: 'click' });
+    await elements.diffSidebarCloseBtn.dispatchEvent({ type: 'click' });
+    assert(!elements.diffSidebar.classList.contains('maximized') && elements.appMain.getAttribute('inert') === null, 'close left maximize residue');
   });
 
   await run('escape closes the diff drawer but leaves inputs alone', async () => {

--- a/internal/serveui/static/app_sessions_test.js
+++ b/internal/serveui/static/app_sessions_test.js
@@ -5576,6 +5576,7 @@ function testSanitizeMessagePreservesDiffComment() {
   return createSessionsHarness().then(({ app }) => {
     const sanitized = app.sanitizeMessage({
       id: 'diff-message', role: 'user', content: 'provider prompt', created: 1,
+      diffComments: [],
       diffComment: {
         id: 'comment-1', parent_id: 'comment-0', path: 'internal/a.go', side: 'old', line: 7,
         file_change_seq: 12, line_text: 'old()', instruction: 'Keep this.',
@@ -5583,10 +5584,10 @@ function testSanitizeMessagePreservesDiffComment() {
         context_after: [{ side: 'new', line: 7, text: 'after' }],
       },
     });
-    if (sanitized?.diffComment?.id !== 'comment-1'
-        || sanitized.diffComment.parent_id !== 'comment-0'
-        || sanitized.diffComment.context_before?.[0]?.text !== 'before'
-        || sanitized.diffComment.context_after?.[0]?.side !== 'new') {
+    if (sanitized?.diffComments?.[0]?.id !== 'comment-1'
+        || sanitized.diffComments[0].parent_id !== 'comment-0'
+        || sanitized.diffComments[0].context_before?.[0]?.text !== 'before'
+        || sanitized.diffComments[0].context_after?.[0]?.side !== 'new') {
       fail(name, 'diff comment metadata was discarded', JSON.stringify(sanitized));
       return;
     }
@@ -7642,11 +7643,14 @@ async function testDiffCommentConvertsToReadableTypedUserMessage() {
     created_at: 1000,
     parts: [
       { type: 'diff_comment', diff_comment: { id: 'dc1', path: 'a.go', side: 'old', line: 4, file_change_seq: 8, line_text: 'old()', instruction: 'Keep it.' } },
+      { type: 'diff_comment', diff_comment: { id: 'dc2', path: 'b.go', side: 'new', line: 9, file_change_seq: 10, line_text: 'new()', instruction: 'Use this.' } },
       { type: 'text', text: '[Inline diff instruction]\nprovider detail' }
     ]
   }]);
   const message = converted[0];
-  if (converted.length !== 1 || message?.diffComment?.instruction !== 'Keep it.' || message?.diffComment?.side !== 'old' || message?.content.indexOf('provider detail') < 0) {
+  if (converted.length !== 1 || message?.diffComments?.length !== 2
+      || message.diffComments[0]?.instruction !== 'Keep it.' || message.diffComments[0]?.side !== 'old'
+      || message.diffComments[1]?.instruction !== 'Use this.' || message?.content.indexOf('provider detail') < 0) {
     fail(name, 'typed diff comment was not projected', JSON.stringify(converted));
     return;
   }

--- a/internal/serveui/static/app_stream_test.js
+++ b/internal/serveui/static/app_stream_test.js
@@ -894,6 +894,7 @@ function createHarness(options = {}) {
     app,
     elements,
     state,
+    document,
     fetchCalls,
     localStorage,
     getEventsStarted: () => getEventsStarted,
@@ -4534,6 +4535,46 @@ async function testBranchContextQueuesSendUntilReady() {
   pass(name);
 }
 
+async function testBranchContextCancellationPreservesDiffCallbacksAndPayload() {
+  const name = 'branch context cancellation preserves parked inline payload and signals cancellation';
+  const harness = createHarness();
+  const { app, state, cleanup } = harness;
+  const session = {
+    id: 'branch_context_inline', title: 'Inline path', provider: 'mock', activeModel: 'test-model',
+    messages: [], lastResponseId: 'resp_prior', activeResponseId: null,
+    branchContextStatus: { phase: 'running', mode: 'notes' },
+  };
+  state.sessions.push(session);
+  state.activeSessionId = session.id;
+  state.selectedProvider = 'mock';
+  state.selectedModel = 'test-model';
+  state.branchContextOperation = { sessionId: session.id, phase: 'running' };
+  const comment = { id: 'dc-parked', path: 'a.go', side: 'new', line: 2, file_change_seq: 3, instruction: 'keep draft' };
+  const starts = [];
+  let canceled = null;
+  await app.sendMessage({
+    prompt: 'provider inline payload',
+    displayPrompt: 'keep draft',
+    contentParts: [{ type: 'diff_comment', diff_comment: comment }],
+    diffComment: comment,
+    diffComments: [comment],
+    attachments: [],
+    preserveComposer: true,
+    _onTransportStarted(detail) { starts.push(detail); },
+    _onTransportCanceled(detail) { canceled = detail; }
+  });
+  const parked = state.branchContextQueuedSend;
+  app.restoreBranchContextQueuedSend(session.id);
+  await cleanup();
+  if (starts.length !== 1 || starts[0]?.queued !== true || !canceled?.canceled
+      || parked?.contentParts?.[0]?.diff_comment?.id !== comment.id
+      || parked?.diffComments?.[0]?.instruction !== 'keep draft') {
+    fail(name, 'park/cancel lifecycle lost callback detail or inline data', JSON.stringify({ starts, canceled, parked }));
+    return;
+  }
+  pass(name);
+}
+
 async function testBranchShortcutSlashCommandsPreserveOptionalInstruction() {
   const name = 'branch shortcut slash commands preserve instructions and do not send empty prompts';
   const harness = createHarness();
@@ -7225,6 +7266,44 @@ async function testSendMessageKeepsComposerWhenAttachmentMaterializationFails() 
   pass(name);
 }
 
+async function testCompletedResponsePreservesDeliberateFocus() {
+  const name = 'completed response preserves deliberate focus and legitimate composer restore';
+  const harness = createHarness();
+  const { app, elements, state, document, cleanup } = harness;
+  let focusCount = 0;
+  elements.promptInput.focus = () => { focusCount += 1; document.activeElement = elements.promptInput; };
+
+  document.activeElement = elements.promptInput;
+  app.setStreaming(true);
+  const commentEditor = { tagName: 'TEXTAREA' };
+  document.activeElement = commentEditor;
+  app.setStreaming(false);
+  if (focusCount !== 0 || document.activeElement !== commentEditor) {
+    fail(name, 'completion stole focus from a deliberately focused control');
+    await cleanup();
+    return;
+  }
+
+  document.activeElement = elements.promptInput;
+  app.setStreaming(true);
+  app.setStreaming(false);
+  if (focusCount !== 1 || document.activeElement !== elements.promptInput) {
+    fail(name, 'untouched composer focus was not legitimately restored');
+    await cleanup();
+    return;
+  }
+
+  // Repeated non-terminal idle transitions have no captured focus to restore.
+  app.setStreaming(false);
+  if (focusCount !== 1) {
+    fail(name, 'repeated idle transition moved focus');
+    await cleanup();
+    return;
+  }
+  await cleanup();
+  pass(name);
+}
+
 async function testSendButtonMorphsToInterjectWhileBusyAndTyping() {
   const name = 'send button morphs to interject while busy and typing';
   const harness = createHarness();
@@ -8450,6 +8529,10 @@ async function testInlineSendPreservesUnrelatedComposerForIdleAndActiveRuns() {
     id: 'dc1', path: 'main.go', side: 'old', line: 7, file_change_seq: 11,
     line_text: 'old()', instruction: 'Keep this call.'
   }};
+  const metadata2 = { type: 'diff_comment', diff_comment: {
+    id: 'dc2', path: 'other.go', side: 'new', line: 9, file_change_seq: 12,
+    line_text: 'new()', instruction: 'Keep this too.'
+  }};
 
   const idle = createHarness();
   const idleSession = { id: 'session_inline_idle', title: 'Inline', messages: [], activeResponseId: '', lastResponseId: 'resp_prior', lastSequenceNumber: 0 };
@@ -8458,14 +8541,18 @@ async function testInlineSendPreservesUnrelatedComposerForIdleAndActiveRuns() {
   idle.state.draftSessionActive = false;
   idle.elements.promptInput.value = 'unrelated idle draft';
   idle.state.attachments = [{ name: 'unrelated.txt', type: 'text/plain' }];
-  await idle.app.sendMessage({ prompt: 'provider anchored prompt', displayPrompt: 'Keep this call.', contentParts: [metadata], attachments: [], preserveComposer: true });
+  await idle.app.sendMessage({ prompt: 'provider anchored prompt', displayPrompt: '2 inline comments', contentParts: [metadata, metadata2], diffComments: [metadata.diff_comment, metadata2.diff_comment], attachments: [], preserveComposer: true });
   const post = idle.fetchCalls.find((call) => call.url === '/ui/v1/responses' && call.method === 'POST');
   const postBody = post?.body ? JSON.parse(post.body) : null;
+  const idleUser = projectedMessages(idleSession).find((entry) => entry.role === 'user');
   if (idle.elements.promptInput.value !== 'unrelated idle draft'
+      || idleUser?.diffComments?.length !== 2
       || idle.state.attachments.length !== 1
-      || postBody?.input?.[0]?.content?.length !== 2
+      || postBody?.input?.length !== 1
+      || postBody?.input?.[0]?.content?.length !== 3
       || postBody?.input?.[0]?.content?.[0]?.type !== 'diff_comment'
-      || postBody?.input?.[0]?.content?.[1]?.text !== 'provider anchored prompt') {
+      || postBody?.input?.[0]?.content?.[1]?.diff_comment?.id !== 'dc2'
+      || postBody?.input?.[0]?.content?.[2]?.text !== 'provider anchored prompt') {
     fail(name, 'idle inline send consumed composer or lost metadata', JSON.stringify({ composer: idle.elements.promptInput.value, postBody }));
     await idle.cleanup();
     return;
@@ -8479,14 +8566,16 @@ async function testInlineSendPreservesUnrelatedComposerForIdleAndActiveRuns() {
   active.state.draftSessionActive = false;
   active.elements.promptInput.value = 'unrelated active draft';
   active.state.attachments = [{ name: 'unrelated.txt', type: 'text/plain' }];
-  await active.app.sendMessage({ prompt: 'provider anchored prompt', displayPrompt: 'Keep this call.', contentParts: [metadata], attachments: [], preserveComposer: true });
+  await active.app.sendMessage({ prompt: 'provider anchored prompt', displayPrompt: '2 inline comments', contentParts: [metadata, metadata2], diffComments: [metadata.diff_comment, metadata2.diff_comment], attachments: [], preserveComposer: true });
   const interrupt = active.fetchCalls.find((call) => call.url.endsWith('/interrupt'));
   const interruptBody = interrupt?.body ? JSON.parse(interrupt.body) : null;
   if (active.elements.promptInput.value !== 'unrelated active draft'
+      || active.state.pendingInterjections?.[0]?.diffComments?.length !== 2
       || active.state.attachments.length !== 1
-      || interruptBody?.content?.length !== 2
+      || interruptBody?.content?.length !== 3
       || interruptBody?.content?.[0]?.type !== 'diff_comment'
-      || interruptBody?.content?.[1]?.text !== 'provider anchored prompt') {
+      || interruptBody?.content?.[1]?.diff_comment?.id !== 'dc2'
+      || interruptBody?.content?.[2]?.text !== 'provider anchored prompt') {
     fail(name, 'active inline send consumed composer or lost metadata', JSON.stringify({ composer: active.elements.promptInput.value, interruptBody }));
     await active.cleanup();
     return;
@@ -8589,6 +8678,7 @@ async function testUncommittedInlineInterjectionRetainsProviderAnchorAsFollowUp(
   await runAppStreamTest(testUncommittedInlineInterjectionRetainsProviderAnchorAsFollowUp);
   await runAppStreamTest(testSendMessageBranchesAndTransfersStreamOwnership);
   await runAppStreamTest(testBranchContextQueuesSendUntilReady);
+  await runAppStreamTest(testBranchContextCancellationPreservesDiffCallbacksAndPayload);
   await runAppStreamTest(testBranchShortcutSlashCommandsPreserveOptionalInstruction);
   await runAppStreamTest(testSendMessageRecoversStaleContinuationAfterConflict);
   await runAppStreamTest(testSendMessageConsumesPostStreamWhenAvailable);
@@ -8610,6 +8700,7 @@ async function testUncommittedInlineInterjectionRetainsProviderAnchorAsFollowUp(
   await runAppStreamTest(testDraftMessageLimitIsTen);
   await runAppStreamTest(testRestoreDraftMessageForSessionIsSessionBound);
   await runAppStreamTest(testRestoreLatestDraftMessageDoesNotCrossSessionBoundary);
+  await runAppStreamTest(testCompletedResponsePreservesDeliberateFocus);
   await runAppStreamTest(testSendButtonMorphsToInterjectWhileBusyAndTyping);
   await runAppStreamTest(testAutoGrowPromptUsesNativeFieldSizingWithoutLayoutReads);
   await runAppStreamTest(testAutoGrowPromptFallbackCoalescesLayoutWork);

--- a/internal/serveui/static/index.html
+++ b/internal/serveui/static/index.html
@@ -153,6 +153,7 @@
   <link rel="preload" as="script" href="intent-storage.js">
   <link rel="preload" as="script" href="app-session-admin.js">
   <link rel="preload" as="script" href="app-diff-comments.js">
+  <link rel="preload" as="script" href="app-diff-queue.js">
   <link rel="preload" as="script" href="app-diffs.js">
   <link rel="preload" as="script" href="app-worktrees.js">
 </head>
@@ -224,7 +225,7 @@
 
     <div class="sidebar-backdrop" id="sidebarBackdrop"></div>
 
-    <main class="main">
+    <main class="main" id="appMain">
       <header class="main-header" tabindex="-1">
         <div class="header-title-row">
           <div class="header-left">
@@ -365,7 +366,7 @@
       <div class="diff-sidebar-header">
         <span class="diff-sidebar-title">Changes</span>
         <span class="diff-sidebar-totals" id="diffSidebarTotals"></span>
-        <button class="diff-bulk-toggle" id="diffBulkToggleBtn" type="button" aria-label="Expand all files" title="Expand all" data-action="expand">
+        <button class="icon-btn diff-bulk-toggle" id="diffBulkToggleBtn" type="button" aria-label="Expand all files" title="Expand all" data-action="expand">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <g class="diff-bulk-expand-icon">
               <path d="m7 9 5-5 5 5"></path>
@@ -376,7 +377,12 @@
               <path d="m7 20 5-5 5 5"></path>
             </g>
           </svg>
-          <span class="diff-bulk-toggle-label"><span class="diff-bulk-toggle-action">Expand</span><span class="diff-bulk-toggle-all"> all</span></span>
+        </button>
+        <button class="icon-btn diff-sidebar-maximize" id="diffMaximizeBtn" type="button" aria-label="Maximize changes" title="Maximize" data-action="maximize">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <g class="diff-maximize-icon"><path d="M8 3H3v5"></path><path d="m3 3 6 6"></path><path d="M16 3h5v5"></path><path d="m21 3-6 6"></path><path d="M8 21H3v-5"></path><path d="m3 21 6-6"></path><path d="M16 21h5v-5"></path><path d="m21 21-6-6"></path></g>
+            <g class="diff-restore-icon"><path d="M9 4v5H4"></path><path d="m9 9-6-6"></path><path d="M15 4v5h5"></path><path d="m15 9 6-6"></path><path d="M9 20v-5H4"></path><path d="m9 15-6 6"></path><path d="M15 20v-5h5"></path><path d="m15 15 6 6"></path></g>
+          </svg>
         </button>
         <button class="icon-btn diff-sidebar-close" id="diffSidebarCloseBtn" type="button" aria-label="Hide changes" title="Hide changes">✕</button>
       </div>
@@ -384,6 +390,12 @@
         <input class="diff-filter-input" id="diffFilterInput" type="search" placeholder="Filter files…" aria-label="Filter changed files" autocomplete="off" spellcheck="false">
       </div>
       <div class="diff-file-list" id="diffFileList" aria-label="Changed files"></div>
+      <div class="diff-queue-status" id="diffQueueStatus" role="status" aria-live="polite" aria-atomic="true">No inline comments queued.</div>
+      <div class="diff-queue-bar" id="diffQueueBar" hidden>
+        <span class="diff-queue-count"></span>
+        <button class="diff-queue-discard" type="button">Discard</button>
+        <button class="diff-queue-send" type="button">Send comments</button>
+      </div>
     </aside>
 
     <aside class="plan-panel" id="planPanel" hidden role="complementary" aria-labelledby="planPanelTitle">
@@ -703,6 +715,7 @@
   <script src="app-branch-commands.js"></script>
   <script src="app-session-events.js"></script>
   <script src="app-diff-comments.js"></script>
+  <script src="app-diff-queue.js"></script>
   <script src="app-diffs.js"></script>
   <script src="app-worktrees.js"></script>
   <!-- term-llm:webrtc-script -->

--- a/internal/serveui/static/sw.js
+++ b/internal/serveui/static/sw.js
@@ -37,6 +37,7 @@ const SHELL_ASSETS = [
   './intent-storage.js',
   './app-session-admin.js',
   './app-diff-comments.js',
+  './app-diff-queue.js',
   './app-diffs.js',
   './app-worktrees.js',
   // term-llm:webrtc-shell-asset


### PR DESCRIPTION
## Summary

Build out the inline diff review loop after the initial line-comment feature:

- preserve focus when responses land and across diff body/list reorders
- pin commented files open so live-follow cannot collapse or scroll away from the review target
- replace the text-heavy bulk control with an icon and add a same-DOM full-window Changes view
- add session-scoped queued inline comments and deliver a review batch as one user message / one agent run

## Review flow

The inline editor now has a split action:

- **Send now** sends only the current anchored instruction
- **Queue comment** captures the path, side, line, sequence, exact text, context, and instruction without starting a run

The sticky queue bar sends N queued comments as exactly one request carrying N `diff_comment` parts and one provider-facing text block. Direct sends never silently absorb the queue. Failed or branch-context-parked sends preserve authored comments and retry identity.

Queue limits are **20 comments client-side**, **25 `diff_comment` parts server-side**, and **256 KiB aggregate metadata** per message.

## Changes surface

- icon-only expand/collapse with dynamic accessible labels
- maximize/restore covers the window without reparenting or rebuilding the panel
- expansion state, scroll anchor, editor drafts, and focus survive maximize/restore
- main/sidebar become inert while maximized; mobile drawer mode omits maximize
- Escape closes the innermost menu/editor first, then restores the panel, then closes the drawer

## Reliability and accessibility

- response completion restores composer focus only when focus is still idle
- body rebuilds and file-order changes restore the exact focused comment control only when it still exists
- commenting promotes an auto-expanded file to explicit `userExpanded`
- stale/removed panels no longer suppress live-follow forever
- split menu has complete focus, arrow-key, Home/End, Tab, outside-pointer, and Escape behavior
- persistent polite queue status, deliberate focus before queue bar hides, and disabled mutations during send
- queued state uses dedicated storage, not the sent-intent registry
- plural `diffComments` flows through send, interjection, deferred retry, sanitize, conversion, and transcript rendering while retaining singular compatibility

## Verification

- every `internal/serveui/static/*_test.js` suite
- `node --check` for all first-party static JavaScript
- isolated `HOME`/XDG `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`
- live Chromium run with three real Ruby files: queue three anchored comments, send one batch, apply all three changes, keep typing in an unrelated inline draft while the response completes, verify focus remains in the textarea, inspect persisted sent markers, and restore from maximized Changes

## Review process

- Fable reviewed and refined the product interaction plan
- Opus reviewed the full implementation
- all blocker/major findings and robustness suggestions were addressed
- the live demo exposed two additional real-browser focus-loss paths (detached body rebuild and list reorder); both now have realistic regression tests
