### PR TITLE
fix(web): scope interactive prompt modals to their own conversation

### DIFF
--- a/frontend/src/stores/app-store.test.ts
+++ b/frontend/src/stores/app-store.test.ts
@@ -5117,6 +5117,71 @@ describe('AppStore compatibility behavior', () => {
     await vi.waitFor(() => expect(store.streamResponse).toHaveBeenCalledWith('r1', 's1', 4));
   });
 
+  it('keeps a background session interactive prompt from opening over the active conversation', () => {
+    const store = new AppStore(config);
+    try {
+      store.sessions.value = [
+        { ...session(), activeResponseId: 'r1' },
+        { ...session(), id: 's2', title: 'Other', activeResponseId: 'r2' },
+      ];
+      store.activeSessionId.value = 's2';
+      store.draftActive.value = false;
+      const run = (sessionId: string, responseId: string) =>
+        initialProjection({
+          responseId,
+          sessionId,
+          epoch: 1,
+          status: 'streaming',
+          lastSequence: 1,
+          startedRev: 0,
+          reconnects: 0,
+        });
+      store.runs.value = { s1: run('s1', 'r1'), s2: run('s2', 'r2') };
+
+      store.applyResponseEvent('s1', {
+        type: 'response.ask_user.prompt',
+        response_id: 'r1',
+        run_epoch: 1,
+        sequence_number: 2,
+        call_id: 'ask-1',
+        questions: [{ question: 'Continue?', options: [{ label: 'Yes' }] }],
+      });
+      store.applyResponseEvent('s1', {
+        type: 'response.approval.prompt',
+        response_id: 'r1',
+        run_epoch: 1,
+        sequence_number: 3,
+        approval_id: 'approval-1',
+        title: 'Allow access?',
+        options: [{ index: 0, label: 'Allow', choice: 'allow' }],
+      });
+
+      // Prompts from another conversation must not hijack the active one…
+      expect(store.askUser.value).toBeNull();
+      expect(store.approval.value).toBeNull();
+      // …but they stay tracked and actionable for their own session.
+      expect(store.interactionStore.find('ask-user', 's1', 'ask-1')).toMatchObject({
+        state: 'waiting',
+      });
+      expect(store.interactionStore.find('approval', 's1', 'approval-1')).toMatchObject({
+        state: 'waiting',
+      });
+
+      // The active conversation still opens its own prompt immediately.
+      store.applyResponseEvent('s2', {
+        type: 'response.ask_user.prompt',
+        response_id: 'r2',
+        run_epoch: 1,
+        sequence_number: 2,
+        call_id: 'ask-2',
+        questions: [{ question: 'Pick one', options: [{ label: 'A' }] }],
+      });
+      expect(store.askUser.value).toMatchObject({ sessionId: 's2', callId: 'ask-2' });
+    } finally {
+      store.dispose();
+    }
+  });
+
   it('does not let stale session state overwrite a prompt opened by the live stream', async () => {
     const store = new AppStore(config);
     store.sessions.value = [session()];

--- a/frontend/src/stores/interaction-store.ts
+++ b/frontend/src/stores/interaction-store.ts
@@ -138,9 +138,10 @@ export class InteractionStore {
     responseId: string,
     requestId: string,
     prompt: ApprovalPrompt | AskUserPrompt,
+    open = true,
   ): void {
     this.upsert(kind, sessionId, responseId, requestId, prompt);
-    if (!this.shouldOpen(kind, sessionId, requestId)) return;
+    if (!open || !this.shouldOpen(kind, sessionId, requestId)) return;
     if (kind === 'ask-user') this.askUser.value = prompt as AskUserPrompt;
     else this.approval.value = prompt as ApprovalPrompt;
   }

--- a/frontend/src/stores/run-engine.ts
+++ b/frontend/src/stores/run-engine.ts
@@ -1006,6 +1006,9 @@ export class RunEngine {
     if (next.plan !== current.plan && sessionId === this.sessionStore.activeSessionId.peek()) {
       this.plans.update(next.plan);
     }
+    // Prompts only open the modal over their own conversation; background
+    // sessions keep them as waiting interaction records until selected.
+    const promptSessionVisible = sessionId === this.sessionStore.activeSessionId.peek();
     if (next.askUser && next.askUser !== current.askUser && next.askUser.callId) {
       this.interactionsStore.present(
         'ask-user',
@@ -1013,6 +1016,7 @@ export class RunEngine {
         next.run.responseId,
         next.askUser.callId,
         next.askUser,
+        promptSessionVisible,
       );
     }
     if (next.approval && next.approval !== current.approval && next.approval.id) {
@@ -1022,6 +1026,7 @@ export class RunEngine {
         next.run.responseId,
         next.approval.id,
         next.approval,
+        promptSessionVisible,
       );
     }
     if (event.type === 'response.interjection') {


### PR DESCRIPTION
## Bug

If the agent in conversation 1 calls `ask_user` (including multi-select questions) while you are viewing conversation 2, the question popup opens over conversation 2. Same for approval prompts.

## Cause

In `RunEngine.applyResponseEvent`, a live `response.ask_user.prompt` / `response.approval.prompt` event calls `InteractionStore.present()`, which sets the global `askUser` / `approval` modal signals unconditionally — regardless of which session the event belongs to. Neighbouring state updates are already scoped (plan updates and the snapshot-recovery path both check `sessionId === sessionStore.activeSessionId`), but the live prompt path was not.

## Fix

- `InteractionStore.present()` takes an `open` flag; when false it only upserts the waiting interaction record without opening the modal.
- `RunEngine` passes `sessionId === activeSessionId` for both prompt kinds.

Background prompts remain tracked as waiting interaction records (visible in the interactions panel, sidebar attention), and selecting that conversation still opens them: selection sync already reopens pending prompts from server `pending_ask_users` / `pending_approvals` state.

## Repro / test

New test in `app-store.test.ts` (`keeps a background session interactive prompt from opening over the active conversation`) fails on main — applying an `ask_user` prompt event for background session `s1` while `s2` is active sets the global modal — and passes with the fix, while asserting active-session prompts still open immediately.

## Validation

- `vitest run`: 33/34 files pass; `webrtc.test.ts` fails identically on clean main (pre-existing, environment-related)
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` clean on touched files