### PR TITLE
fix(web): derive running state from server transports

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -2839,7 +2839,7 @@ func (s *serveServer) cors(next http.HandlerFunc) http.HandlerFunc {
 			}
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Last-Event-ID, X-Term-LLM-Session-ID, X-Term-LLM-Draft-ID, X-Term-LLM-Push-Subscription-ID, session_id, Idempotency-Key, X-Idempotency-Key, X-Term-LLM-Request-ID, X-Term-LLM-UI-Version, X-API-Key, anthropic-version")
-			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number, x-response-id, x-branch-anchor-id, x-term-llm-ui-version")
+			w.Header().Set("Access-Control-Expose-Headers", "x-session-id, x-session-number, x-response-id, x-branch-anchor-id, x-term-llm-ui-version, x-term-llm-response-status")
 		}
 
 		w.Header().Set("X-Term-LLM-UI-Version", serveui.AssetVersion())

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -68,6 +68,7 @@ type responseRunSubscribeResult struct {
 	id               int
 	replay           []responseRunEvent
 	ch               <-chan responseRunEvent
+	status           string
 	snapshotRequired bool
 	minReplayAfter   int64
 }
@@ -1276,6 +1277,7 @@ func (r *responseRun) subscribe(after int64) responseRunSubscribeResult {
 
 	if after < r.minReplayAfter {
 		return responseRunSubscribeResult{
+			status:           r.status,
 			snapshotRequired: true,
 			minReplayAfter:   r.minReplayAfter,
 		}
@@ -1290,14 +1292,14 @@ func (r *responseRun) subscribe(after int64) responseRunSubscribeResult {
 	}
 
 	if r.status != "in_progress" {
-		return responseRunSubscribeResult{replay: replay}
+		return responseRunSubscribeResult{replay: replay, status: r.status}
 	}
 
 	id := r.nextSubscriberID
 	r.nextSubscriberID++
 	ch := make(chan responseRunEvent, defaultResponseRunSubscriberBuffer)
 	r.subscribers[id] = ch
-	return responseRunSubscribeResult{id: id, replay: replay, ch: ch}
+	return responseRunSubscribeResult{id: id, replay: replay, ch: ch, status: r.status}
 }
 
 func (r *responseRun) subscriberWasDropped(id int) bool {
@@ -3090,6 +3092,7 @@ func (s *serveServer) streamResponseRunEvents(ctx context.Context, w http.Respon
 		replayThrough = replay[len(replay)-1].Sequence
 	}
 	w.Header().Set("X-Term-LLM-Replay-Through", strconv.FormatInt(replayThrough, 10))
+	w.Header().Set("X-Term-LLM-Response-Status", subscription.status)
 	setSSEHeaders(w)
 	flusher.Flush()
 	ch := subscription.ch

--- a/cmd/serve_response_runs_test.go
+++ b/cmd/serve_response_runs_test.go
@@ -1187,7 +1187,21 @@ func TestStreamResponseRunEventsReportsAuthoritativeReplayBoundary(t *testing.T)
 			if got := response.Header.Get("X-Term-LLM-Replay-Through"); got != tc.want {
 				t.Fatalf("X-Term-LLM-Replay-Through = %q, want %q", got, tc.want)
 			}
+			if got := response.Header.Get("X-Term-LLM-Response-Status"); got != "completed" {
+				t.Fatalf("X-Term-LLM-Response-Status = %q, want completed", got)
+			}
 		})
