### PR TITLE
fix(web): keep sidebar stable across conversation switches

### DIFF
--- a/frontend/e2e/pinned-switch-jitter.repro.spec.ts
+++ b/frontend/e2e/pinned-switch-jitter.repro.spec.ts
@@ -1,0 +1,215 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const now = 1_800_000_000;
+
+function session(id: string, title: string, number: number, pinned: boolean) {
+  return {
+    id,
+    number,
+    short_title: title,
+    name: title,
+    mode: 'chat',
+    origin: 'web',
+    created_at: now - number * 60,
+    last_message_at: now - number * 60,
+    message_count: number,
+    pinned,
+    archived: false,
+    file_change_summary: { file_count: 0, adds: 0, dels: 0, git: false },
+  };
+}
+
+const sessions = [
+  session('pinned-a', 'Pinned alpha', 1, true),
+  session('pinned-b', 'Pinned beta', 2, true),
+  session('regular-c', 'Regular gamma', 3, false),
+];
+
+async function mockCleanroomAPI(page: Page, projects: boolean) {
+  await page.route('**/v1/**', async (route: Route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const json = (value: unknown) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(value) });
+
+    if (path.endsWith('/v1/capabilities')) return json({ projects: { enabled: projects } });
+    if (path.endsWith('/v1/providers')) {
+      return json({
+        object: 'list',
+        data: [
+          {
+            name: 'cleanroom',
+            configured: true,
+            is_default: true,
+            default_model: 'fixture-model',
+            models: ['fixture-model'],
+          },
+        ],
+      });
+    }
+    if (path.endsWith('/v1/models')) {
+      return json({
+        object: 'list',
+        data: [{ id: 'fixture-model', owned_by: 'cleanroom' }],
+      });
+    }
+    if (path.endsWith('/v1/sessions/status')) return json({ sessions: [] });
+    if (path.endsWith('/v1/sessions') && url.searchParams.get('selected_only') === '1') {
+      const id = url.searchParams.get('selected_session') || 'pinned-a';
+      const selected = sessions.find((entry) => entry.id === id) || sessions[0];
+      return json({
+        selected_session: selected,
+        selected_transcript: {
+          bodies: {
+            rev: 1,
+            messages: [
+              {
+                id: `${id}-message`,
+                sequence: 0,
+                role: 'user',
+                parts: [{ type: 'text', text: `Transcript for ${id}` }],
+              },
+            ],
+          },
+        },
+      });
+    }
+    if (path.endsWith('/v1/sidebar')) {
+      return json({ sessions, recent_sessions: sessions, groups: [] });
+    }
+    if (path.endsWith('/v1/sessions')) return json({ sessions });
+    if (/\/v1\/sessions\/[^/]+\/state$/.test(path)) return json({});
+    if (/\/v1\/sessions\/[^/]+\/transcript$/.test(path)) return json({ messages: [] });
+    return json({});
+  });
+}
+
+type MutationSample = {
+  type: string;
+  session: string;
+  attribute: string | null;
+  oldValue: string | null;
+  value: string | null;
+};
+
+async function beginSidebarMutationTrace(page: Page) {
+  await page.evaluate(() => {
+    type TraceWindow = Window & {
+      __pinnedMutationTrace?: MutationSample[];
+      __pinnedMutationObserver?: MutationObserver;
+    };
+    const target = document.querySelector('#sessionGroups');
+    if (!target) throw new Error('session groups missing');
+    const traceWindow = window as TraceWindow;
+    traceWindow.__pinnedMutationTrace = [];
+    const textNodeSessions = new WeakMap<Node, string>();
+    for (const row of target.querySelectorAll('.session-row')) {
+      const session = row.querySelector('.session-title')?.textContent || '';
+      const walker = document.createTreeWalker(row, NodeFilter.SHOW_ALL);
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        textNodeSessions.set(node, session);
+      }
+    }
+    traceWindow.__pinnedMutationObserver = new MutationObserver((records) => {
+      for (const record of records) {
+        const node = record.target;
+        const element = node instanceof Element ? node : node.parentElement;
+        const row = element?.closest('.session-row');
+        traceWindow.__pinnedMutationTrace!.push({
+          type: record.type,
+          session:
+            textNodeSessions.get(node) ||
+            row?.querySelector('.session-title')?.textContent ||
+            (element?.id === 'sessionGroups' ? '<session-groups-root>' : ''),
+          oldValue: record.oldValue,
+          attribute: record.attributeName,
+          value: node.textContent,
+        });
+      }
+    });
+    traceWindow.__pinnedMutationObserver.observe(target, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true,
+      characterDataOldValue: true,
+    });
+  });
+}
+
+async function finishSidebarMutationTrace(page: Page): Promise<MutationSample[]> {
+  return page.evaluate(() => {
+    type TraceWindow = Window & {
+      __pinnedMutationTrace?: MutationSample[];
+      __pinnedMutationObserver?: MutationObserver;
+    };
+    const traceWindow = window as TraceWindow;
+    traceWindow.__pinnedMutationObserver?.disconnect();
+    return traceWindow.__pinnedMutationTrace || [];
+  });
+}
+
+for (const projects of [false, true]) {
+  test(`switching pinned conversations keeps the ${projects ? 'project' : 'flat'} sidebar stable`, async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name === 'mobile',
+      'desktop sidebar remains visible while switching',
+    );
+    await mockCleanroomAPI(page, projects);
+    await page.goto('./');
+    await expect(page.locator('#startupSplash')).toBeHidden({ timeout: 10_000 });
+    const rows = page.locator('.sidebar-pinned-group .session-row');
+    await expect(rows).toHaveCount(2);
+
+    await page.getByRole('button', { name: 'Pinned alpha', exact: true }).click();
+    await expect(page.getByText('Transcript for pinned-a')).toBeVisible();
+    await page.evaluate(
+      () =>
+        new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
+        ),
+    );
+    await page.locator('#sessionGroups').evaluate((element) => {
+      element.setAttribute('data-cleanroom-identity', 'session-groups');
+      element.querySelectorAll('.session-row').forEach((row, index) => {
+        row.setAttribute('data-cleanroom-identity', `row-${index}`);
+      });
+    });
+
+    await beginSidebarMutationTrace(page);
+    await page.getByRole('button', { name: 'Pinned beta', exact: true }).click();
+    await expect(page.getByText('Transcript for pinned-b')).toBeVisible();
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve(null))));
+    const mutations = await finishSidebarMutationTrace(page);
+
+    await testInfo.attach(`pinned-switch-${projects ? 'projects' : 'flat'}-mutations.json`, {
+      body: JSON.stringify(mutations, null, 2),
+      contentType: 'application/json',
+    });
+
+    await expect(
+      page.locator('#sessionGroups[data-cleanroom-identity="session-groups"]'),
+    ).toHaveCount(1);
+    await expect(page.locator('.session-row[data-cleanroom-identity]')).toHaveCount(3);
+    expect(mutations.filter((entry) => entry.type === 'childList')).toHaveLength(0);
+    expect(
+      mutations
+        .filter((entry) => entry.type === 'attributes')
+        .every((entry) => entry.attribute === 'class' || entry.attribute === 'aria-current'),
+    ).toBe(true);
+
+    const redundantRootWrites = mutations.filter(
+      (entry) =>
+        entry.type === 'characterData' &&
+        entry.session === '<session-groups-root>' &&
+        entry.oldValue === entry.value,
+    );
+    expect(
+      redundantRootWrites.length,
+      'a conversation switch must not trigger a redundant second sidebar render',
+    ).toBeLessThanOrEqual(1);
+  });
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -773,16 +773,19 @@ export function Sidebar() {
       overlayToken.current = null;
     };
   }, [mobile, mobileOpen]);
