### PR TITLE
fix: preserve session model in web navigation

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1195,6 +1195,7 @@ type webSessionEntry struct {
 	Mode          session.SessionMode   `json:"mode,omitempty"`
 	Origin        session.SessionOrigin `json:"origin,omitempty"`
 	Provider      string                `json:"provider,omitempty"`
+	Model         string                `json:"model,omitempty"`
 	ProjectID     string                `json:"project_id,omitempty"`
 	ProjectName   string                `json:"project_name,omitempty"`
 	Archived      bool                  `json:"archived"`
@@ -1220,6 +1221,7 @@ func (s *serveServer) webSessionEntryFromSummary(sess session.SessionSummary) we
 		Mode:          sess.Mode,
 		Origin:        sess.Origin,
 		Provider:      sessionSummaryProviderKey(s.cfgRef, sess),
+		Model:         sess.Model,
 		ProjectID:     sess.ProjectID,
 		ProjectName:   sess.ProjectName,
 		Archived:      sess.Archived,
@@ -1248,6 +1250,7 @@ func (s *serveServer) webSessionEntryFromSession(sess *session.Session) webSessi
 		Mode:          sess.Mode,
 		Origin:        sess.Origin,
 		Provider:      provider,
+		Model:         sess.Model,
 		ProjectID:     sess.ProjectID,
 		ProjectName:   sess.ProjectName,
 		Archived:      sess.Archived,

--- a/cmd/serve_transcript_test.go
+++ b/cmd/serve_transcript_test.go
@@ -538,8 +538,14 @@ func TestHandleSessionsMessageCountMatchesConversationAcrossSelectedTranscriptRe
 	if len(normal.Sessions) != 1 || normal.Sessions[0].MsgCount != conversationCount {
 		t.Fatalf("normal sessions count=%+v, want %d", normal.Sessions, conversationCount)
 	}
+	if normal.Sessions[0].Model != sess.Model {
+		t.Fatalf("normal session model=%q, want %q", normal.Sessions[0].Model, sess.Model)
+	}
 	if normal.SelectedSession == nil || normal.SelectedSession.MsgCount != conversationCount {
 		t.Fatalf("normal selected_session=%+v, want count %d", normal.SelectedSession, conversationCount)
+	}
+	if normal.SelectedSession.Model != sess.Model {
+		t.Fatalf("selected session model=%q, want %q", normal.SelectedSession.Model, sess.Model)
 	}
 
 	selectedByID := requestSessions("/v1/sessions?selected_session=" + sess.ID + "&selected_only=1&include_transcript=1")


### PR DESCRIPTION
## Summary

- include the persisted model in Web UI session summaries
- include the persisted model in selected-session payloads
- prevent navigation from falling back to the provider's default model after leaving and reopening a session

Session #4334 was persisted as `qwen3.8:27b-thinking`, but the Web API returned only its `ollama` provider. After back/forward navigation discarded live response state, the client had no session model and displayed Ollama's default, `gemma4:26b`.

## Tests

- `go test ./cmd -run 'TestHandleSessionsMessageCountMatchesConversationAcrossSelectedTranscriptResponses' -count=1`
- `go test ./cmd` *(two unrelated existing failures in skill-discovery tests because the installed skill set exceeds their configured metadata budget)*
- `git diff --check`
