### PR TITLE
fix: CLI-provider MCP bridge discards tool failure status

### DIFF
--- a/cmd/serve_mcp.go
+++ b/cmd/serve_mcp.go
@@ -265,33 +265,33 @@ func runServeMCP(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build executor that routes to the right tool.
-	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+	executor := func(ctx context.Context, name string, args json.RawMessage) (mcphttp.ToolResult, error) {
 		// Check web tools first.
 		if name == mcpWebSearchToolName && webSearchTool != nil {
 			out, err := webSearchTool.Execute(ctx, args)
 			if err != nil {
-				return "", err
+				return mcphttp.ToolResult{}, err
 			}
-			return out.Content, nil
+			return mcphttp.ToolResult{Content: out.Content, IsError: out.IsError || out.TimedOut}, nil
 		}
 		if name == mcpReadURLToolName && readURLTool != nil {
 			out, err := readURLTool.Execute(ctx, args)
 			if err != nil {
-				return "", err
+				return mcphttp.ToolResult{}, err
 			}
-			return out.Content, nil
+			return mcphttp.ToolResult{Content: out.Content, IsError: out.IsError || out.TimedOut}, nil
 		}
 
 		// Local tools.
 		tool, ok := registry.Get(name)
 		if !ok {
-			return "", fmt.Errorf("unknown tool: %s", name)
+			return mcphttp.ToolResult{}, fmt.Errorf("unknown tool: %s", name)
 		}
 		out, err := tool.Execute(ctx, args)
 		if err != nil {
-			return "", err
+			return mcphttp.ToolResult{}, err
 		}
-		return out.Content, nil
+		return mcphttp.ToolResult{Content: out.Content, IsError: out.IsError || out.TimedOut}, nil
 	}
 
 	// Resolve auth token.

--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -217,12 +217,15 @@ func (p *ClaudeBinProvider) SetEnv(env map[string]string) {
 // Note: The signature uses an anonymous function type (not mcphttp.ToolExecutor)
 // to satisfy the ToolExecutorSetter interface in engine.go.
 func (p *ClaudeBinProvider) SetToolExecutor(executor func(ctx context.Context, name string, args json.RawMessage) (ToolOutput, error)) {
-	// Wrap the ToolOutput executor to satisfy the mcphttp.ToolExecutor (string, error) interface.
+	// Wrap the ToolOutput executor to satisfy the mcphttp.ToolExecutor interface.
 	// For tool outputs with image data, materialise images to temp files and include their
 	// paths in the response text so Claude CLI can read them natively as vision inputs.
-	p.toolExecutor = func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+	p.toolExecutor = func(ctx context.Context, name string, args json.RawMessage) (mcphttp.ToolResult, error) {
 		output, err := executor(ctx, name, args)
-		return p.formatToolOutputForClaude(output), err
+		return mcphttp.ToolResult{
+			Content: p.formatToolOutputForClaude(output),
+			IsError: output.IsError || output.TimedOut,
+		}, err
 	}
 }
 

--- a/internal/llm/cli_bin_shared.go
+++ b/internal/llm/cli_bin_shared.go
@@ -273,14 +273,14 @@ func (s *cliToolBridgeState) deactivate(bridge *cliTurnBridge) {
 // wrappedExecutor routes an HTTP MCP call through the active provider stream so
 // the engine remains the sole owner of tool execution and event emission.
 func (s *cliToolBridgeState) wrappedExecutor(formatOutput func(ToolOutput) string) mcphttp.ToolExecutor {
-	return func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+	return func(ctx context.Context, name string, args json.RawMessage) (mcphttp.ToolResult, error) {
 		s.eventsMu.Lock()
 		bridge := s.currentBridge
 		events := s.currentEvents
 		s.eventsMu.Unlock()
 
 		if bridge == nil || events == nil {
-			return "", fmt.Errorf("tool execution rejected: no active stream bridge for tool call %q", name)
+			return mcphttp.ToolResult{}, fmt.Errorf("tool execution rejected: no active stream bridge for tool call %q", name)
 		}
 
 		callID := fmt.Sprintf("mcp-%s-%d", name, mcpCallCounter.Add(1))
@@ -297,32 +297,36 @@ func (s *cliToolBridgeState) wrappedExecutor(formatOutput func(ToolOutput) strin
 		select {
 		case bridge.toolReqCh <- req:
 		case <-bridge.done:
-			return "", fmt.Errorf("tool execution rejected: stream closed during tool call %q", name)
+			return mcphttp.ToolResult{}, fmt.Errorf("tool execution rejected: stream closed during tool call %q", name)
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return mcphttp.ToolResult{}, ctx.Err()
 		}
 
 		select {
 		case err := <-req.ack:
 			if err != nil {
-				return "", err
+				return mcphttp.ToolResult{}, err
 			}
 		case <-bridge.done:
-			return "", fmt.Errorf("tool execution rejected: stream closed during tool call %q", name)
+			return mcphttp.ToolResult{}, fmt.Errorf("tool execution rejected: stream closed during tool call %q", name)
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return mcphttp.ToolResult{}, ctx.Err()
 		}
 
 		select {
 		case response := <-responseChan:
-			if formatOutput == nil {
-				return response.Result.Content, response.Err
+			content := response.Result.Content
+			if formatOutput != nil {
+				content = formatOutput(response.Result)
 			}
-			return formatOutput(response.Result), response.Err
+			return mcphttp.ToolResult{
+				Content: content,
+				IsError: response.Result.IsError || response.Result.TimedOut,
+			}, response.Err
 		case <-bridge.done:
-			return "", fmt.Errorf("tool execution rejected: stream closed during tool call %q", name)
+			return mcphttp.ToolResult{}, fmt.Errorf("tool execution rejected: stream closed during tool call %q", name)
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return mcphttp.ToolResult{}, ctx.Err()
 		}
 	}
 }

--- a/internal/llm/cli_bin_shared_test.go
+++ b/internal/llm/cli_bin_shared_test.go
@@ -3,14 +3,20 @@ package llm
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/samsaffron/term-llm/internal/mcphttp"
 )
 
 func TestAppendInlineFlushNotice(t *testing.T) {
@@ -34,6 +40,126 @@ func TestAppendInlineFlushNotice(t *testing.T) {
 	if got := state.appendInlineFlushNotice("tool ok"); got != "tool ok" {
 		t.Fatalf("cleared output = %q", got)
 	}
+}
+
+func TestCLIToolBridgePreservesToolFailureStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		response    ToolExecutionResponse
+		wantError   bool
+		wantContent string
+	}{
+		{
+			name:        "success",
+			response:    ToolExecutionResponse{Result: TextOutput("ok")},
+			wantContent: "formatted: ok",
+		},
+		{
+			name:        "semantic error",
+			response:    ToolExecutionResponse{Result: ToolOutput{Content: "exit_code: 7", IsError: true}},
+			wantError:   true,
+			wantContent: "formatted: exit_code: 7",
+		},
+		{
+			name:        "timeout",
+			response:    ToolExecutionResponse{Result: ToolOutput{Content: "timed out", TimedOut: true}},
+			wantError:   true,
+			wantContent: "formatted: timed out",
+		},
+		{
+			name:        "go error",
+			response:    ToolExecutionResponse{Err: errors.New("executor failed")},
+			wantError:   true,
+			wantContent: "Error executing tool: executor failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bridge := &cliTurnBridge{
+				toolReqCh: make(chan cliToolRequest, 1),
+				done:      make(chan struct{}),
+			}
+			events := make(chan Event, 1)
+			var state cliToolBridgeState
+			state.activate(bridge, events)
+			defer state.deactivate(bridge)
+
+			server := mcphttp.NewServer(state.wrappedExecutor(func(output ToolOutput) string {
+				return "formatted: " + output.Content
+			}))
+			url, token, err := server.Start(context.Background(), []mcphttp.ToolSpec{{
+				Name:   "shell",
+				Schema: map[string]interface{}{"type": "object"},
+			}})
+			if err != nil {
+				t.Fatalf("start MCP server: %v", err)
+			}
+			defer server.Stop(context.Background())
+
+			go func() {
+				req := <-bridge.toolReqCh
+				req.ack <- nil
+				req.response <- tt.response
+			}()
+
+			body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shell","arguments":{}}}`)
+			req, err := http.NewRequest(http.MethodPost, url, body)
+			if err != nil {
+				t.Fatalf("create MCP request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json, text/event-stream")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("call MCP tool: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("MCP status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+			responseBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read MCP response: %v", err)
+			}
+			gotError, gotContent := decodeMCPToolCallResponse(t, responseBody)
+			if gotError != tt.wantError {
+				t.Errorf("CallToolResult.IsError = %v, want %v; response: %s", gotError, tt.wantError, responseBody)
+			}
+			if gotContent != tt.wantContent {
+				t.Errorf("CallToolResult content = %q, want %q", gotContent, tt.wantContent)
+			}
+		})
+	}
+}
+
+func decodeMCPToolCallResponse(t *testing.T, body []byte) (bool, string) {
+	t.Helper()
+	payload := bytes.TrimSpace(body)
+	for _, line := range bytes.Split(payload, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("data:")) {
+			payload = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+			break
+		}
+	}
+
+	var response struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(payload, &response); err != nil {
+		t.Fatalf("decode MCP response %q: %v", body, err)
+	}
+	if len(response.Result.Content) != 1 {
+		t.Fatalf("MCP content = %#v, want one item", response.Result.Content)
+	}
+	return response.Result.IsError, response.Result.Content[0].Text
 }
 
 // TestInlineLoopCLIProvidersSupportInlineFlush pins the interjection contract

--- a/internal/mcphttp/http_server.go
+++ b/internal/mcphttp/http_server.go
@@ -22,8 +22,14 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// ToolResult is the text result exposed to an MCP client and its semantic status.
+type ToolResult struct {
+	Content string
+	IsError bool
+}
+
 // ToolExecutor is a function that executes a tool and returns the result.
-type ToolExecutor func(ctx context.Context, name string, args json.RawMessage) (string, error)
+type ToolExecutor func(ctx context.Context, name string, args json.RawMessage) (ToolResult, error)
 
 // ToolSpec describes a tool to expose via MCP.
 type ToolSpec struct {
@@ -142,8 +148,9 @@ func (s *Server) startInternal(host string, port int, token string, tools []Tool
 
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{
-					&mcp.TextContent{Text: result},
+					&mcp.TextContent{Text: result.Content},
 				},
+				IsError: result.IsError,
 			}, nil
 		})
 	}

