### PR TITLE
fix(web): avoid default-only status churn

### DIFF
--- a/frontend/src/stores/app-store.test.ts
+++ b/frontend/src/stores/app-store.test.ts
@@ -2064,6 +2064,52 @@ describe('AppStore compatibility behavior', () => {
     });
   });
 
+  it('preserves sanitizer-shaped session identities across an unchanged status poll', async () => {
+    const store = new AppStore(config);
+    try {
+      const stable = session();
+      store.sessions.value = [stable];
+      store.endpoints.sessionStatus = vi.fn(async () => ({ sessions: [{ id: 's1' }] }));
+      const sessions = store.sessions.value;
+
+      await (store as unknown as { refreshStatus(): Promise<void> }).refreshStatus();
+
+      expect(store.sessions.value).toBe(sessions);
+      expect(store.sessions.value[0]).toBe(stable);
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('applies changed status while preserving unchanged sibling identities', async () => {
+    const store = new AppStore(config);
+    try {
+      const changed = session();
+      const stable = { ...session(), id: 's2', title: 'Stable' };
+      store.sessions.value = [changed, stable];
+      const sessions = store.sessions.value;
+      store.endpoints.sessionStatus = vi.fn(async () => ({
+        sessions: [
+          { id: 's1', short_title: 'Renamed', active_run: true, transcript_rev: 3 },
+          { id: 's2' },
+        ],
+      }));
+
+      await (store as unknown as { refreshStatus(): Promise<void> }).refreshStatus();
+
+      expect(store.sessions.value).not.toBe(sessions);
+      expect(store.sessions.value[0]).not.toBe(changed);
+      expect(store.sessions.value[0]).toMatchObject({
+        title: 'Renamed',
+        activeRun: true,
+        transcriptRev: 3,
+      });
+      expect(store.sessions.value[1]).toBe(stable);
+    } finally {
+      store.dispose();
+    }
+  });
+
   it('clears stale remote activity without dropping an out-of-scope response anchor', async () => {
     const store = new AppStore(config);
     store.sessions.value = [

--- a/frontend/src/stores/status-reconciler.ts
+++ b/frontend/src/stores/status-reconciler.ts
@@ -310,6 +310,14 @@ export class StatusReconciler {
               )
             : session.messages
           : session.messages;
+        const nextActiveRun = Boolean(
+          activeResponseId || (status.active_run && !stoppedServerResponse),
+        );
+        const nextLastResponseId = String(status.last_response_id || '');
+        const nextMessageCount = Math.max(
+          session.messageCount || 0,
+          Number(status.message_count) || 0,
+        );
         const candidate: Session = {
           ...session,
           ...(titleRefreshAllowed && String(status.short_title || '')
@@ -318,12 +326,16 @@ export class StatusReconciler {
                 longTitle: String(status.long_title || '') || session.longTitle,
               }
             : {}),
-          activeResponseId,
-          activeRun: Boolean(activeResponseId || (status.active_run && !stoppedServerResponse)),
+          ...(activeResponseId !== null || session.activeResponseId !== undefined
+            ? { activeResponseId }
+            : {}),
+          ...(nextActiveRun || session.activeRun !== undefined ? { activeRun: nextActiveRun } : {}),
           messages,
-          lastResponseId: String(status.last_response_id || '') || session.lastResponseId,
-          transcriptRev,
-          messageCount: Math.max(session.messageCount || 0, Number(status.message_count) || 0),
+          ...(nextLastResponseId ? { lastResponseId: nextLastResponseId } : {}),
+          ...(transcriptRev || session.transcriptRev !== undefined ? { transcriptRev } : {}),
+          ...(nextMessageCount || session.messageCount !== undefined
+            ? { messageCount: nextMessageCount }
+            : {}),
           lastMessageAt: Number(status.last_message_at)
             ? Math.max(
                 session.lastMessageAt || 0,


### PR DESCRIPTION
## Summary

- avoid adding `false`, `null`, and `0` status defaults to sanitizer-shaped sessions when those values are already implicit
- preserve session identity on the first unchanged status poll after a sidebar refresh
- verify real status changes still update the affected session while unchanged siblings retain identity

## Why

Status reconciliation now preserves unchanged session objects, but sidebar sanitization omits empty status fields such as `activeRun`, `activeResponseId`, and `transcriptRev`. The next status poll previously materialized those fields as `false`, `null`, and `0`, making an otherwise unchanged session look different and forcing one avoidable Preact sidebar repaint after each catalog refresh.

This keeps absent defaults absent until the server reports a meaningful value. Legitimate run, title, revision, count, and activity changes continue through the existing candidate comparison.

## Tests

- `mise x node@24 -- npm test` — 365 passed
- `mise x node@24 -- npm run typecheck`
- `mise x node@24 -- npm run lint:ts`
- `mise x node@24 -- npm run build`
- Prettier check on changed frontend files
