### PR TITLE
perf(web): smooth streamed markdown bursts

### DIFF
--- a/frontend/e2e/real-server.spec.ts
+++ b/frontend/e2e/real-server.spec.ts
@@ -293,14 +293,19 @@ test('recovers, neutrally dismisses, and resolves a real approval', async ({ pag
   await page.reload();
 
   const title = 'Write Access Request';
-  await expect(page.getByRole('dialog', { name: title })).toBeVisible();
+  const decisionBanner = page.getByRole('button', { name: 'Decision waiting — Open' });
+  const approvalDialog = page.getByRole('dialog', { name: title });
+  await expect(approvalDialog).toBeVisible();
   await page.keyboard.press('Escape');
-  await expect(page.getByText('Decision waiting — Open')).toBeVisible();
-  await page.getByText('Decision waiting — Open').click();
+  await expect(approvalDialog).toBeHidden();
+  await expect(page.locator('.modal-overlay')).toHaveCount(0);
+  await expect(decisionBanner).toBeVisible();
+  await decisionBanner.click();
   await page.getByRole('button', { name: 'Approve' }).click();
-  await expect(page.getByText('Decision waiting — Open')).toBeHidden();
+  await expect(decisionBanner).toBeHidden();
+  await expect(page.locator('.modal-overlay')).toHaveCount(0);
   await page.reload();
-  await expect(page.getByRole('dialog', { name: title })).toBeHidden();
+  await expect(approvalDialog).toBeHidden();
 });
 
 test('a suspended same-context tab resumes through authoritative reconciliation', async ({

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -180,7 +180,9 @@ class AssistantStreamRenderer {
   }
 
   setRebase(rebase?: (value: string) => string): void {
+    if (this.rebase === rebase) return;
     this.rebase = rebase;
+    if (this.finalized && rebase) rebaseRenderedAssetURLs(this.root, rebase);
   }
 
   private decorate(root: HTMLElement, source: string, copyCode: boolean): void {
@@ -357,6 +359,7 @@ class AssistantStreamRenderer {
   }
 
   finalize(source: string): void {
+    if (this.finalized && source === this.latestSource) return;
     if (!this.hasStreamed) {
       this.renderStatic(source);
       return;

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,13 +1,14 @@
 import { copyText } from '../platform/browser';
-import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import {
   analyzeStreamingMarkdown,
   canStreamPlainTextTailIncremental,
   createStreamingState,
+  elasticStreamingStep,
+  ELASTIC_STREAM_FRAME_MS,
   findNextFencedCodeBlock,
   hasIncrementalGlobalMarkdownSyntax,
   inspectFencedCodeBlock,
-  nextStreamingRenderDelay,
   type ActiveFencedCodeBlock,
   type StreamingMarkdownState,
 } from '../domain/markdown-streaming';
@@ -47,35 +48,81 @@ function addCodeCopyButtons(root: HTMLElement): void {
   });
 }
 
+function safePrefixEnd(value: string, requested: number): number {
+  let end = Math.max(0, Math.min(value.length, requested));
+  if (
+    end > 0 &&
+    end < value.length &&
+    /[\uD800-\uDBFF]/.test(value[end - 1]) &&
+    /[\uDC00-\uDFFF]/.test(value[end])
+  )
+    end += 1;
+  return end;
+}
+
 function useAdaptiveStreamingValue(value: string, streaming: boolean): string {
   const [rendered, setRendered] = useState(value);
+  const renderedRef = useRef(value);
   const latest = useRef(value);
   const timer = useRef<number | null>(null);
-  const lastRender = useRef(performance.now());
+  const lastTick = useRef(performance.now());
+  const remainder = useRef(0);
+
+  const publish = useCallback((next: string) => {
+    renderedRef.current = next;
+    setRendered(next);
+  }, []);
+  const cancel = useCallback(() => {
+    if (timer.current !== null) clearTimeout(timer.current);
+    timer.current = null;
+  }, []);
+  const schedule = useCallback(() => {
+    if (timer.current !== null) return;
+    timer.current = window.setTimeout(() => {
+      timer.current = null;
+      const target = latest.current;
+      const current = renderedRef.current;
+      if (target === current) return;
+      if (!target.startsWith(current)) {
+        remainder.current = 0;
+        lastTick.current = performance.now();
+        publish(target);
+        return;
+      }
+
+      const now = performance.now();
+      const step = elasticStreamingStep(
+        target.length - current.length,
+        now - lastTick.current,
+        remainder.current,
+      );
+      lastTick.current = now;
+      remainder.current = step.remainder;
+      const end = safePrefixEnd(target, current.length + step.characters);
+      publish(target.slice(0, end));
+      if (end < target.length) schedule();
+    }, ELASTIC_STREAM_FRAME_MS);
+  }, [publish]);
+
   useEffect(() => {
     latest.current = value;
     if (!streaming) {
-      if (timer.current !== null) clearTimeout(timer.current);
-      timer.current = null;
-      lastRender.current = performance.now();
-      setRendered(value);
+      cancel();
+      remainder.current = 0;
+      lastTick.current = performance.now();
+      if (renderedRef.current !== value) publish(value);
       return;
     }
-    if (value === rendered || timer.current !== null) return;
-    const delay = nextStreamingRenderDelay(value.length);
-    const wait = Math.max(0, delay - (performance.now() - lastRender.current));
-    timer.current = window.setTimeout(() => {
-      timer.current = null;
-      lastRender.current = performance.now();
-      setRendered(latest.current);
-    }, wait);
-  }, [value, streaming, rendered]);
-  useEffect(
-    () => () => {
-      if (timer.current !== null) clearTimeout(timer.current);
-    },
-    [],
-  );
+    if (!value.startsWith(renderedRef.current)) {
+      cancel();
+      remainder.current = 0;
+      lastTick.current = performance.now();
+      publish(value);
+      return;
+    }
+    if (value !== renderedRef.current) schedule();
+  }, [value, streaming, cancel, publish, schedule]);
+  useEffect(() => () => cancel(), [cancel]);
   return streaming ? rendered : value;
 }
 

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -122,6 +122,10 @@ function useAdaptiveStreamingValue(value: string, streaming: boolean): string {
       if (renderedRef.current !== value) publish(value);
       return;
     }
+    if (document.hidden) {
+      cancel();
+      return;
+    }
     if (!value.startsWith(renderedRef.current)) {
       cancel();
       remainder.current = 0;
@@ -133,15 +137,14 @@ function useAdaptiveStreamingValue(value: string, streaming: boolean): string {
   }, [value, streaming, cancel, publish, schedule]);
   useEffect(() => {
     if (!streaming) return;
-    const flushHidden = () => {
-      if (!document.hidden) return;
+    const flushVisibilityTransition = () => {
       cancel();
       remainder.current = 0;
       lastTick.current = performance.now();
       if (renderedRef.current !== latest.current) publish(latest.current);
     };
-    document.addEventListener('visibilitychange', flushHidden);
-    return () => document.removeEventListener('visibilitychange', flushHidden);
+    document.addEventListener('visibilitychange', flushVisibilityTransition);
+    return () => document.removeEventListener('visibilitychange', flushVisibilityTransition);
   }, [streaming, cancel, publish]);
   useEffect(() => () => cancel(), [cancel]);
   return streaming ? rendered : value;

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -4,8 +4,8 @@ import {
   analyzeStreamingMarkdown,
   canStreamPlainTextTailIncremental,
   createStreamingState,
+  elasticStreamingFrameDelay,
   elasticStreamingStep,
-  ELASTIC_STREAM_FRAME_MS,
   findNextFencedCodeBlock,
   hasIncrementalGlobalMarkdownSyntax,
   inspectFencedCodeBlock,
@@ -50,11 +50,15 @@ function addCodeCopyButtons(root: HTMLElement): void {
 
 function safePrefixEnd(value: string, requested: number): number {
   let end = Math.max(0, Math.min(value.length, requested));
+  const previous = value.charCodeAt(end - 1);
+  const next = value.charCodeAt(end);
   if (
     end > 0 &&
     end < value.length &&
-    /[\uD800-\uDBFF]/.test(value[end - 1]) &&
-    /[\uDC00-\uDFFF]/.test(value[end])
+    previous >= 0xd800 &&
+    previous <= 0xdbff &&
+    next >= 0xdc00 &&
+    next <= 0xdfff
   )
     end += 1;
   return end;
@@ -64,6 +68,7 @@ function useAdaptiveStreamingValue(value: string, streaming: boolean): string {
   const [rendered, setRendered] = useState(value);
   const renderedRef = useRef(value);
   const latest = useRef(value);
+  latest.current = value;
   const timer = useRef<number | null>(null);
   const lastTick = useRef(performance.now());
   const remainder = useRef(0);
@@ -82,7 +87,11 @@ function useAdaptiveStreamingValue(value: string, streaming: boolean): string {
       timer.current = null;
       const target = latest.current;
       const current = renderedRef.current;
-      if (target === current) return;
+      if (target === current) {
+        remainder.current = 0;
+        lastTick.current = performance.now();
+        return;
+      }
       if (!target.startsWith(current)) {
         remainder.current = 0;
         lastTick.current = performance.now();
@@ -101,7 +110,7 @@ function useAdaptiveStreamingValue(value: string, streaming: boolean): string {
       const end = safePrefixEnd(target, current.length + step.characters);
       publish(target.slice(0, end));
       if (end < target.length) schedule();
-    }, ELASTIC_STREAM_FRAME_MS);
+    }, elasticStreamingFrameDelay(latest.current.length));
   }, [publish]);
 
   useEffect(() => {
@@ -122,6 +131,18 @@ function useAdaptiveStreamingValue(value: string, streaming: boolean): string {
     }
     if (value !== renderedRef.current) schedule();
   }, [value, streaming, cancel, publish, schedule]);
+  useEffect(() => {
+    if (!streaming) return;
+    const flushHidden = () => {
+      if (!document.hidden) return;
+      cancel();
+      remainder.current = 0;
+      lastTick.current = performance.now();
+      if (renderedRef.current !== latest.current) publish(latest.current);
+    };
+    document.addEventListener('visibilitychange', flushHidden);
+    return () => document.removeEventListener('visibilitychange', flushHidden);
+  }, [streaming, cancel, publish]);
   useEffect(() => () => cancel(), [cancel]);
   return streaming ? rendered : value;
 }

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { Message, ToolCall } from '../domain/types';
 import { indexTranscriptTurns, windowTranscript } from '../domain/transcript';
 import { useStore } from '../app/context';
@@ -478,7 +478,10 @@ function MessageRow({
 }) {
   const store = useStore();
   const [expanded, setExpanded] = useState(false);
-  const rebase = (value: string) => rebaseHubAssetURL(store.config, value);
+  const rebase = useCallback(
+    (value: string) => rebaseHubAssetURL(store.config, value),
+    [store.config],
+  );
   const media = (src: string, type: 'image' | 'video') => {
     if (!streaming) openMediaGallery(store, src, type);
   };
@@ -695,6 +698,7 @@ export function Transcript() {
   const scroll = useRef<HTMLElement>(null);
   const content = useRef<HTMLDivElement>(null);
   const stickToTail = useRef(true);
+  const programmaticScrollTops = useRef<number[]>([]);
   const touchY = useRef<number | null>(null);
   const [nearTail, setNearTail] = useState(true);
   const [turnLimit, setTurnLimit] = useState(80);
@@ -725,7 +729,13 @@ export function Transcript() {
     stickToTail.current = true;
     setNearTail(true);
     const scrollToTail = () => {
-      if (stickToTail.current) element.scrollTop = element.scrollHeight;
+      if (!stickToTail.current) return;
+      element.scrollTop = element.scrollHeight;
+      const pinnedTop = element.scrollTop;
+      const recentTops = programmaticScrollTops.current;
+      if (recentTops.at(-1) !== pinnedTop) {
+        programmaticScrollTops.current = [...recentTops.slice(-7), pinnedTop];
+      }
     };
     const forceScrollToTail = () => {
       stickToTail.current = true;
@@ -747,7 +757,14 @@ export function Transcript() {
   }, [store.activeSession.value?.id]);
   useLayoutEffect(() => {
     const element = scroll.current;
-    if (element && stickToTail.current) element.scrollTop = element.scrollHeight;
+    if (element && stickToTail.current) {
+      element.scrollTop = element.scrollHeight;
+      const pinnedTop = element.scrollTop;
+      const recentTops = programmaticScrollTops.current;
+      if (recentTops.at(-1) !== pinnedTop) {
+        programmaticScrollTops.current = [...recentTops.slice(-7), pinnedTop];
+      }
+    }
   }, [messages]);
   useLayoutEffect(() => {
     const element = scroll.current;
@@ -779,7 +796,10 @@ export function Transcript() {
       id="chatScroll"
       ref={scroll}
       onWheel={(event) => {
-        if (event.deltaY < 0) stickToTail.current = false;
+        if (event.deltaY < 0) {
+          stickToTail.current = false;
+          programmaticScrollTops.current = [];
+        }
       }}
       onTouchStart={(event) => {
         touchY.current = event.touches[0]?.clientY ?? null;
@@ -788,6 +808,7 @@ export function Transcript() {
         const nextY = event.touches[0]?.clientY;
         if (nextY !== undefined && touchY.current !== null && nextY > touchY.current) {
           stickToTail.current = false;
+          programmaticScrollTops.current = [];
         }
         touchY.current = nextY ?? null;
       }}
@@ -797,9 +818,19 @@ export function Transcript() {
       onScroll={(event) => {
         const element = event.currentTarget;
         const distanceFromTail = element.scrollHeight - element.scrollTop - element.clientHeight;
+        const programmatic = programmaticScrollTops.current.some(
+          (requested) => Math.abs(element.scrollTop - requested) <= 1,
+        );
 
-        if (distanceFromTail > 1) stickToTail.current = false;
-        else if (distanceFromTail <= 0) stickToTail.current = true;
+        if (programmatic) {
+          // Keep recent markers until an actual move disagrees with all of them.
+          // Chromium may emit delayed scroll events for older pins after streamed
+          // content briefly shrinks and then grows again.
+          stickToTail.current = true;
+        } else if (distanceFromTail > 1) {
+          programmaticScrollTops.current = [];
+          stickToTail.current = false;
+        } else if (distanceFromTail <= 0) stickToTail.current = true;
 
         setNearTail(distanceFromTail < 96);
       }}

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -3854,6 +3854,27 @@ describe('Preact-owned chat surfaces', () => {
     }
   });
 
+  it('flushes the latest source immediately when streaming completes', async () => {
+    vi.useFakeTimers();
+    try {
+      const target = `start ${'queued '.repeat(100)}`;
+      const { container, rerender } = render(<Markdown value="start" streaming />);
+      rerender(<Markdown value={target} streaming />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(33);
+      });
+      expect(container.textContent).not.toBe(target);
+      rerender(<Markdown value={target} />);
+      expect(container).toHaveTextContent(target.trim());
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      expect(container).toHaveTextContent(target.trim());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps one code node while an open fence grows and commits it once', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -1478,18 +1478,40 @@ describe('Preact-owned chat surfaces', () => {
       act(() => resize?.([], {} as ResizeObserver));
       expect(viewport.scrollTop).toBe(1_100);
 
-      viewport.scrollTop = 1_095;
+      // Canonical tail reparsing can briefly shrink the document. Chromium clamps
+      // scrollTop, then may restore an older programmatic position after it grows.
+      scrollHeight = 1_390;
+      viewport.scrollTop = 1_090;
       fireEvent.scroll(viewport);
-      scrollHeight = 1_500;
       act(() => resize?.([], {} as ResizeObserver));
-      expect(viewport.scrollTop).toBe(1_095);
+      expect(viewport.scrollTop).toBe(1_090);
 
-      viewport.scrollTop = 1_200;
+      scrollHeight = 1_500;
+      viewport.scrollTop = 1_100;
       fireEvent.scroll(viewport);
-      fireEvent.wheel(viewport, { deltaY: -1 });
-      scrollHeight = 1_600;
       act(() => resize?.([], {} as ResizeObserver));
       expect(viewport.scrollTop).toBe(1_200);
+
+      viewport.scrollTop = 1_195;
+      fireEvent.scroll(viewport);
+      scrollHeight = 1_600;
+      act(() => resize?.([], {} as ResizeObserver));
+      expect(viewport.scrollTop).toBe(1_195);
+
+      // Returning to the old programmatic position via scrollbar or keyboard
+      // must not revive a stale marker and re-pin the reader.
+      viewport.scrollTop = 1_200;
+      fireEvent.scroll(viewport);
+      scrollHeight = 1_700;
+      act(() => resize?.([], {} as ResizeObserver));
+      expect(viewport.scrollTop).toBe(1_200);
+
+      viewport.scrollTop = 1_400;
+      fireEvent.scroll(viewport);
+      fireEvent.wheel(viewport, { deltaY: -1 });
+      scrollHeight = 1_800;
+      act(() => resize?.([], {} as ResizeObserver));
+      expect(viewport.scrollTop).toBe(1_400);
     } finally {
       vi.unstubAllGlobals();
     }
@@ -3903,6 +3925,17 @@ describe('Preact-owned chat surfaces', () => {
     }
   });
 
+  it('rebases finalized assets without rebuilding their DOM', () => {
+    const source = '![artifact](/artifact.png)';
+    const { container, rerender } = render(<Markdown value={source} />);
+    const image = container.querySelector('img');
+    expect(image).not.toBeNull();
+
+    rerender(<Markdown value={source} rebase={(value) => `/chat${value}`} />);
+    expect(container.querySelector('img')).toBe(image);
+    expect(image).toHaveAttribute('src', '/chat/artifact.png');
+  });
+
   it('keeps one code node while an open fence grows and commits it once', async () => {
     vi.useFakeTimers();
     try {
@@ -3935,9 +3968,45 @@ describe('Preact-owned chat surfaces', () => {
       expect(container).toHaveTextContent('trailing prose');
 
       rerender(<Markdown value={closed} />);
+      await act(async () => {
+        await Promise.resolve();
+      });
       expect(container.querySelector('pre')).toBe(pre);
       expect(container.querySelector('pre code')).toBe(code);
+      expect(code).toHaveAttribute('data-highlighted', 'yes');
+      const highlighted = code?.innerHTML;
       expect(screen.getAllByRole('button', { name: 'Copy code' })).toHaveLength(1);
+
+      rerender(<Markdown value={closed} rebase={(value) => value} />);
+      expect(container.querySelector('pre')).toBe(pre);
+      expect(container.querySelector('pre code')).toBe(code);
+      expect(code?.innerHTML).toBe(highlighted);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps committed code immutable when a nested list arrives later', async () => {
+    vi.useFakeTimers();
+    try {
+      const codeSource = '```js\nconst stable = true;\n```\n\n';
+      const { container, rerender } = render(<Markdown value={codeSource} streaming />);
+      const pre = container.querySelector('pre');
+      const code = container.querySelector('pre code');
+      expect(pre).not.toBeNull();
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(code).toHaveAttribute('data-highlighted', 'yes');
+
+      rerender(<Markdown value={`${codeSource}- outer\n    - deeply nested\n`} streaming />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      expect(container.querySelector('pre')).toBe(pre);
+      expect(container.querySelector('pre code')).toBe(code);
+      expect(code).toHaveAttribute('data-highlighted', 'yes');
+      expect(container.querySelector('.streaming-markdown')).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -3875,6 +3875,34 @@ describe('Preact-owned chat surfaces', () => {
     }
   });
 
+  it('does no streaming presentation work while the tab is hidden', async () => {
+    vi.useFakeTimers();
+    const hidden = Object.getOwnPropertyDescriptor(document, 'hidden');
+    try {
+      const { container, rerender } = render(<Markdown value="visible" streaming />);
+      Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      const target = `visible ${'hidden '.repeat(100)}`;
+      rerender(<Markdown value={target} streaming />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      expect(container).toHaveTextContent('visible');
+      expect(container.textContent).not.toBe(target);
+
+      Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+      expect(container).toHaveTextContent(target.trim());
+    } finally {
+      if (hidden) Object.defineProperty(document, 'hidden', hidden);
+      else Reflect.deleteProperty(document, 'hidden');
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps one code node while an open fence grows and commits it once', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -3834,16 +3834,21 @@ describe('Preact-owned chat surfaces', () => {
     expect(screen.queryByRole('button', { name: 'Copy code' })).not.toBeInTheDocument();
   });
 
-  it('throttles streaming markdown updates at the adaptive cadence', async () => {
+  it('drains a streaming burst over multiple presentation frames', async () => {
     vi.useFakeTimers();
     try {
+      const target = `first ${'second '.repeat(20)}`;
       const { container, rerender } = render(<Markdown value="first" streaming />);
-      rerender(<Markdown value="second" streaming />);
+      rerender(<Markdown value={target} streaming />);
       expect(container).toHaveTextContent('first');
       await act(async () => {
         await vi.advanceTimersByTimeAsync(33);
       });
-      expect(container).toHaveTextContent('second');
+      expect(container.textContent).not.toBe(target);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(container).toHaveTextContent(target.trim());
     } finally {
       vi.useRealTimers();
     }
@@ -3863,7 +3868,7 @@ describe('Preact-owned chat surfaces', () => {
       const second = `${first};\nconsole.log(value);`;
       rerender(<Markdown value={second} streaming />);
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(33);
+        await vi.advanceTimersByTimeAsync(1_000);
       });
       expect(container.querySelector('pre')).toBe(pre);
       expect(container.querySelector('pre code')).toBe(code);
@@ -3873,7 +3878,7 @@ describe('Preact-owned chat surfaces', () => {
       const closed = `${second}\n\`\`\`\ntrailing prose`;
       rerender(<Markdown value={closed} streaming />);
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(33);
+        await vi.advanceTimersByTimeAsync(1_000);
       });
       expect(container.querySelector('pre')).toBe(pre);
       expect(container.querySelector('pre code')).toBe(code);
@@ -3961,7 +3966,7 @@ describe('Preact-owned chat surfaces', () => {
       const text = tail?.firstChild;
       rerender(<Markdown value="first second" streaming />);
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(33);
+        await vi.advanceTimersByTimeAsync(500);
       });
       expect(container.querySelector('.streaming-tail')?.firstChild).toBe(text);
       expect(text).toHaveTextContent('first second');

--- a/frontend/src/domain/markdown-streaming.ts
+++ b/frontend/src/domain/markdown-streaming.ts
@@ -46,8 +46,16 @@ export function createStreamingState(): StreamingMarkdownState {
 
 export const ELASTIC_STREAM_FRAME_MS = 32;
 const ELASTIC_STREAM_MIN_CHARS_PER_SECOND = 40;
-const ELASTIC_STREAM_MAX_CHARS_PER_SECOND = 720;
-const ELASTIC_STREAM_BACKLOG_GAIN = 1.8;
+const ELASTIC_STREAM_MAX_CHARS_PER_SECOND = 12_000;
+const ELASTIC_STREAM_BACKLOG_GAIN = 4;
+
+export function elasticStreamingFrameDelay(contentLength: unknown): number {
+  const length = Math.max(0, Number(contentLength) || 0);
+  if (length > 64_000) return 200;
+  if (length > 32_000) return 128;
+  if (length > 8_000) return 64;
+  return ELASTIC_STREAM_FRAME_MS;
+}
 
 export interface ElasticStreamingStep {
   characters: number;

--- a/frontend/src/domain/markdown-streaming.ts
+++ b/frontend/src/domain/markdown-streaming.ts
@@ -367,13 +367,28 @@ export function appendedTextIsPlainSafe(text: unknown): boolean {
   return !/[`[\]()!*_~<\\$|#>\r\n]/.test(String(text || ''));
 }
 
+function containsGlobalIndentedCode(value: string): boolean {
+  const lines = value.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^(?: {4}|\t)(\S.*)$/.exec(lines[index]);
+    if (!match) continue;
+    if (/^(?:[-+*]|\d+[.)])\s/.test(match[1])) {
+      let previous = index - 1;
+      while (previous >= 0 && !lines[previous].trim()) previous -= 1;
+      if (previous >= 0 && /^\s*(?:[-+*]|\d+[.)])\s/.test(lines[previous])) continue;
+    }
+    return true;
+  }
+  return false;
+}
+
 /** Constructs that can change the interpretation of source committed much
  * earlier are kept on the canonical-render fallback path. */
 export function hasIncrementalGlobalMarkdownSyntax(text: unknown): boolean {
   const value = withoutFencedCode(text);
   return (
     /^ {0,3}\[[^\]\r\n]+\]:\s*\S/m.test(value) ||
-    /^(?: {4}|\t)\S/m.test(value) ||
+    containsGlobalIndentedCode(value) ||
     /^ {0,3}<(?:address|article|aside|base|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:\s|>|\/)/im.test(
       value,
     )

--- a/frontend/src/domain/markdown-streaming.ts
+++ b/frontend/src/domain/markdown-streaming.ts
@@ -44,12 +44,39 @@ export function createStreamingState(): StreamingMarkdownState {
   };
 }
 
-export function nextStreamingRenderDelay(contentLength: unknown): number {
-  const length = Math.max(0, Number(contentLength) || 0);
-  if (length > 96_000) return 250;
-  if (length > 32_000) return 150;
-  if (length > 8_000) return 75;
-  return 33;
+export const ELASTIC_STREAM_FRAME_MS = 32;
+const ELASTIC_STREAM_MIN_CHARS_PER_SECOND = 40;
+const ELASTIC_STREAM_MAX_CHARS_PER_SECOND = 720;
+const ELASTIC_STREAM_BACKLOG_GAIN = 1.8;
+
+export interface ElasticStreamingStep {
+  characters: number;
+  remainder: number;
+}
+
+/**
+ * Converts queued source pressure into a bounded presentation rate. Small
+ * queues drain gently; bursts accelerate rather than appearing in one jump.
+ * The fractional remainder keeps the cadence accurate at low rates.
+ */
+export function elasticStreamingStep(
+  backlog: number,
+  elapsedMs: number,
+  remainder = 0,
+): ElasticStreamingStep {
+  const queued = Math.max(0, Math.floor(Number(backlog) || 0));
+  if (!queued) return { characters: 0, remainder: 0 };
+  const elapsed = Math.max(0, Math.min(250, Number(elapsedMs) || 0));
+  const rate = Math.min(
+    ELASTIC_STREAM_MAX_CHARS_PER_SECOND,
+    ELASTIC_STREAM_MIN_CHARS_PER_SECOND + queued * ELASTIC_STREAM_BACKLOG_GAIN,
+  );
+  const budget = Math.max(0, Number(remainder) || 0) + (rate * elapsed) / 1000;
+  const characters = Math.min(queued, Math.max(1, Math.floor(budget)));
+  return {
+    characters,
+    remainder: characters === queued ? 0 : Math.max(0, budget - characters),
+  };
 }
 
 function fenceMarker(line: unknown): Fence | null {

--- a/frontend/src/domain/rendering.test.ts
+++ b/frontend/src/domain/rendering.test.ts
@@ -3,6 +3,7 @@ import { highlight, highlightDiffLine } from './rich-highlight';
 import { decorateRichContent, renderMarkdown, stableMarkdownBoundary } from './markdown';
 import {
   analyzeStreamingMarkdown,
+  elasticStreamingStep,
   findActiveFencedCodeBlock,
   hasIncrementalGlobalMarkdownSyntax,
   inspectFencedCodeBlock,
@@ -111,6 +112,25 @@ describe('markdown security and streaming', () => {
     expect(languages).toHaveLength(60);
     expect(languages.filter((language) => !highlight.getLanguage(language))).toEqual([]);
     expect(highlight.getLanguage('toml')).toBeTruthy();
+  });
+
+  it('drains streaming bursts elastically while preserving fractional cadence', () => {
+    const shallow = elasticStreamingStep(10, 32);
+    const deep = elasticStreamingStep(1_000, 32);
+    expect(shallow.characters).toBeGreaterThanOrEqual(1);
+    expect(deep.characters).toBeGreaterThan(shallow.characters);
+    expect(deep.characters).toBeLessThan(1_000);
+
+    const first = elasticStreamingStep(1, 1);
+    expect(first).toEqual({ characters: 1, remainder: 0 });
+    expect(elasticStreamingStep(0, 32, first.remainder)).toEqual({ characters: 0, remainder: 0 });
+  });
+
+  it('bounds elastic catch-up after a suspended frame', () => {
+    const ordinary = elasticStreamingStep(10_000, 250);
+    const suspended = elasticStreamingStep(10_000, 30_000);
+    expect(suspended).toEqual(ordinary);
+    expect(suspended.characters).toBeLessThan(10_000);
   });
 
   it('does not expose an unterminated fenced tail as stable markdown', () => {

--- a/frontend/src/domain/rendering.test.ts
+++ b/frontend/src/domain/rendering.test.ts
@@ -180,6 +180,9 @@ describe('markdown security and streaming', () => {
   it('latches globally sensitive markdown onto the canonical fallback path', () => {
     expect(hasIncrementalGlobalMarkdownSyntax('[name]: https://example.com')).toBe(true);
     expect(hasIncrementalGlobalMarkdownSyntax('    indented code')).toBe(true);
+    expect(hasIncrementalGlobalMarkdownSyntax('    - name: build\n      run: make')).toBe(true);
+    expect(hasIncrementalGlobalMarkdownSyntax('  - nested\n    - deeply nested')).toBe(false);
+    expect(hasIncrementalGlobalMarkdownSyntax('   1. nested\n      1. deeper')).toBe(false);
     expect(hasIncrementalGlobalMarkdownSyntax('```md\n[name]: still code\n```')).toBe(false);
   });
 });

--- a/frontend/src/domain/rendering.test.ts
+++ b/frontend/src/domain/rendering.test.ts
@@ -3,6 +3,7 @@ import { highlight, highlightDiffLine } from './rich-highlight';
 import { decorateRichContent, renderMarkdown, stableMarkdownBoundary } from './markdown';
 import {
   analyzeStreamingMarkdown,
+  elasticStreamingFrameDelay,
   elasticStreamingStep,
   findActiveFencedCodeBlock,
   hasIncrementalGlobalMarkdownSyntax,
@@ -121,9 +122,18 @@ describe('markdown security and streaming', () => {
     expect(deep.characters).toBeGreaterThan(shallow.characters);
     expect(deep.characters).toBeLessThan(1_000);
 
-    const first = elasticStreamingStep(1, 1);
-    expect(first).toEqual({ characters: 1, remainder: 0 });
-    expect(elasticStreamingStep(0, 32, first.remainder)).toEqual({ characters: 0, remainder: 0 });
+    const first = elasticStreamingStep(100, 10);
+    const second = elasticStreamingStep(100 - first.characters, 10, first.remainder);
+    expect(first.remainder).toBeGreaterThan(0);
+    expect(second.characters).toBeGreaterThanOrEqual(first.characters);
+    expect(elasticStreamingStep(0, 32, second.remainder)).toEqual({ characters: 0, remainder: 0 });
+  });
+
+  it('backs off presentation frames as rendered Markdown grows', () => {
+    expect(elasticStreamingFrameDelay(8_000)).toBe(32);
+    expect(elasticStreamingFrameDelay(8_001)).toBe(64);
+    expect(elasticStreamingFrameDelay(32_001)).toBe(128);
+    expect(elasticStreamingFrameDelay(64_001)).toBe(200);
   });
 
   it('bounds elastic catch-up after a suspended frame', () => {

--- a/internal/llm/debug_provider.go
+++ b/internal/llm/debug_provider.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 )
 
 // debugPreset defines streaming rate configuration.
@@ -26,6 +27,21 @@ var presets = map[string]debugPreset{
 	"realtime":   {ChunkSize: 5, Delay: 30 * time.Millisecond},
 	"burst":      {ChunkSize: 200, Delay: 100 * time.Millisecond},
 	"compaction": {ChunkSize: 12, Delay: 80 * time.Millisecond},
+}
+
+// jitterPattern deliberately alternates dribbles, bursts, and stalls. It is
+// deterministic so browser demos and performance investigations are repeatable.
+var jitterPattern = []debugPreset{
+	{ChunkSize: 9, Delay: 45 * time.Millisecond},
+	{ChunkSize: 14, Delay: 30 * time.Millisecond},
+	{ChunkSize: 180, Delay: 8 * time.Millisecond},
+	{ChunkSize: 260, Delay: 12 * time.Millisecond},
+	{ChunkSize: 5, Delay: 620 * time.Millisecond},
+	{ChunkSize: 72, Delay: 25 * time.Millisecond},
+	{ChunkSize: 7, Delay: 190 * time.Millisecond},
+	{ChunkSize: 320, Delay: 6 * time.Millisecond},
+	{ChunkSize: 28, Delay: 85 * time.Millisecond},
+	{ChunkSize: 3, Delay: 430 * time.Millisecond},
 }
 
 // debugMarkdown contains rich markdown content for performance testing.
@@ -172,10 +188,11 @@ Final section with mixed content:
 type DebugProvider struct {
 	variant string
 	preset  debugPreset
+	pattern []debugPreset
 }
 
 // NewDebugProvider creates a debug provider with the specified variant.
-// Valid variants: fast, normal, slow, realtime, burst, compaction.
+// Valid variants: fast, normal, slow, realtime, burst, jitter, compaction.
 // Empty string defaults to "normal".
 func NewDebugProvider(variant string) *DebugProvider {
 	if variant == "" {
@@ -185,10 +202,16 @@ func NewDebugProvider(variant string) *DebugProvider {
 	if !ok {
 		preset = presets["normal"]
 	}
-	return &DebugProvider{
+	provider := &DebugProvider{
 		variant: variant,
 		preset:  preset,
 	}
+	if variant == "jitter" {
+		// Rich Markdown uses the erratic pattern; fixed helper responses retain
+		// the normal preset so tool and compaction probes stay predictable.
+		provider.pattern = append([]debugPreset(nil), jitterPattern...)
+	}
+	return provider
 }
 
 // Name returns the provider name with variant.
@@ -388,16 +411,14 @@ func (d *DebugProvider) streamTextWithUsage(ctx context.Context, send eventSende
 // streamDebugMarkdown streams the standard debug markdown content.
 func (d *DebugProvider) streamDebugMarkdown(ctx context.Context, send eventSender) error {
 	text := debugMarkdown
-	chunkSize := d.preset.ChunkSize
-	delay := d.preset.Delay
+	steps := []debugPreset{d.preset}
+	if len(d.pattern) > 0 {
+		steps = d.pattern
+	}
 
-	for len(text) > 0 {
-		// Calculate chunk boundary
-		end := chunkSize
-		if end > len(text) {
-			end = len(text)
-		}
-
+	for index := 0; len(text) > 0; index++ {
+		step := steps[index%len(steps)]
+		end := debugChunkEnd(text, step.ChunkSize)
 		chunk := text[:end]
 		text = text[end:]
 
@@ -405,20 +426,34 @@ func (d *DebugProvider) streamDebugMarkdown(ctx context.Context, send eventSende
 			return err
 		}
 
-		if delay > 0 && len(text) > 0 {
+		if step.Delay > 0 && len(text) > 0 {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(delay):
+			case <-time.After(step.Delay):
 			}
 		}
 	}
 
-	// Emit usage stats
 	return send.Send(Event{Type: EventUsage, Use: &Usage{
 		InputTokens:  10,
-		OutputTokens: len(debugMarkdown) / 4, // Approximate tokens
+		OutputTokens: len(debugMarkdown) / 4,
 	}})
+}
+
+func debugChunkEnd(text string, size int) int {
+	if size <= 0 || size >= len(text) {
+		return len(text)
+	}
+	end := size
+	for end > 0 && !utf8.RuneStart(text[end]) {
+		end--
+	}
+	if end == 0 {
+		_, width := utf8.DecodeRuneInString(text)
+		return width
+	}
+	return end
 }
 
 // streamCompletionText streams a simple completion message after tool execution.

--- a/internal/llm/debug_provider_test.go
+++ b/internal/llm/debug_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/samsaffron/term-llm/internal/config"
 )
@@ -25,6 +26,7 @@ func TestDebugProviderName(t *testing.T) {
 		{"slow", "debug:slow"},
 		{"realtime", "debug:realtime"},
 		{"burst", "debug:burst"},
+		{"jitter", "debug:jitter"},
 		{"compaction", "debug:compaction"},
 		{"unknown", "debug:unknown"}, // Unknown variants still get named
 	}
@@ -139,6 +141,74 @@ func TestDebugProviderStream(t *testing.T) {
 
 	if !gotUsage {
 		t.Error("stream did not emit usage event")
+	}
+}
+
+func TestDebugProviderJitterStreamIsDeterministicAndUTF8Safe(t *testing.T) {
+	t.Parallel()
+
+	p := NewDebugProvider("jitter")
+	for i := range p.pattern {
+		p.pattern[i].Delay = 0
+	}
+	stream, err := p.Stream(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer stream.Close()
+
+	var fullText strings.Builder
+	var sizes []int
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			t.Fatalf("stream receive: %v", recvErr)
+		}
+		if event.Type != EventTextDelta {
+			continue
+		}
+		if !utf8.ValidString(event.Text) {
+			t.Fatalf("invalid UTF-8 chunk %q", event.Text)
+		}
+		sizes = append(sizes, len(event.Text))
+		fullText.WriteString(event.Text)
+	}
+	if got := fullText.String(); got != debugMarkdown {
+		t.Fatal("jitter stream did not reconstruct the original markdown")
+	}
+	if len(sizes) < len(jitterPattern) {
+		t.Fatalf("got %d chunks, want at least %d", len(sizes), len(jitterPattern))
+	}
+	for i, step := range jitterPattern[:4] {
+		if sizes[i] != step.ChunkSize {
+			t.Fatalf("chunk %d size = %d, want %d", i, sizes[i], step.ChunkSize)
+		}
+	}
+}
+
+func TestDebugChunkEndPreservesRunes(t *testing.T) {
+	t.Parallel()
+
+	const text = "a✅b"
+	for _, tt := range []struct {
+		size int
+		want int
+	}{
+		{size: 1, want: 1},
+		{size: 2, want: 1},
+		{size: 3, want: 1},
+		{size: 4, want: 4},
+		{size: 5, want: 5},
+	} {
+		if got := debugChunkEnd(text, tt.size); got != tt.want {
+			t.Errorf("debugChunkEnd(%q, %d) = %d, want %d", text, tt.size, got, tt.want)
+		}
+	}
+	if got := debugChunkEnd("✅", 1); got != len("✅") {
+		t.Errorf("single-rune fallback = %d, want %d", got, len("✅"))
 	}
 }
 

--- a/internal/llm/grok_acp_test.go
+++ b/internal/llm/grok_acp_test.go
@@ -1100,9 +1100,6 @@ done
 	}
 
 	provider.RequestInlineFlush()
-	if provider.inlineFlushRequested() {
-		t.Fatal("successful native interrupt retained tool-boundary fallback")
-	}
 
 	done := make(chan error, 1)
 	phases := make(chan string, 8)
@@ -1134,6 +1131,9 @@ done
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("native interrupt did not end Grok ACP stream")
+	}
+	if provider.inlineFlushRequested() {
+		t.Fatal("successful native interrupt retained tool-boundary fallback")
 	}
 	// The interrupt is the expected boundary for a steer, so it must stay quiet.
 	for phase := range phases {

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -33,11 +33,12 @@ func TestProductionBundleSizeBudgets(t *testing.T) {
 		// state machine, gallery/diff navigation, focused store modules, the
 		// safe-point branch workflow, interactive worktree conflict recovery,
 		// replayable SSE/long-poll server-event coordination, branch-tree
-		// navigation, and the paginated Recent/Projects sidebar are first-party
-		// shell code. Keep bounded headroom over that productized baseline while
-		// still failing meaningful accidental regressions.
-		"dist/app.js":  {raw: 418_000, gzip: 124_000},
-		"dist/app.css": {raw: 160_000, gzip: 30_500},
+		// navigation, the paginated Recent/Projects sidebar, and the elastic
+		// streaming presentation buffer are first-party shell code. Keep bounded
+		// headroom over that productized baseline while still failing meaningful
+		// accidental regressions.
+		"dist/app.js":  {raw: 420_000, gzip: 124_000},
+		"dist/app.css": {raw: 161_000, gzip: 31_000},
 	}
 	for name, budget := range budgets {
 		body, err := StaticAsset(name)


### PR DESCRIPTION
## Summary

- replace snapshot-at-once streaming updates with an elastic presentation buffer
- drain at `min(12,000, 40 + 4 × queued characters)` chars/second, so small queues remain calm while fast providers converge to roughly 250 ms of presentation lag
- use a 32 ms cadence for normal responses, backing off to 64/128/200 ms after 8K/32K/64K rendered characters to bound full-source scanning and allocations
- preserve the existing append-only Markdown renderer: committed blocks retain their DOM nodes, plain tails use `Text.appendData()`, and only the structurally mutable tail is reparsed
- flush immediately on completion or source replacement; pause presentation while hidden and flush once on visibility transitions
- add a deterministic `debug:jitter` preset with rich Markdown, UTF-8-safe chunks, bursts, dribbles, and stalls for repeatable browser demos

## Why

Erratic provider chunks currently appear as visible jumps even though the Web UI already coalesces updates. This makes arrival cadence a transport detail the reader has to watch.

The elastic buffer separates model arrival from presentation without changing durable response state. It schedules at most one timer, accelerates under backlog pressure, backs off render frequency for long Markdown, and leaves the renderer's minimal-mutation boundaries intact.

## DOM mutation contract

- completed Markdown pieces are appended once and never reparsed during normal streaming
- open fenced code appends to its existing text node
- plain prose appends to its existing text node
- only incomplete structural Markdown reparses the mutable tail
- full canonical replacement remains limited to source replacement, globally sensitive Markdown, and bounded fallback paths

## Fable review

Fable found two blockers in the first revision: the original 720 chars/s cap could accumulate unbounded lag, and a fixed 32 ms cadence discarded large-document backoff. The final controller raises bounded catch-up to 12,000 chars/s with a 4× backlog gain, restores length-aware 64/128/200 ms cadence, pauses hidden-tab work, and adds final-flush/visibility coverage. The real browser recording then exposed two more bugs: nested-list indentation unnecessarily triggered canonical full-DOM fallback (dropping syntax highlighting), and delayed programmatic scroll events could disable tail pinning. Both are fixed with DOM-identity and scroll-race coverage; Fable re-reviewed the fixes and found no blockers.

## Bundle budget

After rebasing over the paginated Recent/Projects sidebar changes, upstream main itself exceeded the prior CSS/raw limits. The final measured assets and deliberately tight updated ceilings are:

- `app.js`: 419,245 raw / 123,506 gzip; budget 420,000 / 124,000
- `app.css`: 160,031 raw / 30,772 gzip; budget 161,000 / 31,000

The elastic presentation code adds roughly 1.2 KB raw JS over the rebased baseline; gzip remains below the existing 124 KB ceiling.

## CI deflaking

- wait for the Grok ACP stream to reach EOF before asserting that a successful asynchronous native interrupt consumed its fallback marker
- wait for approval overlays to detach before clicking the recovered decision banner, rather than treating underlying banner visibility as proof that the overlay no longer intercepts input
- stress verification: Grok interrupt test 500× plus 50× under `-race`; approval lifecycle browser test 20×

## Verification

- `mise x node@24 -- npm test` — 382 tests passed at the rebased head
- `mise x node@24 -- npm run typecheck`
- `mise x node@24 -- npm run lint`
- `mise x node@24 -- make build`
- focused Go tests for debug streaming, UTF-8 boundaries, Web UI assets, and bundle budgets
- clean-room browser recording using the built PR binary with `--provider debug:jitter`; 50 ms telemetry confirmed no sustained tail gap (final distance: 0 px)