--- a/internal/mcphttp/http_server_test.go
+++ b/internal/mcphttp/http_server_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestServerStartStop(t *testing.T) {
-	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
-		return "executed: " + name, nil
+	executor := func(ctx context.Context, name string, args json.RawMessage) (ToolResult, error) {
+		return ToolResult{Content: "executed: " + name}, nil
 	}
 
 	server := NewServer(executor)
@@ -73,8 +73,8 @@ func TestServerStartStop(t *testing.T) {
 }
 
 func TestServerAuthMiddleware(t *testing.T) {
-	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
-		return "executed", nil
+	executor := func(ctx context.Context, name string, args json.RawMessage) (ToolResult, error) {
+		return ToolResult{Content: "executed"}, nil
 	}
 
 	server := NewServer(executor)
@@ -143,10 +143,10 @@ func TestServerAuthMiddleware(t *testing.T) {
 // restarts.
 func TestServerStopRespectsContextDeadline(t *testing.T) {
 	executorEntered := make(chan struct{})
-	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+	executor := func(ctx context.Context, name string, args json.RawMessage) (ToolResult, error) {
 		close(executorEntered)
 		<-ctx.Done()
-		return "", ctx.Err()
+		return ToolResult{}, ctx.Err()
 	}
 
 	server := NewServer(executor)
@@ -204,8 +204,8 @@ func TestServerStopRespectsContextDeadline(t *testing.T) {
 }
 
 func TestServerCannotStartTwice(t *testing.T) {
-	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
-		return "executed", nil
+	executor := func(ctx context.Context, name string, args json.RawMessage) (ToolResult, error) {
+		return ToolResult{Content: "executed"}, nil
 	}
 
 	server := NewServer(executor)
@@ -229,8 +229,8 @@ func TestServerCannotStartTwice(t *testing.T) {
 }
 
 func TestStartOnAddress(t *testing.T) {
-	executor := func(ctx context.Context, name string, args json.RawMessage) (string, error) {
-		return "ok", nil
+	executor := func(ctx context.Context, name string, args json.RawMessage) (ToolResult, error) {
+		return ToolResult{Content: "ok"}, nil
 	}
 	tools := []ToolSpec{
 		{Name: "t", Description: "d", Schema: map[string]interface{}{"type": "object"}},


### PR DESCRIPTION
## What changed

- Extended the internal MCP HTTP executor result to carry semantic tool failure status separately from Go transport errors.
- Propagated `ToolOutput.IsError || ToolOutput.TimedOut` through the shared CLI tool bridge and into `mcp.CallToolResult.IsError`.
- Kept the standalone `serve mcp` executor consistent with the new result shape.
- Added an end-to-end HTTP MCP regression test covering success, semantic failure, timeout, and non-nil Go error responses through the bridge-backed executor.

## Why this is high-value

Claude Bin, Grok Bin, Cursor Bin, and Agy Bin all use this shared MCP bridge. Tools such as `shell` intentionally return a nil Go error with `ToolOutput.IsError=true` for nonzero exits, but the old string-only adapter discarded that status and reported the MCP call as successful. That could make ordinary Jarvis runs treat failed file, service, or notification work as completed and skip retry or recovery.

The bridge now preserves the engine's existing failure classification without changing tool output text or transport-error behavior.

## Validation

- `go test ./internal/llm ./internal/mcphttp`
- `go build ./...`
- `go vet ./...`
- `go test ./...` was run both directly and with an isolated HOME. The changed packages passed; the full suite remains blocked by the unrelated existing `internal/filetrack.TestRecordChangeEnforcesTotalBudget` failure (`live budget enforcement pruned more sessions than required`). The direct run also hit user-home skill-discovery assumptions in two `cmd` tests, which passed with the repository-recommended isolated HOME.
