### PR TITLE
fix: Project startup reconciliation performs a full Git workspace scan once per project

### DIFF
--- a/internal/project/assign.go
+++ b/internal/project/assign.go
@@ -133,6 +133,12 @@ func ClaimMatchingSessions(ctx context.Context, store session.Store, p session.P
 // currently available project. Unavailable project paths are skipped so a later
 // run can repair them when the filesystem is mounted again.
 func ReconcileAll(ctx context.Context, store session.Store) (int, error) {
+	return reconcileAll(ctx, store, resolveWorkspaceIdentity)
+}
+
+type reconciliationWorkspaceResolver func(context.Context, string, string) (workspaceIdentity, bool)
+
+func reconcileAll(ctx context.Context, store session.Store, resolveWorkspace reconciliationWorkspaceResolver) (int, error) {
 	projects, ok := session.AsProjectStore(store)
 	if !ok {
 		return 0, nil
@@ -141,18 +147,87 @@ func ReconcileAll(ctx context.Context, store session.Store) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("list projects for reconciliation: %w", err)
 	}
+
+	available := make([]session.Project, 0, len(list))
+	projectsByWorkspace := make(map[workspaceIdentity]string, len(list))
+	for _, p := range list {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		if strings.TrimSpace(p.ID) == "" || p.Archived() {
+			continue
+		}
+		root, err := Resolve(ctx, p.CanonicalDir)
+		if err != nil || !SameIdentity(root.CanonicalDir, p.CanonicalDir) {
+			continue
+		}
+		available = append(available, p)
+		projectsByWorkspace[workspaceIdentity{CanonicalDir: root.CanonicalDir, Git: root.Git}] = p.ID
+	}
+	if len(available) == 0 {
+		return 0, ctx.Err()
+	}
+
+	matchesByProject := make(map[string][]session.ProjectSessionMatch, len(available))
+	projectByWorkspace := make(map[string]string)
+	before := int64(0)
+	for {
+		summaries, err := store.List(ctx, session.ListOptions{
+			Archived:         true,
+			NoProject:        true,
+			Limit:            reconciliationPageSize,
+			BeforeNumber:     before,
+			SortByNumberDesc: true,
+		})
+		if err != nil {
+			return 0, fmt.Errorf("list unassigned sessions: %w", err)
+		}
+		if len(summaries) == 0 {
+			break
+		}
+		for _, summary := range summaries {
+			if err := ctx.Err(); err != nil {
+				return 0, err
+			}
+			if summary.ProjectID != "" {
+				continue
+			}
+			key := strings.TrimSpace(summary.CWD) + "\x00" + strings.TrimSpace(summary.WorktreeDir)
+			projectID, resolved := projectByWorkspace[key]
+			if !resolved {
+				if workspace, ok := resolveWorkspace(ctx, summary.CWD, summary.WorktreeDir); ok {
+					projectID = projectsByWorkspace[workspace]
+				}
+				projectByWorkspace[key] = projectID
+			}
+			if projectID != "" {
+				matchesByProject[projectID] = append(matchesByProject[projectID], session.ProjectSessionMatch{
+					ID: summary.ID, CWD: summary.CWD, WorktreeDir: summary.WorktreeDir,
+				})
+			}
+		}
+		before = summaries[len(summaries)-1].Number
+		if len(summaries) < reconciliationPageSize || before <= 0 {
+			break
+		}
+	}
+
 	total := 0
 	var errs []error
-	for _, p := range list {
+	for _, p := range available {
 		if err := ctx.Err(); err != nil {
 			return total, err
 		}
-		claimed, err := ClaimMatchingSessions(ctx, store, p)
+		matches := matchesByProject[p.ID]
+		if len(matches) == 0 {
+			continue
+		}
+		claimed, err := projects.ClaimProjectSessions(ctx, p.ID, matches)
 		if err != nil {
-			if errors.Is(err, ErrProjectUnavailable) || errors.Is(err, session.ErrNotFound) {
+			if errors.Is(err, session.ErrNotFound) {
 				continue
 			}
-			errs = append(errs, fmt.Errorf("reconcile project %s: %w", p.ID, err))
+			errs = append(errs, fmt.Errorf("reconcile project %s: claim matching project sessions: %w", p.ID, err))
 			continue
 		}
 		total += claimed

--- a/internal/project/assign_test.go
+++ b/internal/project/assign_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,6 +71,63 @@ func TestReconcileAllSkipsUnavailableProject(t *testing.T) {
 	claimed, err := ReconcileAll(ctx, store)
 	if err != nil || claimed != 0 {
 		t.Fatalf("unavailable reconciliation = %d, %v", claimed, err)
+	}
+}
+
+func TestReconcileAllResolvesEachWorkspaceOnceAcrossProjects(t *testing.T) {
+	store := newAssignmentStore(t)
+	ctx := context.Background()
+	const projectCount = 4
+	const workspaceCount = 13
+
+	projects := make([]*session.Project, projectCount)
+	for i := range projects {
+		projects[i] = &session.Project{Name: fmt.Sprintf("Project %d", i), CanonicalDir: t.TempDir()}
+		if err := store.CreateProject(ctx, projects[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	projectByWorkspace := make(map[string]*session.Project, workspaceCount)
+	sessionByWorkspace := make(map[string]string, workspaceCount)
+	now := time.Now()
+	for i := 0; i < workspaceCount; i++ {
+		cwd := filepath.Join(t.TempDir(), fmt.Sprintf("persisted-workspace-%d", i))
+		projectByWorkspace[cwd] = projects[i%projectCount]
+		sessionID := fmt.Sprintf("legacy-workspace-%d", i)
+		sessionByWorkspace[cwd] = sessionID
+		sess := &session.Session{
+			ID: sessionID, Provider: "mock", Model: "mock", CWD: cwd,
+			CreatedAt: now, UpdatedAt: now,
+		}
+		if err := store.Create(ctx, sess); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolverCalls := 0
+	claimed, err := reconcileAll(ctx, store, func(_ context.Context, cwd, _ string) (workspaceIdentity, bool) {
+		resolverCalls++
+		p := projectByWorkspace[cwd]
+		if p == nil {
+			return workspaceIdentity{}, false
+		}
+		return workspaceIdentity{CanonicalDir: p.CanonicalDir}, true
+	})
+	if err != nil || claimed != workspaceCount {
+		t.Fatalf("reconciliation = %d, %v; want %d", claimed, err, workspaceCount)
+	}
+	if resolverCalls != workspaceCount {
+		t.Fatalf("workspace resolver calls = %d; want %d (one per workspace, not %d projects x %d workspaces)", resolverCalls, workspaceCount, projectCount, workspaceCount)
+	}
+	for cwd, wantProject := range projectByWorkspace {
+		sess, err := store.Get(ctx, sessionByWorkspace[cwd])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sess.ProjectID != wantProject.ID {
+			t.Fatalf("workspace %q project = %q; want %q", cwd, sess.ProjectID, wantProject.ID)
+		}
 	}
 }
 

--- a/internal/project/match.go
+++ b/internal/project/match.go
@@ -14,45 +14,74 @@ import (
 // belongs to project. Git snapshots resolve to the main repository; non-Git
 // projects require an exact resolved directory match.
 func MatchesWorkspace(ctx context.Context, cwd, worktreeDir string, project Resolved) bool {
+	workspace, ok := resolveWorkspaceIdentity(ctx, cwd, worktreeDir)
+	return ok && workspace.Git == project.Git && SameIdentity(workspace.CanonicalDir, project.CanonicalDir)
+}
+
+type workspaceIdentity struct {
+	CanonicalDir string
+	Git          bool
+}
+
+// resolveWorkspaceIdentity validates an immutable session execution snapshot
+// and reduces it to the same identity used by registered projects.
+func resolveWorkspaceIdentity(ctx context.Context, cwd, worktreeDir string) (workspaceIdentity, bool) {
 	cwd = strings.TrimSpace(cwd)
 	worktreeDir = strings.TrimSpace(worktreeDir)
-	if project.Git {
-		if worktreeDir != "" {
-			// Persisted managed-worktree snapshots always bind both execution fields
-			// to the same checkout. Reject partial or inconsistent legacy rows.
-			if cwd == "" || !SamePath(cwd, worktreeDir) {
-				return false
-			}
-			wt, err := worktree.Get(worktreeDir)
-			if err != nil || !SamePath(wt.RepoRoot, project.CanonicalDir) {
-				return false
-			}
-			managedRoot, err := worktree.ManagedRoot(project.CanonicalDir)
-			if err != nil {
-				return false
-			}
-			wtDir, err := canonicalBoundary(wt.Dir)
-			if err != nil {
-				return false
-			}
-			managedRoot, err = canonicalBoundary(managedRoot)
-			if err != nil || wtDir == managedRoot || !withinDir(wtDir, managedRoot) {
-				return false
-			}
-			root, err := worktree.MainRepoRootContext(ctx, wtDir)
-			return err == nil && SamePath(root, project.CanonicalDir)
+	if worktreeDir != "" {
+		// Persisted managed-worktree snapshots always bind both execution fields
+		// to the same checkout. Reject partial or inconsistent legacy rows.
+		if cwd == "" || !SamePath(cwd, worktreeDir) {
+			return workspaceIdentity{}, false
 		}
-		if cwd == "" || !worktree.IsGitRepoContext(ctx, cwd) {
-			return false
+		wt, err := worktree.Get(worktreeDir)
+		if err != nil {
+			return workspaceIdentity{}, false
 		}
+		managedRoot, err := worktree.ManagedRoot(wt.RepoRoot)
+		if err != nil {
+			return workspaceIdentity{}, false
+		}
+		wtDir, err := canonicalBoundary(wt.Dir)
+		if err != nil {
+			return workspaceIdentity{}, false
+		}
+		managedRoot, err = canonicalBoundary(managedRoot)
+		if err != nil || wtDir == managedRoot || !withinDir(wtDir, managedRoot) {
+			return workspaceIdentity{}, false
+		}
+		root, err := worktree.MainRepoRootContext(ctx, wtDir)
+		if err != nil || !SamePath(root, wt.RepoRoot) {
+			return workspaceIdentity{}, false
+		}
+		canonical, ok := canonicalWorkspaceDir(root)
+		return workspaceIdentity{CanonicalDir: canonical, Git: true}, ok
+	}
+	if cwd == "" {
+		return workspaceIdentity{}, false
+	}
+	if worktree.IsGitRepoContext(ctx, cwd) {
 		root, err := worktree.MainRepoRootContext(ctx, cwd)
-		return err == nil && SamePath(root, project.CanonicalDir)
+		if err != nil {
+			return workspaceIdentity{}, false
+		}
+		canonical, ok := canonicalWorkspaceDir(root)
+		return workspaceIdentity{CanonicalDir: canonical, Git: true}, ok
 	}
-	if worktreeDir != "" || cwd == "" {
-		return false
+	canonical, ok := canonicalWorkspaceDir(cwd)
+	return workspaceIdentity{CanonicalDir: canonical}, ok
+}
+
+func canonicalWorkspaceDir(path string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", false
 	}
-	resolved, err := filepath.EvalSymlinks(cwd)
-	return err == nil && SamePath(resolved, project.CanonicalDir)
+	resolved, err = canonicalBoundary(resolved)
+	if err != nil {
+		return "", false
+	}
+	return CanonicalStoragePath(resolved), true
 }
 
 // SamePath compares filesystem paths after best-effort canonicalization.


### PR DESCRIPTION
## What changed

- Reworked `ReconcileAll` to validate active project roots once, page through unassigned sessions once, and cache one canonical identity lookup per distinct persisted workspace.
- Grouped session snapshots by canonical project identity, then retained the existing atomic `ClaimProjectSessions` snapshot recheck for each matched project.
- Factored workspace identity resolution out of `MatchesWorkspace` so startup reconciliation and individual project matching use the same Git, managed-worktree, and non-Git validation rules.
- Added a focused four-project/13-workspace test that injects the resolver and asserts exactly 13 resolver calls rather than 52.

## Why this is high-value

Project reconciliation runs on every projects-enabled web startup. Previously each active project repeated the full `NoProject` session walk and re-ran Git repository/root probes for every distinct workspace, making both SQLite paging and short-lived Git process creation scale as O(projects × workspaces). The new path performs one session walk and reduces canonicalization to O(projects + distinct workspaces), while preserving atomic assignment checks and unavailable-project behavior.

## Validation

- `go build ./...`
- `go test -race ./internal/project`
- `go test -run 'TestReconcileAllResolvesEachWorkspaceOnceAcrossProjects' -count=20 ./internal/project`
- `go test ./internal/project`
- `git diff --check`
- `go test ./...` was also run. The changed package passed; the aggregate run hit unrelated current-tree failures in `internal/filetrack` (`TestRecordChangeEnforcesTotalBudget`) and two `cmd` skill-discovery tests because the host's 31 configured skills exhausted their visibility limits. The two `cmd` tests pass with a clean `HOME`.
