### PR TITLE
fix(session): repair missing project schema

### DIFF
--- a/internal/session/project_test.go
+++ b/internal/session/project_test.go
@@ -23,16 +23,17 @@ func newProjectTestStore(t *testing.T) *SQLiteStore {
 	return store
 }
 
-func TestProjectMigration47AndCRUDStableIdentity(t *testing.T) {
-	if schemaVersion != 47 {
-		t.Fatalf("schemaVersion = %d, want 47", schemaVersion)
+func TestProjectMigrationsAndCRUDStableIdentity(t *testing.T) {
+	if projectSchemaVersion != 47 || schemaVersion != 48 {
+		t.Fatalf("schema versions = project %d/current %d, want 47/48", projectSchemaVersion, schemaVersion)
 	}
-	found := false
+	found47, found48 := false, false
 	for _, migration := range migrations {
-		found = found || migration.version == 47
+		found47 = found47 || migration.version == projectSchemaVersion
+		found48 = found48 || migration.version == schemaVersion
 	}
-	if !found {
-		t.Fatal("migration 47 missing")
+	if !found47 || !found48 {
+		t.Fatalf("project migrations present = 47:%t 48:%t", found47, found48)
 	}
 	store := newProjectTestStore(t)
 	ctx := context.Background()
@@ -103,12 +104,45 @@ func TestProjectMigration47UpgradesExistingDatabase(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatal(err)
 	}
-	if version != projectSchemaVersion {
-		t.Fatalf("schema version = %d, want %d", version, projectSchemaVersion)
+	if version != schemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, schemaVersion)
 	}
 	var projectID sql.NullString
 	if err := db.QueryRow("SELECT project_id FROM sessions WHERE id = 'legacy-project-migration'").Scan(&projectID); err != nil {
 		t.Fatalf("read migrated session: %v", err)
+	}
+	if projectID.Valid {
+		t.Fatalf("legacy session project_id = %q, want NULL", projectID.String)
+	}
+	var projectsTable int
+	if err := db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'projects'").Scan(&projectsTable); err != nil {
+		t.Fatal(err)
+	}
+	if projectsTable != 1 {
+		t.Fatalf("projects table count = %d, want 1", projectsTable)
+	}
+}
+
+func TestProjectMigration48RepairsVersion47WithoutProjectColumn(t *testing.T) {
+	db := openProjectMigration46DB(t)
+	if _, err := db.Exec("UPDATE schema_version SET version = ?", projectSchemaVersion); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initSchema(db); err != nil {
+		t.Fatalf("initSchema: %v", err)
+	}
+
+	var version int
+	if err := db.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, schemaVersion)
+	}
+	var projectID sql.NullString
+	if err := db.QueryRow("SELECT project_id FROM sessions WHERE id = 'legacy-project-migration'").Scan(&projectID); err != nil {
+		t.Fatalf("read repaired session: %v", err)
 	}
 	if projectID.Valid {
 		t.Fatalf("legacy session project_id = %q, want NULL", projectID.String)

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -406,7 +406,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // Increment when adding new migrations.
 const (
 	projectSchemaVersion = 47
-	schemaVersion        = projectSchemaVersion
+	schemaVersion        = 48
 )
 
 // migration represents a schema migration.
@@ -1333,6 +1333,19 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{
+		// Schema version alone is not sufficient evidence that every version 47
+		// database has the project objects. Reconcile them idempotently.
+		version:     48,
+		description: "repair missing project schema",
+		up: func(db schemaExecutor) error {
+			if _, err := db.Exec("ALTER TABLE sessions ADD COLUMN project_id TEXT"); err != nil && !isDuplicateColumnError(err) {
+				return err
+			}
+			_, err := db.Exec(projectsSchema)
+			return err
+		},
+	},
 }
 
 // Keep in sync with llm.IsInternalCompactionSummaryText. SQLite migrations and
@@ -1518,8 +1531,10 @@ func initSchemaFull(db *sql.DB, versionErr error, currentVersion int) error {
 	if _, err := db.Exec(schema); err != nil {
 		return fmt.Errorf("create base schema: %w", err)
 	}
-	createProjectsDirectly := (needsBootstrapVersion && !preExistingSessionsTable) ||
-		(!needsBootstrapVersion && currentVersion >= projectSchemaVersion)
+	// Create project objects directly only for a fresh database. Existing
+	// databases reach the project schema through migrations, including the
+	// version 48 repair for databases incorrectly marked as version 47.
+	createProjectsDirectly := needsBootstrapVersion && !preExistingSessionsTable
 	if createProjectsDirectly {
 		if _, err := db.Exec(projectsSchema); err != nil {
 			return fmt.Errorf("create projects schema: %w", err)

--- a/internal/session/workspace_test.go
+++ b/internal/session/workspace_test.go
@@ -19,8 +19,8 @@ func createWorkspaceTestSession(t *testing.T, store *SQLiteStore, id string) *Se
 }
 
 func TestWorkspaceGrantMigration46AndCRUDCascade(t *testing.T) {
-	if schemaVersion != 47 {
-		t.Fatalf("schemaVersion = %d, want 47", schemaVersion)
+	if schemaVersion != 48 {
+		t.Fatalf("schemaVersion = %d, want 48", schemaVersion)
 	}
 	foundMigration := false
 	for _, migration := range migrations {


### PR DESCRIPTION
## Problem

Some existing session databases report schema version 47 but do not have `sessions.project_id`. The startup fast path trusts the version, marks writable stores as having the current columns, and every session create/update then fails with errors such as:

```
table sessions has no column named project_id
```

That leaves chat looking hung while persistence repeatedly fails.

## Fix

- bump the session schema to version 48
- add an idempotent repair migration that adds `sessions.project_id` and creates the project schema
- keep project-object creation out of pre-migration initialization for existing databases, so the repair can add the missing column before creating its index
- add a regression fixture for the exact broken state: schema version 47 with no `project_id`

## Verification

- `go test ./internal/session`
- focused migration tests with `-count=1`
- `go build ./...`
- `git diff --check`

`go test ./...` was also run. It reached the full suite but failed in unrelated environment-sensitive/flaky tests: two skill-discovery tests saw Jarvis's mounted skills instead of their fixtures, and `internal/filetrack` over-pruned its test budget. All session tests passed.
