### PR TITLE
fix: reconcile stale mobile response state

### DIFF
--- a/frontend/src/stores/app-store.test.ts
+++ b/frontend/src/stores/app-store.test.ts
@@ -1721,6 +1721,100 @@ describe('AppStore compatibility behavior', () => {
     expect(internals.resumeResponse).not.toHaveBeenCalled();
   });
 
+  it('does not let an idle status response invalidate a run admitted after the request began', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    const status = deferred<Record<string, unknown>>();
+    store.endpoints.sessionStatus = vi.fn(() => status.promise);
+    const internals = store as unknown as {
+      refreshStatus(): Promise<void>;
+      resumeResponse(sessionId: string, responseId: string): Promise<void>;
+    };
+    internals.resumeResponse = vi.fn(async () => undefined);
+
+    const refresh = internals.refreshStatus();
+    store.sessions.value = [
+      { ...session(), activeRun: true, activeResponseId: 'newly-admitted-response' },
+    ];
+    store.runs.value = {
+      s1: initialProjection({
+        responseId: 'newly-admitted-response',
+        sessionId: 's1',
+        epoch: 1,
+        status: 'streaming',
+        lastSequence: 1,
+        startedRev: 1,
+        startedAt: Date.now() + 1_000,
+        reconnects: 0,
+      }),
+    };
+    status.resolve({ sessions: [{ id: 's1' }] });
+    await refresh;
+
+    expect(store.sessions.value[0]).toMatchObject({
+      activeRun: true,
+      activeResponseId: 'newly-admitted-response',
+    });
+    expect(internals.resumeResponse).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile a response while the server reports anonymous run activity', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [{ ...session(), activeRun: true, activeResponseId: 'r1' }];
+    store.runs.value = {
+      s1: initialProjection({
+        responseId: 'r1',
+        sessionId: 's1',
+        epoch: 1,
+        status: 'streaming',
+        lastSequence: 1,
+        startedRev: 1,
+        startedAt: 1,
+        reconnects: 0,
+      }),
+    };
+    store.endpoints.sessionStatus = vi.fn(async () => ({
+      sessions: [{ id: 's1', active_run: true }],
+    }));
+    const internals = store as unknown as {
+      refreshStatus(): Promise<void>;
+      resumeResponse(sessionId: string, responseId: string): Promise<void>;
+    };
+    internals.resumeResponse = vi.fn(async () => undefined);
+
+    await internals.refreshStatus();
+
+    expect(store.sessions.value[0]?.activeRun).toBe(true);
+    expect(internals.resumeResponse).not.toHaveBeenCalled();
+  });
+
+  it('does not treat an omitted status row as authoritative idle', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [{ ...session(), activeRun: true, activeResponseId: 'out-of-scope' }];
+    store.runs.value = {
+      s1: initialProjection({
+        responseId: 'out-of-scope',
+        sessionId: 's1',
+        epoch: 1,
+        status: 'streaming',
+        lastSequence: 1,
+        startedRev: 1,
+        startedAt: 1,
+        reconnects: 0,
+      }),
+    };
+    store.endpoints.sessionStatus = vi.fn(async () => ({ sessions: [] }));
+    const internals = store as unknown as {
+      refreshStatus(): Promise<void>;
+      resumeResponse(sessionId: string, responseId: string): Promise<void>;
+    };
+    internals.resumeResponse = vi.fn(async () => undefined);
+
+    await internals.refreshStatus();
+
+    expect(internals.resumeResponse).not.toHaveBeenCalled();
+  });
+
   it('forces a post-mutation sidebar fetch after an opportunistic fetch already started', async () => {
     const store = new AppStore(config);
     const first = deferred<Record<string, unknown>>();

--- a/frontend/src/stores/app-store.test.ts
+++ b/frontend/src/stores/app-store.test.ts
@@ -1664,6 +1664,63 @@ describe('AppStore compatibility behavior', () => {
     expect(store.sessions.value[0]).toMatchObject({ activeRun: false, activeResponseId: null });
   });
 
+  it('reconciles a locally running response when the server reports the session idle', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [
+      { ...session(), activeRun: true, activeResponseId: 'finished-while-suspended' },
+    ];
+    store.runs.value = {
+      s1: initialProjection({
+        responseId: 'finished-while-suspended',
+        sessionId: 's1',
+        epoch: 1,
+        status: 'streaming',
+        lastSequence: 4,
+        startedRev: 1,
+        reconnects: 0,
+      }),
+    };
+    store.endpoints.sessionStatus = vi.fn(async () => ({
+      sessions: [{ id: 's1', transcript_rev: 2 }],
+    }));
+    const internals = store as unknown as {
+      refreshStatus(): Promise<void>;
+      resumeResponse(sessionId: string, responseId: string): Promise<void>;
+    };
+    internals.resumeResponse = vi.fn(async () => undefined);
+
+    await internals.refreshStatus();
+
+    expect(store.sessions.value[0]).toMatchObject({ activeRun: false, activeResponseId: null });
+    expect(internals.resumeResponse).toHaveBeenCalledWith('s1', 'finished-while-suspended');
+  });
+
+  it('does not probe a provisional response before the server admits it', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [{ ...session(), activeRun: true }];
+    store.runs.value = {
+      s1: initialProjection({
+        responseId: 'pending_local-response',
+        sessionId: 's1',
+        epoch: 1,
+        status: 'connecting',
+        lastSequence: 0,
+        startedRev: 0,
+        reconnects: 0,
+      }),
+    };
+    store.endpoints.sessionStatus = vi.fn(async () => ({ sessions: [{ id: 's1' }] }));
+    const internals = store as unknown as {
+      refreshStatus(): Promise<void>;
+      resumeResponse(sessionId: string, responseId: string): Promise<void>;
+    };
+    internals.resumeResponse = vi.fn(async () => undefined);
+
+    await internals.refreshStatus();
+
+    expect(internals.resumeResponse).not.toHaveBeenCalled();
+  });
+
   it('forces a post-mutation sidebar fetch after an opportunistic fetch already started', async () => {
     const store = new AppStore(config);
     const first = deferred<Record<string, unknown>>();

--- a/frontend/src/stores/status-reconciler.ts
+++ b/frontend/src/stores/status-reconciler.ts
@@ -14,6 +14,7 @@ export interface StatusRequestMetadata {
   selectionEpoch: number;
   showHidden: boolean;
   categories: string[];
+  activeResponseIds: Record<string, string>;
 }
 
 interface StatusCoordinatorState {
@@ -105,6 +106,13 @@ export class StatusReconciler {
       selectionEpoch: this.host.selectionEpoch(),
       showHidden: this.host.sessionStore.showHidden.peek(),
       categories: [...this.services.config.sidebarCategories],
+      activeResponseIds: Object.fromEntries(
+        Object.entries(this.host.runs.peek())
+          .filter(([, projection]) =>
+            ['connecting', 'checking', 'streaming', 'cancelling'].includes(projection.run.status),
+          )
+          .map(([sessionId, projection]) => [sessionId, projection.run.responseId]),
+      ),
     };
     const request = (async () => {
       // An authoritative request invalidates the old generation immediately,
@@ -188,6 +196,12 @@ export class StatusReconciler {
           projectedRun &&
           ['connecting', 'checking', 'streaming', 'cancelling'].includes(projectedRun.status),
         );
+        const projectedRunWasActiveAtRequest = Boolean(
+          projectedRun && metadata.activeResponseIds[session.id] === projectedRun.responseId,
+        );
+        const idleStatusCannotDisproveProjectedRun = Boolean(
+          !serverReportsActive && clientReportsActive && !projectedRunWasActiveAtRequest,
+        );
         const committedClientMessageId = String(status.client_message_id || '');
         if (
           serverActiveResponseId &&
@@ -202,7 +216,11 @@ export class StatusReconciler {
         const stoppedServerResponse = Boolean(
           serverActiveResponseId && this.host.isLocallyStopped(serverActiveResponseId),
         );
-        const activeResponseId = stoppedServerResponse ? null : serverActiveResponseId;
+        const activeResponseId = idleStatusCannotDisproveProjectedRun
+          ? session.activeResponseId || projectedRun?.responseId || null
+          : stoppedServerResponse
+            ? null
+            : serverActiveResponseId;
         const transcriptRev = Math.max(
           session.transcriptRev || 0,
           Number(status.transcript_rev) || 0,
@@ -220,6 +238,7 @@ export class StatusReconciler {
         if (
           !serverReportsActive &&
           clientReportsActive &&
+          projectedRunWasActiveAtRequest &&
           projectedRun &&
           projectedRun.responseId &&
           !projectedRun.responseId.startsWith('pending_')
@@ -227,11 +246,13 @@ export class StatusReconciler {
           // The status endpoint is authoritative for run liveness, but the
           // response snapshot owns the terminal projection. Mobile browsers
           // can suspend or lose the terminal stream event, so reconcile that
-          // snapshot whenever the two views disagree.
+          // snapshot whenever the two views disagree. A run admitted after
+          // this status request started cannot be disproven by its stale body.
           followUps.push(() => void this.host.resumeResponse(session.id, projectedRun.responseId));
         }
         if (
           !serverActiveResponseId &&
+          !idleStatusCannotDisproveProjectedRun &&
           (session.activeResponseId || this.host.pendingIntents.peek()[session.id]?.length) &&
           transcriptRev >= (projectedRun?.finalRev || 0)
         )

--- a/frontend/src/stores/status-reconciler.ts
+++ b/frontend/src/stores/status-reconciler.ts
@@ -182,6 +182,12 @@ export class StatusReconciler {
         const status = byID.get(session.id);
         if (!status) return session.activeRun ? { ...session, activeRun: false } : session;
         const serverActiveResponseId = String(status.active_response_id || '') || null;
+        const serverReportsActive = Boolean(serverActiveResponseId || status.active_run);
+        const projectedRun = this.host.runs.peek()[session.id]?.run;
+        const clientReportsActive = Boolean(
+          projectedRun &&
+          ['connecting', 'checking', 'streaming', 'cancelling'].includes(projectedRun.status),
+        );
         const committedClientMessageId = String(status.client_message_id || '');
         if (
           serverActiveResponseId &&
@@ -212,9 +218,22 @@ export class StatusReconciler {
             this.host.clearLocallyStopped(stoppedResponseId);
         }
         if (
+          !serverReportsActive &&
+          clientReportsActive &&
+          projectedRun &&
+          projectedRun.responseId &&
+          !projectedRun.responseId.startsWith('pending_')
+        ) {
+          // The status endpoint is authoritative for run liveness, but the
+          // response snapshot owns the terminal projection. Mobile browsers
+          // can suspend or lose the terminal stream event, so reconcile that
+          // snapshot whenever the two views disagree.
+          followUps.push(() => void this.host.resumeResponse(session.id, projectedRun.responseId));
+        }
+        if (
           !serverActiveResponseId &&
           (session.activeResponseId || this.host.pendingIntents.peek()[session.id]?.length) &&
-          transcriptRev >= (this.host.runs.peek()[session.id]?.run.finalRev || 0)
+          transcriptRev >= (projectedRun?.finalRev || 0)
         )
           followUps.push(() => void this.host.refreshSessionMessages(session.id, transcriptRev));
         const titleRefreshAllowed = this.host.renameTarget.peek()?.id !== session.id;


### PR DESCRIPTION
## Summary

- detect when the Web UI still projects a response as active after authoritative session status reports the server idle
- fetch the response snapshot to recover the terminal state and durable transcript instead of leaving the mobile UI spinning forever
- avoid probing provisional `pending_*` response IDs before server admission
- preserve runs admitted after a status request began so a stale idle response cannot interrupt a healthy stream

The existing status loop already polls every 2 seconds while any local run is active. This closes the missing reconciliation path: an idle server status now causes the stale local response projection to refresh rather than merely clearing the session activity flag.

## Tests

- `mise x node@24 -- npm test` (309 passed)
- `mise x node@24 -- npm run typecheck`
- `mise x node@24 -- npm run lint:ts`
- `mise x node@24 -- npx prettier --check src/stores/status-reconciler.ts src/stores/app-store.test.ts`
