### PR TITLE
fix: keep Responses WebSockets alive during tools

### DIFF
--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/gorilla/websocket"
 )
 
 const maxResponsesAPIErrorBodyBytes = 64 * 1024
@@ -54,7 +52,7 @@ type ResponsesClient struct {
 	WebSocketIdleTimeout    time.Duration
 	websocketDisabled       bool
 	wsMu                    sync.Mutex
-	wsConn                  *websocket.Conn
+	wsConn                  *responsesWebSocketConnection
 	wsConnSessionID         string
 	wsConnBetaHeader        string
 	wsLastRequest           *ResponsesRequest

--- a/internal/llm/responses_websocket.go
+++ b/internal/llm/responses_websocket.go
@@ -19,6 +19,225 @@ import (
 
 const responsesWebSocketBetaHeader = "responses_websockets=2026-02-06"
 
+type responsesWebSocketFrameTypeError struct {
+	messageType int
+}
+
+func (e *responsesWebSocketFrameTypeError) Error() string {
+	return fmt.Sprintf("Responses WebSocket returned unsupported frame type %d", e.messageType)
+}
+
+type responsesWebSocketConnection struct {
+	conn *websocket.Conn
+
+	readMu         sync.Mutex
+	readQueue      [][]byte
+	readErr        error
+	readReady      chan struct{}
+	responseActive bool
+	idleTimeout    time.Duration
+	idleTimer      *time.Timer
+	idleGeneration uint64
+}
+
+func newResponsesWebSocketConnection(conn *websocket.Conn, idleTimeout time.Duration) *responsesWebSocketConnection {
+	if idleTimeout == 0 {
+		idleTimeout = 5 * time.Minute
+	}
+	ws := &responsesWebSocketConnection{
+		conn:        conn,
+		readReady:   make(chan struct{}, 1),
+		idleTimeout: idleTimeout,
+	}
+
+	pingHandler := conn.PingHandler()
+	conn.SetPingHandler(func(appData string) error {
+		ws.noteReadActivity()
+		return pingHandler(appData)
+	})
+	conn.SetPongHandler(func(string) error {
+		ws.noteReadActivity()
+		return nil
+	})
+
+	go ws.readPump()
+	return ws
+}
+
+func (c *responsesWebSocketConnection) readPump() {
+	for {
+		messageType, data, err := c.conn.ReadMessage()
+		if err != nil {
+			c.finishReading(err)
+			_ = c.conn.Close()
+			return
+		}
+		if messageType != websocket.TextMessage {
+			err := &responsesWebSocketFrameTypeError{messageType: messageType}
+			c.finishReading(err)
+			_ = c.conn.Close()
+			return
+		}
+
+		c.readMu.Lock()
+		if !c.responseActive {
+			err := errors.New("Responses WebSocket received an application frame while no response was active")
+			c.failReadingLocked(err)
+			c.readMu.Unlock()
+			c.signalReadReady()
+			_ = c.conn.Close()
+			return
+		}
+		c.armIdleTimerLocked()
+		c.readQueue = append(c.readQueue, data)
+		c.readMu.Unlock()
+		c.signalReadReady()
+	}
+}
+
+func (c *responsesWebSocketConnection) startResponse() error {
+	c.readMu.Lock()
+	if c.readErr != nil {
+		err := c.readErr
+		c.readMu.Unlock()
+		return err
+	}
+	if c.responseActive {
+		c.readMu.Unlock()
+		return errors.New("Responses WebSocket response already active")
+	}
+	if len(c.readQueue) != 0 {
+		err := errors.New("Responses WebSocket had stale application frames before response start")
+		c.failReadingLocked(err)
+		c.readMu.Unlock()
+		c.signalReadReady()
+		_ = c.conn.Close()
+		return err
+	}
+	c.responseActive = true
+	c.armIdleTimerLocked()
+	c.readMu.Unlock()
+	return nil
+}
+
+func (c *responsesWebSocketConnection) finishResponse() {
+	c.readMu.Lock()
+	if !c.responseActive {
+		c.readMu.Unlock()
+		return
+	}
+	c.responseActive = false
+	c.disarmIdleTimerLocked()
+	stale := len(c.readQueue) != 0
+	if stale {
+		c.readQueue = nil
+		c.failReadingLocked(errors.New("Responses WebSocket received trailing application frames after response completion"))
+	}
+	c.readMu.Unlock()
+	if stale {
+		c.signalReadReady()
+		_ = c.conn.Close()
+	}
+}
+
+func (c *responsesWebSocketConnection) noteReadActivity() {
+	c.readMu.Lock()
+	if c.responseActive && c.readErr == nil {
+		c.armIdleTimerLocked()
+	}
+	c.readMu.Unlock()
+}
+
+func (c *responsesWebSocketConnection) armIdleTimerLocked() {
+	c.idleGeneration++
+	generation := c.idleGeneration
+	if c.idleTimer != nil {
+		c.idleTimer.Stop()
+	}
+	c.idleTimer = time.AfterFunc(c.idleTimeout, func() {
+		c.readMu.Lock()
+		if !c.responseActive || c.readErr != nil || c.idleGeneration != generation {
+			c.readMu.Unlock()
+			return
+		}
+		c.failReadingLocked(fmt.Errorf("Responses WebSocket response idle timeout after %s", c.idleTimeout))
+		c.readMu.Unlock()
+		c.signalReadReady()
+		_ = c.conn.Close()
+	})
+}
+
+func (c *responsesWebSocketConnection) disarmIdleTimerLocked() {
+	c.idleGeneration++
+	if c.idleTimer != nil {
+		c.idleTimer.Stop()
+		c.idleTimer = nil
+	}
+}
+
+func (c *responsesWebSocketConnection) failReadingLocked(err error) {
+	if c.readErr == nil {
+		c.readErr = err
+	}
+	c.responseActive = false
+	c.disarmIdleTimerLocked()
+}
+
+func (c *responsesWebSocketConnection) finishReading(err error) {
+	c.readMu.Lock()
+	c.failReadingLocked(err)
+	c.readMu.Unlock()
+	c.signalReadReady()
+}
+
+func (c *responsesWebSocketConnection) signalReadReady() {
+	select {
+	case c.readReady <- struct{}{}:
+	default:
+	}
+}
+
+func (c *responsesWebSocketConnection) nextMessage(ctx context.Context) ([]byte, error) {
+	for {
+		c.readMu.Lock()
+		if len(c.readQueue) > 0 {
+			data := c.readQueue[0]
+			c.readQueue[0] = nil
+			c.readQueue = c.readQueue[1:]
+			if len(c.readQueue) == 0 {
+				c.readQueue = nil
+			}
+			c.readMu.Unlock()
+			return data, nil
+		}
+		err := c.readErr
+		c.readMu.Unlock()
+		if err != nil {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-c.readReady:
+		}
+	}
+}
+
+func (c *responsesWebSocketConnection) healthy() bool {
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+	return c.readErr == nil
+}
+
+func (c *responsesWebSocketConnection) close() error {
+	c.readMu.Lock()
+	c.failReadingLocked(errors.New("Responses WebSocket connection closed"))
+	c.readMu.Unlock()
+	c.signalReadReady()
+	return c.conn.Close()
+}
+
 func responsesWebSocketURL(baseURL string) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -86,49 +305,79 @@ func newResponsesWSRequest(req ResponsesRequest) responsesWSRequest {
 	}
 }
 
-func (c *ResponsesClient) writeResponsesWebSocketRequestLocked(conn *websocket.Conn, req ResponsesRequest, reused bool, debugRaw bool) error {
+func prepareResponsesWebSocketRequest(req ResponsesRequest, reused bool, debugRaw bool) ([]byte, error) {
 	wsReq := newResponsesWSRequest(req)
 	body, err := json.Marshal(wsReq)
 	if err != nil {
-		return fmt.Errorf("failed to marshal Responses WebSocket request: %w", err)
+		return nil, fmt.Errorf("failed to marshal Responses WebSocket request: %w", err)
 	}
 	if debugRaw {
 		var prettyBody bytes.Buffer
 		json.Indent(&prettyBody, body, "", "  ")
 		DebugRawSection(debugRaw, fmt.Sprintf("Responses WebSocket Request (reused=%t)", reused), prettyBody.String())
 	}
+	return body, nil
+}
+
+func (c *ResponsesClient) writeResponsesWebSocketRequestLocked(conn *responsesWebSocketConnection, body []byte) error {
 	writeTimeout := c.WebSocketWriteTimeout
 	if writeTimeout == 0 {
 		writeTimeout = 30 * time.Second
 	}
-	if err := conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+	if err := conn.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
 		return fmt.Errorf("set Responses WebSocket write deadline: %w", err)
 	}
-	if err := conn.WriteMessage(websocket.TextMessage, body); err != nil {
+	if err := conn.conn.WriteMessage(websocket.TextMessage, body); err != nil {
 		return fmt.Errorf("write Responses WebSocket request: %w", err)
 	}
-	_ = conn.SetWriteDeadline(time.Time{})
+	_ = conn.conn.SetWriteDeadline(time.Time{})
 	return nil
 }
 
 func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req ResponsesRequest, buildContinuationInput func() []ResponsesInputItem, buildFullInput func() []ResponsesInputItem, debugRaw bool, responseStateGeneration uint64) (Stream, error) {
 	c.wsMu.Lock()
-	wireReq := c.prepareWebSocketContinuationLocked(req, buildContinuationInput, buildFullInput)
 
-	conn, reused, err := c.ensureWebSocket(ctx, wireReq)
+	conn, reused, err := c.ensureWebSocket(ctx, req)
 	if err != nil {
 		c.wsMu.Unlock()
 		return nil, err
 	}
 
-	if err := c.writeResponsesWebSocketRequestLocked(conn, wireReq, reused, debugRaw); err != nil {
-		c.discardWebSocketLocked()
+	wireReq := c.prepareWebSocketContinuationLocked(req, buildContinuationInput, buildFullInput)
+	if c.WebSocketServerState && !reused {
+		// ChatGPT's previous_response_id chain is local to a WebSocket. A fresh
+		// connection cannot continue state created by the socket it replaced.
+		c.clearLastResponseIDIfGeneration(responseStateGeneration, wireReq.SessionID, wireReq.PreviousResponseID)
+		c.wsLastRequest = nil
+		wireReq.PreviousResponseID = ""
+		wireReq.Input = buildFullInput()
+	}
+
+	body, err := prepareResponsesWebSocketRequest(wireReq, reused, debugRaw)
+	if err != nil {
 		c.wsMu.Unlock()
 		return nil, err
 	}
 
 	return newEventStream(ctx, func(ctx context.Context, send eventSender) error {
 		defer c.wsMu.Unlock()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := conn.startResponse(); err != nil {
+			c.discardWebSocketLocked()
+			return err
+		}
+		responseActive := true
+		defer func() {
+			if responseActive {
+				conn.finishResponse()
+			}
+		}()
+		if err := c.writeResponsesWebSocketRequestLocked(conn, body); err != nil {
+			c.discardWebSocketLocked()
+			return err
+		}
 
 		ctxDone := make(chan struct{})
 		var stopCtxWatcher sync.Once
@@ -147,7 +396,7 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 					return
 				default:
 				}
-				_ = conn.Close()
+				_ = conn.close()
 			case <-ctxDone:
 			}
 		}()
@@ -155,39 +404,22 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 
 		handler := newResponsesStreamEventHandler(c, responseStateGeneration, debugRaw, "Responses WebSocket", c.websocketServerStateEnabled(), wireReq.SessionID, wireReq.suppressReasoningSummaryDeltas())
 		retriedFullState := false
-		idleTimeout := c.WebSocketIdleTimeout
-		if idleTimeout == 0 {
-			idleTimeout = 5 * time.Minute
-		}
-		if !reused {
-			pingHandler := conn.PingHandler()
-			conn.SetPingHandler(func(appData string) error {
-				if err := conn.SetReadDeadline(time.Now().Add(idleTimeout)); err != nil {
-					return err
-				}
-				return pingHandler(appData)
-			})
-		}
-		conn.SetPongHandler(func(string) error {
-			return conn.SetReadDeadline(time.Now().Add(idleTimeout))
-		})
 
 		for {
-			_ = conn.SetReadDeadline(time.Now().Add(idleTimeout))
-			messageType, data, err := conn.ReadMessage()
+			data, err := conn.nextMessage(ctx)
 			if err != nil {
 				c.discardWebSocketLocked()
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
+				var frameTypeErr *responsesWebSocketFrameTypeError
+				if errors.As(err, &frameTypeErr) {
+					return frameTypeErr
+				}
 				if finishErr := handler.FinishIncomplete(send); finishErr != nil {
 					return &StreamIncompleteError{Transport: "Responses WebSocket", Terminal: "response.completed", Err: finishErr}
 				}
 				return &StreamIncompleteError{Transport: "Responses WebSocket", Terminal: "response.completed", Err: err}
-			}
-			if messageType != websocket.TextMessage {
-				c.discardWebSocketLocked()
-				return fmt.Errorf("Responses WebSocket returned unsupported frame type %d", messageType)
 			}
 
 			eventType, err := responsesJSONEventType(data)
@@ -227,7 +459,12 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 					if debugRaw {
 						DebugRawSection(debugRaw, "Responses WebSocket Full-State Retry", err.Error())
 					}
-					if err := c.writeResponsesWebSocketRequestLocked(conn, wireReq, true, debugRaw); err != nil {
+					retryBody, prepareErr := prepareResponsesWebSocketRequest(wireReq, true, debugRaw)
+					if prepareErr != nil {
+						c.discardWebSocketLocked()
+						return prepareErr
+					}
+					if err := c.writeResponsesWebSocketRequestLocked(conn, retryBody); err != nil {
 						c.discardWebSocketLocked()
 						return err
 					}
@@ -240,6 +477,12 @@ func (c *ResponsesClient) streamWebSocketPrepared(ctx context.Context, req Respo
 				break
 			}
 		}
+
+		// Park the pump before publishing EventDone. Any already-queued trailing
+		// application frame invalidates the connection, and subsequent pings/closes
+		// remain serviced without an inference idle timer.
+		conn.finishResponse()
+		responseActive = false
 
 		// Stop the cancellation watcher before emitting the terminal EventDone.
 		// Consumers commonly call Close immediately after receiving EventDone; if the
@@ -272,7 +515,8 @@ func isPreviousResponseIDRejected(err error) bool {
 		}
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "previous_response_id") && (strings.Contains(msg, "unsupported") || strings.Contains(msg, "not found"))
+	return strings.Contains(msg, "previous_response_id") &&
+		(strings.Contains(msg, "invalid") || strings.Contains(msg, "unsupported") || strings.Contains(msg, "not found"))
 }
 
 func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesRequest, buildContinuationInput func() []ResponsesInputItem, buildFullInput func() []ResponsesInputItem) ResponsesRequest {
@@ -297,11 +541,15 @@ func (c *ResponsesClient) prepareWebSocketContinuationLocked(req ResponsesReques
 	}
 
 	if c.wsLastRequest == nil {
+		if c.WebSocketServerState {
+			// Connection-local continuation has no baseline on this socket.
+			return useFullInput()
+		}
+		// Other Responses providers may expose durable previous_response_id state
+		// that predates this client connection.
 		if req.Input != nil {
 			return req
 		}
-		// Reuse the already-incremental continuation when available so a resumed
-		// previous_response_id chain does not rebuild the full transcript locally.
 		if continuation := buildContinuationInput(); len(continuation) > 0 {
 			req.Input = continuation
 			return req
@@ -616,7 +864,7 @@ func jsonStringValueForCompare(v reflect.Value) (string, bool) {
 	return v.String(), true
 }
 
-func (c *ResponsesClient) ensureWebSocket(ctx context.Context, req ResponsesRequest) (*websocket.Conn, bool, error) {
+func (c *ResponsesClient) ensureWebSocket(ctx context.Context, req ResponsesRequest) (*responsesWebSocketConnection, bool, error) {
 	betaHeader := ""
 	if c.ExtraHeaders != nil {
 		betaHeader = c.ExtraHeaders["OpenAI-Beta"]
@@ -626,12 +874,12 @@ func (c *ResponsesClient) ensureWebSocket(ctx context.Context, req ResponsesRequ
 	}
 	betaHeader = composeBetaHeader(betaHeader, responsesWebSocketBetaHeader)
 	if c.wsConn != nil {
-		if c.wsConnSessionID == req.SessionID && c.wsConnBetaHeader == betaHeader {
+		if c.wsConn.healthy() && c.wsConnSessionID == req.SessionID && c.wsConnBetaHeader == betaHeader {
 			return c.wsConn, true, nil
 		}
-		// SessionID is sent as a WebSocket handshake header for providers that bind
-		// session state to the connection (notably ChatGPT). Reconnect rather than
-		// reusing a socket authenticated for a different session.
+		// SessionID and feature betas are WebSocket handshake state. A read
+		// error also makes the connection ineligible for reuse, even when it
+		// arrived while no response stream was consuming application frames.
 		c.discardWebSocketLocked()
 	}
 	wsURL := c.WebSocketURL
@@ -682,10 +930,10 @@ func (c *ResponsesClient) ensureWebSocket(ctx context.Context, req ResponsesRequ
 					defer retryCancel()
 					conn, retryResp, retryErr := dialOnce(retryCtx, headerWithFreshAuth(header, c))
 					if retryErr == nil {
-						c.wsConn = conn
+						c.wsConn = newResponsesWebSocketConnection(conn, c.WebSocketIdleTimeout)
 						c.wsConnSessionID = req.SessionID
 						c.wsConnBetaHeader = betaHeader
-						return conn, false, nil
+						return c.wsConn, false, nil
 					}
 					if retryResp != nil {
 						defer closeWebSocketHandshakeResponse(retryResp)
@@ -701,10 +949,10 @@ func (c *ResponsesClient) ensureWebSocket(ctx context.Context, req ResponsesRequ
 		}
 		return nil, false, fmt.Errorf("connect Responses WebSocket: %w", err)
 	}
-	c.wsConn = conn
+	c.wsConn = newResponsesWebSocketConnection(conn, c.WebSocketIdleTimeout)
 	c.wsConnSessionID = req.SessionID
 	c.wsConnBetaHeader = betaHeader
-	return conn, false, nil
+	return c.wsConn, false, nil
 }
 
 func closeWebSocketHandshakeResponse(resp *http.Response) {
@@ -734,9 +982,9 @@ func (c *ResponsesClient) discardWebSocketLocked() {
 		return
 	}
 	closeTimeout := 5 * time.Second
-	_ = c.wsConn.SetWriteDeadline(time.Now().Add(closeTimeout))
-	_ = c.wsConn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-	_ = c.wsConn.Close()
+	_ = c.wsConn.conn.SetWriteDeadline(time.Now().Add(closeTimeout))
+	_ = c.wsConn.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	_ = c.wsConn.close()
 	c.wsConn = nil
 	c.wsConnSessionID = ""
 	c.wsConnBetaHeader = ""

--- a/internal/llm/responses_websocket_test.go
+++ b/internal/llm/responses_websocket_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -341,15 +342,15 @@ func TestResponsesWebSocketCompletionStoresLightweightLastRequest(t *testing.T) 
 		t.Fatalf("Close: %v", err)
 	}
 
-	if fullInputCalls.Load() != 0 {
-		t.Fatalf("buildFullInput calls = %d, want 0", fullInputCalls.Load())
+	if fullInputCalls.Load() != 1 {
+		t.Fatalf("buildFullInput calls = %d, want 1 for fresh connection", fullInputCalls.Load())
 	}
-	if gotReq["previous_response_id"] != "resp_prev" {
-		t.Fatalf("previous_response_id = %#v, want resp_prev", gotReq["previous_response_id"])
+	if _, ok := gotReq["previous_response_id"]; ok {
+		t.Fatalf("fresh connection sent previous_response_id: %#v", gotReq)
 	}
 	input, ok := gotReq["input"].([]any)
-	if !ok || len(input) != 1 || !strings.Contains(toJSON(input[0]), "two") {
-		t.Fatalf("input = %#v, want only continuation input", gotReq["input"])
+	if !ok || len(input) != 3 || !strings.Contains(toJSON(input[0]), "one") || !strings.Contains(toJSON(input[2]), "two") {
+		t.Fatalf("input = %#v, want full transcript on fresh connection", gotReq["input"])
 	}
 
 	client.wsMu.Lock()
@@ -626,6 +627,583 @@ func TestResponsesClientWebSocketServerPingsKeepStreamAlive(t *testing.T) {
 		case EventError:
 			t.Fatalf("stream error: %v", event.Err)
 		}
+	}
+}
+
+func TestResponsesClientWebSocketServerPingReceivesPongWhileIdle(t *testing.T) {
+	const idleTimeout = 40 * time.Millisecond
+
+	var handshakeCount atomic.Int32
+	pingWhileIdle := make(chan struct{}, 1)
+	pongReceived := make(chan string, 1)
+	serverDone := make(chan struct{})
+	var serverDoneOnce sync.Once
+
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer serverDoneOnce.Do(func() { close(serverDone) })
+		handshakeCount.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read first request: %v", err)
+			return
+		}
+		if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_1"}}); err != nil {
+			t.Errorf("write first completion: %v", err)
+			return
+		}
+
+		<-pingWhileIdle
+		conn.SetPongHandler(func(appData string) error {
+			select {
+			case pongReceived <- appData:
+			default:
+			}
+			return nil
+		})
+		if err := conn.WriteControl(websocket.PingMessage, []byte("idle-heartbeat"), time.Now().Add(5*time.Second)); err != nil {
+			t.Errorf("write idle ping: %v", err)
+			return
+		}
+
+		// ReadMessage drives the server-side pong handler and then returns the
+		// second response.create on the same connection.
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read second request: %v", err)
+			return
+		}
+		if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_2"}}); err != nil {
+			t.Errorf("write second completion: %v", err)
+		}
+	}))
+	defer server.Close()
+	defer func() {
+		select {
+		case pingWhileIdle <- struct{}{}:
+		default:
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client := &ResponsesClient{
+		BaseURL:              server.URL,
+		UseWebSocket:         true,
+		WebSocketIdleTimeout: idleTimeout,
+	}
+	first, err := client.Stream(ctx, ResponsesRequest{
+		Model:  "gpt-test",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "first"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("first Stream: %v", err)
+	}
+	drainStreamToDone(t, first)
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first stream: %v", err)
+	}
+
+	parked := time.NewTimer(5 * idleTimeout)
+	select {
+	case <-parked.C:
+	case <-ctx.Done():
+		parked.Stop()
+		t.Fatalf("waiting beyond the active-response idle timeout: %v", ctx.Err())
+	}
+	pingWhileIdle <- struct{}{}
+	select {
+	case pong := <-pongReceived:
+		if pong != "idle-heartbeat" {
+			t.Fatalf("pong payload = %q, want idle-heartbeat", pong)
+		}
+	case <-ctx.Done():
+		t.Fatalf("idle ping was not answered: %v", ctx.Err())
+	}
+
+	second, err := client.Stream(ctx, ResponsesRequest{
+		Model:  "gpt-test",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "second"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("second Stream: %v", err)
+	}
+	drainStreamToDone(t, second)
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second stream: %v", err)
+	}
+	select {
+	case <-serverDone:
+	case <-ctx.Done():
+		t.Fatalf("server did not finish: %v", ctx.Err())
+	}
+	if got := handshakeCount.Load(); got != 1 {
+		t.Fatalf("WebSocket handshakes = %d, want 1 reused connection", got)
+	}
+}
+
+func TestResponsesClientWebSocketIdleCloseReconnectsNextRequest(t *testing.T) {
+	var handshakeCount atomic.Int32
+	closeWhileIdle := make(chan struct{}, 1)
+	closeObserved := make(chan error, 1)
+
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handshake := handshakeCount.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade %d: %v", handshake, err)
+			return
+		}
+		defer conn.Close()
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read request %d: %v", handshake, err)
+			return
+		}
+		var wireReq map[string]any
+		if err := json.Unmarshal(msg, &wireReq); err != nil {
+			t.Errorf("decode request %d: %v", handshake, err)
+			return
+		}
+		if handshake == 2 {
+			if previousResponseID, ok := wireReq["previous_response_id"]; ok {
+				_ = conn.WriteJSON(map[string]any{
+					"type":   "response.failed",
+					"status": 400,
+					"response": map[string]any{
+						"error": map[string]any{"code": "invalid_request_error", "message": "Invalid previous_response_id"},
+					},
+				})
+				t.Errorf("reconnected request sent connection-local previous_response_id %#v", previousResponseID)
+				return
+			}
+			input, ok := wireReq["input"].([]any)
+			if !ok || len(input) != 3 || !strings.Contains(toJSON(input[0]), "first") || !strings.Contains(toJSON(input[2]), "second") {
+				t.Errorf("reconnected input = %#v, want full three-item transcript", wireReq["input"])
+				return
+			}
+		}
+		if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": fmt.Sprintf("resp_%d", handshake)}}); err != nil {
+			t.Errorf("write completion %d: %v", handshake, err)
+			return
+		}
+		if handshake != 1 {
+			return
+		}
+
+		<-closeWhileIdle
+		if err := conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "idle close"), time.Now().Add(5*time.Second)); err != nil {
+			t.Errorf("write idle close: %v", err)
+			return
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_, _, readErr := conn.ReadMessage() // Wait until the client's read pump replies to the close.
+		closeObserved <- readErr
+	}))
+	defer server.Close()
+	defer func() {
+		select {
+		case closeWhileIdle <- struct{}{}:
+		default:
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client := &ResponsesClient{
+		BaseURL:              server.URL,
+		UseWebSocket:         true,
+		DisableServerState:   true,
+		WebSocketServerState: true,
+	}
+	first, err := client.Stream(ctx, ResponsesRequest{
+		Model:  "gpt-test",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "first"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("first Stream: %v", err)
+	}
+	drainStreamToDone(t, first)
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first stream: %v", err)
+	}
+
+	closeWhileIdle <- struct{}{}
+	select {
+	case closeErr := <-closeObserved:
+		if !websocket.IsCloseError(closeErr, websocket.CloseNormalClosure) {
+			t.Fatalf("client did not service idle close with a close reply: %v", closeErr)
+		}
+	case <-ctx.Done():
+		t.Fatalf("idle close was not serviced: %v", ctx.Err())
+	}
+
+	second, err := client.Stream(ctx, ResponsesRequest{
+		Model: "gpt-test",
+		Input: []ResponsesInputItem{
+			{Type: "message", Role: "user", Content: "first"},
+			{Type: "message", Role: "assistant", Content: "first response"},
+			{Type: "message", Role: "user", Content: "second"},
+		},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("second Stream: %v", err)
+	}
+	drainStreamToDone(t, second)
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second stream: %v", err)
+	}
+	if got := handshakeCount.Load(); got != 2 {
+		t.Fatalf("WebSocket handshakes = %d, want reconnect after idle close", got)
+	}
+}
+
+func TestResponsesClientWebSocketApplicationFrameWhileIdleReconnects(t *testing.T) {
+	tests := []struct {
+		name  string
+		frame map[string]any
+	}{
+		{
+			name: "generic error",
+			frame: map[string]any{
+				"type":  "error",
+				"error": map[string]any{"code": "server_error", "message": "idle server error"},
+			},
+		},
+		{
+			name: "connection limit reached",
+			frame: map[string]any{
+				"type":  "error",
+				"error": map[string]any{"code": "websocket_connection_limit_reached", "message": "connection expired"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var handshakeCount atomic.Int32
+			sendIdleFrame := make(chan struct{})
+			idleConnectionClosed := make(chan error, 1)
+			secondRequest := make(chan map[string]any, 1)
+
+			upgrader := websocket.Upgrader{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handshake := handshakeCount.Add(1)
+				conn, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					t.Errorf("upgrade %d: %v", handshake, err)
+					return
+				}
+				defer conn.Close()
+
+				_, msg, err := conn.ReadMessage()
+				if err != nil {
+					t.Errorf("read request %d: %v", handshake, err)
+					return
+				}
+				if handshake == 1 {
+					if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_1"}}); err != nil {
+						t.Errorf("write first completion: %v", err)
+						return
+					}
+					<-sendIdleFrame
+					if err := conn.WriteJSON(tt.frame); err != nil {
+						t.Errorf("write idle frame: %v", err)
+						return
+					}
+					_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+					_, _, err = conn.ReadMessage()
+					idleConnectionClosed <- err
+					return
+				}
+
+				var wireReq map[string]any
+				if err := json.Unmarshal(msg, &wireReq); err != nil {
+					t.Errorf("decode reconnected request: %v", err)
+					return
+				}
+				secondRequest <- wireReq
+				if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_2"}}); err != nil {
+					t.Errorf("write second completion: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			client := &ResponsesClient{
+				BaseURL:              server.URL,
+				UseWebSocket:         true,
+				DisableServerState:   true,
+				WebSocketServerState: true,
+			}
+			defer client.closeWebSocket()
+
+			first, err := client.Stream(ctx, ResponsesRequest{
+				Model:  "gpt-test",
+				Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "first"}},
+				Stream: true,
+			}, false)
+			if err != nil {
+				t.Fatalf("first Stream: %v", err)
+			}
+			drainStreamToDone(t, first)
+			if err := first.Close(); err != nil {
+				t.Fatalf("close first stream: %v", err)
+			}
+
+			close(sendIdleFrame)
+			select {
+			case closeErr := <-idleConnectionClosed:
+				if closeErr == nil {
+					t.Fatal("idle application frame did not make the connection close")
+				}
+			case <-ctx.Done():
+				t.Fatalf("idle application frame was not discarded: %v", ctx.Err())
+			}
+
+			second, err := client.Stream(ctx, ResponsesRequest{
+				Model: "gpt-test",
+				Input: []ResponsesInputItem{
+					{Type: "message", Role: "user", Content: "first"},
+					{Type: "message", Role: "assistant", Content: "first response"},
+					{Type: "message", Role: "user", Content: "second"},
+				},
+				Stream: true,
+			}, false)
+			if err != nil {
+				t.Fatalf("second Stream: %v", err)
+			}
+			drainStreamToDone(t, second)
+			if err := second.Close(); err != nil {
+				t.Fatalf("close second stream: %v", err)
+			}
+
+			var wireReq map[string]any
+			select {
+			case wireReq = <-secondRequest:
+			case <-ctx.Done():
+				t.Fatalf("reconnected request was not observed: %v", ctx.Err())
+			}
+			if _, ok := wireReq["previous_response_id"]; ok {
+				t.Fatalf("reconnected request sent connection-local previous_response_id: %#v", wireReq)
+			}
+			input, ok := wireReq["input"].([]any)
+			if !ok || len(input) != 3 || !strings.Contains(toJSON(input[0]), "first") || !strings.Contains(toJSON(input[2]), "second") {
+				t.Fatalf("reconnected input = %#v, want full three-item transcript", wireReq["input"])
+			}
+			if got := handshakeCount.Load(); got != 2 {
+				t.Fatalf("WebSocket handshakes = %d, want reconnect after idle application frame", got)
+			}
+		})
+	}
+}
+
+func TestResponsesClientWebSocketTrailingFrameAfterCompletionReconnects(t *testing.T) {
+	var handshakeCount atomic.Int32
+	firstConnectionClosed := make(chan error, 1)
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handshake := handshakeCount.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade %d: %v", handshake, err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read request %d: %v", handshake, err)
+			return
+		}
+		if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": fmt.Sprintf("resp_%d", handshake)}}); err != nil {
+			t.Errorf("write completion %d: %v", handshake, err)
+			return
+		}
+		if handshake != 1 {
+			return
+		}
+		if err := conn.WriteJSON(map[string]any{
+			"type":  "error",
+			"error": map[string]any{"code": "server_error", "message": "trailing error"},
+		}); err != nil {
+			t.Errorf("write trailing frame: %v", err)
+			return
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_, _, err = conn.ReadMessage()
+		firstConnectionClosed <- err
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client := &ResponsesClient{BaseURL: server.URL, UseWebSocket: true}
+	defer client.closeWebSocket()
+	request := ResponsesRequest{
+		Model:  "gpt-test",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "request"}},
+		Stream: true,
+	}
+
+	first, err := client.Stream(ctx, request, false)
+	if err != nil {
+		t.Fatalf("first Stream: %v", err)
+	}
+	drainStreamToDone(t, first)
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first stream: %v", err)
+	}
+	select {
+	case closeErr := <-firstConnectionClosed:
+		if closeErr == nil {
+			t.Fatal("trailing application frame did not make the connection close")
+		}
+	case <-ctx.Done():
+		t.Fatalf("trailing application frame was not discarded: %v", ctx.Err())
+	}
+
+	second, err := client.Stream(ctx, request, false)
+	if err != nil {
+		t.Fatalf("second Stream: %v", err)
+	}
+	drainStreamToDone(t, second)
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second stream: %v", err)
+	}
+	if got := handshakeCount.Load(); got != 2 {
+		t.Fatalf("WebSocket handshakes = %d, want reconnect after trailing frame", got)
+	}
+}
+
+func TestResponsesClientWebSocketWriteFailureReconnectSendsFullState(t *testing.T) {
+	withResponsesWebSocketBaseBackoff(t, 0)
+
+	var handshakeCount atomic.Int32
+	releaseFirstConnection := make(chan struct{})
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handshake := handshakeCount.Add(1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade %d: %v", handshake, err)
+			return
+		}
+		defer conn.Close()
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read request %d: %v", handshake, err)
+			return
+		}
+		var wireReq map[string]any
+		if err := json.Unmarshal(msg, &wireReq); err != nil {
+			t.Errorf("decode request %d: %v", handshake, err)
+			return
+		}
+		if handshake == 2 {
+			if previousResponseID, ok := wireReq["previous_response_id"]; ok {
+				t.Errorf("write-failure reconnect sent connection-local previous_response_id %#v", previousResponseID)
+				return
+			}
+			input, ok := wireReq["input"].([]any)
+			if !ok || len(input) != 3 || !strings.Contains(toJSON(input[0]), "first") || !strings.Contains(toJSON(input[2]), "second") {
+				t.Errorf("write-failure reconnect input = %#v, want full three-item transcript", wireReq["input"])
+				return
+			}
+		}
+		if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": fmt.Sprintf("resp_%d", handshake)}}); err != nil {
+			t.Errorf("write completion %d: %v", handshake, err)
+			return
+		}
+		if handshake == 1 {
+			<-releaseFirstConnection
+		}
+	}))
+	defer server.Close()
+	defer close(releaseFirstConnection)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client := &ResponsesClient{
+		BaseURL:              server.URL,
+		UseWebSocket:         true,
+		DisableServerState:   true,
+		WebSocketServerState: true,
+	}
+	first, err := client.Stream(ctx, ResponsesRequest{
+		Model:  "gpt-test",
+		Input:  []ResponsesInputItem{{Type: "message", Role: "user", Content: "first"}},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("first Stream: %v", err)
+	}
+	drainStreamToDone(t, first)
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first stream: %v", err)
+	}
+
+	client.wsMu.Lock()
+	conn := client.wsConn
+	if conn != nil {
+		err = conn.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "poison next write"), time.Now().Add(5*time.Second))
+	}
+	client.wsMu.Unlock()
+	if conn == nil {
+		t.Fatal("WebSocket connection was not retained after first stream")
+	}
+	if err != nil {
+		t.Fatalf("poison WebSocket write path: %v", err)
+	}
+
+	second, err := client.Stream(ctx, ResponsesRequest{
+		Model: "gpt-test",
+		Input: []ResponsesInputItem{
+			{Type: "message", Role: "user", Content: "first"},
+			{Type: "message", Role: "assistant", Content: "first response"},
+			{Type: "message", Role: "user", Content: "second"},
+		},
+		Stream: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("second Stream: %v", err)
+	}
+	retries := 0
+	for {
+		event, recvErr := second.Recv()
+		if recvErr != nil {
+			t.Fatalf("second Recv: %v", recvErr)
+		}
+		switch event.Type {
+		case EventRetry:
+			retries++
+		case EventDone:
+			goto secondDone
+		case EventError:
+			t.Fatalf("second stream error: %v", event.Err)
+		}
+	}
+
+secondDone:
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second stream: %v", err)
+	}
+	if retries != 1 {
+		t.Fatalf("retry events = %d, want 1 for reused write failure", retries)
+	}
+	if got := handshakeCount.Load(); got != 2 {
+		t.Fatalf("WebSocket handshakes = %d, want one write-failure reconnect", got)
 	}
 }
 
