### PR TITLE
fix: render interjected images before reload

### DIFF
--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -1040,12 +1040,14 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		return
 	case "response.interjection":
 		text := stringValue(payload["text"])
-		if text == "" {
+		attachments := attachmentsFromPayload(payload["attachments"])
+		explicitID := stringValue(payload["client_message_id"])
+		if text == "" && len(attachments) == 0 && explicitID == "" {
 			return
 		}
 		r.closeToolGroupLocked()
 		r.currentAssistant = -1
-		id := stringValue(payload["client_message_id"])
+		id := explicitID
 		if id == "" {
 			id = r.nextRecoveryMessageIDLocked("user")
 		}
@@ -1054,7 +1056,7 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 			Role:            "user",
 			Content:         []byte(text),
 			Created:         time.Now().UnixMilli(),
-			Attachments:     attachmentsFromPayload(payload["attachments"]),
+			Attachments:     attachments,
 			InterruptState:  "interject",
 			ClientMessageID: id,
 		})
@@ -2773,7 +2775,7 @@ func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *respons
 		if ev.InterjectionStatus != "" {
 			payload["status"] = string(ev.InterjectionStatus)
 		}
-		if atts := interjectionAttachmentsForEvent(ev.Message); len(atts) > 0 {
+		if atts := s.interjectionAttachmentsForEvent(ev.Message); len(atts) > 0 {
 			payload["attachments"] = atts
 		}
 		return run.appendEvent("response.interjection", payload)
@@ -2823,25 +2825,31 @@ func attachmentsFromPayload(v any) []map[string]any {
 	}
 }
 
