### PR TITLE
feat(herdr): integrate chat lifecycle with Herdr

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -15,6 +15,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/exitcode"
+	"github.com/samsaffron/term-llm/internal/herdr"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -213,9 +214,15 @@ func runChat(cmd *cobra.Command, args []string) error {
 	relaunchHandoff := chatRelaunchHandoff{}
 	mainRuns := chat.NewMainRunManager(ctx)
 	defer mainRuns.Close(5 * time.Second)
+	herdrReporter := herdr.NewReporterFromEnv()
+	defer herdrReporter.Close()
+	var lifecycleReporter chat.LifecycleReporter
+	if herdrReporter != nil {
+		lifecycleReporter = herdrReporter
+	}
 	chatHandoverApprovalMode = nil
 	for {
-		nextResumeID, nextAutoSend, err := runChatOnce(ctx, cmd, initialText, cliAgent, resumeRequested, resumeID, handoverAutoSend, &relaunchHandoff, mainRuns)
+		nextResumeID, nextAutoSend, err := runChatOnce(ctx, cmd, initialText, cliAgent, resumeRequested, resumeID, handoverAutoSend, &relaunchHandoff, mainRuns, lifecycleReporter)
 		if err != nil {
 			return err
 		}
@@ -1017,7 +1024,7 @@ func wireChatSessionUI(ctx context.Context, rt *chatSessionRuntime, p *tea.Progr
 	}
 }
 
-func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string, relaunchHandoff *chatRelaunchHandoff, mainRuns *chat.MainRunManager) (string, string, error) {
+func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent string, resumeRequested bool, resumeID, handoverAutoSend string, relaunchHandoff *chatRelaunchHandoff, mainRuns *chat.MainRunManager, lifecycleReporter chat.LifecycleReporter) (string, string, error) {
 	rt, err := buildChatSessionRuntime(ctx, cmd, chatSessionLaunch{
 		initialText:      initialText,
 		cliAgent:         cliAgent,
@@ -1029,6 +1036,7 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	if err != nil {
 		return "", "", err
 	}
+	rt.model.SetLifecycleReporter(lifecycleReporter)
 
 	// In-process session switches replace the active runtime while the program
 	// keeps running, so all teardown paths resolve the runtime late.
@@ -1127,6 +1135,12 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 		activeRT = next
 		activeUnwire = nil
 		runtimeMu.Unlock()
+
+		// Only the visible session may author the containing pane's lifecycle.
+		// Background runs from the previous model retain their own UI callbacks,
+		// but must not overwrite the foreground model's Herdr state.
+		prev.model.SetLifecycleReporter(nil)
+		next.model.SetLifecycleReporter(lifecycleReporter)
 
 		// Release process-global UI hooks before installing the replacements.
 		// Runtime-owned callbacks stay bound to prev so its adopted background

--- a/docs-site/content/guides/herdr.md
+++ b/docs-site/content/guides/herdr.md
@@ -1,0 +1,45 @@
+---
+title: "Herdr"
+weight: 10
+description: "Run term-llm chat in Herdr and see its live lifecycle state."
+kicker: "Integrations"
+next:
+  label: Shell integration
+  url: /guides/shell-integration/
+---
+
+[Herdr](https://herdr.dev) keeps terminal panes and coding agents running in
+the background. When `term-llm chat` runs inside a Herdr pane, term-llm
+automatically reports its lifecycle state to that pane:
+
+- **Idle** when the chat is ready for a prompt.
+- **Working** while it is generating a response, running a direct shell
+  command, or changing a worktree.
+- **Blocked** when it needs an approval or an answer through `ask_user`.
+
+Start Herdr in the project, then open `term-llm chat` in one of its panes:
+
+```bash
+herdr
+term-llm chat @developer
+```
+
+Herdr injects the connection details into every managed pane. No term-llm or
+Herdr configuration is required. Verify the state from another pane with:
+
+```bash
+herdr agent list
+herdr agent get <pane-id>
+```
+
+Term-llm also reports its persisted chat-session ID, so it is visible through
+Herdr's pane and agent APIs. Herdr does not yet have a built-in term-llm
+restorer, so reopening a restored pane still uses term-llm's normal resume
+command:
+
+```bash
+term-llm chat --resume=<session-id>
+```
+
+Outside a Herdr-managed pane the integration is inert: term-llm does not look
+up a socket, alter your environment, or require Herdr to be installed.

--- a/internal/herdr/reporter.go
+++ b/internal/herdr/reporter.go
@@ -1,0 +1,194 @@
+// Package herdr reports term-llm chat lifecycle changes to a containing Herdr
+// pane. It deliberately has no dependency on Herdr's socket protocol: the
+// release-matched Herdr CLI is the portable integration boundary.
+package herdr
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	source = "custom:term-llm"
+	agent  = "term-llm"
+
+	commandTimeout = 2 * time.Second
+	closeTimeout   = 500 * time.Millisecond
+)
+
+type commandRunner func(context.Context, string, ...string) error
+type binaryFinder func(string) (string, error)
+
+type eventKind uint8
+
+const (
+	reportEvent eventKind = iota
+	releaseEvent
+)
+
+type event struct {
+	kind      eventKind
+	state     string
+	sessionID string
+}
+
+// Reporter sends ordered, best-effort lifecycle reports to Herdr. It is only
+// active when launched from a Herdr pane, so callers can use it unconditionally
+// without making Herdr a runtime dependency.
+type Reporter struct {
+	binPath string
+	paneID  string
+	run     commandRunner
+
+	mu        sync.Mutex
+	closed    bool
+	reported  bool
+	lastState string
+	lastID    string
+	queue     []event
+	wake      chan struct{}
+	done      chan struct{}
+}
+
+// NewReporterFromEnv returns a reporter only for a process running in a
+// Herdr-managed pane. Missing integration variables intentionally leave the
+// caller with a nil reporter and no observable side effects.
+func NewReporterFromEnv() *Reporter {
+	return newReporterFromEnv(os.Getenv, exec.LookPath, runCommand)
+}
+
+func newReporterFromEnv(getenv func(string) string, lookPath binaryFinder, run commandRunner) *Reporter {
+	if getenv("HERDR_ENV") != "1" {
+		return nil
+	}
+	binPath := strings.TrimSpace(getenv("HERDR_BIN_PATH"))
+	if binPath == "" && lookPath != nil {
+		if found, err := lookPath("herdr"); err == nil {
+			binPath = strings.TrimSpace(found)
+		}
+	}
+	paneID := strings.TrimSpace(getenv("HERDR_PANE_ID"))
+	if binPath == "" || paneID == "" {
+		return nil
+	}
+	if run == nil {
+		run = runCommand
+	}
+	r := &Reporter{
+		binPath: binPath,
+		paneID:  paneID,
+		run:     run,
+		wake:    make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	go r.loop()
+	return r
+}
+
+// Report records the current chat state. Repeated reports for the same state
+// and term-llm session are omitted. Calls never wait for Herdr's local socket.
+func (r *Reporter) Report(state, sessionID string) {
+	if r == nil || !validState(state) {
+		return
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed || (r.reported && r.lastState == state && r.lastID == sessionID) {
+		return
+	}
+	r.reported = true
+	r.lastState = state
+	r.lastID = sessionID
+	r.queue = append(r.queue, event{kind: reportEvent, state: state, sessionID: sessionID})
+	r.notify()
+}
+
+// Close relinquishes lifecycle authority after pending reports. It waits only
+// briefly because chat shutdown must never be held hostage by a local CLI
+// failure. Calls are serialized, so Herdr receives state and release reports in
+// order without sequence numbers that could become stale across process restarts.
+func (r *Reporter) Close() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	if r.reported {
+		r.queue = append(r.queue, event{kind: releaseEvent})
+	}
+	r.notify()
+	r.mu.Unlock()
+
+	select {
+	case <-r.done:
+	case <-time.After(closeTimeout):
+	}
+}
+
+func (r *Reporter) loop() {
+	defer close(r.done)
+	for range r.wake {
+		for {
+			event, ok, closed := r.nextEvent()
+			if !ok {
+				if closed {
+					return
+				}
+				break
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+			if event.kind == releaseEvent {
+				_ = r.run(ctx, r.binPath, "pane", "release-agent", r.paneID, "--source", source, "--agent", agent)
+			} else {
+				args := []string{"pane", "report-agent", r.paneID, "--source", source, "--agent", agent, "--state", event.state}
+				if event.sessionID != "" {
+					args = append(args, "--agent-session-id", event.sessionID)
+				}
+				_ = r.run(ctx, r.binPath, args...)
+			}
+			cancel()
+		}
+	}
+}
+
+// notify wakes the worker without ever waiting for it. The caller holds r.mu.
+func (r *Reporter) notify() {
+	select {
+	case r.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (r *Reporter) nextEvent() (event, bool, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.queue) == 0 {
+		return event{}, false, r.closed
+	}
+	next := r.queue[0]
+	r.queue[0] = event{}
+	r.queue = r.queue[1:]
+	return next, true, false
+}
+
+func runCommand(ctx context.Context, path string, args ...string) error {
+	return exec.CommandContext(ctx, path, args...).Run()
+}
+
+func validState(state string) bool {
+	switch state {
+	case "idle", "working", "blocked":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/herdr/reporter_test.go
+++ b/internal/herdr/reporter_test.go
@@ -1,0 +1,154 @@
+package herdr
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordedCommand struct {
+	path string
+	args []string
+}
+
+func TestNewReporterFromEnvRequiresHerdrPaneVariables(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+	}{
+		{name: "outside herdr", env: map[string]string{}},
+		{name: "missing binary", env: map[string]string{"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:p1"}},
+		{name: "missing pane", env: map[string]string{"HERDR_ENV": "1", "HERDR_BIN_PATH": "/usr/local/bin/herdr"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newReporterFromEnv(func(name string) string { return tt.env[name] }, nil, nil)
+			if r != nil {
+				t.Fatal("reporter should be disabled")
+			}
+		})
+	}
+}
+
+func TestNewReporterFromEnvFindsHerdrOnPath(t *testing.T) {
+	r := newReporterFromEnv(func(name string) string {
+		return map[string]string{
+			"HERDR_ENV":     "1",
+			"HERDR_PANE_ID": "w1:p1",
+		}[name]
+	}, func(name string) (string, error) {
+		if name != "herdr" {
+			t.Fatalf("binary lookup = %q, want herdr", name)
+		}
+		return "/opt/herdr/bin/herdr", nil
+	}, nil)
+	if r == nil {
+		t.Fatal("reporter should use herdr from PATH")
+	}
+	if r.binPath != "/opt/herdr/bin/herdr" {
+		t.Fatalf("binary path = %q", r.binPath)
+	}
+	r.Close()
+}
+
+func TestReporterReportsOrderedLifecycleAndRelease(t *testing.T) {
+	var mu sync.Mutex
+	var commands []recordedCommand
+	r := newReporterFromEnv(func(name string) string {
+		return map[string]string{
+			"HERDR_ENV":      "1",
+			"HERDR_BIN_PATH": "/tmp/herdr",
+			"HERDR_PANE_ID":  "w1:p2",
+		}[name]
+	}, nil, func(_ context.Context, path string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		commands = append(commands, recordedCommand{path: path, args: append([]string(nil), args...)})
+		return nil
+	})
+
+	r.Report("idle", "session-a")
+	r.Report("idle", "session-a") // deduplicated
+	r.Report("working", "session-a")
+	r.Report("blocked", "session-a")
+	r.Report("idle", "session-b") // session identity changed
+	r.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := [][]string{
+		{"pane", "report-agent", "w1:p2", "--source", source, "--agent", agent, "--state", "idle", "--agent-session-id", "session-a"},
+		{"pane", "report-agent", "w1:p2", "--source", source, "--agent", agent, "--state", "working", "--agent-session-id", "session-a"},
+		{"pane", "report-agent", "w1:p2", "--source", source, "--agent", agent, "--state", "blocked", "--agent-session-id", "session-a"},
+		{"pane", "report-agent", "w1:p2", "--source", source, "--agent", agent, "--state", "idle", "--agent-session-id", "session-b"},
+		{"pane", "release-agent", "w1:p2", "--source", source, "--agent", agent},
+	}
+	if len(commands) != len(want) {
+		t.Fatalf("commands = %#v, want %d commands", commands, len(want))
+	}
+	for i, got := range commands {
+		if got.path != "/tmp/herdr" || !reflect.DeepEqual(got.args, want[i]) {
+			t.Errorf("command %d = %#v, want path %q args %#v", i, got, "/tmp/herdr", want[i])
+		}
+	}
+}
+
+func TestReporterIgnoresUnknownLifecycleState(t *testing.T) {
+	called := false
+	r := newReporterFromEnv(func(name string) string {
+		return map[string]string{
+			"HERDR_ENV":      "1",
+			"HERDR_BIN_PATH": "/tmp/herdr",
+			"HERDR_PANE_ID":  "w1:p2",
+		}[name]
+	}, nil, func(context.Context, string, ...string) error {
+		called = true
+		return nil
+	})
+	r.Report("unknown", "session-a")
+	r.Close()
+	if called {
+		t.Fatal("invalid state should not invoke Herdr")
+	}
+}
+
+func TestReporterDoesNotBlockWhileHerdrCommandIsRunning(t *testing.T) {
+	commandStarted := make(chan struct{})
+	unblockCommand := make(chan struct{})
+	var once sync.Once
+	r := newReporterFromEnv(func(name string) string {
+		return map[string]string{
+			"HERDR_ENV":      "1",
+			"HERDR_BIN_PATH": "/tmp/herdr",
+			"HERDR_PANE_ID":  "w1:p2",
+		}[name]
+	}, nil, func(context.Context, string, ...string) error {
+		once.Do(func() { close(commandStarted) })
+		<-unblockCommand
+		return nil
+	})
+
+	r.Report("idle", "session-a")
+	<-commandStarted
+	reported := make(chan struct{})
+	go func() {
+		for i := 0; i < 32; i++ {
+			if i%2 == 0 {
+				r.Report("working", "session-a")
+			} else {
+				r.Report("idle", "session-a")
+			}
+		}
+		close(reported)
+	}()
+
+	select {
+	case <-reported:
+	case <-time.After(time.Second):
+		t.Fatal("Report blocked behind the Herdr command")
+	}
+	close(unblockCommand)
+	r.Close()
+}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -155,6 +155,13 @@ type Model struct {
 	store    session.Store     // Session storage backend
 	sess     *session.Session  // Current session
 	messages []session.Message // In-memory messages for current session
+
+	// Optional terminal-host lifecycle integration. Reports are deduplicated in
+	// the model so Update can publish the resulting state unconditionally.
+	lifecycleReporter LifecycleReporter
+	lifecycleReported bool
+	lifecycleState    string
+	lifecycleSession  string
 	// pendingTerminalDirectory is emitted as OSC 7 after a successful runtime
 	// directory change, keeping terminal workspace metadata in sync without a
 	// process-wide chdir.
@@ -2324,6 +2331,11 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 	defer func() {
 		if reportCmd := m.takeTerminalWorkingDirectoryCmd(); reportCmd != nil {
 			cmd = tea.Batch(cmd, reportCmd)
+		}
+		if updated, ok := model.(*Model); ok && updated != nil {
+			updated.reportLifecycleState()
+		} else {
+			m.reportLifecycleState()
 		}
 	}()
 	if m.resizeReflowPending {

--- a/internal/tui/chat/lifecycle.go
+++ b/internal/tui/chat/lifecycle.go
@@ -1,0 +1,44 @@
+package chat
+
+// LifecycleReporter receives the coarse status that a terminal host needs to
+// coordinate an interactive chat. Implementations must return promptly because
+// reports are emitted from Bubble Tea's event loop.
+type LifecycleReporter interface {
+	Report(state, sessionID string)
+}
+
+// SetLifecycleReporter attaches an optional host integration. The current
+// state is emitted straight away so a newly opened chat is visible as idle
+// before the user submits a prompt. Passing nil detaches the current reporter.
+func (m *Model) SetLifecycleReporter(reporter LifecycleReporter) {
+	m.lifecycleReporter = reporter
+	m.lifecycleReported = false
+	m.lifecycleState = ""
+	m.lifecycleSession = ""
+	m.reportLifecycleState()
+}
+
+func (m *Model) reportLifecycleState() {
+	if m.lifecycleReporter == nil {
+		return
+	}
+	state := m.currentLifecycleState()
+	sessionID := sessionIDOf(m.sess)
+	if m.lifecycleReported && m.lifecycleState == state && m.lifecycleSession == sessionID {
+		return
+	}
+	m.lifecycleReported = true
+	m.lifecycleState = state
+	m.lifecycleSession = sessionID
+	m.lifecycleReporter.Report(state, sessionID)
+}
+
+func (m *Model) currentLifecycleState() string {
+	if m.approvalModel != nil || m.askUserModel != nil || (m.pausedForExternalUI && !m.externalProcessActive) {
+		return "blocked"
+	}
+	if m.streaming || m.directShellRun != nil || m.externalProcessActive || m.worktreeOperationBusy() {
+		return "working"
+	}
+	return "idle"
+}

--- a/internal/tui/chat/lifecycle_test.go
+++ b/internal/tui/chat/lifecycle_test.go
@@ -1,0 +1,83 @@
+package chat
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type recordedLifecycleReporter struct {
+	reports []lifecycleReport
+}
+
+type lifecycleReport struct {
+	state     string
+	sessionID string
+}
+
+func (r *recordedLifecycleReporter) Report(state, sessionID string) {
+	r.reports = append(r.reports, lifecycleReport{state: state, sessionID: sessionID})
+}
+
+func TestLifecycleReporterTracksChatStates(t *testing.T) {
+	m := newTestChatModel(true)
+	m.sess = &session.Session{ID: "session-a"}
+	reporter := &recordedLifecycleReporter{}
+	m.SetLifecycleReporter(reporter)
+
+	m.streaming = true
+	m.reportLifecycleState()
+	m.pausedForExternalUI = true
+	m.reportLifecycleState()
+	m.pausedForExternalUI = false
+	m.streaming = false
+	m.directShellRun = &directShellRun{}
+	m.reportLifecycleState()
+	m.directShellRun = nil
+	m.reportLifecycleState()
+
+	want := []lifecycleReport{
+		{state: "idle", sessionID: "session-a"},
+		{state: "working", sessionID: "session-a"},
+		{state: "blocked", sessionID: "session-a"},
+		{state: "working", sessionID: "session-a"},
+		{state: "idle", sessionID: "session-a"},
+	}
+	if !reflect.DeepEqual(reporter.reports, want) {
+		t.Fatalf("reports = %#v, want %#v", reporter.reports, want)
+	}
+}
+
+func TestLifecycleReporterReportsStateAfterUpdate(t *testing.T) {
+	m := newTestChatModel(true)
+	m.sess = &session.Session{ID: "session-a"}
+	reporter := &recordedLifecycleReporter{}
+	m.SetLifecycleReporter(reporter)
+	m.streaming = true
+
+	updated, _ := m.Update(struct{}{})
+	m = updated.(*Model)
+	if got := reporter.reports[len(reporter.reports)-1]; got != (lifecycleReport{state: "working", sessionID: "session-a"}) {
+		t.Fatalf("last report = %#v, want working state", got)
+	}
+
+	m.Update(struct{}{})
+	if len(reporter.reports) != 2 {
+		t.Fatalf("unchanged lifecycle produced %d reports, want 2", len(reporter.reports))
+	}
+}
+
+func TestLifecycleReporterTreatsExternalProcessAsWorking(t *testing.T) {
+	m := newTestChatModel(true)
+	reporter := &recordedLifecycleReporter{}
+	m.SetLifecycleReporter(reporter)
+
+	m.pausedForExternalUI = true
+	m.externalProcessActive = true
+	m.reportLifecycleState()
+
+	if got := reporter.reports[len(reporter.reports)-1]; got.state != "working" {
+		t.Fatalf("external process state = %q, want working", got.state)
+	}
+}


### PR DESCRIPTION
Report idle, working, and blocked chat states to the containing Herdr pane, including the active term-llm session identity. Keep reporting ordered and non-blocking, transfer authority across session switches, and release it on exit.

Support Herdr environments that expose the CLI only through PATH, use the pane-first command syntax accepted by Herdr 0.8.0, and avoid stale sequence state across repeated launches. Add lifecycle and reporter regression coverage plus an integration guide.

<img width="1237" height="1050" alt="Screenshot 2026-08-28 at 12 07 28 pm" src="https://github.com/user-attachments/assets/eff4cdcb-fadd-460a-9650-ad5303b59b23" />