@@ -1146,93 +1724,128 @@ func TestResponsesClientHTTPFallbackWithWebSocketOnlyServerStateSendsFullInput(t
 }
 
 func TestResponsesClientWebSocketPreviousResponseRejectedRetriesFullState(t *testing.T) {
-	var secondRequest map[string]any
-	upgrader := websocket.Upgrader{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			t.Errorf("upgrade: %v", err)
-			return
-		}
-		defer conn.Close()
-
-		// First stream establishes a response id.
-		_, _, err = conn.ReadMessage()
-		if err != nil {
-			t.Errorf("read first request: %v", err)
-			return
-		}
-		_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_1"}})
-
-		// Second stream first attempts previous_response_id.
-		_, msg, err := conn.ReadMessage()
-		if err != nil {
-			t.Errorf("read incremental request: %v", err)
-			return
-		}
-		var incremental map[string]any
-		_ = json.Unmarshal(msg, &incremental)
-		if incremental["previous_response_id"] != "resp_1" {
-			t.Errorf("incremental previous_response_id = %#v", incremental["previous_response_id"])
-		}
-		_ = conn.WriteJSON(map[string]any{
-			"type":   "response.failed",
-			"status": 400,
-			"response": map[string]any{
-				"error": map[string]any{"code": "previous_response_not_found", "message": "Previous response not found", "param": "previous_response_id"},
+	tests := []struct {
+		name     string
+		apiError map[string]any
+	}{
+		{
+			name: "structured previous response not found",
+			apiError: map[string]any{
+				"code":    "previous_response_not_found",
+				"message": "Previous response not found",
+				"param":   "previous_response_id",
 			},
+		},
+		{
+			name: "invalid previous response id",
+			apiError: map[string]any{
+				"code":    "invalid_request_error",
+				"message": "Invalid previous_response_id",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secondRequest := make(chan map[string]any, 1)
+			upgrader := websocket.Upgrader{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					t.Errorf("upgrade: %v", err)
+					return
+				}
+				defer conn.Close()
+
+				// First stream establishes a response id.
+				if _, _, err := conn.ReadMessage(); err != nil {
+					t.Errorf("read first request: %v", err)
+					return
+				}
+				if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_1"}}); err != nil {
+					t.Errorf("write first completion: %v", err)
+					return
+				}
+
+				// Second stream first attempts connection-local continuation.
+				_, msg, err := conn.ReadMessage()
+				if err != nil {
+					t.Errorf("read incremental request: %v", err)
+					return
+				}
+				var incremental map[string]any
+				if err := json.Unmarshal(msg, &incremental); err != nil {
+					t.Errorf("decode incremental request: %v", err)
+					return
+				}
+				if incremental["previous_response_id"] != "resp_1" {
+					t.Errorf("incremental previous_response_id = %#v", incremental["previous_response_id"])
+					return
+				}
+				if err := conn.WriteJSON(map[string]any{
+					"type":   "response.failed",
+					"status": 400,
+					"response": map[string]any{
+						"error": tt.apiError,
+					},
+				}); err != nil {
+					t.Errorf("write continuation rejection: %v", err)
+					return
+				}
+
+				// Client should retry the same turn as full state on this connection.
+				_, msg, err = conn.ReadMessage()
+				if err != nil {
+					t.Errorf("read full-state retry: %v", err)
+					return
+				}
+				var fullState map[string]any
+				if err := json.Unmarshal(msg, &fullState); err != nil {
+					t.Errorf("decode full-state retry: %v", err)
+					return
+				}
+				secondRequest <- fullState
+				if err := conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_2"}}); err != nil {
+					t.Errorf("write second completion: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client := &ResponsesClient{BaseURL: server.URL, UseWebSocket: true, WebSocketServerState: true, DisableServerState: true}
+			defer client.closeWebSocket()
+			discoveryCall := ResponsesInputItem{Raw: json.RawMessage(`{"type":"tool_search_call","execution":"client","call_id":"search-1","status":"completed","arguments":{"query":"eta"}}`)}
+			discoveryOutput := ResponsesInputItem{Raw: json.RawMessage(`{"type":"tool_search_output","execution":"client","call_id":"search-1","status":"completed","tools":[{"type":"function","name":"eta","description":"eta","defer_loading":true,"parameters":{"type":"object"}}]}`)}
+			for _, input := range [][]ResponsesInputItem{
+				{{Type: "message", Role: "user", Content: "one"}},
+				{{Type: "message", Role: "user", Content: "one"}, discoveryCall, discoveryOutput, {Type: "message", Role: "user", Content: "two"}},
+			} {
+				stream, err := client.Stream(context.Background(), ResponsesRequest{Model: "gpt-test", Input: input, Stream: true}, false)
+				if err != nil {
+					t.Fatalf("Stream: %v", err)
+				}
+				drainStreamToDone(t, stream)
+				if err := stream.Close(); err != nil {
+					t.Fatalf("Close: %v", err)
+				}
+			}
+
+			fullState := <-secondRequest
+			if _, ok := fullState["previous_response_id"]; ok {
+				t.Fatalf("full-state retry still had previous_response_id: %#v", fullState)
+			}
+			input, ok := fullState["input"].([]any)
+			if !ok || len(input) != 4 {
+				t.Fatalf("full-state retry input = %#v, want message plus discovery call/output plus continuation", fullState["input"])
+			}
+			var types []string
+			for _, value := range input {
+				item, _ := value.(map[string]any)
+				types = append(types, fmt.Sprint(item["type"]))
+			}
+			if got := strings.Join(types, ","); got != "message,tool_search_call,tool_search_output,message" {
+				t.Fatalf("full-state retry item types = %s", got)
+			}
 		})
-
-		// Client should retry the same turn as full state on the same connection.
-		_, msg, err = conn.ReadMessage()
-		if err != nil {
-			t.Errorf("read full-state retry: %v", err)
-			return
-		}
-		_ = json.Unmarshal(msg, &secondRequest)
-		_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_2"}})
-	}))
-	defer server.Close()
-
-	client := &ResponsesClient{BaseURL: server.URL, UseWebSocket: true, WebSocketServerState: true, DisableServerState: true}
-	discoveryCall := ResponsesInputItem{Raw: json.RawMessage(`{"type":"tool_search_call","execution":"client","call_id":"search-1","status":"completed","arguments":{"query":"eta"}}`)}
-	discoveryOutput := ResponsesInputItem{Raw: json.RawMessage(`{"type":"tool_search_output","execution":"client","call_id":"search-1","status":"completed","tools":[{"type":"function","name":"eta","description":"eta","defer_loading":true,"parameters":{"type":"object"}}]}`)}
-	for _, input := range [][]ResponsesInputItem{
-		{{Type: "message", Role: "user", Content: "one"}},
-		{{Type: "message", Role: "user", Content: "one"}, discoveryCall, discoveryOutput, {Type: "message", Role: "user", Content: "two"}},
-	} {
-		stream, err := client.Stream(context.Background(), ResponsesRequest{Model: "gpt-test", Input: input, Stream: true}, false)
-		if err != nil {
-			t.Fatalf("Stream: %v", err)
-		}
-		for {
-			event, err := stream.Recv()
-			if err != nil {
-				t.Fatalf("Recv: %v", err)
-			}
-			if event.Type == EventDone {
-				break
-			}
-			if event.Type == EventError {
-				t.Fatalf("stream error: %v", event.Err)
-			}
-		}
-		_ = stream.Close()
-	}
-	if _, ok := secondRequest["previous_response_id"]; ok {
-		t.Fatalf("full-state retry still had previous_response_id: %#v", secondRequest)
-	}
-	input, ok := secondRequest["input"].([]any)
-	if !ok || len(input) != 4 {
-		t.Fatalf("full-state retry input = %#v, want message plus discovery call/output plus continuation", secondRequest["input"])
-	}
-	var types []string
-	for _, value := range input {
-		item, _ := value.(map[string]any)
-		types = append(types, fmt.Sprint(item["type"]))
-	}
-	if got := strings.Join(types, ","); got != "message,tool_search_call,tool_search_output,message" {
-		t.Fatalf("full-state retry item types = %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep a connection-scoped Responses WebSocket read pump running between model requests so server ping, close, and transport frames are serviced during long local tool calls
- apply the response idle timeout only while inference is active, not while a tool is running
- invalidate idle/trailing application frames instead of letting them contaminate the next response
- preserve visible retry, cancellation, backoff, and HTTP fallback semantics when a socket dies before a request write
- clear ChatGPT's connection-local `previous_response_id` when reconnecting and rebuild full input on the replacement socket

## Why

Previously, term-llm stopped reading the provider WebSocket after `response.completed`. During a long tool call the socket was parked unread, so server pings and close frames were not processed. Socket death was only discovered after the tool returned.

A live 290-second pre-fix tool pause reproduced the failure: the reused write timed out, five replacement WebSockets sent the stale connection-local `previous_response_id`, OpenAI rejected each one as invalid, and term-llm fell back to SSE.

This follows Codex's connection-scoped read-pump architecture while retaining term-llm's existing stream and fallback contracts.

## Validation

- `go test -race ./internal/llm`
- `go test ./internal/llm`
- focused retry, cancellation, idle ping/pong, idle close, idle error-frame, trailing-frame, and reconnect tests repeated 30–50 times, including under `-race`
- `go build ./...`
- `go vet ./internal/llm`
- patched live Sol test: 250-second tool pause, exact `WS_POSTFIX_LONG_IDLE_OK`, one WebSocket reused after the pause, no retry, fallback, or SSE transition
- reviewed with `claude-bin:opus-max`; its blocking retry-path and idle-timeout findings were fixed, then a final targeted review found no remaining blocking or high-severity issues

`go test ./...` also ran. The changed `internal/llm` package passed; the full run hit unrelated existing failures in request-directory skill discovery tests and `internal/filetrack` budget pruning.
