### PR TITLE
fix: keep mobile runtime model legible

### DIFF
--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -14,8 +14,12 @@ const session = (id: string, title: string, number: number) => ({
   file_change_summary: { file_count: 1, adds: 2, dels: 1, git: true },
 });
 
-async function mockAPI(page: Page, options: { holdStream?: boolean; media?: boolean } = {}) {
+async function mockAPI(
+  page: Page,
+  options: { holdStream?: boolean; media?: boolean; model?: string } = {},
+) {
   const requests: Array<{ method: string; url: string }> = [];
+  const model = options.model || 'gpt-test';
   await page.route('**/v1/**', async (route: Route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -36,17 +40,15 @@ async function mockAPI(page: Page, options: { holdStream?: boolean; media?: bool
             name: 'openai',
             configured: true,
             is_default: true,
-            default_model: 'gpt-test',
-            models: ['gpt-test'],
+            default_model: model,
+            models: [model],
           },
         ],
       });
     if (path.endsWith('/v1/models'))
       return json({
         object: 'list',
-        data: [
-          { id: 'gpt-test', owned_by: 'openai', reasoning_efforts: ['low', 'medium', 'high'] },
-        ],
+        data: [{ id: model, owned_by: 'openai', reasoning_efforts: ['low', 'medium', 'high'] }],
       });
     if (path.endsWith('/v1/sidebar'))
       return json({ sessions: [session('s1', 'First chat', 1), session('s2', 'Second chat', 2)] });
@@ -157,7 +159,7 @@ async function mockAPI(page: Page, options: { holdStream?: boolean; media?: bool
 async function open(
   page: Page,
   suffix = '',
-  options: { holdStream?: boolean; media?: boolean } = {},
+  options: { holdStream?: boolean; media?: boolean; model?: string } = {},
 ) {
   const requests = await mockAPI(page, options);
   await page.goto(`./${suffix}`);
@@ -277,6 +279,28 @@ test('opens diff UI, expands a file and queues an inline comment', async ({ page
   await expect(page.locator('.diff-queue-bar')).toContainText('1 queued');
   await expect(page.getByRole('button', { name: 'Send comments' })).toBeVisible();
   await expect(page.getByText('1 inline comment queued.')).toHaveCount(0);
+});
+
+test('mobile header keeps the active runtime legible without overflowing when controls compete', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile', 'mobile-only layout');
+  await open(page, '', { model: 'gpt-5.6-sol-high' });
+
+  const runtime = page.getByRole('button', { name: /Runtime settings: gpt-5\.6-sol, high effort/ });
+  const label = runtime.locator('.chip-label');
+  await expect(label).toHaveText('gpt-5.6-sol');
+  expect(await label.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(
+    true,
+  );
+  expect(
+    await page
+      .locator('.main-header')
+      .evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+  ).toBe(true);
+
+  await runtime.click();
+  await expect(page.getByRole('dialog', { name: 'Runtime settings' })).toBeVisible();
 });
 
 test('mobile viewport opens a styled sidebar and returns to a usable composer', async ({

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -59,6 +59,7 @@ function RuntimePicker() {
     setOpen(false);
     trigger.current?.focus({ preventScroll: true });
   };
+  const displayModel = compactModelLabel(split.model) || 'Auto';
   const picker = (
     <div class={`model-picker ${locked ? 'locked' : ''}`}>
       <div class="model-chip model-chip-primary" data-chip="model">
@@ -69,17 +70,17 @@ function RuntimePicker() {
           aria-haspopup="dialog"
           aria-controls={popoverID}
           aria-expanded={open}
-          aria-label="Runtime settings"
+          aria-label={`Runtime settings: ${displayModel}${effort ? `, ${effort} effort` : ''}`}
           data-effort-level={effort || 'auto'}
           title={
             locked
-              ? 'View runtime and queue reasoning effort for the next model turn'
-              : 'Choose provider, model, and reasoning effort'
+              ? `${displayModel} · view runtime and queue reasoning effort for the next model turn`
+              : `${displayModel} · choose provider, model, and reasoning effort`
           }
           onClick={() => (open ? close() : setOpen(true))}
         >
           <span class={`chip-label ${!selectedModel && fallbackModel ? 'stats-muted' : ''}`}>
-            {compactModelLabel(split.model) || 'Auto'}
+            {displayModel}
           </span>
           <EffortMeter />
         </button>

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -98,7 +98,8 @@ describe('Preact-owned chat surfaces', () => {
         <Header />
       </StoreContext.Provider>,
     );
-    const trigger = screen.getByRole('button', { name: 'Runtime settings' });
+    const trigger = screen.getByRole('button', { name: /^Runtime settings:/ });
+    expect(trigger).toHaveAccessibleName('Runtime settings: gpt-5, medium effort');
     expect(trigger).toHaveTextContent('gpt-5');
     expect(trigger.querySelectorAll('.effort-meter-bar')).toHaveLength(4);
     expect(trigger).toHaveAttribute('data-effort-level', 'medium');

--- a/frontend/src/styles/integration/preact-overrides.css
+++ b/frontend/src/styles/integration/preact-overrides.css
@@ -708,6 +708,18 @@ mark.diff-word {
     max-width: min(36vw, 10rem);
   }
 
+  /* Keep the model readable when the header is quiet. If contextual actions make
+     the row genuinely crowded, move the control cluster to a compact second row
+     instead of clipping every control into ambiguity. */
+  .header-title-row {
+    flex-wrap: wrap;
+    row-gap: 0.35rem;
+  }
+
+  .header-left {
+    min-width: min(9rem, 40vw);
+  }
+
   .header-title {
     font-size: 0.94rem;
   }
@@ -735,7 +747,7 @@ mark.diff-word {
   }
 
   .model-chip[data-chip='model'] .chip-trigger {
-    max-width: 7.5rem;
+    max-width: min(10.875rem, 40vw);
   }
 
   .diff-toggle {
@@ -824,12 +836,8 @@ mark.diff-word {
     max-width: 7.5rem;
   }
 
-  .model-chip[data-chip='model'] .chip-trigger {
-    max-width: 5.7rem;
-  }
-
   .model-picker .narrow-header-action {
-    padding-inline: 0.25rem;
+    padding-inline: 0.4rem;
   }
 
   .header-context-actions .worktree-trigger {

--- a/frontend/src/styles/layout/header.css
+++ b/frontend/src/styles/layout/header.css
@@ -317,11 +317,12 @@
 }
 
 .model-chip[data-chip='model'] .chip-trigger {
-  max-width: 126px;
+  max-width: 174px;
 }
 
 .model-chip[data-chip='model'] .chip-label {
-  max-width: 84px;
+  flex: 0 1 auto;
+  max-width: 132px;
   line-height: 1.3;
 }
 


### PR DESCRIPTION
## Summary

- let the runtime model chip use available mobile header width so `gpt-5.6-sol` stays intact instead of rendering as `gpt-5.6-…`
- allow the mobile control cluster to wrap as a unit when contextual controls genuinely crowd the header, rather than crushing individual labels
- expose the active model and effort in the runtime button's accessible name and tooltip
- add a mobile regression test using the exact `gpt-5.6-sol-high` runtime

## Design

Reviewed with Opus before implementation. The underlying problem was a stack of fixed caps: 84px globally, 7.5rem on mobile, then 5.7rem below 430px. The fix gives the model a responsive budget (up to 40vw) while preserving room for the menu/title; if plan, diff, MCP, or other contextual actions exceed the remaining width, the controls wrap together onto a compact second row.

That keeps the common one-row header clean and makes the crowded case explicit rather than producing a dangling-token ellipsis.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 304 passed
- `make build`
- `scripts/browser_lifecycle_smoke.sh e2e/chat.spec.ts` — 17 passed, 7 intentionally skipped across desktop/mobile projects
