### PR TITLE
fix(web): make conversation branches drift-safe

### DIFF
--- a/cmd/serve_branch.go
+++ b/cmd/serve_branch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -25,9 +26,13 @@ type webBranchTreeResponse struct {
 }
 
 type createSessionBranchRequest struct {
-	AnchorMessageID int64  `json:"anchor_message_id"`
-	ExpectedRev     *int64 `json:"expected_rev,omitempty"`
-	IdempotencyKey  string `json:"idempotency_key"`
+	AnchorMessageID int64 `json:"anchor_message_id"`
+	// LegacyExpectedRev is accepted and ignored for backward wire compatibility.
+	// Deprecated: this Web endpoint identifies an immutable transcript prefix by
+	// anchor_message_id; lower-level CreateBranch and /v1/responses retain their
+	// distinct full-head compare-and-swap contracts.
+	LegacyExpectedRev *int64 `json:"expected_rev,omitempty"`
+	IdempotencyKey    string `json:"idempotency_key"`
 }
 
 type createSessionBranchResponse struct {
@@ -45,8 +50,10 @@ type prepareSessionPathNotesRequest struct {
 }
 
 type prepareSessionPathNotesResponse struct {
-	Ready  bool `json:"ready"`
-	Reused bool `json:"reused,omitempty"`
+	Ready   bool   `json:"ready"`
+	Reused  bool   `json:"reused,omitempty"`
+	Limited bool   `json:"limited,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 func branchContextSourceMessage(message session.Message) bool {
@@ -133,6 +140,44 @@ func activeWebBranchAnchorSafety(messages []session.Message, activeResponseID st
 	return activeWebBranchAnchorSafe
 }
 
+const webBranchSnapshotMaxAttempts = 3
+
+var errWebBranchSnapshotUnstable = errors.New("conversation branch snapshot changed while loading")
+
+type webBranchContextSnapshot struct {
+	messages          []session.Message
+	activeAnchorRowID int64
+	limited           bool
+}
+
+func (s *serveServer) loadWebBranchContextSnapshot(ctx context.Context, sessionID string) (webBranchContextSnapshot, error) {
+	for attempt := 0; attempt < webBranchSnapshotMaxAttempts; attempt++ {
+		activeResponseID, _, activeEpoch, _, sampledAnchorRowID := s.activeTranscriptRun(sessionID)
+		messages, err := s.store.GetMessages(ctx, sessionID, 0, 0)
+		if err != nil {
+			return webBranchContextSnapshot{}, err
+		}
+		checkResponseID, _, checkEpoch, _, checkAnchorRowID := s.activeTranscriptRun(sessionID)
+		if checkResponseID != activeResponseID || checkEpoch != activeEpoch || checkAnchorRowID != sampledAnchorRowID {
+			if err := ctx.Err(); err != nil {
+				return webBranchContextSnapshot{}, err
+			}
+			continue
+		}
+		if activeResponseID == "" {
+			return webBranchContextSnapshot{messages: messages}, nil
+		}
+		activeAnchorRowID := activeWebBranchAnchorRowID(messages, activeResponseID, sampledAnchorRowID)
+		safeMessages := pruneActiveWebBranchOutput(messages, activeResponseID, activeAnchorRowID)
+		return webBranchContextSnapshot{
+			messages:          safeMessages,
+			activeAnchorRowID: activeAnchorRowID,
+			limited:           len(safeMessages) < len(messages),
+		}, nil
+	}
+	return webBranchContextSnapshot{}, errWebBranchSnapshotUnstable
+}
+
 func webBranchTreePointsForActiveRun(messages []session.Message, activeAnchorRowID int64) []webBranchTreePoint {
 	if activeAnchorRowID < 0 {
 		return nil
@@ -217,25 +262,16 @@ func (s *serveServer) handleSessionTree(w http.ResponseWriter, r *http.Request, 
 		response := webBranchTreeResponse{BranchTree: tree}
 		if strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_branch_points")), "1") ||
 			strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_branch_points")), "true") {
-			activeResponseID, _, activeEpoch, _, sampledAnchorRowID := s.activeTranscriptRun(sessionID)
-			messages, messageErr := s.store.GetMessages(r.Context(), sessionID, 0, 0)
-			if messageErr != nil {
+			snapshot, snapshotErr := s.loadWebBranchContextSnapshot(r.Context(), sessionID)
+			switch {
+			case errors.Is(snapshotErr, errWebBranchSnapshotUnstable):
+				writeOpenAIError(w, http.StatusConflict, "conflict_error", "conversation branch points are changing; refresh and try again")
+				return
+			case snapshotErr != nil:
 				writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to load conversation branch points")
 				return
 			}
-			// Verify that row loading did not cross a moving-boundary publication.
-			checkResponseID, _, checkEpoch, _, checkAnchorRowID := s.activeTranscriptRun(sessionID)
-			if checkResponseID != activeResponseID || checkEpoch != activeEpoch || checkAnchorRowID != sampledAnchorRowID {
-				activeResponseID, activeEpoch, sampledAnchorRowID = checkResponseID, checkEpoch, checkAnchorRowID
-				messages, messageErr = s.store.GetMessages(r.Context(), sessionID, 0, 0)
-				if messageErr != nil {
-					writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to refresh moving conversation branch points")
-					return
-				}
-			}
-			activeAnchorRowID := activeWebBranchAnchorRowID(messages, activeResponseID, sampledAnchorRowID)
-			messages = pruneActiveWebBranchOutput(messages, activeResponseID, activeAnchorRowID)
-			response.BranchPoints = webBranchTreePointsForActiveRun(messages, activeAnchorRowID)
+			response.BranchPoints = webBranchTreePointsForActiveRun(snapshot.messages, snapshot.activeAnchorRowID)
 		}
 		writeJSON(w, http.StatusOK, response)
 	}
@@ -293,57 +329,58 @@ func (s *serveServer) handleCreateSessionBranch(w http.ResponseWriter, r *http.R
 	}
 	activeResponseID, _, _, _, activeAnchorRowID := s.activeTranscriptRun(sourceSessionID)
 	activeSource := activeResponseID != ""
-	var expectedState *session.TranscriptMutationState
-	expectedRev := req.ExpectedRev
 	unlock := func() {}
-	if activeSource {
+	validateActiveAnchor := func() bool {
 		messages, loadErr := s.store.GetMessages(r.Context(), sourceSessionID, 0, 0)
 		if loadErr != nil {
 			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to validate active conversation branch")
-			return
+			return false
 		}
 		status := activeWebBranchAnchorSafety(messages, activeResponseID, activeAnchorRowID, req.AnchorMessageID)
 		switch status {
 		case activeWebBranchAnchorMissing:
 			writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "branch source or anchor was not found")
-			return
+			return false
 		case activeWebBranchAnchorInvalid:
 			writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "branch anchor is not a durable continuation boundary")
-			return
+			return false
 		case activeWebBranchAnchorUnstable:
 			writeOpenAIError(w, http.StatusConflict, "conflict_error", "branch point is not stable while source work is active")
+			return false
+		default:
+			return true
+		}
+	}
+	if activeSource {
+		if !validateActiveAnchor() {
 			return
 		}
-		// The selected stable prefix is validated above and resolved again inside
-		// CreateBranch's transaction. Full-head revisions are expected to advance
-		// while this response appends output after that immutable prefix.
-		expectedRev = nil
 	} else {
-		if expectedRev == nil {
-			mutationStore, ok := s.store.(session.TranscriptUndoRedoStore)
-			if !ok {
-				writeOpenAIError(w, http.StatusConflict, "conflict_error", "revision-safe conversation branching is unavailable")
-				return
-			}
-			state, stateErr := mutationStore.TranscriptMutationState(r.Context(), sourceSessionID)
-			if stateErr != nil {
-				writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to inspect conversation revision")
-				return
-			}
-			expectedState = &state
-		}
 		var busy bool
 		unlock, busy = s.lockBranchSourceRuntime(sourceSessionID)
 		if busy {
-			writeOpenAIError(w, http.StatusConflict, "conflict_error", "cannot branch while source work is active")
-			return
+			// Work may have become active after the initial sample. Prefer its
+			// published durable boundary over rejecting an otherwise safe prefix.
+			activeResponseID, _, _, _, activeAnchorRowID = s.activeTranscriptRun(sourceSessionID)
+			activeSource = activeResponseID != ""
+			if !activeSource {
+				writeOpenAIError(w, http.StatusConflict, "conflict_error", "cannot branch while source work is active")
+				return
+			}
+			unlock = func() {}
+			if !validateActiveAnchor() {
+				return
+			}
 		}
 	}
 	defer unlock()
+	// This Web API is anchor/prefix-based. LegacyExpectedRev is decoded only for
+	// backward wire compatibility and intentionally has no precondition effect:
+	// unrelated suffix drift cannot mutate the immutable row-ID prefix. The
+	// transaction still resolves and validates that anchor; lower-level callers
+	// retain ExpectedRev/ExpectedState compare-and-swap behavior.
 	result, err := branchStore.CreateBranch(r.Context(), sourceSessionID, session.CreateBranchOptions{
 		AnchorMessageID: req.AnchorMessageID,
-		ExpectedState:   expectedState,
-		ExpectedRev:     expectedRev,
 		IdempotencyKey:  req.IdempotencyKey,
 	})
 	switch {
@@ -437,15 +474,39 @@ func (s *serveServer) handleSessionPathNotes(w http.ResponseWriter, r *http.Requ
 		writeJSON(w, http.StatusOK, prepareSessionPathNotesResponse{Ready: true, Reused: true})
 		return
 	}
-	unlockSource, busy := s.lockBranchSourceRuntime(edge.ParentSessionID)
-	if busy {
-		writeOpenAIError(w, http.StatusConflict, "conflict_error", "cannot prepare branch context while source work is active")
+	mode, focus, status, message := branchContextRequestValues(&responsesBranchContextRequest{Mode: mode, Focus: req.Focus})
+	if status != 0 {
+		writeOpenAIError(w, status, "invalid_request_error", message)
 		return
 	}
-	defer unlockSource()
 	workCtx, cancelWork := detachedBranchWorkContext(r.Context())
 	defer cancelWork()
-	pathNote, status, message := s.prepareBranchPathNote(workCtx, edge.ParentSessionID, edge.ForkAfterMessageID, &responsesBranchContextRequest{Mode: mode, Focus: req.Focus})
+	snapshot, err := s.loadWebBranchContextSnapshot(workCtx, edge.ParentSessionID)
+	if errors.Is(err, errWebBranchSnapshotUnstable) {
+		writeOpenAIError(w, http.StatusConflict, "conflict_error", "branch context is changing; try again")
+		return
+	}
+	if err != nil {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to load branch context")
+		return
+	}
+	source, sourceErr := session.MessagesAfterBranchAnchor(snapshot.messages, edge.ForkAfterMessageID)
+	if sourceErr != nil && !snapshot.limited {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "branch source or anchor was not found")
+		return
+	}
+	limitedMessage := ""
+	if snapshot.limited {
+		limitedMessage = "Context was prepared from the latest durable completed part of the active source; in-progress output was omitted."
+	}
+	if sourceErr != nil || len(source) == 0 {
+		if snapshot.limited {
+			limitedMessage = "The path was created without additional notes because no later source context was available."
+		}
+		writeJSON(w, http.StatusOK, prepareSessionPathNotesResponse{Ready: true, Limited: snapshot.limited, Message: limitedMessage})
+		return
+	}
+	pathNote, status, message := s.generateBranchPathNote(workCtx, edge.ParentSessionID, source, mode, focus)
 	if status != 0 {
 		errType := "invalid_request_error"
 		if status == http.StatusConflict {
@@ -465,5 +526,5 @@ func (s *serveServer) handleSessionPathNotes(w http.ResponseWriter, r *http.Requ
 			return
 		}
 	}
-	writeJSON(w, http.StatusOK, prepareSessionPathNotesResponse{Ready: true})
+	writeJSON(w, http.StatusOK, prepareSessionPathNotesResponse{Ready: true, Limited: snapshot.limited, Message: limitedMessage})
 }

--- a/cmd/serve_branch_endpoints_test.go
+++ b/cmd/serve_branch_endpoints_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,29 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
 )
+
+type webBranchSnapshotTestStore struct {
+	session.Store
+	getMessagesCalls int
+	afterGetMessages func()
+}
+
+func (s *webBranchSnapshotTestStore) GetMessages(ctx context.Context, sessionID string, limit, offset int) ([]session.Message, error) {
+	messages, err := s.Store.GetMessages(ctx, sessionID, limit, offset)
+	s.getMessagesCalls++
+	if s.afterGetMessages != nil {
+		s.afterGetMessages()
+	}
+	return messages, err
+}
+
+func (s *webBranchSnapshotTestStore) CreateBranch(ctx context.Context, sourceSessionID string, opts session.CreateBranchOptions) (session.BranchResult, error) {
+	return s.Store.(session.ConversationBranchStore).CreateBranch(ctx, sourceSessionID, opts)
+}
+
+func (s *webBranchSnapshotTestStore) GetBranchTree(ctx context.Context, sessionID string) (session.BranchTree, error) {
+	return s.Store.(session.ConversationBranchStore).GetBranchTree(ctx, sessionID)
+}
 
 func TestWebBranchTreePointsIncludeEveryVisibleUserMessage(t *testing.T) {
 	message := func(id int64, sequence int, value llm.Message) session.Message {
@@ -67,6 +91,113 @@ func TestActiveWebBranchSafetyAcceptsPublishedCompletedToolBoundary(t *testing.T
 	pruned := pruneActiveWebBranchOutput(messages, responseID, 3)
 	if len(pruned) != 3 || pruned[len(pruned)-1].ID != 3 {
 		t.Fatalf("active prefix = %#v", pruned)
+	}
+}
+
+func TestWebBranchContextSnapshotLimitedOnlyWhenRowsAreOmitted(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const (
+		sourceID   = "snapshot-limited-source"
+		responseID = "resp-snapshot-limited"
+	)
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReplaceMessages(ctx, sourceID, []session.Message{
+		*session.NewMessage(sourceID, llm.UserText("request"), -1),
+		*session.NewMessage(sourceID, llm.AssistantText("durable answer"), -1),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := store.GetMessages(ctx, sourceID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := newServeResponseRunManager()
+	t.Cleanup(manager.Close)
+	run := newResponseRun(responseID, sourceID, "", "mock-model", time.Now().Unix(), nil)
+	run.anchorRowID = messages[1].ID
+	run.anchorAvailable = true
+	if err := manager.create(run); err != nil {
+		t.Fatal(err)
+	}
+	manager.setActiveRun(sourceID, responseID)
+	srv := &serveServer{store: store, responseRuns: manager}
+
+	snapshot, err := srv.loadWebBranchContextSnapshot(ctx, sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.limited || len(snapshot.messages) != 2 {
+		t.Fatalf("active snapshot without omitted rows = %#v, want full unlimited snapshot", snapshot)
+	}
+
+	partial := session.NewMessage(sourceID, llm.AssistantText("unsafe partial output"), -1)
+	partial.ResponseID = responseID
+	if err := store.AddMessage(ctx, sourceID, partial); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err = srv.loadWebBranchContextSnapshot(ctx, sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshot.limited || len(snapshot.messages) != 2 || snapshot.messages[1].TextContent != "durable answer" {
+		t.Fatalf("active snapshot with omitted row = %#v, want limited durable prefix", snapshot)
+	}
+}
+
+func TestWebBranchContextSnapshotStopsAfterBoundedInconsistentSamples(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const sourceID = "snapshot-moving-source"
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	manager := newServeResponseRunManager()
+	t.Cleanup(manager.Close)
+	for _, responseID := range []string{"resp-snapshot-a", "resp-snapshot-b"} {
+		run := newResponseRun(responseID, sourceID, "", "mock-model", time.Now().Unix(), nil)
+		if err := manager.create(run); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manager.setActiveRun(sourceID, "resp-snapshot-a")
+	wrapped := &webBranchSnapshotTestStore{Store: store}
+	wrapped.afterGetMessages = func() {
+		if manager.activeRunID(sourceID) == "resp-snapshot-a" {
+			manager.setActiveRun(sourceID, "resp-snapshot-b")
+		} else {
+			manager.setActiveRun(sourceID, "resp-snapshot-a")
+		}
+	}
+	srv := &serveServer{store: wrapped, responseRuns: manager}
+
+	_, err = srv.loadWebBranchContextSnapshot(ctx, sourceID)
+	if !errors.Is(err, errWebBranchSnapshotUnstable) {
+		t.Fatalf("moving snapshot error = %v, want %v", err, errWebBranchSnapshotUnstable)
+	}
+	if wrapped.getMessagesCalls != webBranchSnapshotMaxAttempts {
+		t.Fatalf("moving snapshot reads = %d, want bounded %d", wrapped.getMessagesCalls, webBranchSnapshotMaxAttempts)
+	}
+
+	wrapped.getMessagesCalls = 0
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sourceID+"/tree?include_branch_points=1", nil)
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "branch points are changing") {
+		t.Fatalf("moving branch-point response = %d %s, want visible conflict", rr.Code, rr.Body.String())
+	}
+	if wrapped.getMessagesCalls != webBranchSnapshotMaxAttempts {
+		t.Fatalf("moving endpoint snapshot reads = %d, want bounded %d", wrapped.getMessagesCalls, webBranchSnapshotMaxAttempts)
 	}
 }
 
@@ -240,6 +371,142 @@ func TestSessionBranchEndpointAllowsActiveSourceAtStableAnchor(t *testing.T) {
 	srv.handleSessionByID(rr, req)
 	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "not stable") {
 		t.Fatalf("interjection anchor status/body = %d %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSessionBranchEndpointUsesAnchorDespiteLegacyExpectedRev(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const sourceID = "idle-drift-branch-source"
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", ProviderKey: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReplaceMessages(ctx, sourceID, []session.Message{
+		*session.NewMessage(sourceID, llm.UserText("stable request"), -1),
+		*session.NewMessage(sourceID, llm.AssistantText("stable answer"), -1),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	messages, _ := store.GetMessages(ctx, sourceID, 0, 0)
+	staleState, err := store.(session.TranscriptUndoRedoStore).TranscriptMutationState(ctx, sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddMessage(ctx, sourceID, session.NewMessage(sourceID, llm.UserText("unrelated later suffix"), -1)); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &serveServer{store: store}
+	body := fmt.Sprintf(`{"anchor_message_id":%d,"expected_rev":%d,"idempotency_key":"idle-drift"}`, messages[1].ID, staleState.Rev)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sourceID+"/branches", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleSessionByID(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("idle drift branch status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	var created createSessionBranchResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	childMessages, err := store.GetMessages(ctx, created.Session.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(childMessages) != 2 || childMessages[1].TextContent != "stable answer" {
+		t.Fatalf("idle drift branch copied messages = %#v", childMessages)
+	}
+}
+
+func TestSessionPathNotesUseLatestDurableActivePrefix(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	const (
+		sourceID   = "active-notes-source"
+		responseID = "resp-active-notes"
+	)
+	if err := store.Create(ctx, &session.Session{ID: sourceID, Provider: "mock", ProviderKey: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	partial := *session.NewMessage(sourceID, llm.AssistantText("unsafe partial output"), -1)
+	partial.ResponseID = responseID
+	if err := store.ReplaceMessages(ctx, sourceID, []session.Message{
+		*session.NewMessage(sourceID, llm.UserText("first request"), -1),
+		*session.NewMessage(sourceID, llm.AssistantText("first answer"), -1),
+		*session.NewMessage(sourceID, llm.UserText("later durable finding"), -1),
+		*session.NewMessage(sourceID, llm.AssistantText("later durable answer"), -1),
+		partial,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	messages, _ := store.GetMessages(ctx, sourceID, 0, 0)
+	manager := newServeResponseRunManager()
+	t.Cleanup(manager.Close)
+	run := newResponseRun(responseID, sourceID, "", "mock-model", time.Now().Unix(), nil)
+	run.anchorRowID = messages[3].ID
+	run.anchorAvailable = true
+	if err := manager.create(run); err != nil {
+		t.Fatal(err)
+	}
+	manager.setActiveRun(sourceID, responseID)
+	provider := llm.NewMockProvider("mock").AddTextResponse("- Keep the durable finding.")
+	srv := &serveServer{
+		store:                    store,
+		responseRuns:             manager,
+		pathNotesProviderFactory: func(_, _ string) (llm.Provider, error) { return provider, nil },
+	}
+
+	branchBody := fmt.Sprintf(`{"anchor_message_id":%d,"idempotency_key":"active-notes-branch"}`, messages[1].ID)
+	branchReq := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sourceID+"/branches", strings.NewReader(branchBody))
+	branchReq.Header.Set("Content-Type", "application/json")
+	branchRR := httptest.NewRecorder()
+	srv.handleSessionByID(branchRR, branchReq)
+	if branchRR.Code != http.StatusCreated {
+		t.Fatalf("active notes branch status/body = %d %s", branchRR.Code, branchRR.Body.String())
+	}
+	var created createSessionBranchResponse
+	if err := json.Unmarshal(branchRR.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	notesReq := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+created.Session.ID+"/path-notes", strings.NewReader(`{"mode":"notes"}`))
+	notesReq.Header.Set("Content-Type", "application/json")
+	notesRR := httptest.NewRecorder()
+	srv.handleSessionByID(notesRR, notesReq)
+	if notesRR.Code != http.StatusOK {
+		t.Fatalf("active path notes status/body = %d %s", notesRR.Code, notesRR.Body.String())
+	}
+	var notes prepareSessionPathNotesResponse
+	if err := json.Unmarshal(notesRR.Body.Bytes(), &notes); err != nil {
+		t.Fatal(err)
+	}
+	if !notes.Ready || !notes.Limited || !strings.Contains(notes.Message, "in-progress output was omitted") {
+		t.Fatalf("active path notes response = %#v", notes)
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("path note requests = %d, want 1", len(provider.Requests))
+	}
+	requestText := ""
+	for _, message := range provider.Requests[0].Messages {
+		requestText += llm.MessageText(message)
+	}
+	if !strings.Contains(requestText, "later durable finding") || strings.Contains(requestText, "unsafe partial output") {
+		t.Fatalf("path notes source = %q", requestText)
+	}
+	childMessages, err := store.GetMessages(ctx, created.Session.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(childMessages) != 3 {
+		t.Fatalf("child messages after active notes = %#v", childMessages)
 	}
 }
 

--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -131,38 +131,34 @@ func (s *serveServer) lockBranchSourceRuntime(sessionID string) (func(), bool) {
 	return runtime.mu.Unlock, false
 }
 
-func (s *serveServer) prepareBranchPathNote(ctx context.Context, sourceSessionID string, anchorMessageID int64, requested *responsesBranchContextRequest) (*session.BranchPathNote, int, string) {
+func branchContextRequestValues(requested *responsesBranchContextRequest) (string, string, int, string) {
 	if requested == nil {
-		return nil, 0, ""
+		return "", "", 0, ""
 	}
 	mode := strings.ToLower(strings.TrimSpace(requested.Mode))
 	if mode == "" || mode == "none" || mode == "clean" {
-		return nil, 0, ""
+		return mode, "", 0, ""
 	}
 	if mode != "notes" && mode != "focused" {
-		return nil, http.StatusBadRequest, "branch_context.mode must be clean, notes, or focused"
+		return "", "", http.StatusBadRequest, "branch_context.mode must be clean, notes, or focused"
 	}
 	focus := strings.TrimSpace(requested.Focus)
 	if len([]rune(focus)) > 2000 {
-		return nil, http.StatusBadRequest, "branch context focus is too long"
+		return "", "", http.StatusBadRequest, "branch context focus is too long"
 	}
 	if mode == "focused" && focus == "" {
-		return nil, http.StatusBadRequest, "focused branch context requires focus instructions"
+		return "", "", http.StatusBadRequest, "focused branch context requires focus instructions"
+	}
+	return mode, focus, 0, ""
+}
+
+func (s *serveServer) generateBranchPathNote(ctx context.Context, sourceSessionID string, source []llm.Message, mode, focus string) (*session.BranchPathNote, int, string) {
+	if mode == "" || mode == "none" || mode == "clean" || len(source) == 0 {
+		return nil, 0, ""
 	}
 	sess, err := s.store.Get(ctx, sourceSessionID)
 	if err != nil || sess == nil {
 		return nil, http.StatusBadRequest, "branch source was not found"
-	}
-	messages, err := s.store.GetMessages(ctx, sourceSessionID, 0, 0)
-	if err != nil {
-		return nil, http.StatusInternalServerError, "failed to load branch context"
-	}
-	source, err := session.MessagesAfterBranchAnchor(messages, anchorMessageID)
-	if err != nil {
-		return nil, http.StatusBadRequest, "branch source or anchor was not found"
-	}
-	if len(source) == 0 {
-		return nil, 0, ""
 	}
 	providerName := strings.TrimSpace(sess.ProviderKey)
 	if providerName == "" {
@@ -210,12 +206,26 @@ func (s *serveServer) prepareBranchPathNote(ctx context.Context, sourceSessionID
 	}, 0, ""
 }
 
+func (s *serveServer) prepareBranchPathNote(ctx context.Context, sourceSessionID string, anchorMessageID int64, requested *responsesBranchContextRequest) (*session.BranchPathNote, int, string) {
+	mode, focus, status, message := branchContextRequestValues(requested)
+	if status != 0 || mode == "" || mode == "none" || mode == "clean" {
+		return nil, status, message
+	}
+	messages, err := s.store.GetMessages(ctx, sourceSessionID, 0, 0)
+	if err != nil {
+		return nil, http.StatusInternalServerError, "failed to load branch context"
+	}
+	source, err := session.MessagesAfterBranchAnchor(messages, anchorMessageID)
+	if err != nil {
+		return nil, http.StatusBadRequest, "branch source or anchor was not found"
+	}
+	return s.generateBranchPathNote(ctx, sourceSessionID, source, mode, focus)
+}
+
 func (s *serveServer) prepareBranchPathNoteOnce(ctx context.Context, sourceSessionID string, anchorMessageID int64, idempotencyKey string, requested *responsesBranchContextRequest) (*session.BranchPathNote, int, string, context.Context, func()) {
-	mode := ""
-	focus := ""
-	if requested != nil {
-		mode = strings.ToLower(strings.TrimSpace(requested.Mode))
-		focus = strings.TrimSpace(requested.Focus)
+	mode, focus, status, message := branchContextRequestValues(requested)
+	if status != 0 {
+		return nil, status, message, ctx, func() {}
 	}
 	if mode == "" || mode == "none" || mode == "clean" {
 		return nil, 0, "", ctx, func() {}

--- a/frontend/src/api/endpoints.test.ts
+++ b/frontend/src/api/endpoints.test.ts
@@ -55,4 +55,17 @@ describe('branch tree endpoint', () => {
       undefined,
     );
   });
+
+  it('allows path-note requests to outlive the server detached-work budget', async () => {
+    const json = vi.fn(async () => ({}));
+    const routes = endpoints({ json } as unknown as APIClient);
+
+    await routes.pathNotes('session/one', { mode: 'notes' });
+
+    expect(json).toHaveBeenCalledWith(
+      '/v1/sessions/session%2Fone/path-notes',
+      { method: 'POST', body: JSON.stringify({ mode: 'notes' }) },
+      { policy: 'mutation', timeoutMs: 150_000 },
+    );
+  });
 });

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -224,7 +224,11 @@ export const endpoints = (api: APIClient) => ({
   branch: (id: string, body: unknown) =>
     api.post<Record<string, unknown>>(`/v1/sessions/${encoded(id)}/branches`, body),
   pathNotes: (id: string, body: unknown) =>
-    api.post<Record<string, unknown>>(`/v1/sessions/${encoded(id)}/path-notes`, body),
+    api.json<Record<string, unknown>>(
+      `/v1/sessions/${encoded(id)}/path-notes`,
+      { method: 'POST', body: JSON.stringify(body) },
+      { policy: 'mutation', timeoutMs: 150_000 },
+    ),
   skills: (id: string) =>
     api.json<Record<string, unknown>>(
       `/v1/sessions/${encoded(id)}/skills`,

--- a/frontend/src/components/Modals.tsx
+++ b/frontend/src/components/Modals.tsx
@@ -952,7 +952,10 @@ function BranchContext() {
   const [mode, setMode] = useState<'choices' | 'focused'>('choices');
   const anchor = store.branchTarget.value;
   const prefill = store.branchPrefill.value;
+  const busy = store.branchBusy.value;
+  const error = store.branchError.value;
   const choose = (context: 'clean' | 'notes' | 'focused') => {
+    if (busy) return;
     if (context === 'focused' && mode !== 'focused') {
       setMode('focused');
       return;
@@ -963,43 +966,65 @@ function BranchContext() {
   return (
     <Overlay
       title="Start a conversation path"
-      onEscape={() => (mode === 'focused' ? setMode('choices') : (store.modal.value = ''))}
+      dismissDisabled={busy}
+      onEscape={() => {
+        if (!busy)
+          if (mode === 'focused') setMode('choices');
+          else store.modal.value = '';
+      }}
     >
       <p>Choose how much context to carry after this turn.</p>
-      {mode === 'choices' ? (
-        <div class="branch-context-choices">
-          <button type="button" onClick={() => choose('clean')}>
-            <strong>Clean branch</strong>
-            <small>Continue only with context up to this turn.</small>
-          </button>
-          <button type="button" onClick={() => choose('notes')}>
-            <strong>Bring concise notes</strong>
-            <small>Prepare a short summary of useful later discoveries.</small>
-          </button>
-          <button type="button" onClick={() => choose('focused')}>
-            <strong>Focused context</strong>
-            <small>Tell the agent which later information matters.</small>
-          </button>
-        </div>
-      ) : (
-        <div class="branch-context-focus">
-          <label for="branchContextFocus">What should this path carry forward?</label>
-          <textarea
-            id="branchContextFocus"
-            autoFocus
-            rows={5}
-            value={focus}
-            placeholder="For example: preserve the database findings, but not the abandoned UI approach."
-            onInput={(event) => setFocus(event.currentTarget.value)}
-          />
-          <div class="modal-actions">
-            <button class="btn" onClick={() => setMode('choices')}>
-              Back
+      <div aria-busy={busy ? 'true' : undefined}>
+        {mode === 'choices' ? (
+          <div class="branch-context-choices">
+            <button type="button" disabled={busy} onClick={() => choose('clean')}>
+              <strong>Clean branch</strong>
+              <small>Continue only with context up to this turn.</small>
             </button>
-            <button class="btn primary" disabled={!focus.trim()} onClick={() => choose('focused')}>
-              Create path
+            <button type="button" disabled={busy} onClick={() => choose('notes')}>
+              <strong>Bring concise notes</strong>
+              <small>Prepare a short summary of useful later discoveries.</small>
+            </button>
+            <button type="button" disabled={busy} onClick={() => choose('focused')}>
+              <strong>Focused context</strong>
+              <small>Tell the agent which later information matters.</small>
             </button>
           </div>
+        ) : (
+          <div class="branch-context-focus">
+            <label for="branchContextFocus">What should this path carry forward?</label>
+            <textarea
+              id="branchContextFocus"
+              autoFocus
+              rows={5}
+              value={focus}
+              placeholder="For example: preserve the database findings, but not the abandoned UI approach."
+              disabled={busy}
+              onInput={(event) => setFocus(event.currentTarget.value)}
+            />
+            <div class="modal-actions">
+              <button class="btn" disabled={busy} onClick={() => setMode('choices')}>
+                Back
+              </button>
+              <button
+                class="btn primary"
+                disabled={busy || !focus.trim()}
+                onClick={() => choose('focused')}
+              >
+                Create path
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+      {busy && (
+        <div role="status" aria-live="polite">
+          Creating path…
+        </div>
+      )}
+      {error && (
+        <div class="modal-error" role="alert">
+          {error}
         </div>
       )}
       <p class="branch-tree-note">Filesystem and tool side effects are not undone.</p>

--- a/frontend/src/components/Overlay.tsx
+++ b/frontend/src/components/Overlay.tsx
@@ -32,6 +32,7 @@ export function Overlay({
   children,
   wide = false,
   close = true,
+  dismissDisabled = false,
   onClose,
   onEscape,
   className = '',
@@ -41,6 +42,7 @@ export function Overlay({
   children: preact.ComponentChildren;
   wide?: boolean;
   close?: boolean;
+  dismissDisabled?: boolean;
   onClose?: () => void;
   onEscape?: () => void;
   className?: string;
@@ -88,6 +90,7 @@ export function Overlay({
         delete event.currentTarget.dataset.dismissPointer;
         if (
           close &&
+          !dismissDisabled &&
           startedOutside &&
           event.target === event.currentTarget &&
           token.current &&
@@ -116,8 +119,10 @@ export function Overlay({
           ) {
             event.preventDefault();
             event.stopPropagation();
-            if (onEscape) onEscape();
-            else dismiss();
+            if (!dismissDisabled) {
+              if (onEscape) onEscape();
+              else dismiss();
+            }
             return;
           }
           trapOverlayFocus(event);
@@ -126,7 +131,13 @@ export function Overlay({
         <div class="modal-title-row">
           <h2 id={label}>{title}</h2>
           {close && (
-            <button class="icon-btn" type="button" aria-label={`Close ${title}`} onClick={dismiss}>
+            <button
+              class="icon-btn"
+              type="button"
+              aria-label={`Close ${title}`}
+              disabled={dismissDisabled}
+              onClick={dismiss}
+            >
               <Icon name="close" />
             </button>
           )}

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -2862,7 +2862,7 @@ describe('Preact-owned chat surfaces', () => {
     const store = createStore();
     store.branchTarget.value = '42';
     store.modal.value = 'branch-context';
-    store.branchFrom = vi.fn(async () => undefined);
+    store.branchFrom = vi.fn(async () => true);
     render(
       <StoreContext.Provider value={store}>
         <Modals />
@@ -2871,6 +2871,40 @@ describe('Preact-owned chat surfaces', () => {
     expect(screen.getByRole('heading', { name: 'Start a conversation path' })).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /Bring concise notes/ }));
     expect(store.branchFrom).toHaveBeenCalledWith('42', 'notes', '');
+  });
+
+  it('shows branch progress and a visible failure while blocking double-clicks', async () => {
+    const store = createStore();
+    store.branchTarget.value = '42';
+    store.modal.value = 'branch-context';
+    let rejectRequest!: (reason?: unknown) => void;
+    const request = new Promise<Record<string, unknown>>((_resolve, reject) => {
+      rejectRequest = reject;
+    });
+    store.endpoints.branch = vi.fn(() => request);
+    const { container } = render(
+      <StoreContext.Provider value={store}>
+        <Modals />
+      </StoreContext.Provider>,
+    );
+
+    const notes = screen.getByRole('button', { name: /Bring concise notes/ });
+    await userEvent.dblClick(notes);
+
+    expect(store.endpoints.branch).toHaveBeenCalledOnce();
+    expect(notes).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Close Start a conversation path' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('Creating path…');
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    const backdrop = container.querySelector('.modal-overlay') as HTMLElement;
+    fireEvent.pointerDown(backdrop, { pointerId: 7 });
+    fireEvent.pointerUp(backdrop, { pointerId: 7 });
+    expect(store.modal.value).toBe('branch-context');
+
+    await act(async () => rejectRequest(new Error('branch service unavailable')));
+    expect(await screen.findByRole('alert')).toHaveTextContent('branch service unavailable');
+    expect(notes).toBeEnabled();
   });
 
   it('opens a conversation path from anywhere on its row', async () => {

--- a/frontend/src/domain/transcript.ts
+++ b/frontend/src/domain/transcript.ts
@@ -570,6 +570,8 @@ export function sanitizeSession(
     : [];
   const archived = source.archived_at ? true : Boolean(source.archived);
   const fileSummary = record(source.file_change_summary || source.fileChangeSummary);
+  const rawTranscriptRev = source.transcript_rev ?? source.rev;
+  const transcriptRev = Number(rawTranscriptRev);
   return {
     id: text(source.id) || randomID('sess'),
     number: Number(source.number || source.session_number) || undefined,
@@ -608,7 +610,9 @@ export function sanitizeSession(
     messageCount:
       Number(source.message_count) ||
       messages.filter((message) => ['user', 'assistant'].includes(message.role)).length,
-    transcriptRev: Number(source.transcript_rev || source.rev) || 0,
+    ...(rawTranscriptRev != null && rawTranscriptRev !== '' && Number.isFinite(transcriptRev)
+      ? { transcriptRev: Math.max(0, transcriptRev) }
+      : {}),
     usage: (record(source.usage) as Session['usage']) || undefined,
     goal: (record(source.goal) as Session['goal']) || null,
     fileChangeSummary: fileSummary

--- a/frontend/src/stores/app-store.test.ts
+++ b/frontend/src/stores/app-store.test.ts
@@ -33,10 +33,12 @@ const session = (): Session => ({
 });
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 };
 
 beforeEach(() => localStorage.clear());
@@ -774,6 +776,56 @@ describe('AppStore compatibility behavior', () => {
     );
   });
 
+  it('keeps a known transcript revision when a sidebar summary omits it', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [{ ...session(), transcriptRev: 11 }];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    store.projectsEnabled.value = false;
+    store.endpoints.sessions = vi.fn(async () => ({
+      sessions: [{ id: 's1', title: 'Sidebar summary without a revision' }],
+    }));
+
+    await store.refreshSidebar();
+
+    expect(store.activeSession.value?.transcriptRev).toBe(11);
+  });
+
+  it('uses selected transcript bodies.rev for undo concurrency', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    const selected = {
+      selected_session: { id: 's1', title: 'Test' },
+      selected_transcript: {
+        bodies: {
+          rev: 7,
+          messages: [
+            { id: 41, sequence: 0, role: 'user', parts: [{ type: 'text', text: 'question' }] },
+            {
+              id: 42,
+              sequence: 1,
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'answer' }],
+            },
+          ],
+        },
+      },
+    };
+    store.endpoints.sessionState = vi.fn(async () => ({}));
+    store.endpoints.selectedSession = vi.fn(async () => selected);
+    store.endpoints.mutateTranscript = vi.fn(async () => ({ rev: 8, user_text: 'question' }));
+
+    await store.loadSession('s1');
+    await store.mutateTranscript('undo');
+
+    expect(store.endpoints.mutateTranscript).toHaveBeenCalledWith('s1', 'undo', {
+      expected_rev: 7,
+      expected_head_id: 42,
+    });
+  });
+
   it('forks a settled loaded session from its latest durable message row', async () => {
     const store = new AppStore(config);
     store.sessions.value = [session()];
@@ -781,7 +833,7 @@ describe('AppStore compatibility behavior', () => {
     store.draftActive.value = false;
     store.endpoints.sessionState = vi.fn(async () => ({ lastResponseId: 'resp_msg_42' }));
     store.endpoints.selectedSession = vi.fn(async () => ({
-      selected_session: { id: 's1', title: 'Test', transcript_rev: 3 },
+      selected_session: { id: 's1', title: 'Test' },
       selected_transcript: {
         bodies: {
           rev: 3,
@@ -809,16 +861,18 @@ describe('AppStore compatibility behavior', () => {
         },
       },
     }));
-    store.endpoints.branch = vi.fn(async () => ({}));
+    store.endpoints.branch = vi.fn(async () => ({ session: { id: 's2', title: 'Fork' } }));
     store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
 
     await store.loadSession('s1');
+    expect(store.activeSession.value?.transcriptRev).toBe(3);
     await store.branchCommand('fork');
 
-    expect(store.endpoints.branch).toHaveBeenCalledWith(
-      's1',
-      expect.objectContaining({ anchor_message_id: 42, expected_rev: 3 }),
-    );
+    expect(store.endpoints.branch).toHaveBeenCalledWith('s1', {
+      anchor_message_id: 42,
+      idempotency_key: expect.any(String),
+    });
     expect(store.toasts.value).toEqual([]);
   });
 
@@ -849,8 +903,9 @@ describe('AppStore compatibility behavior', () => {
         ],
       },
     };
-    store.endpoints.branch = vi.fn(async () => ({}));
+    store.endpoints.branch = vi.fn(async () => ({ session: { id: 's2', title: 'Fork' } }));
     store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
 
     await store.branchCommand('fork');
 
@@ -859,6 +914,178 @@ describe('AppStore compatibility behavior', () => {
       expect.objectContaining({ anchor_message_id: 0 }),
     );
     expect(store.toasts.value).toEqual([]);
+  });
+
+  it('shows branch failures and reuses the same idempotency key on retry', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
+    store.endpoints.branch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('branch service unavailable'))
+      .mockResolvedValueOnce({ session: { id: 's2', title: 'Retry child' } });
+
+    expect(await store.branchFrom('42', 'clean')).toBe(false);
+    expect(store.branchError.value).toBe('branch service unavailable');
+    expect(store.toasts.value.at(-1)?.message).toBe('branch service unavailable');
+    expect(await store.branchFrom('42', 'clean')).toBe(true);
+
+    const firstBody = vi.mocked(store.endpoints.branch).mock.calls[0][1] as Record<string, unknown>;
+    const secondBody = vi.mocked(store.endpoints.branch).mock.calls[1][1] as Record<
+      string,
+      unknown
+    >;
+    expect(firstBody.idempotency_key).toBeTruthy();
+    expect(secondBody.idempotency_key).toBe(firstBody.idempotency_key);
+    expect(firstBody).not.toHaveProperty('expected_rev');
+  });
+
+  it('guards an in-flight branch against duplicate clicks', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    const request = deferred<Record<string, unknown>>();
+    store.endpoints.branch = vi.fn(() => request.promise);
+    store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
+
+    const first = store.branchFrom('42', 'clean');
+    const second = store.branchFrom('42', 'clean');
+    expect(store.branchBusy.value).toBe(true);
+    expect(await second).toBe(false);
+    expect(store.endpoints.branch).toHaveBeenCalledOnce();
+
+    request.resolve({ session: { id: 's2', title: 'Single child' } });
+    expect(await first).toBe(true);
+    expect(store.branchBusy.value).toBe(false);
+  });
+
+  it('notifies when fork or thread commands collide with in-flight branch creation', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    const request = deferred<Record<string, unknown>>();
+    store.endpoints.branch = vi.fn(() => request.promise);
+    store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
+
+    const first = store.branchFrom('42', 'clean');
+    await store.branchCommand('fork', 'first follow up');
+    await store.branchCommand('thread', 'second follow up');
+
+    expect(store.endpoints.branch).toHaveBeenCalledOnce();
+    expect(store.toasts.value.slice(-2)).toEqual([
+      expect.objectContaining({
+        message: 'A conversation path is already being created.',
+        kind: 'info',
+      }),
+      expect.objectContaining({
+        message: 'A conversation path is already being created.',
+        kind: 'info',
+      }),
+    ]);
+    request.resolve({ session: { id: 's2', title: 'Single child' } });
+    expect(await first).toBe(true);
+  });
+
+  it('treats an auto-send failure as follow-on work and clears branch retry identity', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    store.endpoints.branch = vi
+      .fn()
+      .mockResolvedValueOnce({ session: { id: 's2', title: 'First child' } })
+      .mockResolvedValueOnce({ session: { id: 's3', title: 'Second child' } });
+    store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
+    store.send = vi.fn(async () => {
+      throw new Error('send transport failed');
+    });
+
+    expect(await store.branchFrom('42', 'clean', '', 'follow up')).toBe(true);
+    expect(store.branchError.value).toBe('');
+    expect(store.toasts.value.at(-1)).toMatchObject({
+      message: 'New path created, but its first message could not be sent: send transport failed',
+      kind: 'error',
+    });
+    expect(await store.branchFrom('42', 'clean')).toBe(true);
+
+    const firstBody = vi.mocked(store.endpoints.branch).mock.calls[0][1] as Record<string, unknown>;
+    const secondBody = vi.mocked(store.endpoints.branch).mock.calls[1][1] as Record<
+      string,
+      unknown
+    >;
+    expect(secondBody.idempotency_key).not.toBe(firstBody.idempotency_key);
+  });
+
+  it('does not dismiss a different modal when branch creation completes', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    store.branchTarget.value = '42';
+    store.modal.value = 'branch-context';
+    const request = deferred<Record<string, unknown>>();
+    store.endpoints.branch = vi.fn(() => request.promise);
+    store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
+
+    const branch = store.branchFrom('42', 'clean');
+    store.modal.value = 'settings';
+    request.resolve({ session: { id: 's2', title: 'Child' } });
+
+    expect(await branch).toBe(true);
+    expect(store.modal.value).toBe('settings');
+  });
+
+  it('keeps and opens a created child when path-note preparation fails', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    store.endpoints.branch = vi.fn(async () => ({ session: { id: 's2', title: 'Child' } }));
+    store.endpoints.pathNotes = vi.fn(async () => {
+      throw new Error('notes helper failed');
+    });
+    store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
+
+    expect(await store.branchFrom('42', 'notes')).toBe(true);
+
+    expect(store.sessions.value.some((entry) => entry.id === 's2')).toBe(true);
+    expect(store.selectSession).toHaveBeenCalledWith(expect.objectContaining({ id: 's2' }));
+    expect(store.endpoints.branch).toHaveBeenCalledOnce();
+    expect(store.toasts.value.at(-1)?.message).toContain(
+      'New path created, but its additional context could not be prepared: notes helper failed',
+    );
+  });
+
+  it('reports when active path notes omit in-progress source output', async () => {
+    const store = new AppStore(config);
+    store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
+    store.draftActive.value = false;
+    store.endpoints.branch = vi.fn(async () => ({ session: { id: 's2', title: 'Child' } }));
+    store.endpoints.pathNotes = vi.fn(async () => ({
+      ready: true,
+      limited: true,
+      message: 'In-progress output was omitted.',
+    }));
+    store.refreshSidebar = vi.fn(async () => undefined);
+    store.selectSession = vi.fn(async () => undefined);
+
+    expect(await store.branchFrom('42', 'focused', 'keep durable findings')).toBe(true);
+
+    expect(store.toasts.value.at(-1)).toMatchObject({
+      message: 'In-progress output was omitted.',
+      kind: 'info',
+    });
   });
 
   it('reconciles a completed runtime response to the latest durable anchor', async () => {

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -167,6 +167,8 @@ export class AppStore {
   readonly branchPathCount: Signal<number>;
   readonly branchTarget: Signal<string>;
   readonly branchPrefill: Signal<string>;
+  readonly branchBusy: Signal<boolean>;
+  readonly branchError: Signal<string>;
   readonly lightbox = signal<{
     src: string;
     type: 'image' | 'video';
@@ -409,6 +411,8 @@ export class AppStore {
     this.branchPathCount = this.branchStore.pathCount;
     this.branchTarget = this.branchStore.target;
     this.branchPrefill = this.branchStore.prefill;
+    this.branchBusy = this.branchStore.busy;
+    this.branchError = this.branchStore.error;
     this.skillStore = new SkillStore(this.services, {
       activeSession: this.activeSession,
       activeSessionId: this.activeSessionId,
@@ -1089,8 +1093,8 @@ export class AppStore {
     focus = '',
     autoSend = '',
     prefill = '',
-  ): Promise<void> {
-    await this.branchStore.branchFrom(messageId, context, focus, autoSend, prefill);
+  ): Promise<boolean> {
+    return this.branchStore.branchFrom(messageId, context, focus, autoSend, prefill);
   }
 
   async refreshDiffComments(sessionId = this.activeSessionId.peek()): Promise<void> {

--- a/frontend/src/stores/branch-store.ts
+++ b/frontend/src/stores/branch-store.ts
@@ -1,5 +1,6 @@
 import { signal, type ReadonlySignal, type Signal } from '@preact/signals';
 import type { Attachment, Message, Session } from '../domain/types';
+import { errorMessage } from '../domain/text';
 import type { Modal } from './store-types';
 import { uuid } from './store-utils';
 import type { AppStoreServices } from './app-store-services';
@@ -27,6 +28,10 @@ export class BranchStore {
   readonly pathCount = signal(0);
   readonly target = signal('');
   readonly prefill = signal('');
+  readonly busy = signal(false);
+  readonly error = signal('');
+
+  private retryOperation: { signature: string; idempotencyKey: string } | null = null;
 
   constructor(
     private readonly services: AppStoreServices,
@@ -71,6 +76,10 @@ export class BranchStore {
       this.services.toast('Start the conversation before creating a thread or fork.', 'error');
       return;
     }
+    if (this.busy.peek()) {
+      this.services.toast('A conversation path is already being created.', 'info');
+      return;
+    }
     if (this.options.attachments.value.length) {
       this.services.toast('Create the thread or fork before attaching files or images.', 'error');
       return;
@@ -83,17 +92,14 @@ export class BranchStore {
             .find((entry) => Number(entry.durableRowId) > 0)?.durableRowId || 0;
     const original = this.options.prompt.value;
     this.options.prompt.value = '';
-    try {
-      await this.branchFrom(String(anchor), 'clean', '', message.trim());
-    } catch (error) {
-      if (!this.options.prompt.value) this.options.prompt.value = original;
-      this.services.toast(error, 'error');
-    }
+    const created = await this.branchFrom(String(anchor), 'clean', '', message.trim());
+    if (!created && !this.options.prompt.value) this.options.prompt.value = original;
   }
 
   openContext(messageId: string, prefill = ''): void {
     this.target.value = messageId;
     this.prefill.value = prefill;
+    this.error.value = '';
     this.options.modal.value = 'branch-context';
   }
 
@@ -103,42 +109,126 @@ export class BranchStore {
     focus = '',
     autoSend = '',
     prefill = '',
-  ): Promise<void> {
+  ): Promise<boolean> {
+    if (this.busy.peek()) return false;
     const session = this.options.activeSession.value;
-    if (!session) return;
-    const data = await this.services.endpoints.branch(session.id, {
-      anchor_message_id: Number(messageId) || 0,
-      expected_rev: session.transcriptRev || 0,
-      idempotency_key: uuid(),
-    });
-    const child =
-      data.session && typeof data.session === 'object'
-        ? (data.session as Record<string, unknown>)
-        : data;
-    const id = String(child.id || data.session_id || '');
-    if (id && (context === 'notes' || context === 'focused'))
-      await this.services.endpoints.pathNotes(id, {
-        mode: context,
-        ...(context === 'focused' ? { focus } : {}),
+    if (!session) return false;
+
+    const anchor = Number(messageId) || 0;
+    const signature = `${session.id}\u0000${anchor}`;
+    if (!this.retryOperation || this.retryOperation.signature !== signature)
+      this.retryOperation = { signature, idempotencyKey: uuid() };
+    const operation = this.retryOperation;
+    const modalTarget = this.target.peek();
+    const ownsBranchModal =
+      this.options.modal.peek() === 'branch-context' && modalTarget === messageId;
+    const finishBranchModal = () => {
+      if (
+        ownsBranchModal &&
+        this.options.modal.peek() === 'branch-context' &&
+        this.target.peek() === modalTarget
+      ) {
+        this.target.value = '';
+        this.prefill.value = '';
+        this.options.modal.value = '';
+      }
+    };
+    let createdID = '';
+    this.busy.value = true;
+    this.error.value = '';
+    try {
+      const data = await this.services.endpoints.branch(session.id, {
+        anchor_message_id: anchor,
+        idempotency_key: operation.idempotencyKey,
       });
-    await this.options.refreshSidebar();
-    this.options.publishSessionChange();
-    let target = this.options.findSession(id);
-    if (!target && id) {
-      target = this.options.createSession({ ...child, id });
-      this.options.prependSession(target);
-    }
-    if (target) {
-      await this.options.selectSession(target);
-      if (autoSend) {
+      const child =
+        data.session && typeof data.session === 'object'
+          ? (data.session as Record<string, unknown>)
+          : data;
+      const id = String(child.id || data.session_id || '').trim();
+      if (!id) throw new Error('Branch response did not identify the new conversation path.');
+
+      createdID = id;
+      if (this.retryOperation === operation) this.retryOperation = null;
+      let target = this.options.findSession(id);
+      if (!target) {
+        target = this.options.createSession({ ...child, id });
+        this.options.prependSession(target);
+      }
+      try {
+        await this.options.refreshSidebar();
+      } catch (error) {
+        this.services.toast(
+          `New path created, but the sidebar could not refresh: ${errorMessage(error)}`,
+          'error',
+        );
+      }
+      target = this.options.findSession(id) || target;
+      if (!this.options.findSession(id)) this.options.prependSession(target);
+      this.options.publishSessionChange();
+
+      if (context === 'notes' || context === 'focused') {
+        try {
+          const result = await this.services.endpoints.pathNotes(id, {
+            mode: context,
+            ...(context === 'focused' ? { focus } : {}),
+          });
+          if (result.limited)
+            this.services.toast(
+              String(
+                result.message ||
+                  'Some source output was omitted from the new path context because it was not available yet.',
+              ),
+              'info',
+            );
+        } catch (error) {
+          this.services.toast(
+            `New path created, but its additional context could not be prepared: ${errorMessage(error)}`,
+            'error',
+          );
+        }
+      }
+      let selected = false;
+      try {
+        await this.options.selectSession(target);
+        selected = true;
+      } catch (error) {
+        this.services.toast(
+          `New path created, but it could not be opened: ${errorMessage(error)}`,
+          'error',
+        );
+      }
+      if (selected && autoSend) {
         this.options.prompt.value = autoSend;
-        await this.options.send();
-      } else if (prefill) {
+        try {
+          await this.options.send();
+        } catch (error) {
+          this.services.toast(
+            `New path created, but its first message could not be sent: ${errorMessage(error)}`,
+            'error',
+          );
+        }
+      } else if (selected && prefill) {
         this.options.prompt.value = prefill;
       }
+      finishBranchModal();
+      return true;
+    } catch (error) {
+      const detail = errorMessage(error);
+      if (createdID) {
+        this.services.toast(
+          `New path created, but the browser could not finish opening it: ${detail}`,
+          'error',
+        );
+        finishBranchModal();
+        return true;
+      }
+      const message = detail || 'Could not create conversation path.';
+      this.error.value = message;
+      this.services.toast(message, 'error');
+      return false;
+    } finally {
+      this.busy.value = false;
     }
-    this.target.value = '';
-    this.prefill.value = '';
-    this.options.modal.value = '';
   }
 }

--- a/frontend/src/stores/selection-store.ts
+++ b/frontend/src/stores/selection-store.ts
@@ -195,6 +195,8 @@ export class SelectionStore {
       const incoming = this.sessionsStore.sessionFrom({
         id,
         ...selectedSource,
+        // The selected transcript revision owns the message bodies being installed.
+        transcript_rev: bodies.rev ?? selectedSource.transcript_rev ?? selectedSource.rev,
         messages: serverMessages,
       });
       const currentIndex = this.sessionsStore.sessions.value.findIndex(

--- a/frontend/src/stores/session-store.ts
+++ b/frontend/src/stores/session-store.ts
@@ -133,6 +133,7 @@ export class SessionStore {
         : incoming.activeRun,
       usage: incoming.usage || existing.usage,
       goal: incoming.goal ?? existing.goal,
+      transcriptRev: incoming.transcriptRev ?? existing.transcriptRev,
       fileChangeSummary: incoming.fileChangeSummary || existing.fileChangeSummary,
     };
   }

--- a/frontend/src/styles/features/branching.css
+++ b/frontend/src/styles/features/branching.css
@@ -132,10 +132,16 @@
   cursor: pointer;
 }
 
-.branch-context-choices button:hover,
-.branch-context-choices button:focus-visible {
+.branch-context-choices button:hover:not(:disabled),
+.branch-context-choices button:focus-visible:not(:disabled) {
   background: var(--surface-2);
   border-color: var(--accent);
+}
+
+.branch-context-choices button:disabled,
+.branch-context-focus textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .branch-context-choices small {

--- a/frontend/src/styles/features/modals.css
+++ b/frontend/src/styles/features/modals.css
@@ -146,6 +146,11 @@
   cursor: not-allowed;
 }
 
+.modal .icon-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .rename-session-modal {
   width: min(420px, 100%);
 }

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -30,11 +30,12 @@ func TestGeneratedBundleAssets(t *testing.T) {
 func TestProductionBundleSizeBudgets(t *testing.T) {
 	budgets := map[string]struct{ raw, gzip int }{
 		// Notification reconciliation/outbox messaging, the owned mobile voice
-		// state machine, gallery/diff navigation, and the focused store modules
-		// are first-party shell code. Keep bounded headroom over that productized
-		// baseline while still failing meaningful accidental regressions.
-		"dist/app.js":  {raw: 390_000, gzip: 113_000},
-		"dist/app.css": {raw: 160_000, gzip: 29_000},
+		// state machine, gallery/diff navigation, focused store modules, and the
+		// safe-point branch workflow are first-party shell code. Keep bounded
+		// headroom over that productized baseline while still failing meaningful
+		// accidental regressions.
+		"dist/app.js":  {raw: 395_000, gzip: 117_000},
+		"dist/app.css": {raw: 160_000, gzip: 30_500},
 	}
 	for name, budget := range budgets {
 		body, err := StaticAsset(name)


### PR DESCRIPTION
## Summary

- make Web conversation branches use the selected durable anchor as the concurrency boundary instead of the mutable transcript head revision
- preserve authoritative transcript revisions across selected-session/sidebar merges
- make branch creation idempotent and visible: prevent duplicate clicks, keep created children reachable, and show inline/toast errors for genuine failures
- prepare notes/focused context from a consistent durable active-run snapshot, omitting partial output when necessary
- harden modal dismissal and follow-on sidebar, selection, context-generation, and first-message failures

## Why

The Preact branch dialog could appear to do nothing when the transcript revision drifted between opening the dialog and creating the branch. The selected row-ID anchor still identified a valid immutable prefix, but the Web endpoint rejected it using a full-head revision check. Errors were then discarded by an unhandled event-handler promise.

Notes/focused branches had another race: the child could be created successfully, then context preparation could fail while the parent was active, leaving the child hidden and allowing repeated clicks to create more children.

## Safety

The Web endpoint now treats `anchor_message_id` as the branch precondition and validates it transactionally. Lower-level `CreateBranch` and `/v1/responses` retain their existing full-head compare-and-swap contracts. Active snapshots are accepted only when run identity, epoch, and published durable boundary remain stable around the transcript read; sampling is capped at three attempts and fails visibly.

Path-note requests use a 150-second client timeout, which exceeds the server's 120-second detached-work budget by 30 seconds.

## Tests

- `HOME=<isolated> XDG_CONFIG_HOME=... XDG_DATA_HOME=... XDG_CACHE_HOME=... go test ./...`
- `go vet ./...`
- `mise x node@24 -- npm --prefix frontend test -- --run` — 338 passed
- `mise x node@24 -- npm --prefix frontend run typecheck`
- `mise x node@24 -- npm --prefix frontend run lint`
- `mise x node@24 -- npm --prefix frontend run format:check`
- `mise x node@24 -- make build`
- `git diff --check`

Opus reviewed the implementation; its timeout, bounded sampling, accurate limited-state, modal ownership, follow-on failure, contract clarity, and disabled-state findings are addressed in this revision.
