### PR TITLE
fix(web): retain loaded paginated sidebar tails

### DIFF
--- a/frontend/src/stores/session-store.test.ts
+++ b/frontend/src/stores/session-store.test.ts
@@ -167,7 +167,7 @@ describe('SessionStore', () => {
     }
   });
 
-  it('drops an inactive local session when a sidebar page omits it', () => {
+  it('drops an inactive local session when a complete sidebar snapshot omits it', () => {
     const store = new AppStore(testConfig);
     try {
       const old = testSession({ id: 's_old', title: 'Old convo' });
@@ -180,6 +180,78 @@ describe('SessionStore', () => {
       });
 
       expect(store.sessions.value.map((session) => session.id)).not.toContain('s_old');
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('preserves the loaded tail when a partial first page omits older sessions', () => {
+    const store = new AppStore(testConfig);
+    try {
+      const loaded = Array.from({ length: 21 }, (_, index) =>
+        testSession({
+          id: `s${index + 1}`,
+          title: `Session ${index + 1}`,
+          created: 21 - index,
+          lastMessageAt: 21 - index,
+        }),
+      );
+      store.sessionStore.replace(loaded);
+
+      store.sessionStore.applySidebar({
+        sessions: loaded.slice(0, 7).map((session) => ({
+          id: session.id,
+          short_title: session.title,
+          created_at: session.created,
+          last_message_at: session.lastMessageAt,
+        })),
+        next_cursor: 'older-page',
+      });
+
+      expect(store.sessions.value.map((session) => session.id)).toEqual(
+        loaded.map((session) => session.id),
+      );
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('preserves loaded project tails only while the project page is incomplete', () => {
+    const store = new AppStore(testConfig);
+    try {
+      store.projectsEnabled.value = true;
+      const project = { id: 'p1', name: 'Alpha' };
+      const sessions = ['s1', 's2', 's3'].map((id, index) => ({
+        id,
+        short_title: id,
+        created_at: 3 - index,
+        last_message_at: 3 - index,
+      }));
+      store.sessionStore.applySidebar({
+        groups: [{ project, sessions, session_count: 3 }],
+      });
+
+      store.sessionStore.applySidebar({
+        groups: [
+          {
+            project,
+            sessions: sessions.slice(0, 1),
+            session_count: 3,
+            next_cursor: 'older-project-page',
+          },
+        ],
+      });
+      expect(store.sessions.value.map((session) => session.id)).toEqual(['s1', 's2', 's3']);
+      expect(store.projects.value[0].sessions?.map((session) => session.id)).toEqual([
+        's1',
+        's2',
+        's3',
+      ]);
+
+      store.sessionStore.applySidebar({
+        groups: [{ project, sessions: sessions.slice(0, 1), session_count: 1 }],
+      });
+      expect(store.sessions.value.map((session) => session.id)).toEqual(['s1']);
     } finally {
       store.dispose();
     }

--- a/frontend/src/stores/session-store.ts
+++ b/frontend/src/stores/session-store.ts
@@ -189,6 +189,8 @@ export class SessionStore {
     const groups = listFrom(data, 'groups');
     const projects: Project[] = [];
     const ungrouped: Session[] = [...direct];
+    const incompleteProjectIDs = new Set<string>();
+    let noProjectPageIncomplete = groups.length === 0 && Boolean(data.next_cursor);
     // Flat listings (projects disabled) carry the cursor at the top level;
     // project sidebars carry it on their "no project" group below.
     this.noProjectCursor.value = String(data.next_cursor || '');
@@ -201,10 +203,13 @@ export class SessionStore {
       if (!projectSource || group.no_project) {
         ungrouped.push(...sessions.map((entry) => this.sessionFrom(entry)));
         this.noProjectCursor.value = String(group.next_cursor || '');
+        noProjectPageIncomplete = Boolean(group.next_cursor);
         continue;
       }
+      const projectID = String(projectSource.id || '');
+      if (group.next_cursor) incompleteProjectIDs.add(projectID);
       const project: Project = {
-        id: String(projectSource.id || ''),
+        id: projectID,
         name: String(projectSource.name || projectSource.title || 'Project'),
         path: String(projectSource.canonical_dir || projectSource.path || ''),
         archived: Boolean(projectSource.archived_at || projectSource.archived),
@@ -235,18 +240,36 @@ export class SessionStore {
         return [session.id, previous && semanticEqual(previous, candidate) ? previous : candidate];
       }),
     );
-    for (const [id, session] of existing)
-      if (!merged.has(id) && this.retainedLocally(id)) merged.set(id, session);
+    // A cursor means the response is only the first page for that catalog partition.
+    // Keep already-loaded tail rows until a complete snapshot proves they disappeared.
+    for (const [id, session] of existing) {
+      const incompletePage = session.projectId
+        ? incompleteProjectIDs.has(session.projectId)
+        : noProjectPageIncomplete;
+      if (!merged.has(id) && (incompletePage || this.retainedLocally(id))) merged.set(id, session);
+    }
     const nextSessions = [...merged.values()].sort(compareSessionsByActivity);
     if (!sameIdentityList(this.sessions.peek(), nextSessions)) this.sessions.value = nextSessions;
 
     const existingProjects = new Map(this.projects.peek().map((project) => [project.id, project]));
     const nextProjects = projects.map((project) => {
+      const previous = existingProjects.get(project.id);
+      const sessions = project.sessions?.map((summary) => merged.get(summary.id) || summary) || [];
+      if (incompleteProjectIDs.has(project.id)) {
+        const listed = new Set(sessions.map((session) => session.id));
+        for (const summary of previous?.sessions || []) {
+          const preserved = merged.get(summary.id);
+          if (preserved?.projectId === project.id && !listed.has(summary.id)) {
+            sessions.push(preserved);
+            listed.add(summary.id);
+          }
+        }
+        sessions.sort(compareSessionsByActivity);
+      }
       const candidate = {
         ...project,
-        sessions: project.sessions?.map((summary) => merged.get(summary.id) || summary),
+        sessions,
       };
-      const previous = existingProjects.get(project.id);
       return previous && semanticEqual(previous, candidate) ? previous : candidate;
     });
     if (!sameIdentityList(this.projects.peek(), nextProjects)) this.projects.value = nextProjects;


### PR DESCRIPTION
## Summary

- treat `next_cursor` as proof that a sidebar response is only a partial catalog page
- merge first-page refreshes into already-loaded flat and project tails instead of deleting omitted rows
- continue removing omitted inactive rows when a complete snapshot has no cursor

## Actual regression reproduced first

The first commit is deliberately test-only (`735f8b63`). Against merged `upstream/main` it fails with the observed catalog collapse:

```text
FAIL preserves the loaded tail when a partial first page omits older sessions
Expected: s1 … s21
Received: s1 … s7
```

The fixture starts with 21 loaded sessions, then applies a seven-row first page carrying `next_cursor`. That is the same 21 → 7 transition seen in the live sidebar.

The second commit makes that exact test green. It also covers grouped project pagination and proves that a later complete snapshot still removes genuinely omitted rows.

## Root cause

Focus and server-event reconciliation refresh the first sidebar page. Both flat `/v1/sessions?limit=30` responses and grouped `/v1/sidebar` groups are paginated. `SessionStore.applySidebar()` previously treated every response as a complete replacement, so refreshing page one discarded pages the browser had already loaded. Pagination then loaded them again, producing the visible 21 → 7 → 21 flash.

A response may remove omitted catalog rows only when it proves that partition is complete. Existing `next_cursor` metadata already provides that proof boundary.

## Tests

- red reproduction confirmed on `upstream/main`: 7 received vs 21 expected
- `mise x node@24 -- npm test` — 367 passed
- `mise x node@24 -- npm run typecheck`
- `mise x node@24 -- npm run lint:ts`
- `mise x node@24 -- npm run build`
- Prettier check on changed files
