### PR TITLE
fix(serve): preserve deprecated enable-widgets flag

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -169,6 +169,7 @@ func init() {
 	serveCmd.Flags().StringArrayVar(&serveToolMap, "tool-map", nil, "Map client tool name to server tool (repeatable, format ClientName:ServerName)")
 	serveCmd.Flags().BoolVar(&serveFilterServerTools, "suppress-server-tool-calls", false, "Hide server-executed tool calls from API responses (use when proxying to external clients)")
 	serveCmd.Flags().StringVar(&serveFilesDir, "files-dir", "", "Directory for serving arbitrary files (videos, PDFs, etc) at {base}/files/")
+	serveCmd.Flags().Bool("enable-widgets", false, "Deprecated no-op; widgets are enabled by default")
 	serveCmd.Flags().BoolVar(&serveDisableWidgets, "disable-widgets", false, "Disable local widget apps under {base}/widgets/<mount>/")
 	serveCmd.Flags().StringVar(&serveWidgetsDir, "widgets-dir", "", "Directory containing widget sub-directories (default: ~/.config/term-llm/widgets)")
 	serveCmd.Flags().DurationVar(&serveResponseTimeout, "response-timeout", defaultServeRequestTimeout, "Maximum inactivity before the first or next completed LLM response (default 30m; pauses for interactive waits)")
@@ -230,6 +231,8 @@ func servePlatformCompletion(cmd *cobra.Command, args []string, toComplete strin
 }
 
 func runServe(cmd *cobra.Command, args []string) error {
+	warnDeprecatedEnableWidgets(cmd)
+
 	svc, err := serve.NewService(serve.Options{
 		Host:      serveHost,
 		Port:      servePort,
@@ -244,6 +247,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	return svc.Run(cmd.Context())
+}
+
+func warnDeprecatedEnableWidgets(cmd *cobra.Command) {
+	if cmd.Flags().Changed("enable-widgets") {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: --enable-widgets is deprecated and has no effect; widgets are enabled by default. Use --disable-widgets to opt out.")
+	}
 }
 
 func withServeSessionLogging(store session.Store) session.Store {

--- a/cmd/serve_widgets_flag_test.go
+++ b/cmd/serve_widgets_flag_test.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
 
 func TestServeWidgetsAreOptOut(t *testing.T) {
 	disableFlag := serveCmd.Flags().Lookup("disable-widgets")
@@ -10,8 +16,13 @@ func TestServeWidgetsAreOptOut(t *testing.T) {
 	if disableFlag.DefValue != "false" {
 		t.Fatalf("serve --disable-widgets default = %q, want false", disableFlag.DefValue)
 	}
-	if enableFlag := serveCmd.Flags().Lookup("enable-widgets"); enableFlag != nil {
-		t.Fatal("serve --enable-widgets should be replaced by --disable-widgets")
+
+	enableFlag := serveCmd.Flags().Lookup("enable-widgets")
+	if enableFlag == nil {
+		t.Fatal("serve --enable-widgets compatibility flag is not registered")
+	}
+	if enableFlag.DefValue != "false" {
+		t.Fatalf("serve --enable-widgets default = %q, want false", enableFlag.DefValue)
 	}
 
 	for _, tc := range []struct {
@@ -29,5 +40,29 @@ func TestServeWidgetsAreOptOut(t *testing.T) {
 				t.Fatalf("serveWidgetsEnabled(%t, %t) = %t, want %t", tc.hasWeb, tc.disabled, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDeprecatedEnableWidgetsWarning(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("enable-widgets", false, "")
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	warnDeprecatedEnableWidgets(cmd)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr without flag = %q, want empty", stderr.String())
+	}
+
+	if err := cmd.Flags().Set("enable-widgets", "true"); err != nil {
+		t.Fatal(err)
+	}
+	warnDeprecatedEnableWidgets(cmd)
+
+	warning := stderr.String()
+	for _, want := range []string{"--enable-widgets is deprecated", "has no effect", "--disable-widgets"} {
+		if !strings.Contains(warning, want) {
+			t.Fatalf("stderr = %q, want it to contain %q", warning, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- restore `serve --enable-widgets` as a compatibility no-op
- print a deprecation warning to stderr whenever the flag is supplied
- direct users to `--disable-widgets` when they need to opt out

This gives existing service definitions and deployment scripts time to migrate after widgets became enabled by default.

## Tests

- `go test ./cmd -run 'TestServeWidgetsAreOptOut|TestDeprecatedEnableWidgetsWarning'`
- `go build ./...`
- live binary smoke with `serve web --enable-widgets`: server starts with widgets enabled and emits the expected warning

`go test ./...` was also run. It has unrelated existing/environment-sensitive failures in two skill-discovery tests and the current frontend bundle-size budget (`app.js` is 427,861 bytes against a 426,000-byte raw budget).
