### PR TITLE
fix: Terminal queued-agent notifications are lost across shutdowns and crashes

### DIFF
--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -600,6 +600,11 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 		_ = db.Close()
 		return nil, err
 	}
+	if err := mgr.replayPendingRunDoneNotifications(); err != nil {
+		notifyCancel()
+		_ = db.Close()
+		return nil, err
+	}
 
 	mgr.wg.Add(1)
 	go mgr.schedulerLoop()
@@ -664,7 +669,7 @@ func (m *jobsV2Manager) recoverRuns() error {
 			InputTokens:  run.InputTokens,
 			OutputTokens: run.OutputTokens,
 		}
-		if err := m.finishRun(run.ID, jobsV2RunFailed, result, errors.New("worker lost before run could finish"), run.Attempt); err != nil {
+		if err := m.finishRunInternal(run.ID, jobsV2RunFailed, result, errors.New("worker lost before run could finish"), run.Attempt, false); err != nil {
 			return fmt.Errorf("recover interrupted run %s: %w", run.ID, err)
 		}
 	}
@@ -1437,6 +1442,10 @@ func (m *jobsV2Manager) finishRunWithRetry(runID string, status jobsV2RunStatus,
 }
 
 func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result jobsV2RunResult, runErr error, attempt int) error {
+	return m.finishRunInternal(runID, status, result, runErr, attempt, true)
+}
+
+func (m *jobsV2Manager) finishRunInternal(runID string, status jobsV2RunStatus, result jobsV2RunResult, runErr error, attempt int, enqueueNotification bool) error {
 	now := time.Now().UTC()
 	exitReason, truncated := classifyRunError(runErr, result)
 	var errText string
@@ -1444,18 +1453,22 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		errText = runErr.Error()
 	}
 	cancelledErrText := context.Canceled.Error()
-	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = CASE WHEN status = ? THEN ? ELSE ? END, finished_at = ?, exit_code = ?, error = CASE WHEN status = ? THEN ? ELSE ? END, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = ?, exit_reason = CASE WHEN status = ? THEN ? ELSE ? END, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?, ?)`,
+	notificationPending := m.notifyDone != nil && jobsV2NotifyTerminalStatus(status)
+	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = CASE WHEN status = ? THEN ? ELSE ? END, finished_at = ?, exit_code = ?, error = CASE WHEN status = ? THEN ? ELSE ? END, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = ?, exit_reason = CASE WHEN status = ? THEN ? ELSE ? END, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, notification_pending = ?, notification_delivered_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?, ?)`,
 		jobsV2RunCancelRequested, jobsV2RunCancelled, status,
 		now, result.ExitCode,
 		jobsV2RunCancelRequested, cancelledErrText, errText,
 		result.Stdout, result.Stderr, result.Thinking, result.Response, result.SessionID,
 		jobsV2RunCancelRequested, exitReasonCancelled, exitReason,
-		boolToInt(truncated), result.TurnCount, result.InputTokens, result.OutputTokens,
+		boolToInt(truncated), result.TurnCount, result.InputTokens, result.OutputTokens, boolToInt(notificationPending),
 		runID, jobsV2RunQueued, jobsV2RunClaimed, jobsV2RunRunning, jobsV2RunCancelRequested)
 	if err != nil {
-		return err
+		return fmt.Errorf("persist run completion: %w", err)
 	}
-	affected, _ := res.RowsAffected()
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("inspect run completion: %w", err)
+	}
 	if affected == 0 {
 		return nil
 	}
@@ -1481,7 +1494,9 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		"input_tokens":  result.InputTokens,
 		"output_tokens": result.OutputTokens,
 	})