+	}
+}
+
+func TestStreamResponseRunEventsReportsInProgressSubscription(t *testing.T) {
+	run := newResponseRun("resp_active_header", "sess_active_header", "", "mock", time.Now().Unix(), func() {})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recorder := httptest.NewRecorder()
+	(&serveServer{}).streamResponseRunEvents(ctx, recorder, run, 0)
+	if got := recorder.Result().Header.Get("X-Term-LLM-Response-Status"); got != "in_progress" {
+		t.Fatalf("X-Term-LLM-Response-Status = %q, want in_progress", got)
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -672,8 +672,11 @@ func TestServeCORSExposesUIVersionHeader(t *testing.T) {
 	if got := rr.Header().Get("X-Term-LLM-UI-Version"); got == "" {
 		t.Fatal("X-Term-LLM-UI-Version header missing")
 	}
-	if got := rr.Header().Get("Access-Control-Expose-Headers"); !strings.Contains(strings.ToLower(got), "x-term-llm-ui-version") {
-		t.Fatalf("Access-Control-Expose-Headers = %q, want x-term-llm-ui-version", got)
+	exposeHeaders := strings.ToLower(rr.Header().Get("Access-Control-Expose-Headers"))
+	for _, name := range []string{"x-term-llm-ui-version", "x-term-llm-response-status"} {
+		if !strings.Contains(exposeHeaders, name) {
+			t.Fatalf("Access-Control-Expose-Headers = %q, want %s", exposeHeaders, name)
+		}
 	}
 	allowHeaders := strings.ToLower(rr.Header().Get("Access-Control-Allow-Headers"))
 	for _, name := range []string{"x-term-llm-ui-version", strings.ToLower(requestSessionIDHeader), legacyRequestSessionIDHeader} {

--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -120,7 +120,11 @@ async function mockAPI(
       return route.fulfill({
         status: 200,
         contentType: 'text/event-stream',
-        headers: { 'x-response-id': 'r1', 'x-session-id': 's1' },
+        headers: {
+          'x-response-id': 'r1',
+          'x-session-id': 's1',
+          'x-term-llm-response-status': 'in_progress',
+        },
         body,
       });
     }
@@ -240,18 +244,21 @@ test('sends through public composer UI and reduces a streamed response', async (
   ).toBe(true);
 });
 
-test('cancels an active response from the public stop control', async ({ page }) => {
+test('drops the stop control when a response transport ends before completion', async ({
+  page,
+}) => {
   const requests = await open(page, '', { holdStream: true });
   await page.getByRole('textbox', { name: 'Message' }).fill('Long request');
   await page.getByRole('button', { name: 'Send message' }).click();
-  await page.locator('#stopBtn').click();
-  await expect
-    .poll(() =>
-      requests.some(
-        (entry) => entry.method === 'POST' && entry.url.endsWith('/v1/responses/r1/cancel'),
-      ),
-    )
-    .toBe(true);
+  await expect(page.locator('#stopBtn')).toBeHidden();
+  await expect(page.getByRole('status', { name: 'Response status is unknown' })).toContainText(
+    'Connection lost',
+  );
+  expect(
+    requests.some(
+      (entry) => entry.method === 'POST' && entry.url.endsWith('/v1/responses/r1/cancel'),
+    ),
+  ).toBe(false);
 });
 
 test('opens diff UI, expands a file and queues an inline comment', async ({ page }) => {
@@ -307,7 +314,10 @@ test('mobile viewport opens a styled sidebar and returns to a usable composer', 
   page,
 }, testInfo) => {
   test.skip(testInfo.project.name !== 'mobile', 'mobile-only interaction');
-  await open(page);
+  await open(page, '', { model: 'gpt-5.6-sol-high' });
+  await page.evaluate(() => document.documentElement.style.setProperty('--safe-top', '59px'));
+  const titleContext = page.locator('.header-title-context');
+  expect((await titleContext.boundingBox())?.width || 0).toBeGreaterThan(140);
   const diffToggle = page.getByRole('button', { name: 'Toggle file changes' });
   const mobileMenu = page.getByRole('button', { name: 'Open sidebar' });
   await expect(diffToggle.locator('.diff-toggle-file-icon')).toBeVisible();
@@ -316,6 +326,13 @@ test('mobile viewport opens a styled sidebar and returns to a usable composer', 
   const sidebar = page.locator('#sidebar');
   await expect(sidebar).toHaveClass(/open/);
   await expect(sidebar).toHaveCSS('visibility', 'visible');
+  await expect(sidebar).toHaveCSS('padding-top', '0px');
+  const [sidebarBox, sidebarHeaderBox] = await Promise.all([
+    sidebar.boundingBox(),
+    sidebar.locator('.sidebar-header').boundingBox(),
+  ]);
+  expect(sidebarHeaderBox?.y).toBe(sidebarBox?.y);
+  await expect(sidebar.locator('.sidebar-header')).toHaveCSS('padding-top', '72.6px');
   await expect(page.locator('#newChatBtn')).toHaveCSS('display', 'flex');
   await expect(page.locator('#newChatBtn svg')).toBeVisible();
   expect(await page.locator('#appMain').evaluate((element) => (element as HTMLElement).inert)).toBe(

--- a/frontend/e2e/real-server.spec.ts
+++ b/frontend/e2e/real-server.spec.ts
@@ -332,6 +332,70 @@ test('a suspended same-context tab resumes through authoritative reconciliation'
   await second.close();
 });
 
+test('a disconnected mobile response stream cannot keep claiming work is running', async ({
+  context,
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile', 'mobile disconnect recovery is covered once');
+  test.setTimeout(45_000);
+  await page.addInitScript(() => {
+    const NativePeer = window.RTCPeerConnection;
+    const peers: RTCPeerConnection[] = [];
+    Object.defineProperty(window, '__responseStreamTestPeers', { value: peers });
+    window.RTCPeerConnection = class extends NativePeer {
+      constructor(configuration?: RTCConfiguration) {
+        super(configuration);
+        peers.push(this);
+      }
+    };
+  });
+  await page.goto('./?new=1');
+  await page.getByRole('textbox', { name: 'Message' }).fill('sleep 5 response transport probe');
+  await page.getByRole('button', { name: 'Send message' }).click();
+  await expect(page.locator('#stopBtn')).toBeVisible();
+  const sessionID = decodeURIComponent(page.url().match(/\/chat\/([^/?#]+)/)?.[1] || '');
+  expect(sessionID).not.toBe('');
+
+  await context.setOffline(true);
+  await page.evaluate(() => {
+    const peers = (window as unknown as { __responseStreamTestPeers?: RTCPeerConnection[] })
+      .__responseStreamTestPeers;
+    peers?.forEach((peer) => peer.close());
+    window.stop();
+  });
+
+  const baseURL = String(testInfo.project.use.baseURL || '');
+  const sessionStatus = async () => {
+    const response = await fetch(
+      `${baseURL}v1/sessions/status?session_id=${encodeURIComponent(sessionID)}`,
+    );
+    const data = (await response.json()) as { sessions?: Array<Record<string, unknown>> };
+    return data.sessions?.find((entry) => String(entry.id || entry.session_id) === sessionID);
+  };
+  await expect.poll(async () => Boolean((await sessionStatus())?.active_run)).toBe(true);
+
+  await expect(page.locator('#stopBtn')).toBeHidden({ timeout: 5_000 });
+  await expect(page.getByRole('status', { name: 'Response status is unknown' })).toContainText(
+    'Connection lost',
+  );
+
+  await expect
+    .poll(
+      async () => {
+        const status = await sessionStatus();
+        return Boolean(status && !status.active_run && !status.active_response_id);
+      },
+      { timeout: 15_000 },
+    )
+    .toBe(true);
+
+  await context.setOffline(false);
+  await expect(page.getByRole('heading', { name: 'Debug Provider Output' }).last()).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('status', { name: 'Response status is unknown' })).toBeHidden();
+});
+
 test('real status endpoint honors browser conditional requests', async ({ page }) => {
   await page.goto('./');
   const result = await page.evaluate(async () => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -227,11 +227,11 @@ function SessionRow({ session }: { session: Session }) {
   const active = store.activeSessionId.value === session.id;
   const projection = store.runs.value[session.id];
   const running =
-    Boolean(session.activeRun) ||
     Boolean(
       projection &&
-      ['connecting', 'checking', 'streaming', 'cancelling'].includes(projection.run.status),
-    );
+      ['connecting', 'checking', 'streaming', 'cancelling'].includes(projection.run.status) &&
+      store.runEngine.hasActiveResponseTransport(session.id, projection.run.responseId),
+    ) || Boolean(store.services.eventFeedHealthy.value && session.activeRun);
   const messageCount = sessionMessageCount(session);
   const activityAt = session.lastMessageAt || session.created;
   const hide = () => {

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -769,6 +769,10 @@ export function Transcript() {
   const showActivity = Boolean(
     store.streaming.value && activity && !(streamingText && activity.kind === 'working'),
   );
+  const livenessUnknown = store.runLivenessUnknown.value;
+  const livenessText = activeRun?.run.responseId.startsWith('pending_')
+    ? 'Waiting for server confirmation…'
+    : 'Connection lost — checking status…';
   return (
     <section
       class="chat-scroll"
@@ -830,6 +834,7 @@ export function Transcript() {
             run.messages?.map((message) => {
               const context = rowContexts.get(message);
               const streaming = Boolean(
+                store.streaming.value &&
                 activeRun &&
                 message.role === 'assistant' &&
                 message.responseId === activeRun.run.responseId &&
@@ -855,6 +860,16 @@ export function Transcript() {
         {activeRun?.modelSwap && (
           <div class="message model-swap transient" role="status">
             {activeRun.modelSwap.content}
+          </div>
+        )}
+        {livenessUnknown && (
+          <div
+            class="streaming-indicator streaming-indicator-unknown"
+            role="status"
+            aria-live="polite"
+            aria-label="Response status is unknown"
+          >
+            <span class="streaming-indicator-text">{livenessText}</span>
           </div>
         )}
         {showActivity && activity && (

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -1074,6 +1074,7 @@ describe('Preact-owned chat surfaces', () => {
         ],
       },
     };
+    store.runEngine.markResponseTransportActive('s1', 'response-1');
     store.currentPlan.value = {
       plan: [{ step: 'Implement the semantic activity label', status: 'in_progress' }],
     };
@@ -1128,6 +1129,7 @@ describe('Preact-owned chat surfaces', () => {
         reconnects: 0,
       }),
     };
+    store.runEngine.markResponseTransportActive('s1', 'response-1');
     render(
       <StoreContext.Provider value={store}>
         <Transcript />
@@ -1162,6 +1164,48 @@ describe('Preact-owned chat surfaces', () => {
     expect(
       screen.queryByRole('status', { name: 'Assistant is responding: Working' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('stops claiming a response is running when its owned transport is lost', () => {
+    const store = createStore();
+    try {
+      store.runs.value = {
+        s1: initialProjection({
+          responseId: 'r1',
+          sessionId: 's1',
+          epoch: 1,
+          status: 'streaming',
+          lastSequence: 1,
+          startedRev: 0,
+          reconnects: 0,
+        }),
+      };
+      store.runEngine.markResponseTransportActive('s1', 'r1');
+      render(
+        <StoreContext.Provider value={store}>
+          <Transcript />
+          <Composer />
+        </StoreContext.Provider>,
+      );
+
+      expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('status', { name: 'Assistant is responding: Working' }),
+      ).toBeInTheDocument();
+
+      act(() => store.runEngine.clearResponseTransport('s1', 'r1'));
+
+      expect(screen.queryByRole('button', { name: 'Stop' })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('status', { name: 'Assistant is responding: Working' }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('status', { name: 'Response status is unknown' })).toHaveTextContent(
+        'Connection lost — checking status…',
+      );
+      expect(screen.getByRole('button', { name: 'Checking whether sent' })).toBeDisabled();
+    } finally {
+      store.dispose();
+    }
   });
 
   it('formats tool parameters as readable typed rows and preserves partial argument fallbacks', async () => {
@@ -2004,6 +2048,7 @@ describe('Preact-owned chat surfaces', () => {
         reconnects: 0,
       }),
     };
+    store.runEngine.markResponseTransportActive('s1', 'r1');
     render(
       <StoreContext.Provider value={store}>
         <Composer />
@@ -2221,6 +2266,7 @@ describe('Preact-owned chat surfaces', () => {
       ...entry,
       activeRun: true,
     }));
+    store.services.eventFeedHealthy.value = true;
 
     const { container } = render(
       <StoreContext.Provider value={store}>
@@ -2314,6 +2360,7 @@ describe('Preact-owned chat surfaces', () => {
         reconnects: 0,
       }),
     };
+    store.runEngine.markResponseTransportActive('s1', 'r1');
 
     const { container } = render(
       <StoreContext.Provider value={store}>

--- a/frontend/src/stores/app-store-services.ts
+++ b/frontend/src/stores/app-store-services.ts
@@ -38,6 +38,7 @@ export class AppStoreServices {
   readonly authRequired = signal(false);
   readonly networkState = signal<'unknown' | 'online' | 'offline' | 'retrying'>('unknown');
   readonly connected = signal(false);
+  readonly eventFeedHealthy = signal(false);
   readonly toasts = signal<Toast[]>([]);
   readonly diagnostics = signal<StoreDiagnostics>({
     staleStatusResults: 0,

--- a/frontend/src/stores/app-store.test.ts
+++ b/frontend/src/stores/app-store.test.ts
@@ -2137,6 +2137,70 @@ describe('AppStore compatibility behavior', () => {
     expect(store.sessions.value[0]).toMatchObject({ activeRun: false, activeResponseId: null });
   });
 
+  it('blocks a duplicate send when status reports a remote run before this tab attaches', () => {
+    const store = new AppStore(config);
+    try {
+      store.sessions.value = [{ ...session(), activeRun: true, activeResponseId: 'remote-r1' }];
+      store.activeSessionId.value = 's1';
+
+      expect(store.runs.value).toEqual({});
+      expect(store.streaming.value).toBe(false);
+      expect(store.sendBlocked.value).toBe(true);
+    } finally {
+      store.dispose();
+    }
+  });
+
+  it('uses the owned response transport for running state without declaring completion on loss', () => {
+    const store = new AppStore(config);
+    try {
+      store.sessions.value = [{ ...session(), activeRun: true, activeResponseId: 'r1' }];
+      store.activeSessionId.value = 's1';
+      store.runs.value = {
+        s1: initialProjection({
+          responseId: 'r1',
+          sessionId: 's1',
+          epoch: 1,
+          status: 'streaming',
+          lastSequence: 1,
+          startedRev: 0,
+          reconnects: 0,
+        }),
+      };
+
+      expect(store.streaming.value).toBe(false);
+      expect(store.runLivenessUnknown.value).toBe(true);
+      expect(store.sendBlocked.value).toBe(true);
+
+      store.runEngine.markResponseTransportActive('s1', 'r1', 1);
+      expect(store.streaming.value).toBe(true);
+      expect(store.runLivenessUnknown.value).toBe(false);
+
+      store.runEngine.markResponseTransportActive('s1', 'r1', 2);
+      store.runEngine.clearResponseTransport('s1', 'r1', 1);
+      expect(store.streaming.value).toBe(true);
+
+      store.runEngine.clearResponseTransport('s1', 'r1', 2);
+      expect(store.streaming.value).toBe(false);
+      expect(store.runLivenessUnknown.value).toBe(true);
+      expect(store.runs.value.s1.run.status).toBe('streaming');
+      expect(store.sendBlocked.value).toBe(true);
+
+      store.runEngine.markResponseTransportActive('s1', 'r1', 2);
+      store.applyResponseEvent('s1', {
+        type: 'response.output_text.delta',
+        response_id: 'r1',
+        run_epoch: 1,
+        sequence_number: 2,
+        delta: 'still alive',
+      });
+      expect(store.streaming.value).toBe(true);
+      expect(store.runLivenessUnknown.value).toBe(false);
+    } finally {
+      store.dispose();
+    }
+  });
+
   it('reconciles a locally running response when the server reports the session idle', async () => {
     const store = new AppStore(config);
     store.sessions.value = [
@@ -2361,6 +2425,7 @@ describe('AppStore compatibility behavior', () => {
   it('does not let an idle status response invalidate a run admitted after the request began', async () => {
     const store = new AppStore(config);
     store.sessions.value = [session()];
+    store.activeSessionId.value = 's1';
     const status = deferred<Record<string, unknown>>();
     store.endpoints.sessionStatus = vi.fn(() => status.promise);
     const internals = store as unknown as {
@@ -2385,6 +2450,7 @@ describe('AppStore compatibility behavior', () => {
         reconnects: 0,
       }),
     };
+    store.runEngine.markResponseTransportActive('s1', 'newly-admitted-response');
     status.resolve({ sessions: [{ id: 's1' }] });
     await refresh;
 
@@ -2392,6 +2458,7 @@ describe('AppStore compatibility behavior', () => {
       activeRun: true,
       activeResponseId: 'newly-admitted-response',
     });
+    expect(store.streaming.value).toBe(true);
     expect(internals.resumeResponse).not.toHaveBeenCalled();
   });
 
@@ -3066,6 +3133,7 @@ describe('AppStore compatibility behavior', () => {
         reconnects: 0,
       }),
     };
+    store.runEngine.markResponseTransportActive('s1', 'r1');
     store.queueDiffComment({
       id: 'queued-comment',
       path: 'main.go',
@@ -3131,6 +3199,7 @@ describe('AppStore compatibility behavior', () => {
         reconnects: 0,
       }),
     };
+    store.runEngine.markResponseTransportActive('s1', 'r1');
     store.refreshDiffComments = vi.fn(async () => undefined);
     store.endpoints.interrupt = vi.fn(async () => ({}));
 

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -197,6 +197,7 @@ export class AppStore {
   readonly activeProjection: ReadonlySignal<ResponseProjection | null>;
   readonly visibleMessages: ReadonlySignal<Message[]>;
   readonly streaming: ReadonlySignal<boolean>;
+  readonly runLivenessUnknown: ReadonlySignal<boolean>;
   readonly sendBlocked: ReadonlySignal<boolean>;
 
   private lifecycleInstalled = false;
@@ -383,6 +384,7 @@ export class AppStore {
     this.activeProjection = this.runEngine.activeProjection;
     this.visibleMessages = this.runEngine.visibleMessages;
     this.streaming = this.runEngine.streaming;
+    this.runLivenessUnknown = this.runEngine.runLivenessUnknown;
     this.sendBlocked = this.runEngine.sendBlocked;
     this.locallyStoppedResponses = this.runEngine.locallyStoppedResponses;
     this.widgetStore = new WidgetStore(this.services);

--- a/frontend/src/stores/run-engine.ts
+++ b/frontend/src/stores/run-engine.ts
@@ -73,9 +73,13 @@ export class RunEngine {
   readonly activeProjection: ReadonlySignal<ResponseProjection | null>;
   readonly visibleMessages: ReadonlySignal<Message[]>;
   readonly streaming: ReadonlySignal<boolean>;
+  readonly runLivenessUnknown: ReadonlySignal<boolean>;
   readonly sendBlocked: ReadonlySignal<boolean>;
 
   private readonly supervisors = new StreamSupervisors();
+  private readonly activeResponseTransports = signal<
+    Record<string, { responseId: string; generation: number }>
+  >({});
   readonly locallyStoppedResponses = new Set<string>();
   private readonly retiredResponses = new Set<string>();
   private readonly handledCompletionEvents = new Set<string>();
@@ -119,19 +123,65 @@ export class RunEngine {
         }));
       return [...messages, ...pending];
     });
-    this.streaming = computed(() =>
-      ['connecting', 'checking', 'streaming', 'cancelling'].includes(
-        this.activeProjection.value?.run.status || '',
-      ),
-    );
+    this.streaming = computed(() => {
+      const projection = this.activeProjection.value;
+      return Boolean(
+        projection &&
+        ['connecting', 'checking', 'streaming', 'cancelling'].includes(projection.run.status) &&
+        this.hasActiveResponseTransport(projection.run.sessionId, projection.run.responseId),
+      );
+    });
+    this.runLivenessUnknown = computed(() => {
+      const projection = this.activeProjection.value;
+      return Boolean(
+        projection &&
+        ['connecting', 'checking', 'streaming', 'cancelling'].includes(projection.run.status) &&
+        !this.hasActiveResponseTransport(projection.run.sessionId, projection.run.responseId),
+      );
+    });
     this.sendBlocked = computed(
       () =>
         composer.sendPending.value ||
+        this.runLivenessUnknown.value ||
+        Boolean(sessionStore.activeSession.value?.activeRun && !this.streaming.value) ||
         Boolean(
           this.pendingIntents.value[sessionStore.activeSessionId.value]?.some(
             (intent) => intent.state === 'checking',
           ),
         ),
+    );
+  }
+
+  markResponseTransportActive(sessionId: string, responseId: string, generation = 0): void {
+    const current = this.activeResponseTransports.peek()[sessionId];
+    if (
+      !sessionId ||
+      !responseId ||
+      (current?.responseId === responseId && current.generation === generation)
+    )
+      return;
+    this.activeResponseTransports.value = {
+      ...this.activeResponseTransports.peek(),
+      [sessionId]: { responseId, generation },
+    };
+  }
+
+  clearResponseTransport(sessionId: string, responseId = '', generation?: number): void {
+    const current = this.activeResponseTransports.peek()[sessionId];
+    if (
+      !current ||
+      (responseId && current.responseId !== responseId) ||
+      (generation !== undefined && current.generation !== generation)
+    )
+      return;
+    const next = { ...this.activeResponseTransports.peek() };
+    delete next[sessionId];
+    this.activeResponseTransports.value = next;
+  }
+
+  hasActiveResponseTransport(sessionId: string, responseId: string): boolean {
+    return Boolean(
+      responseId && this.activeResponseTransports.value[sessionId]?.responseId === responseId,
     );
   }
 
@@ -537,7 +587,16 @@ export class RunEngine {
       },
     };
     const transportGeneration = streamOwner.transportGeneration;
-    await this.consumeResponseBody(response.body, streamOwner, transportGeneration);
+    const serverReportedInProgress =
+      response.headers.get('x-term-llm-response-status') === 'in_progress';
+    if (serverReportedInProgress)
+      this.markResponseTransportActive(ownerID, responseId, transportGeneration);
+    await this.consumeResponseBody(
+      response.body,
+      streamOwner,
+      transportGeneration,
+      serverReportedInProgress,
+    );
     if (!this.supervisors.ownsTransport(streamOwner, transportGeneration)) return ownerID;
     const current = this.runs.value[ownerID];
     if (current && ['connecting', 'streaming'].includes(current.run.status))
@@ -602,6 +661,7 @@ export class RunEngine {
     body: ReadableStream<Uint8Array>,
     owner: StreamSupervisor,
     transportGeneration = owner.transportGeneration,
+    serverReportedInProgress = false,
   ): Promise<boolean> {
     let cleanCompletion = false;
     const watchdog = () =>
@@ -615,9 +675,14 @@ export class RunEngine {
         },
         35_000,
       );
+    const transportActivity = () => {
+      if (serverReportedInProgress && this.supervisors.ownsTransport(owner, transportGeneration))
+        this.markResponseTransportActive(owner.sessionId, owner.responseId, transportGeneration);
+      watchdog();
+    };
     watchdog();
     try {
-      for await (const frame of decodeSSE(body, owner.abort.signal, watchdog)) {
+      for await (const frame of decodeSSE(body, owner.abort.signal, transportActivity)) {
         if (!this.supervisors.ownsTransport(owner, transportGeneration)) {
           this.services.bumpDiagnostic('staleStreamCallbacks');
           return false;
@@ -640,6 +705,7 @@ export class RunEngine {
       }
       return cleanCompletion;
     } finally {
+      this.clearResponseTransport(owner.sessionId, owner.responseId, transportGeneration);
       this.supervisors.clearWatchdog(owner, transportGeneration);
     }
   }
@@ -672,7 +738,16 @@ export class RunEngine {
         return;
       if (!response.ok || !response.body)
         throw new Error(`Response stream returned ${response.status}`);
-      const clean = await this.consumeResponseBody(response.body, owner, transportGeneration);
+      const serverReportedInProgress =
+        response.headers.get('x-term-llm-response-status') === 'in_progress';
+      if (serverReportedInProgress)
+        this.markResponseTransportActive(owner.sessionId, owner.responseId, transportGeneration);
+      const clean = await this.consumeResponseBody(
+        response.body,
+        owner,
+        transportGeneration,
+        serverReportedInProgress,
+      );
       if (!this.supervisors.ownsTransport(owner, transportGeneration) || abort.signal.aborted)
         return;
       const projection = this.runs.peek()[owner.sessionId];
@@ -682,6 +757,8 @@ export class RunEngine {
         ['completed', 'cancelled', 'failed'].includes(projection.run.status)
       )
         this.supervisors.retire(owner);
+      else if (clean && projection)
+        this.scheduleSupervisorRetry(owner, new Error('Response ended before terminal event'));
       else if (!clean && projection && ['connecting', 'streaming'].includes(projection.run.status))
         this.scheduleSupervisorRetry(owner, new Error('Response stream ended before completion'));
     } catch (error) {
@@ -752,6 +829,12 @@ export class RunEngine {
         void this.host.resumeResponse(sessionId, current.run.responseId);
       return;
     }
+    if (owner)
+      this.markResponseTransportActive(
+        sessionId,
+        current.run.responseId,
+        owner.transportGeneration,
+      );
     let next: ResponseProjection;
     try {
       next = reduceResponse(current, event);
@@ -874,6 +957,7 @@ export class RunEngine {
         }
       }
       this.locallyStoppedResponses.delete(next.run.responseId);
+      this.clearResponseTransport(sessionId, next.run.responseId);
       this.retireIntent(sessionId);
       this.sessionStore.patch(sessionId, {
         activeResponseId: null,
@@ -1185,6 +1269,7 @@ export class RunEngine {
         },
       };
       if (!this.supervisors.checkpoint(owner, transportGeneration, snapshotSequence)) return;
+      if (terminal) this.clearResponseTransport(sessionId, responseId);
       const recoveredClientIDs = new Set(
         projected
           .map((message) => message.clientMessageId)

--- a/frontend/src/stores/server-event-coordinator.test.ts
+++ b/frontend/src/stores/server-event-coordinator.test.ts
@@ -68,16 +68,23 @@ function harness() {
   const services = {
     endpoints,
     isDisposed: false,
+    eventFeedHealthy: signal(false),
     bumpDiagnostic: (key: string) => diagnostics.push(key),
   } as unknown as AppStoreServices;
-  return { coordinator: new ServerEventCoordinator(services, host), endpoints, diagnostics, calls };
+  return {
+    coordinator: new ServerEventCoordinator(services, host),
+    services,
+    endpoints,
+    diagnostics,
+    calls,
+  };
 }
 
 afterEach(() => vi.useRealTimers());
 
 describe('ServerEventCoordinator', () => {
   it('reconnects SSE directly when interests change without reporting a poll fallback', async () => {
-    const { coordinator, endpoints, diagnostics } = harness();
+    const { coordinator, services, endpoints, diagnostics } = harness();
     const ready = new TextEncoder().encode(
       `event: ready\ndata: ${JSON.stringify({
         v: 1,
@@ -107,11 +114,13 @@ describe('ServerEventCoordinator', () => {
     coordinator.updateInterest('s1');
     await coordinator.prepare();
     expect(coordinator.isHealthy()).toBe(true);
+    expect(services.eventFeedHealthy.value).toBe(true);
     coordinator.updateInterest('s2');
     await vi.waitFor(() => expect(endpoints.serverEventStream).toHaveBeenCalledTimes(2));
     expect(endpoints.serverEventPoll).not.toHaveBeenCalled();
     expect(diagnostics).not.toContain('serverEventPollFallbacks');
     coordinator.dispose();
+    expect(services.eventFeedHealthy.value).toBe(false);
   });
 
   it('runs authoritative recovery for a snapshot-required event', async () => {

--- a/frontend/src/stores/server-event-coordinator.ts
+++ b/frontend/src/stores/server-event-coordinator.ts
@@ -127,6 +127,7 @@ export class ServerEventCoordinator {
   private setMode(mode: ServerEventTransport): void {
     const wasHealthy = this.isHealthy();
     this.mode = mode;
+    this.services.eventFeedHealthy.value = this.isHealthy();
     if (
       wasHealthy &&
       !this.isHealthy() &&
@@ -425,6 +426,7 @@ export class ServerEventCoordinator {
     this.transport?.abort(this.lifetime.signal.reason);
     window.clearTimeout(this.flushTimer);
     this.mode = 'stopped';
+    this.services.eventFeedHealthy.value = false;
     this.markPrepared();
   }
 }

--- a/frontend/src/styles/features/lightbox.css
+++ b/frontend/src/styles/features/lightbox.css
@@ -203,7 +203,7 @@
       transform var(--panel-transition-duration) var(--panel-transition-easing),
       visibility 0s linear var(--panel-transition-duration);
     box-shadow: none;
-    padding-top: var(--safe-top);
+    padding-top: 0;
     padding-bottom: var(--safe-bottom);
     visibility: hidden;
     pointer-events: none;

--- a/frontend/src/styles/integration/preact-overrides.css
+++ b/frontend/src/styles/integration/preact-overrides.css
@@ -370,6 +370,12 @@
   }
 }
 
+.streaming-indicator-unknown .streaming-indicator-text {
+  background-image: none;
+  color: var(--text-muted);
+  animation: none;
+}
+
 @keyframes streaming-status-enter {
   from {
     opacity: 0;
@@ -833,7 +839,7 @@ mark.diff-word {
 
 @media (width <= 430px) {
   .header-title-context {
-    max-width: 7.5rem;
+    max-width: none;
   }
 
   .model-picker .narrow-header-action {

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -35,7 +35,7 @@ func TestProductionBundleSizeBudgets(t *testing.T) {
 		// replayable SSE/long-poll server-event coordination, and branch-tree
 		// navigation are first-party shell code. Keep bounded headroom over that
 		// productized baseline while still failing meaningful accidental regressions.
-		"dist/app.js":  {raw: 416_000, gzip: 124_000},
+		"dist/app.js":  {raw: 417_000, gzip: 124_000},
 		"dist/app.css": {raw: 160_000, gzip: 30_500},
 	}
 	for name, budget := range budgets {


### PR DESCRIPTION
## Summary

- derive local response "running" state from ownership of a healthy server-authored response event transport, not a client wall-clock lease
- expose the response status captured with the server's subscribe decision via `X-Term-LLM-Response-Status`, including CORS support
- treat terminal events and clean `[DONE]` as ending the running claim; treat abrupt EOF/network failure as unknown and recover through a bounded snapshot/resubscribe path
- gate remote-session running indicators on the health of the global `/v1/events` feed
- hide Working/Stop and show `Connection lost — checking status…` when a nonterminal projection loses transport authority
- block duplicate sends while response liveness is unknown or a remote active run has not yet been attached
- scope response transport ownership by generation so stale cleanup cannot clear a newer stream

The invariant is: the Web UI may claim a response is running only while it owns current server-authored event transport evidence for that response.

The added UI logic produces a 416,155-byte raw app bundle, so the raw budget moves from 416,000 to 417,000 bytes (+1,000); the 124,000-byte gzip budget is unchanged.

## Tests

- `npm --prefix frontend test` — 370 passed
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run lint:ts`
- `go test ./cmd -run 'TestStreamResponseRunEventsReports|TestServeCORSMiddleware'`
- `go test ./internal/serveui`
- real-server mobile browser smoke: disconnect the response transport while the server still reports `active_run=true`, verify Working/Stop disappear immediately, then reconnect and recover

The first CI run also hit the unrelated flaky `TestGrokBinProviderNativeInterruptEndsActiveProseTurn`; it passes locally across three consecutive runs.
