### PR TITLE
fix: Script-backed custom tools report execution failures as successes

### DIFF
--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -29,6 +29,12 @@ type CustomScriptTool struct {
 	toolConfig *ToolConfig
 }
 
+func scriptToolErrorOutput(err *ToolError) llm.ToolOutput {
+	output := llm.TextOutput(formatToolError(err))
+	output.IsError = true
+	return output
+}
+
 // newCustomScriptTool creates a CustomScriptTool from a definition and agent directory.
 func newCustomScriptTool(def agents.CustomToolDef, agentDir string, limits OutputLimits, toolConfigs ...*ToolConfig) *CustomScriptTool {
 	return &CustomScriptTool{
@@ -73,13 +79,13 @@ func (t *CustomScriptTool) Preview(args json.RawMessage) string {
 func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
 	// Validate agentDir is set
 	if t.agentDir == "" {
-		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "no agent directory configured"))), nil
+		return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "no agent directory configured")), nil
 	}
 
 	// Resolve and validate the script path
 	scriptPath, err := t.resolveScript()
 	if err != nil {
-		return llm.TextOutput(formatToolError(err.(*ToolError))), nil
+		return scriptToolErrorOutput(err.(*ToolError)), nil
 	}
 
 	// Determine timeout; cap at 24h as a safety net
@@ -97,14 +103,14 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 	if t.toolConfig != nil {
 		workDir = t.toolConfig.WorkingDir()
 		if workDir == "" && t.toolConfig.RequiresExplicitWorkingDir() {
-			return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "an explicit session working directory is required to run custom tools"))), nil
+			return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "an explicit session working directory is required to run custom tools")), nil
 		}
 	}
 	if workDir == "" {
 		var err error
 		workDir, err = os.Getwd()
 		if err != nil {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "cannot get working directory: %v", err))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "cannot get working directory: %v", err)), nil
 		}
 	}
 
@@ -132,7 +138,7 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 		// Build the command according to the calling convention.
 		cmd, err := t.buildCommand(execCtx, scriptPath, args)
 		if err != nil {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "build command: %v", err))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "build command: %v", err)), nil
 		}
 		cmd.Dir = workDir
 		cmd.Env = append([]string(nil), env...)
@@ -141,7 +147,7 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 
 		cleanup, prepErr := prepareToolCommand(cmd)
 		if prepErr != nil {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "script setup error: %v", prepErr))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "script setup error: %v", prepErr)), nil
 		}
 
 		execErr = cmd.Run()
@@ -167,11 +173,13 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 		if exitErr, ok := execErr.(*exec.ExitError); ok {
 			result.ExitCode = exitErr.ExitCode()
 		} else {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "script error: %v", execErr))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "script error: %v", execErr)), nil
 		}
 	}
 
-	return llm.TextOutput(formatShellResult(result, t.limits)), nil
+	output := llm.TextOutput(formatShellResult(result, t.limits))
+	output.IsError = result.ExitCode != 0
+	return output, nil
 }
 
 // buildCommand constructs the exec.Cmd for the script according to the calling convention.

--- a/internal/tools/custom_tool_test.go
+++ b/internal/tools/custom_tool_test.go
@@ -139,20 +139,79 @@ func TestCustomScriptTool_BuildCommand_NamedArgs(t *testing.T) {
 	}
 }
 
