### PR TITLE
fix: update-recent rescans and reloads every completed session on every run

### DIFF
--- a/cmd/memory_freshen.go
+++ b/cmd/memory_freshen.go
@@ -121,7 +121,11 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 	}
 
 	if memoryDryRun {
-		input, err := collectMemoryUpdateRecentInput(ctx, store, sessStore, agentName)
+		lastUpdatedRecentAt, err := readLastUpdatedRecentAt(ctx, store, agentName)
+		if err != nil {
+			return err
+		}
+		input, err := collectMemoryUpdateRecentInput(ctx, store, sessStore, agentName, lastUpdatedRecentAt)
 		if err != nil {
 			return err
 		}
@@ -148,17 +152,23 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := withLockedRecentFile(recentPath, func() error {
-		if _, err := readLastUpdatedRecentAt(ctx, store, agentName); err != nil {
+		lastUpdatedRecentAt, err := readLastUpdatedRecentAt(ctx, store, agentName)
+		if err != nil {
 			return err
 		}
+		// Capture the next checkpoint before enumerating sessions so activity that
+		// arrives during this run remains eligible for the next one.
+		nextUpdatedRecentAt := time.Now().UTC()
 
-		input, err := collectMemoryUpdateRecentInput(ctx, store, sessStore, agentName)
+		input, err := collectMemoryUpdateRecentInput(ctx, store, sessStore, agentName, lastUpdatedRecentAt)
 		if err != nil {
 			return err
 		}
 		if strings.TrimSpace(input.Text) == "" {
-			if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), time.Now().UTC().Format(time.RFC3339)); err != nil {
-				return fmt.Errorf("update last update-recent timestamp: %w", err)
+			if input.Exhausted {
+				if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), nextUpdatedRecentAt.Format(time.RFC3339)); err != nil {
+					return fmt.Errorf("update last update-recent timestamp: %w", err)
+				}
 			}
 			return nil
 		}
@@ -191,9 +201,10 @@ func runMemoryUpdateRecent(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		now := time.Now().UTC()
-		if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), now.Format(time.RFC3339)); err != nil {
-			return fmt.Errorf("update last update-recent timestamp: %w", err)
+		if input.Exhausted {
+			if err := store.SetMeta(ctx, memoryUpdateRecentMetaKey(agentName), nextUpdatedRecentAt.Format(time.RFC3339)); err != nil {
+				return fmt.Errorf("update last update-recent timestamp: %w", err)
+			}
 		}
 
 		return nil
@@ -431,8 +442,13 @@ func memoryCompactRecentUserPrompt(candidateRecent string) string {
 	return fmt.Sprintf("CANDIDATE RECENT MEMORY TO COMPACT:\n\n%s", candidateRecent)
 }
 
-func listUpdateRecentSessions(ctx context.Context, sessStore session.Store, agentName string, current *session.Session) ([]memoryUpdateRecentSession, error) {
-	complete, err := listCompleteSessions(ctx, sessStore)
+func listUpdateRecentSessions(ctx context.Context, sessStore session.Store, agentName string, updatedAtOrAfter time.Time, current *session.Session) ([]memoryUpdateRecentSession, error) {
+	complete, err := sessStore.List(ctx, session.ListOptions{
+		Agent:            agentName,
+		Status:           session.StatusComplete,
+		UpdatedAtOrAfter: updatedAtOrAfter,
+		Limit:            -1,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list complete sessions: %w", err)
 	}
@@ -441,41 +457,23 @@ func listUpdateRecentSessions(ctx context.Context, sessStore session.Store, agen
 	sessions := make([]memoryUpdateRecentSession, 0, len(complete)+1)
 
 	for _, summary := range complete {
-		sess, err := sessStore.Get(ctx, summary.ID)
-		if err != nil {
-			return nil, fmt.Errorf("get session %s: %w", summary.ID, err)
-		}
-		if sess == nil {
+		// Keep custom stores that ignore the new List filters from leaking another
+		// agent or an older session into this update.
+		if updateRecentSessionAgent(summary.Agent) != agentName || (!updatedAtOrAfter.IsZero() && summary.UpdatedAt.Before(updatedAtOrAfter)) {
 			continue
-		}
-		if resolveMemoryAgent(sess.Agent) != agentName {
-			continue
-		}
-
-		status := summary.Status
-		if status == "" {
-			status = sess.Status
-		}
-		number := summary.Number
-		if number == 0 {
-			number = sess.Number
-		}
-		updatedAt := summary.UpdatedAt
-		if updatedAt.IsZero() {
-			updatedAt = sess.UpdatedAt
 		}
 
 		sessions = append(sessions, memoryUpdateRecentSession{
 			ID:        summary.ID,
-			Number:    number,
-			Status:    status,
-			UpdatedAt: updatedAt,
+			Number:    summary.Number,
+			Status:    summary.Status,
+			UpdatedAt: summary.UpdatedAt,
 		})
 		seen[summary.ID] = struct{}{}
 	}
 
 	if current != nil {
-		if _, exists := seen[current.ID]; !exists && resolveMemoryAgent(current.Agent) == agentName {
+		if _, exists := seen[current.ID]; !exists && updateRecentSessionAgent(current.Agent) == agentName && (updatedAtOrAfter.IsZero() || !current.UpdatedAt.Before(updatedAtOrAfter)) {
 			sessions = append(sessions, memoryUpdateRecentSession{
 				ID:        current.ID,
 				Number:    current.Number,
@@ -498,18 +496,27 @@ func listUpdateRecentSessions(ctx context.Context, sessStore session.Store, agen
 	return sessions, nil
 }
 
-type memoryUpdateRecentInput struct {
-	Text    string
-	Offsets map[string]int
+func updateRecentSessionAgent(agent string) string {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return "default"
+	}
+	return agent
 }
 
-func collectMemoryUpdateRecentInput(ctx context.Context, store *memorydb.Store, sessStore session.Store, agentName string) (memoryUpdateRecentInput, error) {
+type memoryUpdateRecentInput struct {
+	Text      string
+	Offsets   map[string]int
+	Exhausted bool
+}
+
+func collectMemoryUpdateRecentInput(ctx context.Context, store *memorydb.Store, sessStore session.Store, agentName string, updatedAtOrAfter time.Time) (memoryUpdateRecentInput, error) {
 	current, err := sessStore.GetCurrent(ctx)
 	if err != nil {
 		return memoryUpdateRecentInput{}, fmt.Errorf("get current session: %w", err)
 	}
 
-	sessions, err := listUpdateRecentSessions(ctx, sessStore, agentName, current)
+	sessions, err := listUpdateRecentSessions(ctx, sessStore, agentName, updatedAtOrAfter, current)
 	if err != nil {
 		return memoryUpdateRecentInput{}, err
 	}
@@ -521,8 +528,9 @@ func collectMemoryUpdateRecentInput(ctx context.Context, store *memorydb.Store, 
 
 	trackedOffsets := map[string]int{}
 	var inputBuilder strings.Builder
+	exhausted := true
 
-	for _, sess := range sessions {
+	for i, sess := range sessions {
 		if currentID != "" && sess.ID == currentID {
 			continue
 		}
@@ -553,11 +561,12 @@ func collectMemoryUpdateRecentInput(ctx context.Context, store *memorydb.Store, 
 		lastMessage := messages[len(messages)-1]
 		trackedOffsets[sess.ID] = lastMessage.Sequence + 1
 		if inputBuilder.Len() >= memoryUpdateRecentMaxInputChars {
+			exhausted = i == len(sessions)-1
 			break
 		}
 	}
 
-	return memoryUpdateRecentInput{Text: inputBuilder.String(), Offsets: trackedOffsets}, nil
+	return memoryUpdateRecentInput{Text: inputBuilder.String(), Offsets: trackedOffsets, Exhausted: exhausted}, nil
 }
 
 func formatUpdateRecentSessionBlock(sess memoryUpdateRecentSession, messages []session.Message) string {

--- a/cmd/memory_freshen_test.go
+++ b/cmd/memory_freshen_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -331,6 +332,143 @@ func TestReadLastUpdatedRecentAt_RoundTrip(t *testing.T) {
 	if !ts.Equal(now) {
 		t.Errorf("got %v, want %v", ts, now)
 	}
+}
+
+func TestCollectMemoryUpdateRecentInputOnlyLoadsUpdatedAgentSessions(t *testing.T) {
+	ctx := context.Background()
+	checkpoint := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	oldUpdatedAt := checkpoint.Add(-time.Hour)
+	recentUpdatedAt := checkpoint.Add(time.Minute)
+
+	summaries := make([]session.SessionSummary, 0, 1002)
+	for i := 0; i < 1000; i++ {
+		summaries = append(summaries, session.SessionSummary{
+			ID:        "old-" + strconv.Itoa(i),
+			Number:    int64(i + 1),
+			Agent:     "jarvis",
+			Status:    session.StatusComplete,
+			UpdatedAt: oldUpdatedAt,
+		})
+	}
+	summaries = append(summaries,
+		session.SessionSummary{ID: "recent-jarvis", Number: 1001, Agent: "jarvis", Status: session.StatusComplete, UpdatedAt: recentUpdatedAt},
+		session.SessionSummary{ID: "recent-other", Number: 1002, Agent: "other", Status: session.StatusComplete, UpdatedAt: recentUpdatedAt},
+	)
+
+	sessStore := &updateRecentCountingStore{
+		summaries: summaries,
+		messages: map[string][]session.Message{
+			"recent-jarvis": {{Role: llm.RoleUser, TextContent: "new activity", Sequence: 0}},
+			"recent-other":  {{Role: llm.RoleUser, TextContent: "other activity", Sequence: 0}},
+		},
+		messageCalls: map[string]int{},
+	}
+	memStore, err := memorydb.NewStore(memorydb.Config{Path: filepath.Join(t.TempDir(), "memory.db")})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer memStore.Close()
+
+	input, err := collectMemoryUpdateRecentInput(ctx, memStore, sessStore, "jarvis", checkpoint)
+	if err != nil {
+		t.Fatalf("collectMemoryUpdateRecentInput: %v", err)
+	}
+	if !strings.Contains(input.Text, "new activity") || strings.Contains(input.Text, "other activity") {
+		t.Fatalf("input text = %q, want only recent jarvis activity", input.Text)
+	}
+	if sessStore.listCalls != 1 {
+		t.Fatalf("List calls = %d, want 1", sessStore.listCalls)
+	}
+	if sessStore.getCalls != 0 {
+		t.Fatalf("Get calls = %d, want 0", sessStore.getCalls)
+	}
+	if len(sessStore.messageCalls) != 1 || sessStore.messageCalls["recent-jarvis"] != 1 {
+		t.Fatalf("GetMessagesFrom calls = %#v, want only recent-jarvis", sessStore.messageCalls)
+	}
+	if !sessStore.lastListOptions.UpdatedAtOrAfter.Equal(checkpoint) || sessStore.lastListOptions.Agent != "jarvis" {
+		t.Fatalf("List options = %#v, want agent and update checkpoint filters", sessStore.lastListOptions)
+	}
+}
+
+func TestCollectMemoryUpdateRecentInputNoOpDoesNotLoadHistoricalSessions(t *testing.T) {
+	ctx := context.Background()
+	checkpoint := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	summaries := make([]session.SessionSummary, 1000)
+	for i := range summaries {
+		summaries[i] = session.SessionSummary{
+			ID:        "old-" + strconv.Itoa(i),
+			Number:    int64(i + 1),
+			Agent:     "jarvis",
+			Status:    session.StatusComplete,
+			UpdatedAt: checkpoint.Add(-time.Hour),
+		}
+	}
+	sessStore := &updateRecentCountingStore{
+		summaries:    summaries,
+		messageCalls: map[string]int{},
+	}
+	memStore, err := memorydb.NewStore(memorydb.Config{Path: filepath.Join(t.TempDir(), "memory.db")})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer memStore.Close()
+
+	input, err := collectMemoryUpdateRecentInput(ctx, memStore, sessStore, "jarvis", checkpoint)
+	if err != nil {
+		t.Fatalf("collectMemoryUpdateRecentInput: %v", err)
+	}
+	if input.Text != "" || !input.Exhausted {
+		t.Fatalf("input = %#v, want an exhausted no-op", input)
+	}
+	if sessStore.getCalls != 0 || len(sessStore.messageCalls) != 0 {
+		t.Fatalf("historical point queries: Get=%d GetMessagesFrom=%#v", sessStore.getCalls, sessStore.messageCalls)
+	}
+}
+
+type updateRecentCountingStore struct {
+	session.NoopStore
+	summaries       []session.SessionSummary
+	messages        map[string][]session.Message
+	listCalls       int
+	getCalls        int
+	messageCalls    map[string]int
+	lastListOptions session.ListOptions
+}
+
+func (s *updateRecentCountingStore) List(_ context.Context, opts session.ListOptions) ([]session.SessionSummary, error) {
+	s.listCalls++
+	s.lastListOptions = opts
+	result := make([]session.SessionSummary, 0)
+	for _, summary := range s.summaries {
+		if opts.Status != "" && summary.Status != opts.Status {
+			continue
+		}
+		if opts.Agent != "" && updateRecentSessionAgent(summary.Agent) != strings.TrimSpace(opts.Agent) {
+			continue
+		}
+		if !opts.UpdatedAtOrAfter.IsZero() && summary.UpdatedAt.Before(opts.UpdatedAtOrAfter) {
+			continue
+		}
+		result = append(result, summary)
+	}
+	return result, nil
+}
+
+func (s *updateRecentCountingStore) Get(_ context.Context, _ string) (*session.Session, error) {
+	s.getCalls++
+	return nil, nil
+}
+
+func (s *updateRecentCountingStore) GetMessagesFrom(_ context.Context, sessionID string, fromSeq, _ int) ([]session.Message, error) {
+	s.messageCalls[sessionID]++
+	messages := s.messages[sessionID]
+	result := make([]session.Message, 0, len(messages))
+	for _, message := range messages {
+		if message.Sequence >= fromSeq {
+			result = append(result, message)
+		}
+	}
+	return result, nil
 }
 
 // -- helpers --

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -2461,7 +2461,7 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 	}
 	query := `
 		SELECT s.id, s.number, s.name, s.summary, ` + generatedShortCol + `, ` + generatedLongCol + `, ` + titleSourceCol + `,
-		       s.provider, COALESCE(s.provider_key, ''), s.model, s.mode, ` + originCol + `, s.archived, ` + pinnedCol + `, s.created_at, s.updated_at, ` + lastMessageAtCol + `, ` + lastUserMessageAtCol + `,
+		       s.provider, COALESCE(s.provider_key, ''), s.model, s.mode, ` + originCol + `, COALESCE(s.agent, ''), s.archived, ` + pinnedCol + `, s.created_at, s.updated_at, ` + lastMessageAtCol + `, ` + lastUserMessageAtCol + `,
 		       ` + messageCountCol + ` as message_count, ` + transcriptRevCol + ` as transcript_rev,
 		       s.user_turns, s.llm_turns, s.tool_calls, s.input_tokens, s.cached_input_tokens, ` + cacheWriteCol + `, s.output_tokens, s.status, s.tags, COALESCE(s.cwd, ''), ` + worktreeDirCol + `, ` + projectIDCol + `, ` + projectNameCol + `, ` + goalCol + `, ` + shareCol + `
 		` + fromClause + projectJoin + `
@@ -2487,9 +2487,17 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 		query += " AND s.mode = ?"
 		args = append(args, string(opts.Mode))
 	}
+	if agent := strings.TrimSpace(opts.Agent); agent != "" {
+		query += " AND COALESCE(NULLIF(TRIM(s.agent), ''), 'default') = ?"
+		args = append(args, agent)
+	}
 	if opts.Status != "" {
 		query += " AND s.status = ?"
 		args = append(args, string(opts.Status))
+	}
+	if !opts.UpdatedAtOrAfter.IsZero() {
+		query += " AND s.updated_at >= ?"
+		args = append(args, opts.UpdatedAtOrAfter.UTC())
 	}
 	if opts.Tag != "" {
 		// Substring match on comma-separated tags
@@ -2555,8 +2563,12 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 	if limit == 0 {
 		limit = 50 // Default
 	}
-	query += " LIMIT ?"
-	args = append(args, limit)
+	if limit < 0 {
+		query += " LIMIT -1"
+	} else {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
 	if opts.Offset > 0 {
 		query += " OFFSET ?"
 		args = append(args, opts.Offset)
@@ -2575,7 +2587,7 @@ func (s *SQLiteStore) List(ctx context.Context, opts ListOptions) ([]SessionSumm
 		var mode, status, tags, generatedShortTitle, generatedLongTitle, titleSource, origin, cwd, worktreeDir, projectID, projectName, goalRaw, shareRaw sql.NullString
 		var lastMessageAt, lastUserMessageAt sql.NullTime
 		err := rows.Scan(&sum.ID, &number, &sum.Name, &sum.Summary, &generatedShortTitle, &generatedLongTitle, &titleSource, &sum.Provider, &sum.ProviderKey, &sum.Model, &mode,
-			&origin, &sum.Archived, &sum.Pinned, &sum.CreatedAt, &sum.UpdatedAt, &lastMessageAt, &lastUserMessageAt, &sum.MessageCount, &sum.TranscriptRev,
+			&origin, &sum.Agent, &sum.Archived, &sum.Pinned, &sum.CreatedAt, &sum.UpdatedAt, &lastMessageAt, &lastUserMessageAt, &sum.MessageCount, &sum.TranscriptRev,
 			&sum.UserTurns, &sum.LLMTurns, &sum.ToolCalls, &sum.InputTokens, &sum.CachedInputTokens, &sum.CacheWriteTokens, &sum.OutputTokens,
 			&status, &tags, &cwd, &worktreeDir, &projectID, &projectName, &goalRaw, &shareRaw)
 		if err != nil {

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -484,6 +484,64 @@ func TestSQLiteStoreListByNumberCursorReturnsCompleteSessions(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreListFiltersByAgentAndUpdatedAt(t *testing.T) {
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	checkpoint := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	seed := []struct {
+		id        string
+		agent     string
+		updatedAt time.Time
+	}{
+		{id: "old-jarvis", agent: "jarvis", updatedAt: checkpoint.Add(-time.Hour)},
+		{id: "recent-jarvis", agent: "jarvis", updatedAt: checkpoint},
+		{id: "recent-other", agent: "other", updatedAt: checkpoint.Add(time.Minute)},
+		{id: "recent-default", updatedAt: checkpoint.Add(time.Minute)},
+	}
+	for _, candidate := range seed {
+		sess := &Session{
+			ID:       candidate.id,
+			Provider: "test",
+			Model:    "test-model",
+			Mode:     ModeChat,
+			Agent:    candidate.agent,
+			Status:   StatusComplete,
+		}
+		if err := store.Create(ctx, sess); err != nil {
+			t.Fatalf("Create(%s): %v", candidate.id, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE sessions SET updated_at = ? WHERE id = ?`, candidate.updatedAt, candidate.id); err != nil {
+			t.Fatalf("set updated_at for %s: %v", candidate.id, err)
+		}
+	}
+
+	got, err := store.List(ctx, ListOptions{
+		Agent:            "jarvis",
+		Status:           StatusComplete,
+		UpdatedAtOrAfter: checkpoint,
+		Limit:            -1,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "recent-jarvis" || got[0].Agent != "jarvis" {
+		t.Fatalf("List = %#v, want recent jarvis summary with agent", got)
+	}
+
+	got, err = store.List(ctx, ListOptions{Agent: "default", UpdatedAtOrAfter: checkpoint, Limit: -1})
+	if err != nil {
+		t.Fatalf("List default agent: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "recent-default" {
+		t.Fatalf("default-agent List = %#v, want recent-default", got)
+	}
+}
+
 func TestSQLiteStoreListByNumberCursorUsesSessionNumberIndex(t *testing.T) {
 	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
 	if err != nil {

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -146,6 +146,7 @@ type SessionSummary struct {
 	Model               string             `json:"model"`
 	Mode                SessionMode        `json:"mode,omitempty"`
 	Origin              SessionOrigin      `json:"origin,omitempty"`
+	Agent               string             `json:"agent,omitempty"`
 	Archived            bool               `json:"archived,omitempty"`
 	Pinned              bool               `json:"pinned,omitempty"`
 	MessageCount        int                `json:"message_count"`
@@ -176,10 +177,12 @@ type ListOptions struct {
 	Provider         string                // Filter by provider
 	Model            string                // Filter by model
 	Mode             SessionMode           // Filter by mode (chat, ask, plan, exec)
+	Agent            string                // Filter by agent; empty persisted agents belong to "default"
 	Status           SessionStatus         // Filter by status
+	UpdatedAtOrAfter time.Time             // Include sessions updated at or after this timestamp
 	Tag              string                // Filter by tag (substring match)
 	Categories       []string              // Sidebar/web categories (all, chat, web, ask, plan, exec)
-	Limit            int                   // Max results (0 = use default)
+	Limit            int                   // Max results (0 = use default, negative = unlimited)
 	Offset           int                   // Pagination offset
 	BeforeNumber     int64                 // Keyset cursor: only sessions with number < this value
 	SortByNumberDesc bool                  // Order by session number descending instead of activity sort


### PR DESCRIPTION
## What changed

- Use the persisted update-recent checkpoint as an inclusive `updated_at` candidate boundary when listing completed sessions.
- Push agent and update-time filtering into `session.Store.List`, expose `Agent` on `SessionSummary`, and remove the per-summary `Get` lookup.
- Keep per-session offsets as the exact idempotency boundary. Capture the next checkpoint before enumeration and only advance it after the candidate set is exhausted, so concurrent activity and input-cap backlogs remain eligible.
- Add counting-store coverage with 1,000 historical sessions plus SQLite coverage for agent/time filtering and inclusive timestamp ties.

## Why this is high-value

`memory update-recent` is a recurring Jarvis maintenance job. Previously, even a no-op run paged through every completed session, loaded each session to discover its agent, read every stored offset, and queried every matching transcript tail. That work and SQLite contention grew with the entire durable session history.

After this change, steady-state no-op work is bounded to the current-session lookup and one indexed candidate-list query. Historical sessions older than the successful checkpoint produce no `Get`, offset, or `GetMessagesFrom` calls. The existing `idx_sessions_updated_at` index supplies the timestamp range scan; agent filtering is applied before rows leave SQLite.

## Validation

- `go test ./cmd -run 'TestCollectMemoryUpdateRecentInput|TestReadLastUpdatedRecentAt|TestReadWriteUpdateRecentOffset' -count=1`
- `go test ./internal/session -run 'TestSQLiteStoreListFiltersByAgentAndUpdatedAt|TestSQLiteStoreListByNumberCursor' -count=1`
- `go build ./...`
- `go vet ./cmd ./internal/session`
- `git diff --check`
- `go test ./...` ran; all touched packages passed. The repository-wide run remains blocked by pre-existing `internal/filetrack.TestRecordChangeEnforcesTotalBudget` (`live budget enforcement pruned more sessions than required`), which reproduces alone and has no diff on this branch.