-  const standalone = store.sessions.value.filter(
+  const catalog = store.sidebarSessions.value;
+  const standalone = catalog.filter(
     (session) => !session.projectId && isSidebarSessionVisible(session),
   );
-  const sessionByID = new Map(store.sessions.value.map((session) => [session.id, session]));
+  const sessionByID = new Map(catalog.map((session) => [session.id, session]));
   const recent = store.recentSessions.value
     .map((summary) => sessionByID.get(summary.id) || summary)
     .filter(isSidebarSessionVisible);
-  const activeRecent = store.activeSession.value;
+  const projectsEnabled = store.projectsEnabled.value;
+  const activeRecent = projectsEnabled
+    ? catalog.find((session) => session.id === store.activeSessionId.peek())
+    : undefined;
   if (
-    store.projectsEnabled.value &&
     activeRecent &&
     isSidebarSessionVisible(activeRecent) &&
     !recent.some((session) => session.id === activeRecent.id)
@@ -790,14 +793,13 @@ export function Sidebar() {
     recent.push(activeRecent);
   recent.sort(compareSessionsByActivity);
   const sidebarSessions = [
-    ...store.sessions.value,
+    ...catalog,
     ...store.projects.value.flatMap((project) => project.sessions || []),
   ].filter(isSidebarSessionVisible);
   const results = store.searchResults.value;
   const brand = store.config.title.trim() || displayName(store.config.agentName);
-  const sidebarView = store.projectsEnabled.value ? store.sidebarView.value : 'recent';
-  const visibleForView =
-    store.projectsEnabled.value && sidebarView === 'recent' ? recent : sidebarSessions;
+  const sidebarView = projectsEnabled ? store.sidebarView.value : 'recent';
+  const visibleForView = projectsEnabled && sidebarView === 'recent' ? recent : sidebarSessions;
   const pinnedIDs = new Set<string>();
   const pinned = visibleForView.filter((session) => {
     if (!session.pinned || pinnedIDs.has(session.id)) return false;
@@ -946,9 +948,9 @@ export function Sidebar() {
             <div
               class="session-groups"
               id="sessionGroups"
-              role={store.projectsEnabled.value && !results ? 'tabpanel' : undefined}
+              role={projectsEnabled && !results ? 'tabpanel' : undefined}
               aria-labelledby={
-                store.projectsEnabled.value && !results
+                projectsEnabled && !results
                   ? sidebarView === 'recent'
                     ? 'sidebarViewRecent'
                     : 'sidebarViewProjects'
@@ -983,12 +985,12 @@ export function Sidebar() {
                         <SessionRow
                           key={session.id}
                           session={session}
-                          showProject={store.projectsEnabled.value && sidebarView === 'recent'}
+                          showProject={projectsEnabled && sidebarView === 'recent'}
                         />
                       ))}
                     </section>
                   )}
-                  {store.projectsEnabled.value ? (
+                  {projectsEnabled ? (
                     sidebarView === 'recent' ? (
                       <div class="flat-session-date-groups sidebar-recent-groups">
                         <SessionDateGroups sessions={recentRegular} showProject />
@@ -1018,7 +1020,7 @@ export function Sidebar() {
               )}
             </div>
           </div>
-          {store.projectsEnabled.value && (
+          {projectsEnabled && (
             <div class="sidebar-view-footer">
               <SidebarViewSwitch disabled={Boolean(results)} />
             </div>

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -117,6 +117,7 @@ export class AppStore {
   readonly notificationController: NotificationController;
 
   readonly sessions: Signal<Session[]>;
+  readonly sidebarSessions: ReadonlySignal<Session[]>;
   readonly recentSessions: Signal<Session[]>;
   readonly recentCursor: Signal<string>;
   readonly sidebarView: Signal<SidebarView>;
@@ -249,6 +250,7 @@ export class AppStore {
       newChat: (replace, projectId) => this.newChat(replace, projectId),
     });
     this.sessions = this.sessionStore.sessions;
+    this.sidebarSessions = this.sessionStore.sidebarSessions;
     this.recentSessions = this.sessionStore.recentSessions;
     this.recentCursor = this.sessionStore.recentCursor;
     this.sidebarView = this.sessionStore.sidebarView;

--- a/frontend/src/stores/session-store.test.ts
+++ b/frontend/src/stores/session-store.test.ts
@@ -113,6 +113,34 @@ describe('SessionStore', () => {
     }
   });
 
+  it('keeps transcript hydration out of the sidebar projection', () => {
+    const store = new AppStore(testConfig);
+    try {
+      const session = testSession({ messageCount: 3 });
+      store.sessions.value = [session];
+      const sidebarSession = store.sidebarSessions.value[0];
+      const updates: unknown[] = [];
+      const unsubscribe = store.sidebarSessions.subscribe((value) => updates.push(value));
+
+      store.sessionStore.update(session.id, (current) => ({
+        ...current,
+        messages: [{ id: 'm1', role: 'user', content: 'hydrated', created: 1 }],
+        transcriptRev: 2,
+      }));
+
+      expect(store.sidebarSessions.value[0]).toBe(sidebarSession);
+      expect(updates).toHaveLength(1);
+
+      store.sessionStore.patch(session.id, { title: 'Visible title change' });
+      expect(store.sidebarSessions.value[0]).not.toBe(sidebarSession);
+      expect(store.sidebarSessions.value[0].title).toBe('Visible title change');
+      expect(updates).toHaveLength(2);
+      unsubscribe();
+    } finally {
+      store.dispose();
+    }
+  });
+
   it('normalizes and merges sidebar payloads without replacing live session state', () => {
     const store = new AppStore(testConfig);
     try {

--- a/frontend/src/stores/session-store.ts
+++ b/frontend/src/stores/session-store.ts
@@ -42,6 +42,34 @@ function sameIdentityList<T>(left: T[], right: T[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
+const TRANSCRIPT_ONLY_SESSION_FIELDS = [
+  'usage',
+  'goal',
+  'mcpServers',
+  'mcpEnabled',
+  'transcriptRev',
+  'messageBodiesRev',
+  'lastResponseId',
+  'activeResponseId',
+  'activeModel',
+  'activeProvider',
+  'activeEffort',
+  'activeReasoningMode',
+  'workingDir',
+  'worktreeDir',
+  'fileChangeSummary',
+] as const satisfies readonly (keyof Session)[];
+
+function sidebarSessionProjection(session: Session): Session {
+  const messageCount = Number.isFinite(session.messageCount)
+    ? Math.max(0, session.messageCount || 0)
+    : session.messages.filter((message) => message.role === 'user' || message.role === 'assistant')
+        .length;
+  const projection = { ...session, messages: [], messageCount };
+  for (const field of TRANSCRIPT_ONLY_SESSION_FIELDS) delete projection[field];
+  return projection;
+}
+
 export interface SessionStoreHost {
   hasRun: (sessionId: string) => boolean;
   modal: Signal<Modal>;
@@ -53,6 +81,25 @@ export interface SessionStoreHost {
 /** Owns session/project catalog state, sidebar loading, search, and catalog mutations. */
 export class SessionStore {
   readonly sessions = signal<Session[]>([]);
+  private readonly sidebarSessionCache = new Map<string, Session>();
+  private sidebarSessionList: Session[] = [];
+  readonly sidebarSessions = computed(() => {
+    const sessions = this.sessions.value;
+    const present = new Set(sessions.map((session) => session.id));
+    for (const id of this.sidebarSessionCache.keys()) {
+      if (!present.has(id)) this.sidebarSessionCache.delete(id);
+    }
+    const projected = sessions.map((session) => {
+      const candidate = sidebarSessionProjection(session);
+      const previous = this.sidebarSessionCache.get(session.id);
+      if (previous && semanticEqual(previous, candidate)) return previous;
+      this.sidebarSessionCache.set(session.id, candidate);
+      return candidate;
+    });
+    if (sameIdentityList(this.sidebarSessionList, projected)) return this.sidebarSessionList;
+    this.sidebarSessionList = projected;
+    return projected;
+  });
   readonly recentSessions = signal<Session[]>([]);
   readonly recentCursor = signal('');
   readonly sidebarView: Signal<SidebarView>;


### PR DESCRIPTION
## Summary

- keep a stable, computed sidebar projection separate from transcript-heavy session state
- stop conversation selection and transcript hydration from forcing a redundant second sidebar render
- preserve normal sidebar updates for titles, pin state, activity, attention, and message counts
- cover both flat (`--no-projects`) and project-enabled sidebars with a cleanroom browser regression

## Reproduction and verification

The cleanroom test uses two pinned conversations and records sidebar DOM mutations while switching between them.

- old compiled build: **2/2 scenarios failed**, each producing two redundant root writes
- fixed compiled build: **10/10 repeated scenarios passed** across flat and project sidebars
- `make build`: pass
- frontend unit suite: **468/468 pass**
- frontend format, lint, and typecheck: pass
- focused existing Sidebar suite: **125/125 pass**

`go test ./...` still has unrelated environment/main failures in skill-discovery tests and the pre-existing production CSS size budget (`app.css` is 168280 bytes against a 168000-byte budget). All other packages completed successfully.

## Fable review

Fable rejected the first implementation because it manually synchronized parallel signals, broke 12 existing Sidebar tests, used fragile imperative DOM updates, and only covered projects-disabled mode. This revision applies that review: `sidebarSessions` is now a computed projection, direct session writes cannot desynchronize it, the imperative row mutation and memo hacks are gone, both sidebar modes are tested, and the full existing component suite passes.