-func TestCustomScriptTool_Execute_ScriptNotFound(t *testing.T) {
+func TestCustomScriptTool_Execute_FailureStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		script      string
+		mode        os.FileMode
+		wantContent string
+	}{
+		{
+			name:        "missing script",
+			script:      "missing.sh",
+			wantContent: "script not found",
+		},
+		{
+			name:        "unexecutable script",
+			script:      "unexecutable.sh",
+			mode:        0644,
+			wantContent: "script error",
+		},
+		{
+			name:        "nonzero exit",
+			script:      "fails.sh",
+			mode:        0755,
+			wantContent: "exit_code: 7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.mode != 0 {
+				content := "#!/bin/sh\necho diagnostic >&2\n"
+				if tt.script == "fails.sh" {
+					content += "exit 7\n"
+				}
+				if err := os.WriteFile(filepath.Join(dir, tt.script), []byte(content), tt.mode); err != nil {
+					t.Fatalf("write script: %v", err)
+				}
+			}
+
+			tool := makeCustomTool(t, dir, agents.CustomToolDef{
+				Name:        "test_tool",
+				Description: "Test failure status",
+				Script:      tt.script,
+			})
+			out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !out.IsError {
+				t.Errorf("expected IsError=true, got output: %s", out.Content)
+			}
+			if !containsStr(out.Content, tt.wantContent) {
+				t.Errorf("expected output containing %q, got %q", tt.wantContent, out.Content)
+			}
+		})
+	}
+}
+
+func TestCustomScriptTool_Execute_SuccessStatus(t *testing.T) {
 	dir := t.TempDir()
+	writeScript(t, dir, "success.sh", "#!/bin/sh\necho success\n")
 	tool := makeCustomTool(t, dir, agents.CustomToolDef{
-		Name:        "missing",
-		Description: "Missing script",
-		Script:      "nonexistent.sh",
+		Name:        "success",
+		Description: "Successful script",
+		Script:      "success.sh",
 	})
 
 	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !containsStr(out.Content, "FILE_NOT_FOUND") && !containsStr(out.Content, "not found") {
-		t.Errorf("expected file-not-found error in output, got %q", out.Content)
+	if out.IsError || out.TimedOut {
+		t.Fatalf("successful script returned failure flags: %+v", out)
 	}
 }
 

--- a/internal/tools/run_agent_script.go
+++ b/internal/tools/run_agent_script.go
@@ -103,64 +103,64 @@ func (t *RunAgentScriptTool) Preview(args json.RawMessage) string {
 func (t *RunAgentScriptTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
 	var a RunAgentScriptArgs
 	if err := json.Unmarshal(args, &a); err != nil {
-		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, err.Error()))), nil
+		return scriptToolErrorOutput(NewToolError(ErrInvalidParams, err.Error())), nil
 	}
 
 	if a.Script == "" {
-		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "script is required"))), nil
+		return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "script is required")), nil
 	}
 
 	// Validate AgentDir is configured
 	if t.config.AgentDir == "" {
-		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "no agent directory configured"))), nil
+		return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "no agent directory configured")), nil
 	}
 
 	// Security: reject path separators and traversal
 	if strings.Contains(a.Script, "/") || strings.Contains(a.Script, "\\") || strings.Contains(a.Script, "..") {
-		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "script name must not contain path separators or '..'"))), nil
+		return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "script name must not contain path separators or '..'")), nil
 	}
 
 	// Resolve absolute path and verify containment within AgentDir
 	absScript := filepath.Join(t.config.AgentDir, a.Script)
 	absScript, err := filepath.Abs(absScript)
 	if err != nil {
-		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "resolve path: %v", err))), nil
+		return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "resolve path: %v", err)), nil
 	}
 
 	agentDir, err := filepath.Abs(t.config.AgentDir)
 	if err != nil {
-		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "resolve agent dir: %v", err))), nil
+		return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "resolve agent dir: %v", err)), nil
 	}
 
 	if !strings.HasPrefix(absScript, agentDir+string(filepath.Separator)) {
-		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "script path escapes agent directory"))), nil
+		return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "script path escapes agent directory")), nil
 	}
 
 	// Resolve symlinks and re-check containment
 	realScript, err := filepath.EvalSymlinks(absScript)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrFileNotFound, "script not found: %s", a.Script))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrFileNotFound, "script not found: %s", a.Script)), nil
 		}
-		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "resolve symlinks: %v", err))), nil
+		return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "resolve symlinks: %v", err)), nil
 	}
 
 	realAgentDir, err := filepath.EvalSymlinks(agentDir)
 	if err != nil {
-		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "resolve agent dir symlinks: %v", err))), nil
+		return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "resolve agent dir symlinks: %v", err)), nil
 	}
 
 	if !strings.HasPrefix(realScript, realAgentDir+string(filepath.Separator)) {
-		return llm.TextOutput(formatToolError(NewToolError(ErrSymlinkEscape, "script symlink escapes agent directory"))), nil
+		return scriptToolErrorOutput(NewToolError(ErrSymlinkEscape, "script symlink escapes agent directory")), nil
 	}
 
 	// Verify target is a file
 	info, err := os.Stat(realScript)
 	if err != nil {
-		return llm.TextOutput(formatToolError(NewToolErrorf(ErrFileNotFound, "script not found: %s", a.Script))), nil
+		return scriptToolErrorOutput(NewToolErrorf(ErrFileNotFound, "script not found: %s", a.Script)), nil
 	}
 	if info.IsDir() {
-		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "script target is a directory, not a file"))), nil
+		return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "script target is a directory, not a file")), nil
 	}
 
 	// Set timeout
@@ -178,14 +178,14 @@ func (t *RunAgentScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 	if t.config != nil {
 		workDir = t.config.WorkingDir()
 		if workDir == "" && t.config.RequiresExplicitWorkingDir() {
-			return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, "an explicit session working directory is required to run agent scripts"))), nil
+			return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "an explicit session working directory is required to run agent scripts")), nil
 		}
 	}
 	if workDir == "" {
 		var err error
 		workDir, err = os.Getwd()
 		if err != nil {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "cannot get working directory: %v", err))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "cannot get working directory: %v", err)), nil
 		}
 	}
 
@@ -193,7 +193,7 @@ func (t *RunAgentScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 	if strings.TrimSpace(a.Args) != "" {
 		argv, err = splitShellWords(a.Args)
 		if err != nil {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrInvalidParams, "invalid args: %v", err))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrInvalidParams, "invalid args: %v", err)), nil
 		}
 	}
 
