### PR TITLE
fix(ci): align Hub smoke and bundle budget

### DIFF
--- a/frontend/e2e/hub-production.spec.ts
+++ b/frontend/e2e/hub-production.spec.ts
@@ -2,12 +2,9 @@ import { expect, test } from '@playwright/test';
 
 const hubRoot = process.env.TERM_LLM_HUB_SMOKE_ROOT || '';
 const hubToken = process.env.TERM_LLM_HUB_SMOKE_TOKEN || '';
-const relayURL = process.env.TERM_LLM_WEBRTC_RELAY_URL || '';
 
-test('Hub bearer mount preserves a WebRTC-fallback send across reload', async ({
-  page,
-}, testInfo) => {
-  test.skip(!hubRoot || !hubToken || !relayURL, 'production-shaped Hub smoke is not configured');
+test('Hub bearer mount preserves a proxied send across reload', async ({ page }, testInfo) => {
+  test.skip(!hubRoot || !hubToken, 'production-shaped Hub smoke is not configured');
   test.skip(testInfo.project.name === 'mobile', 'the exact production path is covered once');
   test.setTimeout(60_000);
 
@@ -21,9 +18,8 @@ test('Hub bearer mount preserves a WebRTC-fallback send across reload', async ({
   expect(page.url()).not.toContain('token=');
   await expect.poll(async () => (await page.request.get(`${hubRoot}api/nodes`)).status()).toBe(200);
 
-  // Keep WebRTC enabled in the production bundle but make the first signaling
-  // generation unavailable. The app must preserve HTTPS through the Hub proxy.
-  await page.request.post(`${relayURL}/control`, { data: { hang_sessions: 1 } });
+  // The node has WebRTC enabled, but Hub mounts must keep browser traffic on
+  // the authenticated same-origin proxy.
   const nodeRoot = `${hubRoot}node/production-node/`;
   await page.goto(`${nodeRoot}?new=1`);
   await expect(page.getByRole('textbox', { name: 'Message' })).toBeVisible();
@@ -35,7 +31,7 @@ test('Hub bearer mount preserves a WebRTC-fallback send across reload', async ({
   expect(mount).toEqual({
     prefix: '/hub/node/production-node',
     nodeBasePath: '/chat',
-    webrtc: true,
+    webrtc: false,
   });
 
   await page.getByRole('textbox', { name: 'Message' }).fill('Production shaped Hub resume');

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -31,11 +31,11 @@ func TestProductionBundleSizeBudgets(t *testing.T) {
 	budgets := map[string]struct{ raw, gzip int }{
 		// Notification reconciliation/outbox messaging, the owned mobile voice
 		// state machine, gallery/diff navigation, focused store modules, the
-		// safe-point branch workflow, interactive worktree conflict recovery, and
-		// the replayable SSE/long-poll server-event coordinator are first-party
-		// shell code. Keep bounded headroom over that productized baseline while
-		// still failing meaningful accidental regressions.
-		"dist/app.js":  {raw: 412_000, gzip: 118_500},
+		// safe-point branch workflow, interactive worktree conflict recovery,
+		// replayable SSE/long-poll server-event coordination, and branch-tree
+		// navigation are first-party shell code. Keep bounded headroom over that
+		// productized baseline while still failing meaningful accidental regressions.
+		"dist/app.js":  {raw: 416_000, gzip: 124_000},
 		"dist/app.css": {raw: 160_000, gzip: 30_500},
 	}
 	for name, budget := range budgets {

--- a/scripts/hub_browser_lifecycle_smoke.sh
+++ b/scripts/hub_browser_lifecycle_smoke.sh
@@ -114,6 +114,5 @@ if [[ -z "${PLAYWRIGHT_CHROMIUM_EXECUTABLE:-}" ]] && command -v chromium >/dev/n
 fi
 TERM_LLM_SMOKE_URL="${hub_root}node/production-node/" \
 TERM_LLM_HUB_SMOKE_ROOT="$hub_root" TERM_LLM_HUB_SMOKE_TOKEN="$hub_token" \
-TERM_LLM_WEBRTC_RELAY_URL="$relay_url" \
 npm run test:e2e -- --workers=1 --reporter=line --output="$results" e2e/hub-production.spec.ts "$@"
 succeeded=true


### PR DESCRIPTION
## Summary

- update the production Hub browser smoke for the intentional WebRTC disablement on proxied nodes
- keep the smoke focused on authenticated proxy send/reload behavior and remove its stale relay control dependency
- raise the app bundle budget from 412,000/118,500 bytes to 416,000/124,000 bytes for the current 413,446-byte server-event and branch-navigation bundle

The latest `main` CI failed in both `test` and `frontend`: the former exceeded the stale bundle budget, while the latter still expected Hub-proxied WebRTC to be enabled after #1078 deliberately disabled it.

## Verification

- `go test ./internal/serveui`
- `mise x node@24 -- npm --prefix frontend run typecheck`
- `mise x node@24 -- npm --prefix frontend test` (365 tests)
- `mise x node@24 -- scripts/hub_browser_lifecycle_smoke.sh` (desktop passed, mobile intentionally skipped)
- Prettier check for the changed spec
- `bash -n scripts/hub_browser_lifecycle_smoke.sh`

`go test ./...` reaches the full suite but two unrelated `cmd` tests fail locally because Jarvis's user-level skills are injected ahead of their temporary fixture skills. Both tests passed in the failing GitHub Actions run.
