### PR TITLE
fix: run unbound custom tools from agent directory

### DIFF
--- a/docs-site/content/reference/built-in-tools.md
+++ b/docs-site/content/reference/built-in-tools.md
@@ -124,6 +124,8 @@ sqlite3 "$DB_PATH" \
   "SELECT * FROM runs WHERE job='$NAME' ORDER BY started DESC LIMIT $LIMIT;"
 ```
 
+Custom tools run from the session working directory when the session is bound to a workspace. In unbound remote sessions, such as a dedicated `--no-projects` Web UI, they run from their agent directory instead of inheriting the server process's working directory. This keeps agent-contained tools usable without weakening the ambient-CWD protection for general shell and file tools.
+
 **Field reference:**
 
 | Field | Required | Description |

--- a/internal/tools/custom_tool.go
+++ b/internal/tools/custom_tool.go
@@ -101,13 +101,18 @@ func (t *CustomScriptTool) Execute(ctx context.Context, args json.RawMessage) (l
 		timeout = 3600
 	}
 
-	// Working directory: same as the session BaseDir, falling back to process cwd
-	// only for legacy callers that have not forbidden ambient execution.
+	// Working directory: use the bound session workspace when present. Unbound
+	// remote sessions must not inherit the daemon's ambient CWD, but custom
+	// scripts still have a deterministic trusted home: the agent directory.
+	// Local/legacy callers may continue falling back to the process CWD.
 	workDir := ""
 	if t.toolConfig != nil {
 		workDir = t.toolConfig.WorkingDir()
 		if workDir == "" && t.toolConfig.RequiresExplicitWorkingDir() {
-			return scriptToolErrorOutput(NewToolError(ErrInvalidParams, "an explicit session working directory is required to run custom tools")), nil
+			workDir, err = filepath.Abs(t.agentDir)
+			if err != nil {
+				return scriptToolErrorOutput(NewToolErrorf(ErrExecutionFailed, "resolve agent working directory: %v", err)), nil
+			}
 		}
 	}
 	if workDir == "" {

--- a/internal/tools/custom_tool_test.go
+++ b/internal/tools/custom_tool_test.go
@@ -223,6 +223,57 @@ func TestCustomScriptTool_Execute_SuccessStatus(t *testing.T) {
 	}
 }
 
+func TestCustomScriptTool_Execute_UnboundRemoteUsesAgentDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution working-directory test requires POSIX executable files")
+	}
+	agentDir := t.TempDir()
+	writeScript(t, agentDir, "pwd.sh", "#!/bin/sh\npwd\n")
+	cfg := &ToolConfig{RequireExplicitWorkingDir: true}
+	tool := newCustomScriptTool(agents.CustomToolDef{
+		Name:        "pwd",
+		Description: "Print working directory",
+		Script:      "pwd.sh",
+	}, agentDir, DefaultOutputLimits(), cfg)
+
+	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.IsError {
+		t.Fatalf("unbound custom tool failed: %s", out.Content)
+	}
+	if !strings.Contains(out.Content, agentDir) {
+		t.Fatalf("working directory output = %q, want agent dir %q", out.Content, agentDir)
+	}
+}
+
+func TestCustomScriptTool_Execute_BoundSessionUsesSessionDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution working-directory test requires POSIX executable files")
+	}
+	agentDir := t.TempDir()
+	sessionDir := t.TempDir()
+	writeScript(t, agentDir, "pwd.sh", "#!/bin/sh\npwd\n")
+	cfg := &ToolConfig{BaseDir: sessionDir, RequireExplicitWorkingDir: true}
+	tool := newCustomScriptTool(agents.CustomToolDef{
+		Name:        "pwd",
+		Description: "Print working directory",
+		Script:      "pwd.sh",
+	}, agentDir, DefaultOutputLimits(), cfg)
+
+	out, err := tool.Execute(context.Background(), json.RawMessage("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.IsError {
+		t.Fatalf("bound custom tool failed: %s", out.Content)
+	}
+	if !strings.Contains(out.Content, sessionDir) {
+		t.Fatalf("working directory output = %q, want session dir %q", out.Content, sessionDir)
+	}
+}
+
 func TestCustomScriptTool_Execute_ContextFailureStatus(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("script execution status test requires POSIX executable files")


### PR DESCRIPTION
## Summary

- run script-backed custom tools from their agent directory when a remote session has no bound workspace
- preserve the bound session working directory when one exists
- document the fallback and cover both bound and unbound behavior

## Why

Dedicated `--no-projects` Web UI sessions intentionally have no session CWD and reject ambient daemon-CWD execution. That protection also blocked trusted agent-contained custom tools before their scripts ran:

```text
Error [INVALID_PARAMS]: an explicit session working directory is required to run custom tools
```

The agent directory is already the containment boundary for resolving custom scripts, so it is the deterministic safe fallback. General shell and file tools remain unable to inherit the daemon's ambient CWD.

## Tests

- `go test ./internal/tools`
- `mise x node@24 -- make build`
- `go test ./cmd` and `go test ./...` were also run; both reach unrelated existing failures from local skill-inventory expectations, and the full suite additionally hits the current `app.css` gzip budget. The changed `internal/tools` package passes.