@@ -213,7 +213,7 @@ func (t *RunAgentScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 
 	var setupErr *runAgentScriptSetupError
 	if errors.As(execErr, &setupErr) {
-		return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "script setup error: %v", setupErr.err))), nil
+		return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "script setup error: %v", setupErr.err)), nil
 	}
 
 	result := ShellResult{
@@ -233,9 +233,11 @@ func (t *RunAgentScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 		if exitErr, ok := execErr.(*exec.ExitError); ok {
 			result.ExitCode = exitErr.ExitCode()
 		} else {
-			return llm.TextOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "script error: %v", execErr))), nil
+			return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "script error: %v", execErr)), nil
 		}
 	}
 
-	return llm.TextOutput(formatShellResult(result, t.limits)), nil
+	output := llm.TextOutput(formatShellResult(result, t.limits))
+	output.IsError = result.ExitCode != 0
+	return output, nil
 }

--- a/internal/tools/run_agent_script_test.go
+++ b/internal/tools/run_agent_script_test.go
@@ -91,6 +91,10 @@ func TestRunAgentScriptTool(t *testing.T) {
 			}
 
 			text := output.Content
+			wantIsError := tt.wantErr != ""
+			if output.IsError != wantIsError {
+				t.Errorf("IsError = %v, want %v; output: %s", output.IsError, wantIsError, text)
+			}
 			if tt.wantErr != "" {
 				if !strings.Contains(text, tt.wantErr) {
 					t.Errorf("expected error containing %q, got: %s", tt.wantErr, text)
@@ -102,6 +106,53 @@ func TestRunAgentScriptTool(t *testing.T) {
 			}
 			if tt.wantExit != "" && !strings.Contains(text, tt.wantExit) {
 				t.Errorf("expected %q in output, got: %s", tt.wantExit, text)
+			}
+		})
+	}
+}
+
+func TestRunAgentScriptTool_ExecutionFailureStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        os.FileMode
+		content     string
+		wantContent string
+	}{
+		{
+			name:        "unexecutable script",
+			mode:        0644,
+			content:     "#!/bin/sh\necho diagnostic >&2\n",
+			wantContent: "script error",
+		},
+		{
+			name:        "nonzero exit",
+			mode:        0755,
+			content:     "#!/bin/sh\necho diagnostic >&2\nexit 7\n",
+			wantContent: "exit_code: 7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(agentDir, "test.sh"), []byte(tt.content), tt.mode); err != nil {
+				t.Fatalf("write script: %v", err)
+			}
+			tool := NewRunAgentScriptTool(&ToolConfig{AgentDir: agentDir}, DefaultOutputLimits())
+			args, err := json.Marshal(RunAgentScriptArgs{Script: "test.sh"})
+			if err != nil {
+				t.Fatalf("marshal args: %v", err)
+			}
+
+			output, err := tool.Execute(context.Background(), args)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if !output.IsError {
+				t.Errorf("expected IsError=true, got output: %s", output.Content)
+			}
+			if !strings.Contains(output.Content, tt.wantContent) {
+				t.Errorf("expected output containing %q, got: %s", tt.wantContent, output.Content)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed

- Added a shared script-tool error-output helper that preserves existing formatted diagnostics while setting `ToolOutput.IsError=true` for validation, resolution, setup, and execution failures.
- Marked captured nonzero exit statuses as errors in both `CustomScriptTool` and `RunAgentScriptTool`.
- Added regression coverage for missing scripts, unexecutable scripts, diagnostic output followed by exit 7, validation failures, and successful execution.

## Why this is high-value

Jarvis uses agent- and skill-declared script tools for routine memory, notification, infrastructure, and integration work. These tools previously returned failure text and nonzero exit codes with a successful status, so the engine could emit `ToolSuccess=true`, persist `ToolResult.IsError=false`, and allow the model to treat an operation that never completed as successful. Correct failure metadata now reaches every caller without changing script output formatting or timeout handling.

## Validation

- `gofmt -w internal/tools/custom_tool.go internal/tools/custom_tool_test.go internal/tools/run_agent_script.go internal/tools/run_agent_script_test.go`
- `go build ./...`
- `go test ./internal/tools -run 'Test(CustomScriptTool|RunAgentScriptTool)' -count=1`
- `go test ./internal/llm -run 'TestEngineToolOutputIsErrorMarksToolExecEndFailed|TestEngineTimeoutOutputContinuesLoop' -count=1`
- `go test ./...` reached and passed the changed `internal/tools` package, but the full run was blocked by unrelated failures in untouched packages: two `cmd` skill-discovery tests see the host's 31 configured skills instead of their request-directory fixture within the configured visibility budget, and `internal/filetrack.TestRecordChangeEnforcesTotalBudget` reports over-pruning.
- `git diff --check`
