### PR TITLE
fix: Isolated skill completion can persist a visible result without the context the parent model needs

### DIFF
--- a/cmd/serve_runtime_test.go
+++ b/cmd/serve_runtime_test.go
@@ -445,6 +445,33 @@ func (s *serveRuntimeTestStore) AddMessage(ctx context.Context, sessionID string
 	return nil
 }
 
+func (s *serveRuntimeTestStore) AddMessages(ctx context.Context, sessionID string, messages []*session.Message) error {
+	if s.addMessageHook != nil {
+		for _, msg := range messages {
+			if err := s.addMessageHook(ctx, sessionID, msg); err != nil {
+				return err
+			}
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	staged := make([]session.Message, len(messages))
+	nextID := s.nextID
+	for i, msg := range messages {
+		nextID++
+		msg.ID = nextID
+		copyMsg := *msg
+		if copyMsg.Sequence < 0 {
+			copyMsg.Sequence = len(s.messages[sessionID]) + i
+		}
+		staged[i] = copyMsg
+	}
+	s.nextID = nextID
+	s.messages[sessionID] = append(s.messages[sessionID], staged...)
+	s.addMessageCalls += len(messages)
+	return nil
+}
+
 func (s *serveRuntimeTestStore) UpdateMessage(ctx context.Context, sessionID string, msg *session.Message) error {
 	if s.updateMessageHook != nil {
 		if err := s.updateMessageHook(ctx, sessionID, msg); err != nil {

--- a/cmd/serve_skills.go
+++ b/cmd/serve_skills.go
@@ -1021,7 +1021,7 @@ func (s *serveServer) persistServeSkillRunResultAtBoundary(ctx context.Context, 
 				retryDelay = min(retryDelay*2, time.Second)
 			}
 			defer runtime.mu.Unlock()
-			if contextMessage := s.persistServeSkillRunResult(run, runErr); contextMessage != nil {
+			if contextMessage := s.persistServeSkillRunResult(ctx, run, runErr); contextMessage != nil {
 				runtime.history = append(runtime.history, *contextMessage)
 				runtime.refreshSideQuestionSnapshot(runtime.history)
 			}
@@ -1033,7 +1033,7 @@ func (s *serveServer) persistServeSkillRunResultAtBoundary(ctx context.Context, 
 	retryDelay := 25 * time.Millisecond
 	for {
 		persisted := manager.runIfSessionIdle(run.SessionID, func() {
-			s.persistServeSkillRunResult(run, runErr)
+			s.persistServeSkillRunResult(ctx, run, runErr)
 		})
 		if persisted {
 			return
@@ -1060,7 +1060,7 @@ func (s *serveServer) waitForServeSkillBoundaryRetry(ctx context.Context, delay 
 	}
 }
 
-func (s *serveServer) persistServeSkillRunResult(run *serveSkillRun, runErr error) *llm.Message {
+func (s *serveServer) persistServeSkillRunResult(ctx context.Context, run *serveSkillRun, runErr error) *llm.Message {
 	if s.store == nil || run == nil || run.Activation == nil {
 		return nil
 	}
@@ -1084,19 +1084,27 @@ func (s *serveServer) persistServeSkillRunResult(run *serveSkillRun, runErr erro
 		resultText += "\n\n" + output
 	}
 	visible := &session.Message{SessionID: run.SessionID, Role: llm.RoleEvent, Parts: []llm.Part{{Type: llm.PartSkillActivation, SkillActivation: provenance}, {Type: llm.PartText, Text: resultText}}, TextContent: resultText, CreatedAt: completedAt, Sequence: -1}
-	if err := s.store.AddMessage(context.Background(), run.SessionID, visible); err != nil {
-		log.Printf("[serve] persist skill result event for %s: %v", run.SessionID, err)
-	}
-	var activeContext *llm.Message
+	messages := []*session.Message{visible}
+	var developer *session.Message
 	if strings.TrimSpace(output) != "" {
 		contextText := fmt.Sprintf("<isolated_skill_result name=%q run_id=%q child_session_id=%q status=%q>\n%s\n</isolated_skill_result>", run.SkillName, run.ID, childSessionID, status, output)
-		developer := &session.Message{SessionID: run.SessionID, Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartSkillActivation, SkillActivation: provenance}, {Type: llm.PartText, Text: contextText}}, TextContent: contextText, CreatedAt: completedAt, Sequence: -1}
-		if err := s.store.AddMessage(context.Background(), run.SessionID, developer); err != nil {
-			log.Printf("[serve] persist skill result context for %s: %v", run.SessionID, err)
-		} else {
-			message := developer.ToLLMMessage()
-			activeContext = &message
-		}
+		developer = &session.Message{SessionID: run.SessionID, Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartSkillActivation, SkillActivation: provenance}, {Type: llm.PartText, Text: contextText}}, TextContent: contextText, CreatedAt: completedAt, Sequence: -1}
+		messages = append(messages, developer)
 	}
-	return activeContext
+
+	var err error
+	if len(messages) == 1 {
+		err = s.store.AddMessage(ctx, run.SessionID, visible)
+	} else {
+		err = s.store.AddMessages(ctx, run.SessionID, messages)
+	}
+	if err != nil {
+		log.Printf("[serve] persist skill result for %s: %v", run.SessionID, err)
+		return nil
+	}
+	if developer == nil {
+		return nil
+	}
+	message := developer.ToLLMMessage()
+	return &message
 }

--- a/cmd/serve_skills_test.go
+++ b/cmd/serve_skills_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -605,6 +606,58 @@ func TestServeSkillRunResultSerializesWithRuntimeAndUpdatesHistory(t *testing.T)
 	runtime.mu.Unlock()
 	if len(history) != 2 || history[1].Role != llm.RoleDeveloper || !strings.Contains(llm.MessageText(history[1]), "runtime result") {
 		t.Fatalf("runtime history after skill result = %#v", history)
+	}
+}
+
+func TestServeSkillRunResultBatchFailureLeavesNoVisibleHalfCompletion(t *testing.T) {
+	setup, _ := serveSkillTestSetup(t)
+	activation, err := skills.NewActivator(setup.Registry).Activate(skills.ActivationRequest{Name: "forked", Origin: skills.SkillActivationUser})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newServeRuntimeTestStore()
+	store.sessions["sess-atomic-boundary"] = &session.Session{ID: "sess-atomic-boundary"}
+	runtime := &serveRuntime{engine: llm.NewEngine(llm.NewMockProvider("mock"), nil), store: store, history: []llm.Message{llm.UserText("parent")}, historyPersisted: true}
+	manager := newServeSessionManager(time.Minute, 4, func(context.Context) (*serveRuntime, error) { return runtime, nil })
+	defer manager.Close()
+	if _, err := manager.GetOrCreate(context.Background(), "sess-atomic-boundary"); err != nil {
+		t.Fatal(err)
+	}
+	srv := &serveServer{store: store, sessionMgr: manager}
+	run := newServeSkillRun("skill-atomic-boundary", "sess-atomic-boundary", "child-atomic", activation, func() {})
+	run.finish(runpkg.ChildRunResult{RunID: run.ID, ChildSessionID: run.ChildSessionID, Output: "valuable child result", CompletedAt: time.Now()}, nil)
+
+	insertAttempts := 0
+	store.addMessageHook = func(context.Context, string, *session.Message) error {
+		insertAttempts++
+		if insertAttempts == 2 {
+			return errors.New("injected second insert failure")
+		}
+		return nil
+	}
+	srv.persistServeSkillRunResultAtBoundary(context.Background(), run, nil)
+	messages, _ := store.GetMessages(context.Background(), run.SessionID, 0, 0)
+	if len(messages) != 0 {
+		t.Fatalf("failed batch persisted half-completion: %#v", messages)
+	}
+	runtime.mu.Lock()
+	history := append([]llm.Message(nil), runtime.history...)
+	runtime.mu.Unlock()
+	if len(history) != 1 {
+		t.Fatalf("failed batch updated runtime history: %#v", history)
+	}
+
+	store.addMessageHook = nil
+	srv.persistServeSkillRunResultAtBoundary(context.Background(), run, nil)
+	messages, _ = store.GetMessages(context.Background(), run.SessionID, 0, 0)
+	if len(messages) != 2 || messages[0].Role != llm.RoleEvent || messages[1].Role != llm.RoleDeveloper {
+		t.Fatalf("retried batch messages = %#v", messages)
+	}
+	runtime.mu.Lock()
+	history = append([]llm.Message(nil), runtime.history...)
+	runtime.mu.Unlock()
+	if len(history) != 2 || history[1].Role != llm.RoleDeveloper || !strings.Contains(llm.MessageText(history[1]), "valuable child result") {
+		t.Fatalf("runtime history after retry = %#v", history)
 	}
 }
 

--- a/internal/session/logger.go
+++ b/internal/session/logger.go
@@ -134,6 +134,13 @@ func (s *LoggingStore) AddMessage(ctx context.Context, sessionID string, msg *Me
 	return err
 }
 
+// AddMessages wraps Store.AddMessages with error logging.
+func (s *LoggingStore) AddMessages(ctx context.Context, sessionID string, messages []*Message) error {
+	err := s.Store.AddMessages(ctx, sessionID, messages)
+	s.logOnce("AddMessages", err)
+	return err
+}
+
 // AddMessageUnlogged performs an AddMessage operation without consuming the
 // wrapper's one-time warning. Callers use this only when they inspect and
 // recover a known error before retrying through AddMessage normally.

--- a/internal/session/noop.go
+++ b/internal/session/noop.go
@@ -52,6 +52,10 @@ func (s *NoopStore) AddMessage(ctx context.Context, sessionID string, msg *Messa
 	return nil
 }
 
+func (s *NoopStore) AddMessages(ctx context.Context, sessionID string, messages []*Message) error {
+	return nil
+}
+
 func (s *NoopStore) UpdateMessage(ctx context.Context, sessionID string, msg *Message) error {
 	return ErrNotFound
 }

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -2900,6 +2900,100 @@ func (s *SQLiteStore) AddMessage(ctx context.Context, sessionID string, msg *Mes
 	return err
 }
 
+// AddMessages appends a batch of messages in one transaction.
+func (s *SQLiteStore) AddMessages(ctx context.Context, sessionID string, messages []*Message) error {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	partsJSON := make([]string, len(messages))
+	for i, msg := range messages {
+		if msg == nil {
+			return fmt.Errorf("message %d is nil", i)
+		}
+		msg.SessionID = sessionID
+		if msg.CreatedAt.IsZero() {
+			msg.CreatedAt = time.Now()
+		}
+		serialized, err := msg.PartsJSONForStorage(s.cfg.StripImageBase64)
+		if err != nil {
+			return fmt.Errorf("serialize message %d parts: %w", i, err)
+		}
+		partsJSON[i] = serialized
+	}
+
+	var committed []messageInsertResult
+	err := retryOnBusy(ctx, 5, func() error {
+		results, err := s.addMessages(ctx, sessionID, messages, partsJSON)
+		if err != nil {
+			return err
+		}
+		committed = results
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for i, result := range committed {
+		messages[i].ID = result.id
+		messages[i].Sequence = result.sequence
+	}
+	return nil
+}
+
+type messageInsertResult struct {
+	id       int64
+	sequence int
+}
+
+func (s *SQLiteStore) addMessages(ctx context.Context, sessionID string, messages []*Message, partsJSON []string) ([]messageInsertResult, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get connection: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return nil, fmt.Errorf("begin immediate transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	var maxSeq sql.NullInt64
+	if err := conn.QueryRowContext(ctx, `SELECT MAX(sequence) FROM messages WHERE session_id = ?`, sessionID).Scan(&maxSeq); err != nil {
+		return nil, fmt.Errorf("get max sequence: %w", err)
+	}
+	nextSequence := 0
+	if maxSeq.Valid {
+		nextSequence = int(maxSeq.Int64) + 1
+	}
+
+	results := make([]messageInsertResult, len(messages))
+	for i, msg := range messages {
+		sequence := msg.Sequence
+		if sequence < 0 {
+			sequence = nextSequence
+		}
+		if sequence >= nextSequence {
+			nextSequence = sequence + 1
+		}
+		id, _, err := s.insertMessageAndBumpSession(ctx, conn, sessionID, msg, partsJSON[i], sequence)
+		if err != nil {
+			return nil, fmt.Errorf("insert message %d: %w", i, err)
+		}
+		results[i] = messageInsertResult{id: id, sequence: sequence}
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return nil, fmt.Errorf("commit transaction: %w", err)
+	}
+	committed = true
+	return results, nil
+}
+
 // AddMessageWithTranscriptRev adds a message and returns the revision bumped by
 // the same transaction.
 func (s *SQLiteStore) AddMessageWithTranscriptRev(ctx context.Context, sessionID string, msg *Message) (int64, error) {

--- a/internal/session/sqlite_test.go
+++ b/internal/session/sqlite_test.go
@@ -2912,6 +2912,50 @@ func TestSQLiteStoreMigratesCompactionCountColumn(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreAddMessagesRollsBackOnSecondInsertFailure(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer store.Close()
+
+	sess := &Session{ID: NewID(), Provider: "test", Model: "test-model", Mode: ModeChat}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	visible := NewMessage(sess.ID, llm.Message{Role: llm.RoleEvent, Parts: []llm.Part{{Type: llm.PartText, Text: "visible completion"}}}, -1)
+	developer := NewMessage(sess.ID, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "parent context"}}}, -1)
+	visible.ClientMessageID = "duplicate-batch-id"
+	developer.ClientMessageID = "duplicate-batch-id"
+
+	if err := store.AddMessages(ctx, sess.ID, []*Message{visible, developer}); err == nil {
+		t.Fatal("AddMessages succeeded despite second insert uniqueness violation")
+	}
+	messages, err := store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after failure: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("failed batch committed messages: %#v", messages)
+	}
+
+	developer.ClientMessageID = "retry-batch-id"
+	if err := store.AddMessages(ctx, sess.ID, []*Message{visible, developer}); err != nil {
+		t.Fatalf("AddMessages retry: %v", err)
+	}
+	messages, err = store.GetMessages(ctx, sess.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after retry: %v", err)
+	}
+	if len(messages) != 2 || messages[0].Role != llm.RoleEvent || messages[1].Role != llm.RoleDeveloper {
+		t.Fatalf("retried batch messages = %#v", messages)
+	}
+	if messages[0].Sequence != 0 || messages[1].Sequence != 1 {
+		t.Fatalf("retried batch sequences = %d, %d", messages[0].Sequence, messages[1].Sequence)
+	}
+}
+
 func TestSQLiteStoreAddMessageConcurrentAutoSequence(t *testing.T) {
 	ctx := context.Background()
 	store, err := NewSQLiteStore(Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -59,6 +59,9 @@ type Store interface {
 
 	// Message operations - stores full llm.Message with Parts
 	AddMessage(ctx context.Context, sessionID string, msg *Message) error
+	// AddMessages appends all messages atomically. Auto-allocated sequences preserve
+	// slice order; if any insert fails, none of the messages are committed.
+	AddMessages(ctx context.Context, sessionID string, messages []*Message) error
 	// UpdateMessage replaces the content of an existing message (by msg.ID) with
 	// the supplied msg (role, parts, text, duration, sequence are updated in
 	// place). Used for "persist as we go" upserts of an in-progress assistant


### PR DESCRIPTION
## What changed

- Added an atomic `AddMessages` session-store operation and implemented it as one SQLite transaction with ordered sequence allocation.
- Persist isolated-skill completion events and their developer-context messages as one batch using the boundary context.
- Update the active runtime history only after the full batch commits.
- Added regression coverage for a failure on the second insert, rollback, and a successful retry that commits both messages in order and appends exactly one developer result.

## Why this is high-value

Isolated skills are part of Jarvis's normal review, search, and research path. Previously, the visible completion event could commit before the developer message failed or the process exited. That left the transcript advertising a successful child run while the parent model silently lost the completed output, often forcing expensive work to be rerun. The transaction removes that split-write window without changing successful behavior.

## Validation

- `gofmt -w cmd/serve_skills.go cmd/serve_skills_test.go cmd/serve_runtime_test.go internal/session/store.go internal/session/sqlite.go internal/session/sqlite_test.go internal/session/logger.go internal/session/noop.go`
- `go build ./...`
- `go test ./internal/session -run 'TestSQLiteStoreAddMessagesRollsBackOnSecondInsertFailure' -count=1`
- `go test ./cmd -run 'TestServeSkillRunResult(BatchFailureLeavesNoVisibleHalfCompletion|SerializesWithRuntimeAndUpdatesHistory|WaitsForParentTurnBoundary)' -count=1`
- `go test ./...` (changed packages and regression tests pass; the full run remains red on unrelated pre-existing environment-sensitive skill discovery tests in `cmd` and `TestRecordChangeEnforcesTotalBudget` in `internal/filetrack`)
- `git diff --check`
