### PR TITLE
fix(web): hide terminal-origin sessions from sidebar

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -408,13 +408,18 @@ function ProjectGroup({ project }: { project: Project }) {
   const { menu: menuRef, up } = useMenuFlip(menu);
   const menuTrigger = useRef<HTMLButtonElement>(null);
   const keyboardMenu = useMenuKeyboard(menu, () => setMenu(false), menuTrigger);
-  const listedSessionIDs = new Set((project.sessions || []).map((session) => session.id));
+  const listedSessionIDs = new Set(
+    (project.sessions || []).filter(isSidebarSessionVisible).map((session) => session.id),
+  );
   const sessions = [
-    ...(project.sessions || []).map(
-      (session) => store.sessions.value.find((entry) => entry.id === session.id) || session,
-    ),
+    ...(project.sessions || [])
+      .filter(isSidebarSessionVisible)
+      .map((session) => store.sessions.value.find((entry) => entry.id === session.id) || session),
     ...store.sessions.value.filter(
-      (session) => session.projectId === project.id && !listedSessionIDs.has(session.id),
+      (session) =>
+        session.projectId === project.id &&
+        isSidebarSessionVisible(session) &&
+        !listedSessionIDs.has(session.id),
     ),
   ].sort(
     (left, right) =>
@@ -621,6 +626,13 @@ function HubAgents() {
   );
 }
 
+function isSidebarSessionVisible(session: Session): boolean {
+  // TUI-origin sessions include native background-agent runs. They remain
+  // addressable directly and through spawn-agent links, but should not make a
+  // web sidebar shared with the terminal look like an agent process monitor.
+  return session.origin !== 'tui';
+}
+
 export function Sidebar() {
   const store = useStore();
   const collapsed = store.sidebarCollapsed.value;
@@ -658,11 +670,13 @@ export function Sidebar() {
       overlayToken.current = null;
     };
   }, [mobile, mobileOpen]);
-  const standalone = store.sessions.value.filter((session) => !session.projectId);
+  const standalone = store.sessions.value.filter(
+    (session) => !session.projectId && isSidebarSessionVisible(session),
+  );
   const sidebarSessions = [
     ...store.sessions.value,
     ...store.projects.value.flatMap((project) => project.sessions || []),
-  ];
+  ].filter(isSidebarSessionVisible);
   const results = store.searchResults.value;
   const brand = store.config.title.trim() || displayName(store.config.agentName);
   const pinned = sidebarSessions.filter(

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -2147,6 +2147,26 @@ describe('Preact-owned chat surfaces', () => {
     expect(screen.queryByRole('link', { name: 'Back to Hub' })).not.toBeInTheDocument();
   });
 
+  it('keeps terminal-origin agent sessions out of the default sidebar', () => {
+    const store = createStore();
+    store.sessions.value = [
+      ...store.sessions.value,
+      {
+        ...store.sessions.value[0],
+        id: 'agent-session',
+        title: 'Background agent investigation',
+        origin: 'tui',
+      },
+    ];
+    render(
+      <StoreContext.Provider value={store}>
+        <Sidebar />
+      </StoreContext.Provider>,
+    );
+
+    expect(screen.getByText('Test')).toBeInTheDocument();
+    expect(screen.queryByText('Background agent investigation')).not.toBeInTheDocument();
+  });
   it('shows server-observed running state before this tab attaches to the stream', () => {
     const store = createStore();
     store.activeSessionId.value = '';


### PR DESCRIPTION
## Summary

Hide terminal-origin sessions from the default `serve web` sidebar.

Background agent sessions created by native/TUI jobs currently share the session database with the web UI, which makes them appear as ordinary conversations. The sidebar now filters them out while retaining them in the client session store so direct links and spawn-agent child links remain usable. Explicit search remains available.

## Testing

- `mise x node@24 -- npm test -- --run src/components/components.test.tsx` (94 passed)
- `mise x node@24 -- npm run typecheck`
- `git diff --check`
