### PR TITLE
fix(hub): disable WebRTC for proxied nodes

### DIFF
--- a/cmd/serve_hub_proxy.go
+++ b/cmd/serve_hub_proxy.go
@@ -425,9 +425,11 @@ func hubRebaseUIPrefix(body []byte, basePath, mount string) (out []byte, baseHit
 
 // hubInjectContext injects window.TERM_LLM_HUB into the served HTML head so
 // the node's web UI knows it was opened via the hub and can render a "Back
-// to Hub" link. The hub URL is root-relative because the proxied UI is
-// same-origin with the hub; it includes the hub mount when served under a
-// prefix such as /hub.
+// to Hub" link. It also disables the node's direct WebRTC transport: Hub
+// pages should keep browser traffic on the authenticated same-origin proxy,
+// rather than contacting the node's external signaling URL cross-origin.
+// The hub URL is root-relative because the proxied UI is same-origin with the
+// hub; it includes the hub mount when served under a prefix such as /hub.
 func hubInjectContext(body []byte, t *hubProxyTarget) []byte {
 	hubURL := t.hubURL
 	if hubURL == "" {
@@ -442,7 +444,7 @@ func hubInjectContext(body []byte, t *hubProxyTarget) []byte {
 	if err != nil {
 		return body
 	}
-	snippet := []byte(`<script>window.TERM_LLM_HUB=` + string(ctxJSON) + `;</script></head>`)
+	snippet := []byte(`<script>window.__WEBRTC_ENABLED__=false;</script><script>window.TERM_LLM_HUB=` + string(ctxJSON) + `;</script></head>`)
 	if bytes.Contains(body, []byte("</head>")) {
 		return bytes.Replace(body, []byte("</head>"), snippet, 1)
 	}

--- a/cmd/serve_hub_test.go
+++ b/cmd/serve_hub_test.go
@@ -868,7 +868,7 @@ func TestHubProxyInjectsTokenAndStripsCredentials(t *testing.T) {
 }
 
 func TestHubProxyRebasesAndInjectsHubContext(t *testing.T) {
-	const body = `<html><head><base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";</script></head><body></body></html>`
+	const body = `<html><head><base href="/chat/"><script>window.TERM_LLM_UI_PREFIX="/chat";window.__WEBRTC_ENABLED__=true;</script></head><body></body></html>`
 	s := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		io.WriteString(w, body)
@@ -889,6 +889,9 @@ func TestHubProxyRebasesAndInjectsHubContext(t *testing.T) {
 	}
 	if !strings.Contains(got, `window.TERM_LLM_HUB={"nodeBasePath":"/chat","nodeId":"alpha","nodeName":"Alpha","url":"/"}`) {
 		t.Errorf("hub context not injected: %s", got)
+	}
+	if enabled, disabled := strings.Index(got, `window.__WEBRTC_ENABLED__=true`), strings.Index(got, `window.__WEBRTC_ENABLED__=false`); enabled < 0 || disabled < enabled {
+		t.Errorf("Hub proxy must override node WebRTC enablement after the node setting: %s", got)
 	}
 	if cl := rec.Header().Get("Content-Length"); cl != fmt.Sprintf("%d", len(got)) {
 		t.Errorf("Content-Length = %q, want %d", cl, len(got))


### PR DESCRIPTION
## Summary

- disable the direct WebRTC transport when a node UI is mounted through Hub
- keep browser traffic on Hub's authenticated same-origin proxy
- preserve WebRTC for nodes opened directly

## Problem

A WebRTC-enabled node injects its absolute signaling URL into the served HTML. Hub rebases the node UI onto `/node/<id>/`, but the browser still tries to negotiate against that external signaling origin.

For example, opening `https://hub.samsaffron.com/node/jarvis/` caused a preflight from the Hub origin to `https://wasnotwas.com/jarvis-api/webrtc/session`. The signaling endpoint does not expose cross-origin CORS, so negotiation failed and retried indefinitely.

More fundamentally, Hub-proxied pages should retain Hub as their transport and authentication boundary. Direct WebRTC bypasses that boundary and requires separate cross-origin signaling and authentication behavior.

## Fix

Hub now injects `window.__WEBRTC_ENABLED__=false` after the node's own head configuration. The WebRTC module reads the final value when it initializes, so Hub-mounted pages stay on HTTPS/SSE through the proxy. Direct node pages are unchanged.

The proxy regression test starts with WebRTC enabled and verifies that Hub's disabling override appears later in the document.

## Verification

- `go test ./cmd -run 'TestHubProxyRebasesAndInjectsHubContext|TestHubProxy'`
- `go build ./...`
- `git diff --check`

The full `go test ./cmd` run also reached the Hub tests successfully, but two unrelated skill-discovery tests failed because this Jarvis environment injects its configured global skills into their prompts.
