### PR TITLE
build: embed metadata in Make builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 .PHONY: build frontend frontend-deps
 
 FRONTEND_STAMP := frontend/node_modules/.term-llm-install-stamp
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo dev)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+TERM_LLM_LDFLAGS := -s -w \
+	-X github.com/samsaffron/term-llm/cmd.Version=$(VERSION) \
+	-X github.com/samsaffron/term-llm/cmd.Commit=$(COMMIT) \
+	-X github.com/samsaffron/term-llm/cmd.Date=$(BUILD_DATE)
 
 build: frontend
-	go build -o term-llm .
+	go build -ldflags "$(TERM_LLM_LDFLAGS)" -o term-llm .
 
 frontend: frontend-deps
 	npm --prefix frontend run build

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make build
 ./term-llm version
 ```
 
-`make build` installs the locked frontend dependencies when needed, generates the embedded web UI, and then builds the Go binary. The generated frontend bundles are intentionally not checked into Git, so plain `go build` from a fresh checkout will fail until `make frontend` has run.
+`make build` installs the locked frontend dependencies when needed, generates the embedded web UI, and then builds the Go binary with the current version, commit, and UTC build time embedded. The generated frontend bundles are intentionally not checked into Git, so plain `go build` from a fresh checkout will fail until `make frontend` has run.
 
 `go install github.com/samsaffron/term-llm@latest` cannot build this repository: in addition to the generated frontend prerequisite, the application intentionally uses local `replace` directives for the owned Bubble Tea, Ultraviolet, and reflow modules. Use the installer/release archive or `make build` from a complete checkout.
 

--- a/internal/contain/images/agent/bootstrap/scripts/update.sh
+++ b/internal/contain/images/agent/bootstrap/scripts/update.sh
@@ -35,24 +35,13 @@ if [ "$BEFORE" = "$COMMIT" ]; then
 else
     log "Updated $BEFORE -> $COMMIT"
 fi
-VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
-BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+log "Building with make"
 
-log "Building version=$VERSION commit=$COMMIT date=$BUILD_DATE"
-
-make frontend
-
-go build \
-    -ldflags "-s -w \
-        -X github.com/samsaffron/term-llm/cmd.Version=${VERSION} \
-        -X github.com/samsaffron/term-llm/cmd.Commit=${COMMIT} \
-        -X github.com/samsaffron/term-llm/cmd.Date=${BUILD_DATE}" \
-    -o /tmp/term-llm-new \
-    ./main.go
+make build
 
 log "Installing binary to $BINARY_DEST..."
-sudo install -m 755 /tmp/term-llm-new "$BINARY_DEST"
-rm -f /tmp/term-llm-new
+sudo install -m 755 "$SRC_DIR/term-llm" "$BINARY_DEST"
+rm -f "$SRC_DIR/term-llm"
 
 log "Done! Installed:"
 "$BINARY_DEST" version


### PR DESCRIPTION
## Summary

- embed version, commit, and UTC build time in binaries produced by `make build`
- make the container self-updater use the canonical Make build instead of duplicating `go build` and linker flags
- document the metadata behavior for source builds

## Why

After the Preact merge made `make` the canonical build path, local and self-update builds reported:

```
term-llm version dev (commit: unknown, built: unknown)
```

The Makefile now owns the same metadata linker flags used by release builds, while keeping `VERSION`, `COMMIT`, and `BUILD_DATE` overridable.

## Tests

- `mise x node@24 -- make build`
- `./term-llm version` → `v0.9.0 (commit: a83b18f9, built: <UTC timestamp>)`
- `mise x node@24 -- make build VERSION=v-test COMMIT=deadbeef BUILD_DATE=2026-01-02T03:04:05Z`
- `./term-llm version` → `v-test (commit: deadbeef, built: 2026-01-02T03:04:05Z)`
- `bash -n internal/contain/images/agent/bootstrap/scripts/update.sh`
- `git diff --check`
