### PR TITLE
feat: configure memory embedding batch size

### DIFF
--- a/cmd/memory_mine.go
+++ b/cmd/memory_mine.go
@@ -1125,7 +1125,10 @@ func runMemoryEmbedPhase(ctx context.Context, cfg *config.Config, store *memoryd
 	}
 
 	embeddedCount := 0
-	const embedBatchSize = 32
+	embedBatchSize := cfg.Embed.BatchSize
+	if embedBatchSize <= 0 {
+		embedBatchSize = 32
+	}
 	for i := 0; i < len(fragments); i += embedBatchSize {
 		end := i + embedBatchSize
 		if end > len(fragments) {

--- a/docs-site/content/guides/text-embeddings.md
+++ b/docs-site/content/guides/text-embeddings.md
@@ -121,6 +121,16 @@ For Qwen3 embedding models served by Ollama, `RETRIEVAL_QUERY` automatically add
 
 Embedding providers normally use their own credentials, separate from text and image providers. ChatGPT and Venice are exceptions: `chatgpt:<model>` reuses the existing ChatGPT/Codex OAuth login, while `venice:<model>` reuses `providers.venice`. Select either explicitly with `-p` or `embed.provider`; automatic detection remains limited to configured Gemini and OpenAI API keys.
 
+Memory mining embeds documents in batches of 32 by default. Reduce `embed.batch_size` for CPU-only local models that cannot finish a large batch within the provider timeout:
+
+```yaml
+embed:
+  provider: ollama:qwen3-embedding:4b
+  batch_size: 8
+  ollama:
+    base_url: http://127.0.0.1:11435
+```
+
 **Jina AI** is a great choice for getting started. Sign up at [jina.ai/embeddings](https://jina.ai/embeddings/) for a free API key with 10M tokens, no credit card required.
 
 **Voyage AI** is Anthropic's recommended embedding partner (acquired by MongoDB, Feb 2025). The API remains fully available.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1043,12 +1043,13 @@ type TranscriptionElevenLabsConfig struct {
 
 // EmbedConfig configures text embedding generation
 type EmbedConfig struct {
-	Provider string            `mapstructure:"provider"` // default embedding provider: gemini, openai, chatgpt, venice, jina, voyage, ollama
-	OpenAI   EmbedOpenAIConfig `mapstructure:"openai"`
-	Gemini   EmbedGeminiConfig `mapstructure:"gemini"`
-	Jina     EmbedJinaConfig   `mapstructure:"jina"`
-	Voyage   EmbedVoyageConfig `mapstructure:"voyage"`
-	Ollama   EmbedOllamaConfig `mapstructure:"ollama"`
+	Provider  string            `mapstructure:"provider"`   // default embedding provider: gemini, openai, chatgpt, venice, jina, voyage, ollama
+	BatchSize int               `mapstructure:"batch_size"` // document embedding batch size; default 32
+	OpenAI    EmbedOpenAIConfig `mapstructure:"openai"`
+	Gemini    EmbedGeminiConfig `mapstructure:"gemini"`
+	Jina      EmbedJinaConfig   `mapstructure:"jina"`
+	Voyage    EmbedVoyageConfig `mapstructure:"voyage"`
+	Ollama    EmbedOllamaConfig `mapstructure:"ollama"`
 }
 
 // EmbedOpenAIConfig configures OpenAI embedding generation

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -256,6 +256,7 @@ var keySpecs = []KeySpec{
 	def("transcription.elevenlabs.model", DefaultTranscriptionElevenLabsModel),
 
 	optional("embed.provider"),
+	def("embed.batch_size", 32),
 	optional("embed.openai.api_key", sensitive()),
 	def("embed.openai.model", DefaultEmbedOpenAIModel),
 	optional("embed.gemini.api_key", sensitive()),


### PR DESCRIPTION
## Summary

- add `embed.batch_size`, defaulting to the existing batch size of 32
- make memory document indexing honor the configured batch size
- document a batch size of 8 for CPU-only Ollama embedding servers

## Why

The 32-document default is efficient for hosted and GPU providers, but Qwen3-Embedding-4B on a CPU-only Ollama endpoint can exceed the provider's two-minute request timeout at that size. A batch of 8 completes reliably without changing behavior for existing users.

This is specifically needed to re-embed Jarvis's 365-fragment memory DB locally: the original batch of 32 timed out with zero persisted vectors, while batches of 8 make steady resumable progress.

## Validation

- `mise x node@24 -- make build`
- `go test ./internal/config`
- `go build ./...`
- live config validation with `embed.batch_size: 8`
- live CPU-only Qwen memory indexing with persisted vectors
- `git diff --check`

The broad `go test ./cmd` remains blocked by existing environment-sensitive skill discovery tests (`TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`); the changed config package passes.
