### PR TITLE
fix: Shell descendants can mutate files after the final tracking snapshot

### DIFF
--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -420,6 +420,7 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 	if prepErr != nil {
 		return errorOutput(formatToolError(NewToolErrorf(ErrExecutionFailed, "command setup error: %v", prepErr))), nil
 	}
+	cleanup = sync.OnceFunc(cleanup)
 	defer cleanup()
 
 	stdout := newLimitedBuffer(t.limits.MaxBytes)
@@ -435,6 +436,9 @@ func (t *ShellTool) Execute(ctx context.Context, args json.RawMessage) (llm.Tool
 
 	// Run command
 	err := cmd.Run()
+	// Stop descendants before reading the filesystem so tracking captures the
+	// state the shell invocation actually leaves behind.
+	cleanup()
 
 	// Diff against the snapshot even on timeout or failure — partial writes
 	// are real changes.

--- a/internal/tools/shell_leak_repro_test.go
+++ b/internal/tools/shell_leak_repro_test.go
@@ -5,9 +5,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/filetrack"
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 // TestShellTool_BackgroundedChildKilled pins down the session-1708 behaviour:
@@ -110,5 +115,107 @@ func runAndAssertReaped(t *testing.T, tool *ShellTool, command, sentinel string,
 		_ = exec.Command("pkill", "-f", sentinel).Run()
 		t.Fatalf("descendant sentinel process still alive after shell returned:\n  pgrep -f %s -> %q\n  tool output: %s",
 			sentinel, stray, output)
+	}
+}
+
+type blockingAttributedRecorder struct {
+	*fakeFileRecorder
+	recordStarted chan filetrack.ChangeRecord
+	release       chan struct{}
+}
+
+func (r *blockingAttributedRecorder) RecordAttributedChange(ctx context.Context, rec filetrack.ChangeRecord) (*llm.FileChange, error) {
+	select {
+	case r.recordStarted <- rec:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-r.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return r.fakeFileRecorder.RecordAttributedChange(ctx, rec)
+}
+
+func TestShellToolCleansBackgroundDescendantsBeforeTracking(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("process-group cleanup regression is Linux-specific")
+	}
+
+	dir := t.TempDir()
+	trackedPath := filepath.Join(dir, "tracked.txt")
+	childReleasePath := filepath.Join(dir, "child-release")
+	if err := os.WriteFile(trackedPath, []byte("before\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := &blockingAttributedRecorder{
+		fakeFileRecorder: &fakeFileRecorder{},
+		recordStarted:    make(chan filetrack.ChangeRecord, 1),
+		release:          make(chan struct{}),
+	}
+	recorderReleased := false
+	defer func() {
+		if !recorderReleased {
+			close(recorder.release)
+		}
+	}()
+
+	tool := NewShellTool(nil, nil, DefaultOutputLimits())
+	tool.recorder = recorder
+	command := "(printf ready > child-ready; while [ ! -e child-release ]; do sleep 0.01; done; printf 'second\\n' > tracked.txt) </dev/null >/dev/null 2>&1 & " +
+		"while [ ! -e child-ready ]; do sleep 0.01; done; printf 'initial\\n' > tracked.txt"
+	args := mustMarshalShellArgs(ShellArgs{
+		Command:    command,
+		WorkingDir: dir,
+		OutputClaims: []OutputClaim{{
+			Path: "tracked.txt",
+			Kind: filetrack.ClaimTransform,
+		}},
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		out, err := tool.Execute(trackingContext(), args)
+		if err == nil && out.IsError {
+			err = fmt.Errorf("shell command failed: %s", out.Content)
+		}
+		done <- err
+	}()
+
+	var rec filetrack.ChangeRecord
+	select {
+	case rec = <-recorder.recordStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shell tracking did not reach the recorder")
+	}
+	if got := string(rec.After); got != "initial\n" {
+		t.Fatalf("recorded after-content = %q, want initial value", got)
+	}
+
+	// If cleanup is deferred until Execute returns, releasing this known-live
+	// child lets it mutate the file while the recorder keeps tracking blocked.
+	if err := os.WriteFile(childReleasePath, []byte("release\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	final, err := os.ReadFile(trackedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(final) != string(rec.After) {
+		t.Fatalf("file changed after tracking snapshot: recorded %q, final %q", rec.After, final)
+	}
+
+	close(recorder.release)
+	recorderReleased = true
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("shell Execute did not return after recorder release")
 	}
 }


### PR DESCRIPTION
## What changed

- Made shell process cleanup locally idempotent so it remains safe as both an immediate call and a deferred panic fallback.
- Invoke cleanup immediately after `cmd.Run()` returns, before post-command filesystem tracking reads or persists file state.
- Added a Linux regression test with a redirected background child and a blocking file recorder. The test synchronizes the child so it can only attempt its second write after tracking has captured the first write, then verifies cleanup prevents that late mutation and the recorded after-content matches the final file.

## Why this is high-value

Shell is a hot path in Jarvis's daily work, and file history drives attribution plus undo/redo. Previously, a successful foreground shell could exit while descendants remained alive during the tracking window. A descendant could then mutate a file after its after-content had been read, leaving durable history inconsistent with the filesystem at `Execute` return. Cleaning descendants first also shortens their resource lifetime and avoids leaving a reaped command PID exposed to process-group reuse until tracking completes.

## Validation

- `go test ./internal/tools -run '^(TestShellToolCleansBackgroundDescendantsBeforeTracking|TestShellTool_BackgroundedChildKilled|TestShellTool_SetsidDescendantKilled)$' -count=1`
- `go test ./internal/tools -run '^TestShellToolCleansBackgroundDescendantsBeforeTracking$' -count=10`
- `go test -race ./internal/tools -run '^(TestShellToolCleansBackgroundDescendantsBeforeTracking|TestShellTool_BackgroundedChildKilled|TestShellTool_SetsidDescendantKilled)$' -count=1`
- `go test ./internal/tools -count=1`
- `go build ./...`
- `XDG_CONFIG_HOME=<empty temp dir> TERM_LLM_REPO= GOTOOLCHAIN=go1.25.8 go test ./...`

The first bare host `go test ./...` run used Go 1.27 and Jarvis's global skill config; it exposed unrelated skill-selection test pollution and Go-version-sensitive frontend gzip budget failures. The isolated rerun above uses the repository's declared Go 1.25.8 toolchain and passed the complete suite.