-	m.enqueueRunDoneNotification(run, status, result, exitReason, truncated, errText)
+	if enqueueNotification {
+		m.enqueueRunDoneNotification(run, status, result, exitReason, truncated, errText)
+	}
 
 	if status == jobsV2RunFailed || status == jobsV2RunTimedOut {
 		job, err := m.GetJob(run.JobID)
@@ -1516,6 +1531,53 @@ func jobsV2NotifyTerminalStatus(status jobsV2RunStatus) bool {
 	default:
 		return false
 	}
+}
+
+func (m *jobsV2Manager) replayPendingRunDoneNotifications() error {
+	if m == nil || m.notifyDone == nil {
+		return nil
+	}
+	rows, err := m.db.Query(`SELECT id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at FROM job_runs_v2 WHERE notification_pending = 1 AND status IN (?, ?, ?, ?) ORDER BY finished_at, id`, jobsV2RunSucceeded, jobsV2RunFailed, jobsV2RunCancelled, jobsV2RunTimedOut)
+	if err != nil {
+		return fmt.Errorf("load pending completion notifications: %w", err)
+	}
+
+	var pending []jobsV2Run
+	for rows.Next() {
+		run, err := scanRunV2(rows)
+		if err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan pending completion notification: %w", err)
+		}
+		pending = append(pending, run)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("scan pending completion notifications: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close pending completion notifications query: %w", err)
+	}
+
+	for _, run := range pending {
+		result := jobsV2RunResult{
+			Stdout:       run.Stdout,
+			Stderr:       run.Stderr,
+			Thinking:     run.Thinking,
+			Response:     run.Response,
+			SessionID:    run.SessionID,
+			ExitReason:   run.ExitReason,
+			Truncated:    run.Truncated,
+			TurnCount:    run.TurnCount,
+			InputTokens:  run.InputTokens,
+			OutputTokens: run.OutputTokens,
+		}
+		if run.ExitCode != nil {
+			result.ExitCode = *run.ExitCode
+		}
+		m.enqueueRunDoneNotification(run, run.Status, result, run.ExitReason, run.Truncated, run.Error)
+	}
+	return nil
 }
 
 func (m *jobsV2Manager) enqueueRunDoneNotification(run jobsV2Run, status jobsV2RunStatus, result jobsV2RunResult, exitReason string, truncated bool, errText string) {
@@ -1564,6 +1626,9 @@ func (m *jobsV2Manager) notifyRunDone(run jobsV2Run, status jobsV2RunStatus, res
 		notifyErr = m.notifyDone(attemptCtx, run, job, status, result, exitReason, truncated, errText)
 		cancelAttempt()
 		if notifyErr == nil {
+			if _, err := m.db.Exec(`UPDATE job_runs_v2 SET notification_pending = 0, notification_delivered_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND notification_pending = 1`, run.ID); err != nil {
+				log.Printf("jobs v2: completion notification for run %q was delivered but could not be marked complete: %v", run.ID, err)
+			}
 			return
 		}
 		if notifyCtx.Err() != nil {

--- a/cmd/serve_jobs_v2_migrations.go
+++ b/cmd/serve_jobs_v2_migrations.go
@@ -9,7 +9,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/sqliteutil"
 )
 
-const jobsV2SchemaVersion = 1
+const jobsV2SchemaVersion = 2
 
 const jobsV2MarkerSchema = `CREATE TABLE jobs_v2_schema_version (
 	id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -58,6 +58,8 @@ var jobsV2BootstrapStatements = []string{
 		turn_count INTEGER NOT NULL DEFAULT 0,
 		input_tokens INTEGER NOT NULL DEFAULT 0,
 		output_tokens INTEGER NOT NULL DEFAULT 0,
+		notification_pending INTEGER NOT NULL DEFAULT 0,
+		notification_delivered_at TIMESTAMP,
 		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`,
@@ -72,6 +74,7 @@ var jobsV2BootstrapStatements = []string{
 		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`,
 	`CREATE INDEX idx_job_run_events_v2_run_id_id ON job_run_events_v2(run_id, id)`,
+	`CREATE INDEX idx_job_runs_v2_notification_pending ON job_runs_v2(notification_pending, finished_at) WHERE notification_pending = 1`,
 	jobsV2RunSummaryIndexSQL,
 	jobsV2RunGlobalSummaryIndexSQL,
 	jobsV2MarkerSchema,
@@ -89,6 +92,11 @@ var jobsV2Migrations = []jobsV2Migration{
 		description: "adopt legacy jobs schema and reconcile run metadata and indexes",
 		up:          reconcileLegacyJobsV2Schema,
 	},
+	{
+		version:     2,
+		description: "persist queued-agent completion notification delivery state",
+		up:          addJobsV2NotificationState,
+	},
 }
 
 var jobsV2LegacyColumns = []struct {
@@ -104,6 +112,33 @@ var jobsV2LegacyColumns = []struct {
 	{name: "input_tokens", definition: "INTEGER NOT NULL DEFAULT 0", typeName: "INTEGER", notNull: true, defaultSQL: "0"},
 	{name: "output_tokens", definition: "INTEGER NOT NULL DEFAULT 0", typeName: "INTEGER", notNull: true, defaultSQL: "0"},
 	{name: "session_id", definition: "TEXT", typeName: "TEXT"},
+	{name: "notification_pending", definition: "INTEGER NOT NULL DEFAULT 0", typeName: "INTEGER", notNull: true, defaultSQL: "0"},
+	{name: "notification_delivered_at", definition: "TIMESTAMP", typeName: "TIMESTAMP"},
+}
+
+func addJobsV2NotificationState(tx sqliteutil.Executor) error {
+	columns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "notification_pending", definition: "INTEGER NOT NULL DEFAULT 0"},
+		{name: "notification_delivered_at", definition: "TIMESTAMP"},
+	}
+	for _, column := range columns {
+		exists, err := sqliteutil.ColumnExists(tx, "job_runs_v2", column.name)
+		if err != nil {
+			return fmt.Errorf("inspect job_runs_v2.%s: %w", column.name, err)
+		}
+		if !exists {
+			if _, err := tx.Exec(`ALTER TABLE job_runs_v2 ADD COLUMN "` + column.name + `" ` + column.definition); err != nil {
+				return fmt.Errorf("add job_runs_v2.%s: %w", column.name, err)
+			}
+		}
+	}
+	if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_job_runs_v2_notification_pending ON job_runs_v2(notification_pending, finished_at) WHERE notification_pending = 1`); err != nil {
+		return fmt.Errorf("create pending run notification index: %w", err)
+	}
+	return nil
 }
 
 func reconcileLegacyJobsV2Schema(tx sqliteutil.Executor) error {
@@ -176,6 +211,7 @@ func canonicalizeLegacyJobsV2Tables(tx sqliteutil.Executor) error {
 	statements := []string{
 		`DROP INDEX IF EXISTS idx_job_runs_v2_job_id`,
 		`DROP INDEX IF EXISTS idx_job_runs_v2_status`,
+		`DROP INDEX IF EXISTS idx_job_runs_v2_notification_pending`,
 		`DROP INDEX IF EXISTS idx_job_runs_v2_summary_by_job_created`,
 		`DROP INDEX IF EXISTS idx_job_runs_v2_summary_created`,
 		`DROP INDEX IF EXISTS idx_job_run_events_v2_run_id`,
@@ -204,11 +240,13 @@ func canonicalizeLegacyJobsV2Tables(tx sqliteutil.Executor) error {
 			turn_count INTEGER NOT NULL DEFAULT 0,
 			input_tokens INTEGER NOT NULL DEFAULT 0,
 			output_tokens INTEGER NOT NULL DEFAULT 0,
+			notification_pending INTEGER NOT NULL DEFAULT 0,
+			notification_delivered_at TIMESTAMP,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
-		`INSERT INTO job_runs_v2(id,job_id,attempt,trigger,scheduled_for,status,worker_id,session_id,started_at,finished_at,exit_code,error,stdout,stderr,thinking,response,exit_reason,truncated,turn_count,input_tokens,output_tokens,created_at,updated_at)
-		 SELECT id,job_id,attempt,trigger,scheduled_for,status,worker_id,session_id,started_at,finished_at,exit_code,error,stdout,stderr,thinking,response,exit_reason,truncated,turn_count,input_tokens,output_tokens,created_at,updated_at FROM job_runs_v2_old`,
+		`INSERT INTO job_runs_v2(id,job_id,attempt,trigger,scheduled_for,status,worker_id,session_id,started_at,finished_at,exit_code,error,stdout,stderr,thinking,response,exit_reason,truncated,turn_count,input_tokens,output_tokens,notification_pending,notification_delivered_at,created_at,updated_at)
+		 SELECT id,job_id,attempt,trigger,scheduled_for,status,worker_id,session_id,started_at,finished_at,exit_code,error,stdout,stderr,thinking,response,exit_reason,truncated,turn_count,input_tokens,output_tokens,notification_pending,notification_delivered_at,created_at,updated_at FROM job_runs_v2_old`,
 		`CREATE TABLE job_run_events_v2 (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			run_id TEXT NOT NULL REFERENCES job_runs_v2(id) ON DELETE CASCADE,

--- a/cmd/serve_jobs_v2_migrations_test.go
+++ b/cmd/serve_jobs_v2_migrations_test.go
@@ -25,6 +25,50 @@ func TestJobsV2MigrationListInvariants(t *testing.T) {
 	}
 }
 
+func TestJobsV2MigratesNotificationDeliveryStateFromVersionOne(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "jobs.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := execJobsV2Schema(db); err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`DROP INDEX idx_job_runs_v2_notification_pending`,
+		`ALTER TABLE job_runs_v2 DROP COLUMN notification_delivered_at`,
+		`ALTER TABLE job_runs_v2 DROP COLUMN notification_pending`,
+		`UPDATE jobs_v2_schema_version SET version = 1`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("prepare version one schema: %v\n%s", err, statement)
+		}
+	}
+
+	if err := initJobsV2Schema(context.Background(), db); err != nil {
+		t.Fatal(err)
+	}
+	for _, column := range []string{"notification_pending", "notification_delivered_at"} {
+		exists, err := sqliteutil.ColumnExists(db, "job_runs_v2", column)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Fatalf("missing migrated column %s", column)
+		}
+	}
+	var version, indexes int
+	if err := db.QueryRow(`SELECT version FROM jobs_v2_schema_version WHERE id = 1`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_job_runs_v2_notification_pending'`).Scan(&indexes); err != nil {
+		t.Fatal(err)
+	}
+	if version != jobsV2SchemaVersion || indexes != 1 {
+		t.Fatalf("migrated version=%d pending indexes=%d, want version=%d and one index", version, indexes, jobsV2SchemaVersion)
+	}
+}
+
 func TestJobsV2FreshAndCurrentPathsRunZeroMigrationCallbacks(t *testing.T) {
 	original := jobsV2Migrations
 	jobsV2Migrations = append([]jobsV2Migration(nil), original...)
@@ -173,6 +217,7 @@ func TestJobsV2MigrationRepairsEveryIndividualLegacyColumnHole(t *testing.T) {
 				`DROP TABLE jobs_v2_schema_version`,
 				`DROP INDEX IF EXISTS idx_job_runs_v2_summary_by_job_created`,
 				`DROP INDEX IF EXISTS idx_job_runs_v2_summary_created`,
+				`DROP INDEX IF EXISTS idx_job_runs_v2_notification_pending`,
 				`ALTER TABLE job_runs_v2 DROP COLUMN "` + column.name + `"`,
 			} {
 				if _, err := db.Exec(statement); err != nil {

--- a/cmd/serve_jobs_v2_notify_test.go
+++ b/cmd/serve_jobs_v2_notify_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -662,5 +663,139 @@ func TestJobsV2CloseCancelsCompletionNotification(t *testing.T) {
 	}
 	if got := attempts.Load(); got != 1 {
 		t.Fatalf("notification attempts after shutdown = %d, want 1", got)
+	}
+}
+
+func TestJobsV2PendingNotificationSurvivesShutdownAndIsDeliveredOnce(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "jobs.db")
+	notifyStarted := make(chan struct{}, 1)
+	mgr, err := newJobsV2ManagerWithNotifier(dbPath, 0, nil, func(ctx context.Context, _ jobsV2Run, _ jobsV2Job, _ jobsV2RunStatus, _ jobsV2RunResult, _ string, _ bool, _ string) error {
+		notifyStarted <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	if err != nil {
+		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
+	}
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "durable-notify-shutdown",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+	if err := mgr.finishRun(run.ID, jobsV2RunSucceeded, jobsV2RunResult{Stdout: "ok"}, nil, run.Attempt); err != nil {
+		t.Fatalf("finishRun: %v", err)
+	}
+	select {
+	case <-notifyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("completion notification did not start")
+	}
+	if err := mgr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var deliveries atomic.Int32
+	delivered := make(chan struct{}, 1)
+	mgr, err = newJobsV2ManagerWithNotifier(dbPath, 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
+		deliveries.Add(1)
+		delivered <- struct{}{}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reopen jobs manager: %v", err)
+	}
+	select {
+	case <-delivered:
+	case <-time.After(time.Second):
+		_ = mgr.Close()
+		t.Fatal("pending completion notification was not replayed")
+	}
+	waitForServeCondition(t, time.Second, func() bool {
+		var marked int
+		return mgr.db.QueryRow(`SELECT COUNT(*) FROM job_runs_v2 WHERE id = ? AND notification_pending = 0 AND notification_delivered_at IS NOT NULL`, run.ID).Scan(&marked) == nil && marked == 1
+	}, "completion notification delivery marker")
+	if err := mgr.Close(); err != nil {
+		t.Fatalf("close reopened manager: %v", err)
+	}
+
+	mgr, err = newJobsV2ManagerWithNotifier(dbPath, 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
+		deliveries.Add(1)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("second reopen jobs manager: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err := mgr.Close(); err != nil {
+		t.Fatalf("close second reopened manager: %v", err)
+	}
+	if got := deliveries.Load(); got != 1 {
+		t.Fatalf("successful notification deliveries = %d, want exactly 1", got)
+	}
+}
+
+func TestJobsV2PendingNotificationSurvivesCrashBeforeDispatch(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "jobs.db")
+	var deliveries atomic.Int32
+	mgr, err := newJobsV2ManagerWithNotifier(dbPath, 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
+		deliveries.Add(1)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newJobsV2ManagerWithNotifier: %v", err)
+	}
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "durable-notify-crash",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob: %v", err)
+	}
+	result := jobsV2RunResult{Stdout: "ok"}
+	if err := mgr.finishRunInternal(run.ID, jobsV2RunSucceeded, result, nil, run.Attempt, false); err != nil {
+		t.Fatalf("persist terminal run without dispatch: %v", err)
+	}
+	if got := deliveries.Load(); got != 0 {
+		t.Fatalf("notification deliveries before simulated crash = %d, want 0", got)
+	}
+	if err := mgr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	delivered := make(chan struct{}, 1)
+	mgr, err = newJobsV2ManagerWithNotifier(dbPath, 0, nil, func(context.Context, jobsV2Run, jobsV2Job, jobsV2RunStatus, jobsV2RunResult, string, bool, string) error {
+		deliveries.Add(1)
+		delivered <- struct{}{}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reopen jobs manager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	select {
+	case <-delivered:
+	case <-time.After(time.Second):
+		t.Fatal("crash-window completion notification was not replayed")
+	}
+	if got := deliveries.Load(); got != 1 {
+		t.Fatalf("notification deliveries after reopen = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
## What changed

- Added durable `notification_pending` and `notification_delivered_at` state to terminal job runs, including a jobs schema v2 migration and a partial index for startup replay.
- Set notification state in the same SQLite update that makes a run terminal, eliminating the crash window between terminal persistence and enqueueing process-local work.
- Replay pending terminal-run notifications during manager startup and clear the pending marker only after the notifier returns successfully.
- Suppress immediate dispatch while startup recovery terminalizes interrupted runs, then replay the resulting pending rows once through the common startup path.
- Added integration coverage for shutdown cancellation/reopen delivery, crash-equivalent terminal persistence before dispatch, successful delivery marking, one-time replay, and version 1 schema migration.

## Why this is high-value

Jarvis and scheduled `queue_agent` jobs commonly use `notify_when_done` to continue a web session or report back to Telegram. Previously, a normal serve reload, crash, or exhausted in-process retry window could leave the completed result only in the jobs database while the originating conversation never heard back. Persisting delivery state with the terminal transition turns these silent losses into startup-recoverable work while preserving asynchronous completion behavior.

The run ID remains the durable delivery identity, and successfully delivered rows are marked so later restarts do not replay them again.

## Validation

- `go test ./cmd -run 'TestJobsV2(Migration|Migrates|PendingNotification|CloseCancels|Notify)' -count=1`
- `go test -race ./cmd -run 'TestJobsV2PendingNotification' -count=1`
- `go build ./...`
- `git diff --check`
- `go test ./...` was run; all affected jobs tests and most packages passed, but the full command remains blocked by unrelated failures: two environment-sensitive skill-discovery tests select the configured global skills instead of their temporary fixture, and `internal/filetrack`'s `TestRecordChangeEnforcesTotalBudget` fails in the untouched package when run independently as well.
