### PR TITLE
feat: add OAuth, Venice, and task-aware embeddings

### DIFF
--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -57,7 +57,7 @@ Examples:
 }
 
 func init() {
-	embedCmd.Flags().StringVarP(&embedProvider, "provider", "p", "", "Override embedding provider (gemini, openai, chatgpt, jina, voyage, ollama), optionally with model (e.g., chatgpt:text-embedding-3-large)")
+	embedCmd.Flags().StringVarP(&embedProvider, "provider", "p", "", "Override embedding provider (gemini, openai, chatgpt, venice, jina, voyage, ollama), optionally with model (e.g., venice:text-embedding-qwen3-8b)")
 	embedCmd.Flags().StringArrayVarP(&embedFiles, "file", "f", nil, "Input file(s) to embed (can be specified multiple times)")
 	embedCmd.Flags().StringVarP(&embedOutput, "output", "o", "", "Write output to file instead of stdout")
 	embedCmd.Flags().StringVar(&embedFormat, "format", "json", "Output format: json, array, plain")

--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -57,7 +57,7 @@ Examples:
 }
 
 func init() {
-	embedCmd.Flags().StringVarP(&embedProvider, "provider", "p", "", "Override embedding provider (gemini, openai, jina, voyage, ollama), optionally with model (e.g., openai:text-embedding-3-large)")
+	embedCmd.Flags().StringVarP(&embedProvider, "provider", "p", "", "Override embedding provider (gemini, openai, chatgpt, jina, voyage, ollama), optionally with model (e.g., chatgpt:text-embedding-3-large)")
 	embedCmd.Flags().StringArrayVarP(&embedFiles, "file", "f", nil, "Input file(s) to embed (can be specified multiple times)")
 	embedCmd.Flags().StringVarP(&embedOutput, "output", "o", "", "Write output to file instead of stdout")
 	embedCmd.Flags().StringVar(&embedFormat, "format", "json", "Output format: json, array, plain")

--- a/docs-site/content/guides/text-embeddings.md
+++ b/docs-site/content/guides/text-embeddings.md
@@ -90,6 +90,7 @@ term-llm embed --similarity "What is AI?" "Machine learning is a subset of AI" "
 term-llm embed "hello" -p openai                          # use OpenAI
 term-llm embed "hello" -p openai:text-embedding-3-large   # specific API-key model
 term-llm embed "hello" -p chatgpt:text-embedding-3-large  # reuse ChatGPT OAuth
+term-llm embed "hello" -p venice:text-embedding-qwen3-8b   # reuse providers.venice
 term-llm embed "hello" -p gemini                           # use Gemini
 term-llm embed "hello" -p jina                             # use Jina (free tier)
 term-llm embed "hello" -p voyage                           # use Voyage AI
@@ -113,11 +114,12 @@ For Qwen3 embedding models served by Ollama, `RETRIEVAL_QUERY` automatically add
 | Gemini (default) | `gemini-embedding-001` | 3072 (128–3072) | `GEMINI_API_KEY` | Yes |
 | OpenAI | `text-embedding-3-small` | 1536 (customizable) | `OPENAI_API_KEY` | No |
 | ChatGPT OAuth | `text-embedding-3-small` | 1536 (customizable) | `term-llm auth login chatgpt` | Subscription access |
+| Venice | `text-embedding-qwen3-8b` | 4096 (customizable) | `providers.venice.api_key` | No |
 | [Jina AI](https://jina.ai/embeddings/) | `jina-embeddings-v3` | 1024 (customizable) | `JINA_API_KEY` | Yes (10M tokens) |
 | [Voyage AI](https://voyageai.com) | `voyage-3.5` | 1024 (256–2048) | `VOYAGE_API_KEY` | No |
 | Ollama | `nomic-embed-text` | 768 | — | Local |
 
-Embedding providers normally use their own credentials, separate from text and image providers. ChatGPT is the exception: `chatgpt:<model>` reuses the existing ChatGPT/Codex OAuth login. Select it explicitly with `-p chatgpt:<model>` or `embed.provider`; automatic detection remains limited to configured Gemini and OpenAI API keys.
+Embedding providers normally use their own credentials, separate from text and image providers. ChatGPT and Venice are exceptions: `chatgpt:<model>` reuses the existing ChatGPT/Codex OAuth login, while `venice:<model>` reuses `providers.venice`. Select either explicitly with `-p` or `embed.provider`; automatic detection remains limited to configured Gemini and OpenAI API keys.
 
 **Jina AI** is a great choice for getting started. Sign up at [jina.ai/embeddings](https://jina.ai/embeddings/) for a free API key with 10M tokens, no credit card required.
 

--- a/docs-site/content/guides/text-embeddings.md
+++ b/docs-site/content/guides/text-embeddings.md
@@ -88,7 +88,8 @@ term-llm embed --similarity "What is AI?" "Machine learning is a subset of AI" "
 ```bash
 # Provider/model selection
 term-llm embed "hello" -p openai                          # use OpenAI
-term-llm embed "hello" -p openai:text-embedding-3-large   # specific model
+term-llm embed "hello" -p openai:text-embedding-3-large   # specific API-key model
+term-llm embed "hello" -p chatgpt:text-embedding-3-large  # reuse ChatGPT OAuth
 term-llm embed "hello" -p gemini                           # use Gemini
 term-llm embed "hello" -p jina                             # use Jina (free tier)
 term-llm embed "hello" -p voyage                           # use Voyage AI
@@ -97,10 +98,13 @@ term-llm embed "hello" -p ollama:nomic-embed-text          # local Ollama
 # Custom dimensions (Matryoshka)
 term-llm embed "hello" --dimensions 256
 
-# Gemini task type hints
+# Retrieval task type hints
 term-llm embed "search query" --task-type RETRIEVAL_QUERY -p gemini
 term-llm embed -f doc.txt --task-type RETRIEVAL_DOCUMENT -p gemini
+term-llm embed "search query" --task-type RETRIEVAL_QUERY -p ollama:qwen3-embedding:4b
 ```
+
+For Qwen3 embedding models served by Ollama, `RETRIEVAL_QUERY` automatically adds Qwen's recommended retrieval instruction while document text remains unchanged.
 
 ### Embedding Providers
 
@@ -108,11 +112,12 @@ term-llm embed -f doc.txt --task-type RETRIEVAL_DOCUMENT -p gemini
 |----------|--------------|------------|---------------------|-----------|
 | Gemini (default) | `gemini-embedding-001` | 3072 (128–3072) | `GEMINI_API_KEY` | Yes |
 | OpenAI | `text-embedding-3-small` | 1536 (customizable) | `OPENAI_API_KEY` | No |
+| ChatGPT OAuth | `text-embedding-3-small` | 1536 (customizable) | `term-llm auth login chatgpt` | Subscription access |
 | [Jina AI](https://jina.ai/embeddings/) | `jina-embeddings-v3` | 1024 (customizable) | `JINA_API_KEY` | Yes (10M tokens) |
 | [Voyage AI](https://voyageai.com) | `voyage-3.5` | 1024 (256–2048) | `VOYAGE_API_KEY` | No |
 | Ollama | `nomic-embed-text` | 768 | — | Local |
 
-Embedding providers use their own credentials, separate from text and image providers. The default provider is auto-detected from your LLM provider (Gemini users → Gemini, OpenAI users → OpenAI, Anthropic users → Voyage if configured, otherwise Gemini).
+Embedding providers normally use their own credentials, separate from text and image providers. ChatGPT is the exception: `chatgpt:<model>` reuses the existing ChatGPT/Codex OAuth login. Select it explicitly with `-p chatgpt:<model>` or `embed.provider`; automatic detection remains limited to configured Gemini and OpenAI API keys.
 
 **Jina AI** is a great choice for getting started. Sign up at [jina.ai/embeddings](https://jina.ai/embeddings/) for a free API key with 10M tokens, no credit card required.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1043,7 +1043,7 @@ type TranscriptionElevenLabsConfig struct {
 
 // EmbedConfig configures text embedding generation
 type EmbedConfig struct {
-	Provider string            `mapstructure:"provider"` // default embedding provider: gemini, openai, jina, voyage, ollama
+	Provider string            `mapstructure:"provider"` // default embedding provider: gemini, openai, chatgpt, jina, voyage, ollama
 	OpenAI   EmbedOpenAIConfig `mapstructure:"openai"`
 	Gemini   EmbedGeminiConfig `mapstructure:"gemini"`
 	Jina     EmbedJinaConfig   `mapstructure:"jina"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1043,7 +1043,7 @@ type TranscriptionElevenLabsConfig struct {
 
 // EmbedConfig configures text embedding generation
 type EmbedConfig struct {
-	Provider string            `mapstructure:"provider"` // default embedding provider: gemini, openai, chatgpt, jina, voyage, ollama
+	Provider string            `mapstructure:"provider"` // default embedding provider: gemini, openai, chatgpt, venice, jina, voyage, ollama
 	OpenAI   EmbedOpenAIConfig `mapstructure:"openai"`
 	Gemini   EmbedGeminiConfig `mapstructure:"gemini"`
 	Jina     EmbedJinaConfig   `mapstructure:"jina"`

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -102,6 +102,8 @@ const (
 	DefaultTranscriptionElevenLabsModel = "scribe_v2"
 
 	DefaultEmbedOpenAIModel   = "text-embedding-3-small"
+	DefaultEmbedChatGPTModel  = DefaultEmbedOpenAIModel
+	DefaultEmbedVeniceModel   = "text-embedding-qwen3-8b"
 	DefaultEmbedGeminiModel   = "gemini-embedding-001"
 	DefaultEmbedJinaModel     = "jina-embeddings-v3"
 	DefaultEmbedVoyageModel   = "voyage-3.5"

--- a/internal/embedding/chatgpt.go
+++ b/internal/embedding/chatgpt.go
@@ -1,0 +1,55 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samsaffron/term-llm/internal/credentials"
+)
+
+// ChatGPTProvider uses the user's ChatGPT/Codex OAuth session with OpenAI's
+// official embeddings endpoint. ChatGPT OAuth access and OpenAI API-key billing
+// are separate authentication paths even though the wire API is identical.
+type ChatGPTProvider struct {
+	model           string
+	loadCredentials func() (*credentials.ChatGPTCredentials, error)
+	refresh         func(*credentials.ChatGPTCredentials) error
+	embed           func(context.Context, string, string, EmbedRequest) (*EmbeddingResult, error)
+}
+
+func NewChatGPTProvider() *ChatGPTProvider {
+	return &ChatGPTProvider{
+		model:           openaiDefaultModel,
+		loadCredentials: credentials.GetChatGPTCredentials,
+		refresh:         credentials.RefreshChatGPTCredentials,
+		embed: func(ctx context.Context, accessToken, model string, req EmbedRequest) (*EmbeddingResult, error) {
+			provider := NewOpenAIProvider(accessToken)
+			provider.model = model
+			return provider.Embed(ctx, req)
+		},
+	}
+}
+
+func (p *ChatGPTProvider) Name() string {
+	return "ChatGPT"
+}
+
+func (p *ChatGPTProvider) DefaultModel() string {
+	return openaiDefaultModel
+}
+
+func (p *ChatGPTProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbeddingResult, error) {
+	creds, err := p.loadCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("ChatGPT embedding requires ChatGPT login: %w", err)
+	}
+	if creds.IsExpired() {
+		if err := p.refresh(creds); err != nil {
+			return nil, fmt.Errorf("refresh ChatGPT OAuth token for embedding: %w", err)
+		}
+	}
+	if creds.AccessToken == "" {
+		return nil, fmt.Errorf("ChatGPT embedding credentials have no access token")
+	}
+	return p.embed(ctx, creds.AccessToken, p.model, req)
+}

--- a/internal/embedding/chatgpt_test.go
+++ b/internal/embedding/chatgpt_test.go
@@ -1,0 +1,75 @@
+package embedding
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/credentials"
+)
+
+func TestChatGPTProviderUsesOAuthTokenAndModel(t *testing.T) {
+	creds := &credentials.ChatGPTCredentials{AccessToken: "oauth-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
+	provider := NewChatGPTProvider()
+	provider.model = "text-embedding-3-large"
+	provider.loadCredentials = func() (*credentials.ChatGPTCredentials, error) { return creds, nil }
+	provider.refresh = func(*credentials.ChatGPTCredentials) error {
+		t.Fatal("unexpected token refresh")
+		return nil
+	}
+	provider.embed = func(_ context.Context, token, model string, req EmbedRequest) (*EmbeddingResult, error) {
+		if token != "oauth-token" {
+			t.Fatalf("token = %q", token)
+		}
+		if model != "text-embedding-3-large" {
+			t.Fatalf("model = %q", model)
+		}
+		if len(req.Texts) != 1 || req.Texts[0] != "hello" {
+			t.Fatalf("request = %#v", req)
+		}
+		return &EmbeddingResult{Model: model, Dimensions: 3072}, nil
+	}
+
+	result, err := provider.Embed(context.Background(), EmbedRequest{Texts: []string{"hello"}})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if result.Model != "text-embedding-3-large" || result.Dimensions != 3072 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestChatGPTProviderRefreshesExpiredToken(t *testing.T) {
+	creds := &credentials.ChatGPTCredentials{AccessToken: "expired", ExpiresAt: time.Now().Add(-time.Hour).Unix()}
+	provider := NewChatGPTProvider()
+	provider.loadCredentials = func() (*credentials.ChatGPTCredentials, error) { return creds, nil }
+	provider.refresh = func(got *credentials.ChatGPTCredentials) error {
+		if got != creds {
+			t.Fatal("refresh received different credentials")
+		}
+		got.AccessToken = "refreshed"
+		got.ExpiresAt = time.Now().Add(time.Hour).Unix()
+		return nil
+	}
+	provider.embed = func(_ context.Context, token, _ string, _ EmbedRequest) (*EmbeddingResult, error) {
+		if token != "refreshed" {
+			t.Fatalf("token = %q", token)
+		}
+		return &EmbeddingResult{}, nil
+	}
+
+	if _, err := provider.Embed(context.Background(), EmbedRequest{Texts: []string{"hello"}}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+}
+
+func TestChatGPTProviderReportsCredentialFailure(t *testing.T) {
+	provider := NewChatGPTProvider()
+	provider.loadCredentials = func() (*credentials.ChatGPTCredentials, error) {
+		return nil, errors.New("missing")
+	}
+	if _, err := provider.Embed(context.Background(), EmbedRequest{}); err == nil {
+		t.Fatal("expected credential error")
+	}
+}

--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/config"
@@ -45,10 +46,12 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*Embeddin
 		model = req.Model
 	}
 
-	// Ollama's /api/embed endpoint supports batch input
+	texts := prepareOllamaTexts(model, req.TaskType, req.Texts)
+
+	// Ollama's /api/embed endpoint supports batch input.
 	ollamaReq := ollamaEmbedRequest{
 		Model: model,
-		Input: req.Texts,
+		Input: texts,
 	}
 
 	jsonBody, err := json.Marshal(ollamaReq)
@@ -104,6 +107,17 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*Embeddin
 	}
 
 	return result, nil
+}
+
+func prepareOllamaTexts(model, taskType string, texts []string) []string {
+	if taskType != "RETRIEVAL_QUERY" || !strings.HasPrefix(strings.ToLower(model), "qwen3-embedding") {
+		return texts
+	}
+	prepared := make([]string, len(texts))
+	for i, text := range texts {
+		prepared[i] = "Instruct: Given a user question, retrieve relevant passages that answer it\nQuery: " + text
+	}
+	return prepared
 }
 
 // Ollama API types

--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -46,7 +46,7 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*Embeddin
 		model = req.Model
 	}
 
-	texts := prepareOllamaTexts(model, req.TaskType, req.Texts)
+	texts := prepareQwen3EmbeddingTexts(model, req.TaskType, req.Texts)
 
 	// Ollama's /api/embed endpoint supports batch input.
 	ollamaReq := ollamaEmbedRequest{
@@ -109,8 +109,9 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*Embeddin
 	return result, nil
 }
 
-func prepareOllamaTexts(model, taskType string, texts []string) []string {
-	if taskType != "RETRIEVAL_QUERY" || !strings.HasPrefix(strings.ToLower(model), "qwen3-embedding") {
+func prepareQwen3EmbeddingTexts(model, taskType string, texts []string) []string {
+	modelLower := strings.ToLower(model)
+	if taskType != "RETRIEVAL_QUERY" || !strings.Contains(modelLower, "qwen3") || !strings.Contains(modelLower, "embedding") {
 		return texts
 	}
 	prepared := make([]string, len(texts))

--- a/internal/embedding/ollama_test.go
+++ b/internal/embedding/ollama_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 )
 
-func TestPrepareOllamaTextsAddsQwenRetrievalInstruction(t *testing.T) {
+func TestPrepareQwen3EmbeddingTextsAddsRetrievalInstruction(t *testing.T) {
 	input := []string{"Where is the deployment note?"}
-	got := prepareOllamaTexts("qwen3-embedding:4b", "RETRIEVAL_QUERY", input)
+	got := prepareQwen3EmbeddingTexts("qwen3-embedding:4b", "RETRIEVAL_QUERY", input)
 	want := []string{"Instruct: Given a user question, retrieve relevant passages that answer it\nQuery: Where is the deployment note?"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("prepared texts = %#v, want %#v", got, want)
@@ -17,7 +17,7 @@ func TestPrepareOllamaTextsAddsQwenRetrievalInstruction(t *testing.T) {
 	}
 }
 
-func TestPrepareOllamaTextsLeavesDocumentsAndOtherModelsAlone(t *testing.T) {
+func TestPrepareQwen3EmbeddingTextsLeavesDocumentsAndOtherModelsAlone(t *testing.T) {
 	input := []string{"document"}
 	tests := []struct {
 		model    string
@@ -28,8 +28,8 @@ func TestPrepareOllamaTextsLeavesDocumentsAndOtherModelsAlone(t *testing.T) {
 		{model: "qwen3-embedding:4b", taskType: ""},
 	}
 	for _, tt := range tests {
-		if got := prepareOllamaTexts(tt.model, tt.taskType, input); !reflect.DeepEqual(got, input) {
-			t.Fatalf("prepareOllamaTexts(%q, %q) = %#v", tt.model, tt.taskType, got)
+		if got := prepareQwen3EmbeddingTexts(tt.model, tt.taskType, input); !reflect.DeepEqual(got, input) {
+			t.Fatalf("prepareQwen3EmbeddingTexts(%q, %q) = %#v", tt.model, tt.taskType, got)
 		}
 	}
 }

--- a/internal/embedding/ollama_test.go
+++ b/internal/embedding/ollama_test.go
@@ -1,0 +1,35 @@
+package embedding
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPrepareOllamaTextsAddsQwenRetrievalInstruction(t *testing.T) {
+	input := []string{"Where is the deployment note?"}
+	got := prepareOllamaTexts("qwen3-embedding:4b", "RETRIEVAL_QUERY", input)
+	want := []string{"Instruct: Given a user question, retrieve relevant passages that answer it\nQuery: Where is the deployment note?"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("prepared texts = %#v, want %#v", got, want)
+	}
+	if input[0] != "Where is the deployment note?" {
+		t.Fatalf("input mutated: %#v", input)
+	}
+}
+
+func TestPrepareOllamaTextsLeavesDocumentsAndOtherModelsAlone(t *testing.T) {
+	input := []string{"document"}
+	tests := []struct {
+		model    string
+		taskType string
+	}{
+		{model: "qwen3-embedding:4b", taskType: "RETRIEVAL_DOCUMENT"},
+		{model: "nomic-embed-text", taskType: "RETRIEVAL_QUERY"},
+		{model: "qwen3-embedding:4b", taskType: ""},
+	}
+	for _, tt := range tests {
+		if got := prepareOllamaTexts(tt.model, tt.taskType, input); !reflect.DeepEqual(got, input) {
+			t.Fatalf("prepareOllamaTexts(%q, %q) = %#v", tt.model, tt.taskType, got)
+		}
+	}
+}

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -85,6 +85,31 @@ func NewEmbeddingProvider(cfg *config.Config, providerOverride string) (Embeddin
 		}
 		return p, nil
 
+	case "venice":
+		providerCfg := cfg.GetProviderConfig("venice")
+		if providerCfg == nil {
+			return nil, fmt.Errorf("Venice embedding requires a configured providers.venice entry")
+		}
+		if err := providerCfg.ResolveForInference(); err != nil {
+			return nil, fmt.Errorf("resolve Venice embedding credentials: %w", err)
+		}
+		apiKey := strings.TrimSpace(providerCfg.ResolvedAPIKey)
+		if apiKey == "" && strings.TrimSpace(providerCfg.APIKey) != "" {
+			resolved, err := config.ResolveValue(providerCfg.APIKey)
+			if err != nil {
+				return nil, fmt.Errorf("resolve Venice embedding API key: %w", err)
+			}
+			apiKey = strings.TrimSpace(resolved)
+		}
+		if apiKey == "" {
+			return nil, fmt.Errorf("VENICE_API_KEY not configured. Set providers.venice.api_key or VENICE_API_KEY")
+		}
+		p := NewVeniceProvider(apiKey, providerCfg.BaseURL)
+		if model != "" {
+			p.model = model
+		}
+		return p, nil
+
 	case "gemini":
 		apiKey := cfg.Embed.Gemini.APIKey
 		if apiKey == "" {
@@ -136,7 +161,7 @@ func NewEmbeddingProvider(cfg *config.Config, providerOverride string) (Embeddin
 		return p, nil
 
 	default:
-		return nil, fmt.Errorf("unknown embedding provider: %s (valid: gemini, openai, chatgpt, jina, voyage, ollama)", provider)
+		return nil, fmt.Errorf("unknown embedding provider: %s (valid: gemini, openai, chatgpt, venice, jina, voyage, ollama)", provider)
 	}
 }
 

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -78,6 +78,13 @@ func NewEmbeddingProvider(cfg *config.Config, providerOverride string) (Embeddin
 		}
 		return p, nil
 
+	case "chatgpt":
+		p := NewChatGPTProvider()
+		if model != "" {
+			p.model = model
+		}
+		return p, nil
+
 	case "gemini":
 		apiKey := cfg.Embed.Gemini.APIKey
 		if apiKey == "" {
@@ -129,7 +136,7 @@ func NewEmbeddingProvider(cfg *config.Config, providerOverride string) (Embeddin
 		return p, nil
 
 	default:
-		return nil, fmt.Errorf("unknown embedding provider: %s (valid: gemini, openai, jina, voyage, ollama)", provider)
+		return nil, fmt.Errorf("unknown embedding provider: %s (valid: gemini, openai, chatgpt, jina, voyage, ollama)", provider)
 	}
 }
 

--- a/internal/embedding/provider_test.go
+++ b/internal/embedding/provider_test.go
@@ -7,6 +7,20 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestNewEmbeddingProviderChatGPTOAuthModel(t *testing.T) {
+	provider, err := NewEmbeddingProvider(&config.Config{}, "chatgpt:text-embedding-3-large")
+	if err != nil {
+		t.Fatalf("NewEmbeddingProvider: %v", err)
+	}
+	chatgpt, ok := provider.(*ChatGPTProvider)
+	if !ok {
+		t.Fatalf("provider type = %T", provider)
+	}
+	if chatgpt.model != "text-embedding-3-large" {
+		t.Fatalf("model = %q", chatgpt.model)
+	}
+}
+
 func TestNewEmbeddingProviderResolvesOllamaBaseURL(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Embed.Ollama.BaseURL = "$(printf https://ollama.example.test)"
@@ -93,6 +107,7 @@ func TestParseProviderModel(t *testing.T) {
 	}{
 		{"openai", "openai", ""},
 		{"openai:text-embedding-3-large", "openai", "text-embedding-3-large"},
+		{"chatgpt:text-embedding-3-large", "chatgpt", "text-embedding-3-large"},
 		{"gemini", "gemini", ""},
 		{"gemini:gemini-embedding-001", "gemini", "gemini-embedding-001"},
 		{"ollama:nomic-embed-text", "ollama", "nomic-embed-text"},

--- a/internal/embedding/provider_test.go
+++ b/internal/embedding/provider_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 )
 
+func TestNewEmbeddingProviderVeniceModel(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"venice": {APIKey: "venice-key"},
+	}}
+	provider, err := NewEmbeddingProvider(cfg, "venice:text-embedding-qwen3-8b")
+	if err != nil {
+		t.Fatalf("NewEmbeddingProvider: %v", err)
+	}
+	venice, ok := provider.(*VeniceProvider)
+	if !ok {
+		t.Fatalf("provider type = %T", provider)
+	}
+	if venice.model != "text-embedding-qwen3-8b" {
+		t.Fatalf("model = %q", venice.model)
+	}
+}
+
 func TestNewEmbeddingProviderChatGPTOAuthModel(t *testing.T) {
 	provider, err := NewEmbeddingProvider(&config.Config{}, "chatgpt:text-embedding-3-large")
 	if err != nil {
@@ -108,6 +125,7 @@ func TestParseProviderModel(t *testing.T) {
 		{"openai", "openai", ""},
 		{"openai:text-embedding-3-large", "openai", "text-embedding-3-large"},
 		{"chatgpt:text-embedding-3-large", "chatgpt", "text-embedding-3-large"},
+		{"venice:text-embedding-qwen3-8b", "venice", "text-embedding-qwen3-8b"},
 		{"gemini", "gemini", ""},
 		{"gemini:gemini-embedding-001", "gemini", "gemini-embedding-001"},
 		{"ollama:nomic-embed-text", "ollama", "nomic-embed-text"},

--- a/internal/embedding/venice.go
+++ b/internal/embedding/venice.go
@@ -1,0 +1,124 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/providerhttp"
+)
+
+const (
+	veniceEmbedBaseURL = "https://api.venice.ai/api/v1"
+	veniceEmbedTimeout = 2 * time.Minute
+)
+
+// VeniceProvider implements Venice's OpenAI-compatible embeddings endpoint.
+type VeniceProvider struct {
+	apiKey  string
+	model   string
+	baseURL string
+	client  *http.Client
+}
+
+func NewVeniceProvider(apiKey, baseURL string) *VeniceProvider {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = veniceEmbedBaseURL
+	}
+	return &VeniceProvider{
+		apiKey:  apiKey,
+		model:   config.DefaultEmbedVeniceModel,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: veniceEmbedTimeout},
+	}
+}
+
+func (p *VeniceProvider) Name() string {
+	return "Venice"
+}
+
+func (p *VeniceProvider) DefaultModel() string {
+	return config.DefaultEmbedVeniceModel
+}
+
+func (p *VeniceProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbeddingResult, error) {
+	model := p.model
+	if req.Model != "" {
+		model = req.Model
+	}
+	payload := veniceEmbedRequest{
+		Model:          model,
+		Input:          prepareQwen3EmbeddingTexts(model, req.TaskType, req.Texts),
+		EncodingFormat: "float",
+		Dimensions:     req.Dimensions,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Venice embedding request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create Venice embedding request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("Venice embedding request: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read Venice embedding response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, providerhttp.NewStatusError("Venice embedding", resp, responseBody)
+	}
+	var apiResp veniceEmbedResponse
+	if err := json.Unmarshal(responseBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("decode Venice embedding response: %w", err)
+	}
+	result := &EmbeddingResult{
+		Model:      apiResp.Model,
+		Embeddings: make([]Embedding, len(apiResp.Data)),
+	}
+	if apiResp.Usage.PromptTokens > 0 || apiResp.Usage.TotalTokens > 0 {
+		result.Usage = &UsageInfo{PromptTokens: apiResp.Usage.PromptTokens, TotalTokens: apiResp.Usage.TotalTokens}
+	}
+	for i, item := range apiResp.Data {
+		result.Embeddings[i] = Embedding{Index: item.Index, Vector: item.Embedding}
+		if i < len(req.Texts) {
+			result.Embeddings[i].Text = req.Texts[i]
+		}
+	}
+	if len(result.Embeddings) > 0 {
+		result.Dimensions = len(result.Embeddings[0].Vector)
+	}
+	return result, nil
+}
+
+type veniceEmbedRequest struct {
+	Model          string   `json:"model"`
+	Input          []string `json:"input"`
+	EncodingFormat string   `json:"encoding_format"`
+	Dimensions     int      `json:"dimensions,omitempty"`
+}
+
+type veniceEmbedResponse struct {
+	Model string `json:"model"`
+	Data  []struct {
+		Index     int       `json:"index"`
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+	Usage struct {
+		PromptTokens int64 `json:"prompt_tokens"`
+		TotalTokens  int64 `json:"total_tokens"`
+	} `json:"usage"`
+}

--- a/internal/embedding/venice_test.go
+++ b/internal/embedding/venice_test.go
@@ -1,0 +1,55 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestVeniceProviderEmbedsWithQwenQueryInstruction(t *testing.T) {
+	var got veniceEmbedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"text-embedding-qwen3-8b","data":[{"index":0,"embedding":[0.1,0.2,0.3]}],"usage":{"prompt_tokens":4,"total_tokens":4}}`))
+	}))
+	defer server.Close()
+
+	provider := NewVeniceProvider("test-key", server.URL)
+	result, err := provider.Embed(context.Background(), EmbedRequest{
+		Texts:    []string{"Where is the deploy note?"},
+		TaskType: "RETRIEVAL_QUERY",
+	})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	wantInput := []string{"Instruct: Given a user question, retrieve relevant passages that answer it\nQuery: Where is the deploy note?"}
+	if !reflect.DeepEqual(got.Input, wantInput) {
+		t.Fatalf("input = %#v, want %#v", got.Input, wantInput)
+	}
+	if got.Model != "text-embedding-qwen3-8b" || got.EncodingFormat != "float" {
+		t.Fatalf("request = %#v", got)
+	}
+	if result.Model != got.Model || result.Dimensions != 3 || result.Usage == nil || result.Usage.TotalTokens != 4 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestVeniceProviderLeavesNonQwenDocumentsUnchanged(t *testing.T) {
+	input := []string{"document"}
+	got := prepareQwen3EmbeddingTexts("text-embedding-bge-en-icl", "RETRIEVAL_DOCUMENT", input)
+	if !reflect.DeepEqual(got, input) {
+		t.Fatalf("input = %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add a `chatgpt` embedding provider that reuses the existing ChatGPT/Codex OAuth login against OpenAI's official embeddings endpoint
- add a `venice` embedding provider that reuses `providers.venice` and Venice's OpenAI-compatible embeddings endpoint
- default Venice embeddings to `text-embedding-qwen3-8b`, with explicit model overrides for every Venice catalog option
- preserve Qwen3's asymmetric retrieval contract for Ollama and Venice by adding its recommended instruction only to `RETRIEVAL_QUERY` inputs
- expose the providers in CLI help and document OAuth, Venice, and Qwen usage

## Why

ChatGPT OAuth can successfully call `POST https://api.openai.com/v1/embeddings`, but term-llm previously rejected `-p chatgpt:<model>`. Venice now exposes nine embedding models through a real embeddings endpoint, but term-llm could not reuse an existing Venice provider credential for embeddings. Separately, Qwen3 model cards report a 1–5% retrieval improvement from query-side instructions; the Ollama provider previously discarded `EmbedRequest.TaskType`.

The Qwen behavior remains narrowly model-gated: only model IDs containing both `qwen3` and `embedding`, with requests marked `RETRIEVAL_QUERY`, are transformed. Documents and other models remain byte-for-byte unchanged.

## Live verification

```text
chatgpt:text-embedding-3-large
  dimensions: 3072
  status: successful

venice:text-embedding-qwen3-8b
  dimensions: 4096
  status: successful
```

Qwen3-Embedding-4B CPU-only benchmark, Q4_K_M, 4K context, isolated Ollama with CUDA hidden:

```text
cold request:  2.076 s
model load:    1.867 s
warm median:   122.6 ms
warm p95:      131.4 ms
resident RSS:  3.33 GB
GPU VRAM:      0 B
```

A normal CUDA-visible Ollama process retained about 1.9 GB VRAM even with `num_gpu=0`; a genuinely CPU-only process was required for the zero-VRAM result.

## Memory retrieval evaluation

Same current memory DB snapshot, same 197 valid examples from the existing 200-case Jarvis eval, top-five hybrid retrieval, one discarded warm-up call:

| Provider | Hit@1 | Hit@3 | Hit@5 | MRR@5 | Median | p95 |
|---|---:|---:|---:|---:|---:|---:|
| Gemini clean baseline | **90.86%** | 92.39% | 92.89% | **91.67%** | 826 ms | — |
| Venice Qwen3-8B | 88.83% | **93.40%** | **95.94%** | 91.11% | 827 ms | 2,161 ms |
| Qwen3-4B CPU | 86.80% | 92.89% | 94.92% | 89.80% | **235 ms** | 277 ms |
| Venice Qwen3-0.6B | 82.74% | 90.36% | 94.42% | 86.92% | 697 ms | 1,059 ms |
| ChatGPT text-embedding-3-large | 79.70% | 81.73% | 81.73% | 80.54% | 250 ms | 313 ms |

The local Qwen index was built once on GPU, then unloaded; all measured Qwen query retrieval ran against the CPU-only server. No live Jarvis memory provider was changed by the evaluation.

## Tests

- `go test ./internal/embedding ./internal/config ./internal/credentials`
- `mise x node@24 -- make build`
- live `term-llm embed` smoke with ChatGPT and Venice
- corpus-grounded 197-example retrieval evaluation across five providers
