### PR TITLE
fix(web): preserve direct node auth with Hub context

### DIFF
--- a/internal/serveui/static/app-core.js
+++ b/internal/serveui/static/app-core.js
@@ -52,7 +52,7 @@ const parseSidebarSessionCategories = (raw) => {
 
 const STORAGE_KEYS = {};
 Object.entries(STORAGE_BASE_KEYS).forEach(([name, key]) => {
-  STORAGE_KEYS[name] = scopedStorageKey(key);
+  STORAGE_KEYS[name] = name === 'token' && HUB_CONTEXT && !HUB_CONTEXT.nodeBasePath ? key : scopedStorageKey(key);
 });
 
 const migrateHubScopedStorage = () => {

--- a/internal/serveui/static/app_core_test.js
+++ b/internal/serveui/static/app_core_test.js
@@ -477,10 +477,32 @@ pendingAsyncTests.push((async function testExternalAuth401RejectsUnsafeLoginURL(
   pass(name);
 })();
 
-(function testHubScopedStorageMigratesUnscopedKeysExceptToken() {
-  const name = 'hub scoped storage copies direct keys except token';
+(function testDirectHubAwareNodeKeepsUnscopedStorage() {
+  const name = 'direct Hub-aware node keeps direct storage and token';
   const testApp = loadAppCoreWith({
     hub: { url: '/', nodeId: 'jarvis', nodeName: 'Jarvis' },
+    initialStorage: {
+      term_llm_token: 'direct-token',
+      term_llm_active_session: 'sess_direct',
+      term_llm_selected_model: 'gpt-5.5'
+    }
+  });
+
+  if (testApp.STORAGE_KEYS.token !== 'term_llm_token') {
+    fail(name, `token key = ${JSON.stringify(testApp.STORAGE_KEYS.token)}`);
+    return;
+  }
+  if (testApp.state.token !== 'direct-token' || testApp.state.activeSessionId !== 'sess_direct' || testApp.state.selectedModel !== 'gpt-5.5') {
+    fail(name, `state did not read expected direct values: ${JSON.stringify({ token: testApp.state.token, activeSessionId: testApp.state.activeSessionId, selectedModel: testApp.state.selectedModel })}`);
+    return;
+  }
+  pass(name);
+})();
+
+(function testHubProxyScopedStorageMigratesUnscopedKeysExceptToken() {
+  const name = 'Hub-proxied storage copies direct keys except token';
+  const testApp = loadAppCoreWith({
+    hub: { url: '/', nodeId: 'jarvis', nodeName: 'Jarvis', nodeBasePath: '/chat' },
     initialStorage: {
       term_llm_token: 'direct-token',
       term_llm_active_session: 'sess_direct',
@@ -499,10 +521,10 @@ pendingAsyncTests.push((async function testExternalAuth401RejectsUnsafeLoginURL(
   pass(name);
 })();
 
-(function testHubScopedStorageKeepsExistingScopedValues() {
-  const name = 'hub scoped storage keeps existing scoped values over direct keys';
+(function testHubProxyScopedStorageKeepsExistingScopedValues() {
+  const name = 'Hub-proxied storage keeps existing scoped values over direct keys';
   const testApp = loadAppCoreWith({
-    hub: { url: '/', nodeId: 'jarvis', nodeName: 'Jarvis' },
+    hub: { url: '/', nodeId: 'jarvis', nodeName: 'Jarvis', nodeBasePath: '/chat' },
     initialStorage: {
       term_llm_token: 'direct-token',
       'term_llm_token:jarvis': 'scoped-token'


### PR DESCRIPTION
## Summary

- keep the established unscoped bearer-token key when a Hub-aware node is opened directly
- retain per-node token isolation when the UI is actually mounted through the Hub proxy (`nodeBasePath` is present)
- cover direct Hub-aware and Hub-proxied storage behavior separately

## Problem

`--hub-url` injects `TERM_LLM_HUB` on a directly opened node so the UI can render **Back to Hub**. The storage scoping logic treated that navigation-only context as if the UI were mounted through the Hub proxy and switched the token lookup from `term_llm_token` to `term_llm_token:<node>`.

HTTPS requests could still succeed when an external proxy injected the backend credential. Once WebRTC connected and bypassed that proxy, requests had no bearer token, returned 401, and opened the token modal.

Actual Hub-proxied HTML includes `nodeBasePath`, so the fix uses that distinction only for the bearer key. Other node-specific UI state remains scoped in both modes.

## Verification

- `node internal/serveui/static/app_core_test.js`
- `node internal/serveui/static/app_webrtc_test.js`
- `go test ./internal/serveui`
- `go build ./...`
- live shared-browser smoke on `wasnotwas.com/chat`: WebRTC reached `data-channel-open`, `Reply with WEBRTC_OK only.` returned `WEBRTC_OK`, no 401/token modal, connection remained active