-func interjectionAttachmentsForEvent(msg llm.Message) []map[string]any {
+func (s *serveServer) interjectionAttachmentsForEvent(msg llm.Message) []map[string]any {
 	var out []map[string]any
 	imageCount := 0
 	for _, part := range msg.Parts {
 		if part.Type != llm.PartImage {
 			continue
 		}
+		imageURL, serveablePath := s.sessionMessageImageURL(part)
+		if imageURL == "" {
+			continue
+		}
 		imageCount++
-		mediaType := "image"
+		mediaType := "image/*"
 		if part.ImageData != nil && part.ImageData.MediaType != "" {
 			mediaType = part.ImageData.MediaType
 		}
 		attachment := map[string]any{
 			"name": fmt.Sprintf("image %d", imageCount),
 			"type": mediaType,
+			"url":  imageURL,
 		}
-		if part.ImageData != nil && part.ImageData.Width > 0 && part.ImageData.Height > 0 {
-			attachment["width"] = part.ImageData.Width
-			attachment["height"] = part.ImageData.Height
+		width, height := sessionMessageImageDimensions(part, serveablePath)
+		if width > 0 && height > 0 {
+			attachment["width"] = width
+			attachment["height"] = height
 		}
 		out = append(out, attachment)
 	}

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -8,12 +8,14 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -1667,7 +1669,20 @@ func TestResponseRunRecoverySynthesizesMissingLegacyInterjectionID(t *testing.T)
 func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	run := newResponseRun("resp_interjection", "sess_test", "", "mock", time.Now().Unix(), func() {})
 	streamState := newResponseRunStreamState("mock", "")
-	server := &serveServer{}
+	imageOutputDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	uploadDir := serveUploadsDir()
+	if err := os.MkdirAll(uploadDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	imagePath := filepath.Join(uploadDir, "interjection.jpg")
+	if err := os.WriteFile(imagePath, []byte("test image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := &serveServer{
+		cfg:    serveServerConfig{basePath: "/ui"},
+		cfgRef: &config.Config{Image: config.ImageConfig{OutputDir: imageOutputDir}},
+	}
 
 	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{Type: llm.EventTextDelta, Text: "before"}); err != nil {
 		t.Fatalf("appendTextDeltaSegmentEvent before: %v", err)
@@ -1675,7 +1690,7 @@ func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	if err := server.appendResponseRunEvent(nil, run, streamState, llm.Event{
 		Type: llm.EventInterjection, Text: "check X", InterjectionID: "client-check-x",
 		Message: llm.Message{Parts: []llm.Part{{
-			Type: llm.PartImage, ImageData: &llm.ToolImageData{MediaType: "image/jpeg", Width: 200, Height: 400},
+			Type: llm.PartImage, ImagePath: imagePath, ImageData: &llm.ToolImageData{MediaType: "image/jpeg", Width: 200, Height: 400},
 		}}},
 	}); err != nil {
 		t.Fatalf("append interjection: %v", err)
@@ -1720,15 +1735,25 @@ func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	if !ok || len(interjectionAttachments) != 1 || interjectionAttachments[0]["width"] != 200 || interjectionAttachments[0]["height"] != 400 {
 		t.Fatalf("messages[1].attachments = %#v, want orientation-correct 200x400 metadata", messages[1]["attachments"])
 	}
+	imageURL, _ := interjectionAttachments[0]["url"].(string)
+	if !strings.HasPrefix(imageURL, "/ui/images/") {
+		t.Fatalf("messages[1].attachments URL = %q, want a serveable image URL", imageURL)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/images/"+filepath.Base(imageURL), nil)
+	rr := httptest.NewRecorder()
+	server.handleImage(rr, req)
+	if rr.Code != http.StatusOK || rr.Body.String() != "test image" {
+		t.Fatalf("interjection image response = %d %q, want 200 with original image", rr.Code, rr.Body.String())
+	}
 	if got := messages[2]["content"]; got != "after" {
 		t.Fatalf("messages[2].content = %v, want after", got)
 	}
 	if first, second := messages[0]["assistant_segment_ordinal"], messages[2]["assistant_segment_ordinal"]; first != 0 || second != 1 {
 		t.Fatalf("assistant segment ordinals = %v, %v; want 0, 1 across interjection", first, second)
 	}
-	atts := []map[string]any{{"name": "image 1", "type": "image/png"}}
-	if err := run.appendEvent("response.interjection", map[string]any{"text": "see image", "client_message_id": "img-1", "attachments": atts}); err != nil {
-		t.Fatalf("append image interjection: %v", err)
+	atts := []map[string]any{{"name": "image 1", "type": "image/png", "url": "/ui/images/image-only.png"}}
+	if err := run.appendEvent("response.interjection", map[string]any{"text": "", "client_message_id": "img-1", "attachments": atts}); err != nil {
+		t.Fatalf("append image-only interjection: %v", err)
 	}
 	recovery = run.recoveryPayloadLocked()
 	messages = recovery["messages"].([]map[string]any)
@@ -1745,6 +1770,36 @@ func TestResponseRunInterjectionSplitsRecoveryMessages(t *testing.T) {
 	}
 	if got := messages[2]["content"]; got != "after" {
 		t.Fatalf("messages[2].content = %v, want after", got)
+	}
+}
+
+func TestResponseRunPreservesImageOnlyBoundaryWhenAttachmentCannotBeServed(t *testing.T) {
+	imagePath := filepath.Join(t.TempDir(), "outside.jpg")
+	if err := os.WriteFile(imagePath, []byte("test image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := &serveServer{
+		cfg:    serveServerConfig{basePath: "/ui"},
+		cfgRef: &config.Config{Image: config.ImageConfig{OutputDir: t.TempDir()}},
+	}
+	run := newResponseRun("resp_unserveable_interjection", "sess_test", "", "mock", time.Now().Unix(), nil)
+	if err := server.appendResponseRunEvent(nil, run, newResponseRunStreamState("mock", ""), llm.Event{
+		Type:           llm.EventInterjection,
+		InterjectionID: "image-only-unserveable",
+		Message: llm.Message{Parts: []llm.Part{{
+			Type: llm.PartImage, ImagePath: imagePath, ImageData: &llm.ToolImageData{MediaType: "image/jpeg"},
+		}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	recovery := run.recoveryPayloadLocked()
+	messages := recovery["messages"].([]map[string]any)
+	if len(messages) != 1 || messages[0]["client_message_id"] != "image-only-unserveable" {
+		t.Fatalf("recovery messages = %#v, want preserved image-only user boundary", messages)
+	}
+	if attachments, ok := messages[0]["attachments"].([]map[string]any); ok && len(attachments) > 0 {
+		t.Fatalf("recovery attachments = %#v, want rejected attachment omitted", attachments)
 	}
 }
 

--- a/frontend/src/domain/response.test.ts
+++ b/frontend/src/domain/response.test.ts
@@ -73,6 +73,70 @@ describe('response projection', () => {
     expect(projection.phase).toBeUndefined();
   });
 
+  it('projects interjection image attachments before transcript reload', () => {
+    const projection = reduceResponse(
+      initialProjection(run),
+      event('response.interjection', 1, {
+        text: 'inspect this image',
+        client_message_id: 'interjection-image-1',
+        attachments: [
+          {
+            name: 'image 1',
+            type: 'image/png',
+            url: '/ui/images/interjection.png',
+            width: 320,
+            height: 180,
+          },
+        ],
+      }),
+    );
+
+    expect(projection.messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'inspect this image',
+        attachments: [
+          {
+            name: 'image 1',
+            type: 'image/png',
+            url: '/ui/images/interjection.png',
+            width: 320,
+            height: 180,
+          },
+        ],
+      }),
+    ]);
+  });
+
+  it('projects image-only interjections before transcript reload', () => {
+    const projection = reduceResponse(
+      initialProjection(run),
+      event('response.interjection', 1, {
+        text: '',
+        client_message_id: 'interjection-image-only-1',
+        attachments: [
+          {
+            name: 'image 1',
+            type: 'image/png',
+            url: '/ui/images/image-only.png',
+          },
+        ],
+      }),
+    );
+
+    expect(projection.messages[0]).toMatchObject({
+      role: 'user',
+      content: '',
+      attachments: [
+        {
+          name: 'image 1',
+          type: 'image/png',
+          url: '/ui/images/image-only.png',
+        },
+      ],
+    });
+  });
+
   it('streams stable assistant segments without replacing earlier content', () => {
     let projection = initialProjection(run);
     projection = reduceResponse(projection, event('response.created', 1));

--- a/frontend/src/domain/response.ts
+++ b/frontend/src/domain/response.ts
@@ -2,6 +2,7 @@ import type {
   ActiveRun,
   ApprovalPrompt,
   AskUserPrompt,
+  Attachment,
   CurrentPlan,
   GuardianReview,
   Message,
@@ -48,6 +49,29 @@ const text = (value: unknown): string =>
 const number = (value: unknown, fallback = 0): number =>
   Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
 const clone = <T>(value: T): T => structuredClone(value);
+
+function responseAttachments(value: unknown): Attachment[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const attachments = value
+    .filter((entry): entry is Record<string, unknown> =>
+      Boolean(entry && typeof entry === 'object'),
+    )
+    .map((entry): Attachment | null => {
+      const url = text(entry.url || entry.preview_url || entry.previewURL);
+      const type = text(entry.type || entry.mime_type) || 'image/*';
+      if (!url) return null;
+      const width = number(entry.width);
+      const height = number(entry.height);
+      return {
+        name: text(entry.name || entry.filename) || 'attachment',
+        type,
+        url,
+        ...(width > 0 && height > 0 ? { width, height } : {}),
+      } satisfies Attachment;
+    })
+    .filter((entry): entry is Attachment => entry !== null);
+  return attachments.length ? attachments : undefined;
+}
 
 export function initialProjection(run: ActiveRun): ResponseProjection {
   return {
@@ -499,6 +523,7 @@ export function reduceResponse(
             id: `${responseId}:intent:${clientMessageId}`,
             role: 'user',
             content: text(event.text || event.content || event.message),
+            attachments: responseAttachments(event.attachments),
             clientMessageId,
             created: Date.now(),
             responseId,


### PR DESCRIPTION
## Summary

- emit serveable image URLs and dimensions with `response.interjection` events
- project streamed interjection attachments into the Web UI immediately
- preserve image-only interjections in response recovery
- keep unservable image-only user boundaries without exposing rejected files

## Reproduction and verification

A pristine `upstream/main` cleanroom server using the slow debug provider reproduced the bug: the interjected image+text message appeared during streaming, but contained no `<img>` until reload.

After this patch, the same isolated browser-to-Go cleanroom probe passes for both image+text and image-only interjections, verifying:

- the image element appears before reload
- its URL returns `200 image/png`
- it decodes while visible before reload
- it remains visible after reload

Additional checks:

- `go test ./cmd -run 'TestResponseRunInterjectionSplitsRecoveryMessages|TestResponseRunPreservesImageOnlyBoundaryWhenAttachmentCannotBeServed|TestResponseRunRejectsInterjectionWithoutClientMessageID'`
- `go build ./...`
- frontend full Vitest suite: 31 files / 311 tests
- frontend TypeScript typecheck, ESLint, and Prettier check

`go test ./...` was also run; unrelated environment-sensitive tests failed because this agent's globally installed skills leak into prompt tests, a root-permission atomic-write test does not fail under the container user, and existing bundle gzip budgets differ in this environment. The changed `cmd` tests pass in isolation.

## Review

Reviewed with `claude-bin:opus-max`. Applied its blocking Prettier fix and its recommendations to align fallback image MIME types, exercise the real upload-copy path, and preserve image-only recovery boundaries when an attachment is rejected as unservable.
