### PR TITLE
fix(web): prioritize model in mobile header

### DIFF
--- a/frontend/src/styles/app.test.ts
+++ b/frontend/src/styles/app.test.ts
@@ -15,6 +15,10 @@ function readStylesheet(path: string): string {
 }
 
 const appCSS = readStylesheet(resolve(stylesRoot, 'app.css'));
+const preactOverrides = readFileSync(
+  resolve(stylesRoot, 'integration/preact-overrides.css'),
+  'utf8',
+);
 
 describe('stylesheet manifest', () => {
   it('inlines every module and keeps the Preact integration layer last', () => {
@@ -74,6 +78,20 @@ describe('header styles', () => {
 
   it('gives clipped worktree labels enough line height for descenders', () => {
     expect(appCSS).toMatch(/\.worktree-trigger \.chip-label\s*\{[^}]*line-height: 1\.3;/s);
+  });
+
+  it('keeps the mobile header on one model-priority row', () => {
+    const start = preactOverrides.indexOf('@media (width <= 767px)');
+    const end = preactOverrides.indexOf('@media (hover: none)', start);
+    const mobile = preactOverrides.slice(start, end);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    expect(mobile).toMatch(/\.header-title-row\s*\{[^}]*flex-wrap: nowrap;/s);
+    expect(mobile).toMatch(/\.header-left\s*\{[^}]*flex: 1 1 0;[^}]*min-width: 0;/s);
+    expect(mobile).toMatch(/\.header-title-context\s*\{[^}]*overflow: hidden;/s);
+    expect(mobile).toMatch(/\.header-project-subtitle\s*\{[^}]*display: none;/s);
+    expect(mobile).not.toMatch(/\.header-title-row\s*\{[^}]*flex-wrap: wrap;/s);
   });
 });
 

--- a/frontend/src/styles/integration/preact-overrides.css
+++ b/frontend/src/styles/integration/preact-overrides.css
@@ -715,24 +715,31 @@ mark.diff-word {
     min-height: 58px;
   }
 
-  .header-title-context {
-    max-width: min(36vw, 10rem);
-  }
-
-  /* Keep the model readable when the header is quiet. If contextual actions make
-     the row genuinely crowded, move the control cluster to a compact second row
-     instead of clipping every control into ambiguity. */
+  /* Keep the mobile header to one physical row. Runtime is the primary live
+     control, so the conversation title yields via ellipsis and project context
+     stays in the sidebar rather than competing with the model. */
   .header-title-row {
-    flex-wrap: wrap;
-    row-gap: 0.35rem;
+    flex-wrap: nowrap;
   }
 
   .header-left {
-    min-width: min(9rem, 40vw);
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .header-title-context {
+    max-width: none;
+    overflow: hidden;
+  }
+
+  .header-project-subtitle {
+    display: none;
   }
 
   .header-title {
+    display: block;
     font-size: 0.94rem;
+    white-space: nowrap;
   }
 
   .header-controls-row {


### PR DESCRIPTION
## Summary

- keep the mobile header on **1 physical row** instead of wrapping controls beneath long conversation titles
- prioritize the full runtime model control while clamping the conversation title to a single ellipsized line
- omit the project subtitle below 768px; project context remains available in the sidebar
- preserve the existing menu, plan/status, and diff actions
- add a stylesheet regression test for the model-priority mobile layout

## Tests

- `npm test` — 405 tests passed
- `npm run lint`
- `npm run typecheck`
- `npm run build`
