### PR TITLE
fix(web): tighten mobile header layout

### DIFF
--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -307,7 +307,10 @@ test('mobile viewport opens a styled sidebar and returns to a usable composer', 
   page,
 }, testInfo) => {
   test.skip(testInfo.project.name !== 'mobile', 'mobile-only interaction');
-  await open(page);
+  await open(page, '', { model: 'gpt-5.6-sol-high' });
+  await page.evaluate(() => document.documentElement.style.setProperty('--safe-top', '59px'));
+  const titleContext = page.locator('.header-title-context');
+  expect((await titleContext.boundingBox())?.width || 0).toBeGreaterThan(140);
   const diffToggle = page.getByRole('button', { name: 'Toggle file changes' });
   const mobileMenu = page.getByRole('button', { name: 'Open sidebar' });
   await expect(diffToggle.locator('.diff-toggle-file-icon')).toBeVisible();
@@ -316,6 +319,13 @@ test('mobile viewport opens a styled sidebar and returns to a usable composer', 
   const sidebar = page.locator('#sidebar');
   await expect(sidebar).toHaveClass(/open/);
   await expect(sidebar).toHaveCSS('visibility', 'visible');
+  await expect(sidebar).toHaveCSS('padding-top', '0px');
+  const [sidebarBox, sidebarHeaderBox] = await Promise.all([
+    sidebar.boundingBox(),
+    sidebar.locator('.sidebar-header').boundingBox(),
+  ]);
+  expect(sidebarHeaderBox?.y).toBe(sidebarBox?.y);
+  await expect(sidebar.locator('.sidebar-header')).toHaveCSS('padding-top', '72.6px');
   await expect(page.locator('#newChatBtn')).toHaveCSS('display', 'flex');
   await expect(page.locator('#newChatBtn svg')).toBeVisible();
   expect(await page.locator('#appMain').evaluate((element) => (element as HTMLElement).inert)).toBe(

--- a/frontend/src/styles/features/lightbox.css
+++ b/frontend/src/styles/features/lightbox.css
@@ -203,7 +203,7 @@
       transform var(--panel-transition-duration) var(--panel-transition-easing),
       visibility 0s linear var(--panel-transition-duration);
     box-shadow: none;
-    padding-top: var(--safe-top);
+    padding-top: 0;
     padding-bottom: var(--safe-bottom);
     visibility: hidden;
     pointer-events: none;

--- a/frontend/src/styles/integration/preact-overrides.css
+++ b/frontend/src/styles/integration/preact-overrides.css
@@ -833,7 +833,7 @@ mark.diff-word {
 
 @media (width <= 430px) {
   .header-title-context {
-    max-width: 7.5rem;
+    max-width: none;
   }
 
   .model-picker .narrow-header-action {


### PR DESCRIPTION
## Summary

- remove the duplicated mobile safe-area padding that pushed the sidebar header far below the iOS status bar
- let the session title use the otherwise-empty header space on narrow phones instead of capping it at 7.5rem
- extend the mobile browser test with a simulated 59px safe-area inset and a long runtime label

## Tests

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (367 passed)
- `scripts/browser_lifecycle_smoke.sh e2e/chat.spec.ts --project=mobile --grep "mobile viewport opens"`
