### PR TITLE
fix: Persisted jobs silently run without a durable session after session creation fails

### DIFF
--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -358,7 +358,10 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 
 	var sess *session.Session
 	if store != nil && !req.DeferSession {
-		sess = r.ensureRunSession(ctx, store, req, provider, cfg.DefaultProvider, modelName, agentName, settings)
+		sess, err = r.ensureRunSession(ctx, store, req, provider, cfg.DefaultProvider, modelName, agentName, settings)
+		if err != nil {
+			return nil, err
+		}
 		runtime.sessionMeta = sess
 	}
 	if toolMgr != nil {
@@ -585,12 +588,12 @@ func configureInteractiveSink(toolMgr *tools.ToolManager, sink runpkg.EventSink)
 	}
 }
 
-func (r *cmdRunner) ensureRunSession(ctx context.Context, store session.Store, req runpkg.Request, provider llm.Provider, providerKey, modelName, agentName string, settings SessionSettings) *session.Session {
+func (r *cmdRunner) ensureRunSession(ctx context.Context, store session.Store, req runpkg.Request, provider llm.Provider, providerKey, modelName, agentName string, settings SessionSettings) (*session.Session, error) {
 	if store == nil || strings.TrimSpace(req.SessionID) == "" {
-		return nil
+		return nil, nil
 	}
 	if existing, err := store.Get(ctx, req.SessionID); err == nil && existing != nil {
-		return existing
+		return existing, nil
 	}
 	name := strings.TrimSpace(req.SessionName)
 	summary := name
@@ -627,12 +630,12 @@ func (r *cmdRunner) ensureRunSession(ctx context.Context, store session.Store, r
 	}
 	if err := store.Create(ctx, sess); err != nil {
 		if existing, getErr := store.Get(ctx, req.SessionID); getErr == nil && existing != nil {
-			return existing
+			return existing, nil
 		}
 		log.Printf("[runner] session Create failed for %s: %v", req.SessionID, err)
-		return nil
+		return nil, fmt.Errorf("create session %q: %w", req.SessionID, err)
 	}
-	return sess
+	return sess, nil
 }
 
 func (r *cmdRunner) runProgressive(ctx context.Context, runtime *serveRuntime, engine *llm.Engine, llmReq llm.Request, inputMessages []llm.Message, req runpkg.Request, sess *session.Session, store session.Store, provider llm.Provider, collector *runnerEventCollector) (runpkg.Result, error) {

--- a/cmd/runner_test.go
+++ b/cmd/runner_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
+	"github.com/samsaffron/term-llm/internal/session"
 )
 
 func TestCmdRunnerUnboundRemoteSettingsRejectAmbientCWD(t *testing.T) {
@@ -154,7 +156,7 @@ func TestCmdRunnerEnsureRunSessionUsesExplicitPrimaryWorkspace(t *testing.T) {
 	store := newServeRuntimeTestStore()
 	workingDir := t.TempDir()
 
-	sess := runner.ensureRunSession(
+	sess, err := runner.ensureRunSession(
 		context.Background(),
 		store,
 		runpkg.Request{Platform: runpkg.PlatformConsole, SessionID: "working-dir-session"},
@@ -164,11 +166,97 @@ func TestCmdRunnerEnsureRunSessionUsesExplicitPrimaryWorkspace(t *testing.T) {
 		"",
 		SessionSettings{BaseDir: workingDir, PrimaryWorkspace: workingDir},
 	)
+	if err != nil {
+		t.Fatalf("ensureRunSession: %v", err)
+	}
 	if sess == nil {
 		t.Fatal("ensureRunSession returned nil")
 	}
 	if sess.CWD != workingDir {
 		t.Fatalf("session CWD = %q, want %q", sess.CWD, workingDir)
+	}
+}
+
+type cmdRunnerCreateFailureStore struct {
+	session.Store
+	createErr        error
+	concurrentCreate *session.Session
+}
+
+func (s *cmdRunnerCreateFailureStore) Create(ctx context.Context, _ *session.Session) error {
+	if s.concurrentCreate != nil {
+		_ = s.Store.Create(ctx, s.concurrentCreate)
+	}
+	return s.createErr
+}
+
+func TestCmdRunnerPersistedSessionCreateFailure(t *testing.T) {
+	createErr := errors.New("session database is read-only")
+	tests := []struct {
+		name             string
+		concurrentCreate bool
+		wantErr          bool
+	}{
+		{name: "unrecovered failure", wantErr: true},
+		{name: "concurrent create is recovered", concurrentCreate: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const sessionID = "persisted-job-session"
+			baseStore := newServeRuntimeTestStore()
+			store := &cmdRunnerCreateFailureStore{Store: baseStore, createErr: createErr}
+			if tc.concurrentCreate {
+				store.concurrentCreate = &session.Session{
+					ID:       sessionID,
+					Provider: "mock",
+					Model:    "mock-model",
+					Status:   session.StatusActive,
+				}
+			}
+			provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+			cfg := &config.Config{
+				DefaultProvider: "mock",
+				Providers: map[string]config.ProviderConfig{
+					"mock": {Model: "mock-model"},
+				},
+			}
+			runner := newCmdRunner(cfg, cmdRunnerOptions{Store: store}).(*cmdRunner)
+			includeConfiguredTools := false
+
+			result, err := runner.Run(context.Background(), runpkg.Request{
+				Platform:               runpkg.PlatformJob,
+				Prompt:                 "run the job",
+				SessionID:              sessionID,
+				Persist:                true,
+				ProviderInstance:       provider,
+				Cwd:                    t.TempDir(),
+				IncludeConfiguredTools: &includeConfiguredTools,
+			}, nil)
+
+			if tc.wantErr {
+				if !errors.Is(err, createErr) {
+					t.Fatalf("Run() error = %v, want wrapped %v", err, createErr)
+				}
+				if requests := provider.RecordedRequests(); len(requests) != 0 {
+					t.Fatalf("provider requests = %d, want 0", len(requests))
+				}
+				if result.SessionID != "" || result.Provider != "" || result.Model != "" || result.Response != "" || result.Engine != nil || result.ProviderInstance != nil || result.Progressive != nil {
+					t.Fatalf("Run() result = %+v, want zero result", result)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Run() error = %v, want nil", err)
+			}
+			if requests := provider.RecordedRequests(); len(requests) != 1 {
+				t.Fatalf("provider requests = %d, want 1", len(requests))
+			}
+			if result.Response != "ok" {
+				t.Fatalf("Run() response = %q, want %q", result.Response, "ok")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

- Return a wrapped session creation error when `cmdRunner` cannot create a requested durable session and the post-failure lookup still finds no concurrently created session.
- Abort runner preparation before the provider is called; the existing deferred cleanup closes the partially constructed runtime.
- Preserve the existing concurrent-create recovery path.
- Add regression coverage for both the unrecovered write failure and the concurrent-create fallback.

## Why this is high-value

Scheduled jobs and queued agents use `cmdRunner`, request persistence by default, and advertise a session ID. Previously, a SQLite write failure could be logged and ignored, allowing the provider run to report success while producing no durable session metadata or transcript. That loses resume, inspection, memory-processing, and restart-recovery data precisely when storage is degraded.

## Validation

- `go test ./cmd -run '^(TestCmdRunnerEnsureRunSessionUsesExplicitPrimaryWorkspace|TestCmdRunnerPersistedSessionCreateFailure)$'` — pass
- `go build ./...` — pass
- `go test ./...` — run; the changed `cmd` package and all other relevant packages pass. The suite remains blocked only by the unrelated existing `internal/serveui` bundle budget (`app.css` gzip 32,707 bytes vs 32,000-byte budget); rerunning with an isolated home also removed ambient skill-visibility failures.
- `git diff --check` — pass
