### PR TITLE
test: stabilize interaction dismissal smoke

### DIFF
--- a/frontend/e2e/real-server.spec.ts
+++ b/frontend/e2e/real-server.spec.ts
@@ -234,8 +234,8 @@ test('recovers and resolves an ask-user request across real same-context tabs', 
   const question = 'Which path should the browser fixture take?';
   await expect(page.getByText(question)).toBeVisible();
   await expect(second.getByText(question)).toBeVisible();
-
-  await page.getByRole('dialog', { name: 'Answer question' }).press('Escape');
+  await expect(page.getByRole('dialog', { name: 'Answer question' })).toBeVisible();
+  await page.keyboard.press('Escape');
   await expect(page.getByText('Decision waiting — Open')).toBeVisible();
   await second.getByRole('radio', { name: /Safe/ }).check();
   await second.getByRole('button', { name: 'Continue' }).click();
@@ -289,7 +289,7 @@ test('recovers, neutrally dismisses, and resolves a real approval', async ({ pag
 
   const title = 'Write Access Request';
   await expect(page.getByRole('dialog', { name: title })).toBeVisible();
-  await page.getByRole('dialog', { name: title }).press('Escape');
+  await page.keyboard.press('Escape');
   await expect(page.getByText('Decision waiting — Open')).toBeVisible();
   await page.getByText('Decision waiting — Open').click();
   await page.getByRole('button', { name: 'Approve' }).click();


### PR DESCRIPTION
## Summary

- send Escape through Playwright's page keyboard after confirming interaction dialogs are visible
- avoid locator action retries when Escape intentionally removes the target dialog during `keydown`
- apply the same stable dismissal pattern to approval and ask-user recovery coverage

## Why CI failed

The main-branch frontend job timed out in the real approval smoke at `locator.press('Escape')`. The dialog correctly handled Escape and detached itself during `keydown`, but Playwright treated that detachment as an interrupted locator action, retried against the replacement DOM, and eventually hit the 30-second test timeout.

## Tests

- `mise x node@24 -- npm run lint`
- `mise x node@24 -- npm run test -- --run` (304 passed)
- `mise x node@24 -- scripts/browser_lifecycle_smoke.sh e2e/real-server.spec.ts --project=desktop --grep='real approval' --repeat-each=20` (20 passed)
- `mise x node@24 -- scripts/browser_lifecycle_smoke.sh` (37 passed, 15 skipped)
