### PR TITLE
fix(web): keep the open conversation visible through background sidebar refreshes

### DIFF
--- a/frontend/src/stores/session-store.test.ts
+++ b/frontend/src/stores/session-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { initialProjection } from '../domain/response';
 import { AppStore } from './app-store';
 import { testConfig, testSession } from './store-test-fixtures';
@@ -63,6 +63,115 @@ describe('SessionStore', () => {
         activeResponseId: 'r1',
       });
       expect(store.sessions.value[0].messages).toHaveLength(1);
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('retains the active flat-list session when a sidebar page omits it', () => {
+    const store = new AppStore(testConfig);
+    try {
+      const active = testSession({
+        id: 's_old',
+        title: 'Old convo',
+        messages: [{ id: 'm_old', role: 'user', content: 'Still here', created: 1 }],
+      });
+      store.sessionStore.prepend(active);
+      store.sessionStore.activate(active);
+
+      store.sessionStore.applySidebar({
+        sessions: [{ id: 's_recent', title: 'Recent convo' }],
+      });
+
+      expect(store.activeSession.value?.id).toBe('s_old');
+      expect(store.activeSession.value?.messages).toEqual([
+        expect.objectContaining({ id: 'm_old', content: 'Still here' }),
+      ]);
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('retains the active project session when grouped sidebar data omits it', () => {
+    const store = new AppStore(testConfig);
+    try {
+      store.projectsEnabled.value = true;
+      const active = testSession({
+        id: 's_old',
+        title: 'Old project convo',
+        projectId: 'project-old',
+        messages: [{ id: 'm_old', role: 'user', content: 'Project transcript', created: 1 }],
+      });
+      store.sessionStore.prepend(active);
+      store.sessionStore.activate(active);
+
+      store.sessionStore.applySidebar({
+        groups: [
+          {
+            project: { id: 'project-recent', name: 'Recent project' },
+            sessions: [{ id: 's_recent', title: 'Recent convo' }],
+          },
+        ],
+      });
+
+      expect(store.activeSession.value?.id).toBe('s_old');
+      expect(store.activeSession.value?.messages).toEqual([
+        expect.objectContaining({ id: 'm_old', content: 'Project transcript' }),
+      ]);
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('drops an inactive local session when a sidebar page omits it', () => {
+    const store = new AppStore(testConfig);
+    try {
+      const old = testSession({ id: 's_old', title: 'Old convo' });
+      const recent = testSession({ id: 's_recent', title: 'Recent convo', lastMessageAt: 2 });
+      store.sessionStore.replace([recent, old]);
+      store.sessionStore.activate(recent);
+
+      store.sessionStore.applySidebar({
+        sessions: [{ id: 's_recent', title: 'Recent convo' }],
+      });
+
+      expect(store.sessions.value.map((session) => session.id)).not.toContain('s_old');
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('clears selection on archive and leaves it cleared through the next sidebar refresh', async () => {
+    const store = new AppStore(testConfig);
+    try {
+      const active = testSession({ id: 's_old', title: 'Old convo' });
+      store.sessionStore.prepend(active);
+      store.sessionStore.activate(active);
+      store.endpoints.patchSession = vi.fn(async () => ({}));
+
+      await store.archiveSession(active);
+      store.sessionStore.applySidebar({
+        sessions: [{ id: 's_recent', title: 'Recent convo' }],
+      });
+
+      expect(store.activeSessionId.value).toBe('');
+      expect(store.sessions.value.map((session) => session.id)).not.toContain('s_old');
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('removes the old active draft row when rekeying a session', () => {
+    const store = new AppStore(testConfig);
+    try {
+      const draft = testSession({ id: 'draft_x', title: 'Draft convo' });
+      store.sessionStore.prepend(draft);
+      store.sessionStore.activate(draft);
+
+      store.runEngine.rekeySession('draft_x', 's9', { id: 's9', title: 'Durable convo' });
+
+      expect(store.sessions.value.map((session) => session.id)).not.toContain('draft_x');
+      expect(store.activeSessionId.value).toBe('s9');
     } finally {
       store.dispose();
     }

--- a/frontend/src/stores/session-store.ts
+++ b/frontend/src/stores/session-store.ts
@@ -138,6 +138,17 @@ export class SessionStore {
     };
   }
 
+  /**
+   * Rows the client owns survive a server rebuild: live runs, unsent drafts,
+   * and the open conversation. Deliberately scoped to applySidebar's
+   * rebuild-from-server loop only — do not centralize into replace(), which
+   * must stay lossy so RunEngine.rekeySession can drop the pre-rekey draft_
+   * row while activeSessionId still points at it (it re-points afterward).
+   */
+  private retainedLocally(id: string): boolean {
+    return this.host.hasRun(id) || id.startsWith('draft_') || id === this.activeSessionId.peek();
+  }
+
   applySidebar(data: Record<string, unknown>): void {
     const direct = listFrom(data, 'data', 'sessions', 'items').map((entry) =>
       this.sessionFrom(entry),
@@ -191,8 +202,7 @@ export class SessionStore {
       ]),
     );
     for (const [id, session] of existing)
-      if (!merged.has(id) && (this.host.hasRun(id) || id.startsWith('draft_')))
-        merged.set(id, session);
+      if (!merged.has(id) && this.retainedLocally(id)) merged.set(id, session);
     this.sessions.value = [...merged.values()].sort(compareSessionsByActivity);
     this.projects.value = projects.map((project) => ({
       ...project,


### PR DESCRIPTION
## Bug

Switching to an old/resumed conversation (convo B) while another conversation (convo A) has a turn running in the background: when A's turn completes, B's view resets to the empty "How can I help?" state, even though the user is actively looking at B.

## Root cause

`SessionStore.applySidebar()` rebuilds `sessions.value` from the server's "recent sessions" page merged with locally-known sessions. A locally-known session missing from that page was only retained if it had an active run or was an unsent `draft_` session:

```ts
for (const [id, session] of existing)
  if (!merged.has(id) && (this.host.hasRun(id) || id.startsWith('draft_')))
    merged.set(id, session);
```

An old/resumed session with no active run at that moment, and not on the "recent" server page, was silently dropped from `sessions.value` by any background sidebar refresh (the poll/reconcile loop does this routinely; A's turn completing triggers one such cycle). `activeSession` is `computed(() => sessions.value.find(s => s.id === activeSessionId.value) ?? null)`, so it became `null`, and the transcript fell back to the empty state — a real invariant break: the conversation the user is looking at must stay visible. Worse, if the user then sent a message, `RunEngine.send()` saw `activeSession.value === null` and minted a brand new `draft_` session instead of continuing the one on screen.

Reproduced directly with a vitest test exercising `applySidebar` (fails without the fix: `expected undefined to be 's_old'`).

## Fix

Added a `retainedLocally(id)` predicate, scoped to `applySidebar`'s rebuild-from-server loop only, that additionally retains the currently active session id:

```ts
private retainedLocally(id: string): boolean {
  return this.host.hasRun(id) || id.startsWith('draft_') || id === this.activeSessionId.peek();
}
```

Deliberately **not** centralized into the generic `replace()` setter — that would break `RunEngine.rekeySession`, which intentionally drops the pre-rekey `draft_...` row from `sessions.value` while `activeSessionId` still points at the old id (it re-points afterward). A regression test pins this.

## Tests added (`session-store.test.ts`)

- Active session retained when a flat sidebar page omits it.
- Active session retained when a grouped/project sidebar payload omits it.
- An *inactive* session with no run is still dropped as before (no over-retention).
- Archiving the active session clears selection via `newChat()`, and a later refresh doesn't resurrect it.
- `rekeySession` still removes the pre-rekey `draft_` row (guards against a future "helpful" centralization of this guard).

## Verification

- `npx vitest run` — 31 files / 347 tests pass.
- `npm run typecheck` — passes.
- `npm run format:check` / `npm run lint` — pass.
- `go build ./...`, `go test ./...`, `go vet ./...` — pass (no Go files touched).
- Reviewed twice by a second model (plan review before implementation, diff review after) — approved with minor nits, both applied (explanatory comment on the scoping decision; retitled one test for accuracy).
