### PR TITLE
feat(web): add interactive /shell terminal to the web UI

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -784,6 +784,13 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 			runtimeFactory:      runtimeFactory,
 			agentRuntimeFactory: agentRuntimeFactory,
 			widgetsMgr:          widgetsMgr,
+			shells: newServeShellManager(serveSessionTTL, func(sessionID string) bool {
+				if store == nil {
+					return false
+				}
+				sess, getErr := store.Get(context.Background(), sessionID)
+				return getErr == nil && sess != nil
+			}),
 		}
 		if hasJobs {
 			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers, resolvedApproval, s.notifyJobsV2RunDone)
@@ -1371,6 +1378,9 @@ type serveServer struct {
 	commitOperationsWG       sync.WaitGroup
 	commitRunsWG             sync.WaitGroup
 	commitStopping           bool
+	shellsMu                 sync.Mutex
+	shells                   *serveShellManager
+	shellsClosed             bool
 }
 
 // fileTrackStore returns the file-change history store, or nil when file
@@ -1553,6 +1563,7 @@ func (s *serveServer) Stop(ctx context.Context) error {
 			close(s.shutdownCh)
 		}
 	})
+	s.closeShellManager()
 	s.stopEventWatcher()
 	// Synchronize with a concurrently starting lifecycle loop, or permanently
 	// suppress a late start once shutdown has begun.

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -84,6 +84,9 @@ func (s *serveServer) capabilityList() []string {
 	caps := []string{}
 	if s.cfg.ui {
 		caps = append(caps, "web")
+		if platformServeShellSupported() && s.store != nil {
+			caps = append(caps, "shell")
+		}
 	}
 	if s.cfg.api {
 		caps = append(caps, "api")
@@ -1968,6 +1971,11 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 	suffix := ""
 	if len(parts) > 1 {
 		suffix = parts[1]
+	}
+
+	if suffix == "shell" || strings.HasPrefix(suffix, "shell/") {
+		s.handleSessionShell(w, r, sessionID, suffix)
+		return
 	}
 
 	if suffix == "attention/seen" {

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -186,16 +186,16 @@ func TestHubReverseNodeProxyStreamsChunkedResponse(t *testing.T) {
 	}
 }
 
-func TestHubReverseNodeProxyStreamsIncrementalSSE(t *testing.T) {
-	firstEvent := "data: first\n\n"
-	secondEvent := "data: second\n\n"
+func TestHubReverseNodeProxyStreamsShellSSEIncrementally(t *testing.T) {
+	firstEvent := "event: ready\ndata: {\"shell_id\":\"sh_one\",\"next_offset\":0}\n\n"
+	secondEvent := "event: output\ndata: {\"offset\":0,\"next_offset\":2,\"data\":\"aGk=\"}\n\n"
 	releaseBackend := make(chan struct{})
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(releaseBackend) }) }
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/chat/events" {
-			t.Errorf("backend path = %q", r.URL.Path)
+		if r.URL.Path != "/chat/v1/sessions/shell-session/shell/stream" || r.URL.Query().Get("shell_id") != "sh_one" || r.URL.Query().Get("offset") != "0" {
+			t.Errorf("backend target = %q", r.URL.RequestURI())
 			return
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -221,7 +221,7 @@ func TestHubReverseNodeProxyStreamsIncrementalSSE(t *testing.T) {
 
 	requestCtx, cancelRequest := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelRequest()
-	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, hubTS.URL+"/node/artist/events", nil)
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, hubTS.URL+"/node/artist/v1/sessions/shell-session/shell/stream?shell_id=sh_one&offset=0", nil)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}

--- a/cmd/serve_mcp_handler.go
+++ b/cmd/serve_mcp_handler.go
@@ -617,6 +617,7 @@ func (s *serveServer) promoteDraftMCPSelection(ctx context.Context, draftID, ses
 	if err := s.store.Delete(ctx, draftID); err != nil {
 		return fmt.Errorf("draft session Delete failed after promoting MCP selection from %s: %w", draftID, err)
 	}
+	s.closeSessionShell(draftID)
 	return nil
 }
 

--- a/cmd/serve_projects.go
+++ b/cmd/serve_projects.go
@@ -377,10 +377,15 @@ func (s *serveServer) handleCapabilities(w http.ResponseWriter, r *http.Request)
 	} else if _, err := s.currentGitRoot(); err == nil {
 		worktreesEnabled = true
 	}
-	w.Header().Set("ETag", fmt.Sprintf(`W/"projects-%t-worktrees-%t"`, s.projectsEnabled, worktreesEnabled))
+	shellEnabled := s.cfg.ui && platformServeShellSupported() && s.store != nil
+	w.Header().Set("ETag", fmt.Sprintf(`W/"projects-%t-worktrees-%t-shell-%t"`, s.projectsEnabled, worktreesEnabled, shellEnabled))
 	payload := map[string]any{
 		"projects":  map[string]bool{"enabled": s.projectsEnabled},
 		"worktrees": map[string]bool{"enabled": worktreesEnabled},
+		"shell": map[string]any{
+			"enabled": shellEnabled, "version": 1,
+			"transport": "http_sse", "replay_bytes": serveShellReplayBytes,
+		},
 		"event_feed": map[string]any{
 			"version": 1, "sse": true, "long_poll": true,
 			"heartbeat_ms": serveEventHeartbeat.Milliseconds(), "replay_limit": serveEventReplayLimit,

--- a/cmd/serve_shell.go
+++ b/cmd/serve_shell.go
@@ -1,0 +1,777 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	serveShellReplayBytes = 1 << 20
+	serveShellHeartbeat   = 8 * time.Second
+	serveShellChunkBytes  = 32 << 10
+	serveShellInputBytes  = 64 << 10
+	serveShellMinCols     = 2
+	serveShellMaxCols     = 500
+	serveShellMinRows     = 1
+	serveShellMaxRows     = 300
+	serveShellDrainWait   = 3 * time.Second
+)
+
+var (
+	errServeShellUnsupported = errors.New("interactive shells are unsupported on this platform")
+	errServeShellClosed      = errors.New("shell manager closed")
+	errServeShellStale       = errors.New("shell generation is stale")
+)
+
+type serveShellExit struct {
+	Code int
+	Err  error
+}
+
+type serveShellProcess interface {
+	Write([]byte) (int, error)
+	Resize(cols, rows int) error
+	Close()
+	Done() <-chan serveShellExit
+}
+
+type serveShell struct {
+	id        string
+	sessionID string
+	cwd       string
+	process   serveShellProcess
+
+	mu         sync.Mutex
+	writeMu    sync.Mutex
+	output     []byte
+	baseOffset int64
+	nextOffset int64
+	exited     bool
+	exitCode   int
+	lastUsed   time.Time
+	changed    chan struct{}
+}
+
+type serveShellSnapshot struct {
+	reset      bool
+	baseOffset int64
+	nextOffset int64
+	dataOffset int64
+	data       []byte
+	exited     bool
+	exitCode   int
+	changed    <-chan struct{}
+}
+
+func newServeShell(id, sessionID, cwd string) *serveShell {
+	return &serveShell{id: id, sessionID: sessionID, cwd: cwd, lastUsed: time.Now(), changed: make(chan struct{})}
+}
+
+func (s *serveShell) notifyLocked() {
+	close(s.changed)
+	s.changed = make(chan struct{})
+}
+
+func (s *serveShell) appendOutput(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	s.mu.Lock()
+	s.nextOffset += int64(len(data))
+	s.lastUsed = time.Now()
+	if len(data) >= serveShellReplayBytes {
+		s.output = append(s.output[:0], data[len(data)-serveShellReplayBytes:]...)
+		s.baseOffset = s.nextOffset - int64(len(s.output))
+	} else {
+		s.output = append(s.output, data...)
+		if overflow := len(s.output) - serveShellReplayBytes; overflow > 0 {
+			copy(s.output, s.output[overflow:])
+			s.output = s.output[:len(s.output)-overflow]
+			s.baseOffset += int64(overflow)
+		}
+	}
+	s.notifyLocked()
+	s.mu.Unlock()
+}
+
+func (s *serveShell) watchExit() {
+	exit, ok := <-s.process.Done()
+	if !ok {
+		exit = serveShellExit{Code: -1}
+	}
+	s.mu.Lock()
+	if !s.exited {
+		s.exited = true
+		s.exitCode = exit.Code
+		s.lastUsed = time.Now()
+		s.notifyLocked()
+	}
+	s.mu.Unlock()
+}
+
+func (s *serveShell) alive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.exited
+}
+
+func (s *serveShell) touch() {
+	s.mu.Lock()
+	s.lastUsed = time.Now()
+	s.mu.Unlock()
+}
+
+func (s *serveShell) idleSince() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastUsed
+}
+
+func (s *serveShell) snapshot(offset int64) serveShellSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastUsed = time.Now()
+	reset := offset < s.baseOffset || offset > s.nextOffset
+	if reset {
+		offset = s.baseOffset
+	}
+	available := s.nextOffset - offset
+	if available > serveShellChunkBytes {
+		available = serveShellChunkBytes
+	}
+	start := int(offset - s.baseOffset)
+	end := start + int(available)
+	var data []byte
+	if start >= 0 && end <= len(s.output) && start < end {
+		data = append([]byte(nil), s.output[start:end]...)
+	}
+	return serveShellSnapshot{
+		reset: reset, baseOffset: s.baseOffset, nextOffset: s.nextOffset,
+		dataOffset: offset, data: data, exited: s.exited, exitCode: s.exitCode, changed: s.changed,
+	}
+}
+
+func (s *serveShell) write(data []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if !s.alive() {
+		return io.ErrClosedPipe
+	}
+	for len(data) > 0 {
+		n, err := s.process.Write(data)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		data = data[n:]
+	}
+	s.touch()
+	return nil
+}
+
+func (s *serveShell) resize(cols, rows int) error {
+	if !s.alive() {
+		return io.ErrClosedPipe
+	}
+	if err := s.process.Resize(cols, rows); err != nil {
+		return err
+	}
+	s.touch()
+	return nil
+}
+
+func (s *serveShell) close() {
+	if s.process != nil {
+		s.process.Close()
+	}
+	s.mu.Lock()
+	if !s.exited {
+		s.exited = true
+		s.exitCode = -1
+		s.lastUsed = time.Now()
+		s.notifyLocked()
+	}
+	s.mu.Unlock()
+}
+
+type serveShellManager struct {
+	ttl    time.Duration
+	exists func(string) bool
+
+	mu      sync.Mutex
+	shells  map[string]*serveShell
+	closed  bool
+	stopCh  chan struct{}
+	closeCh sync.Once
+}
+
+func newServeShellManager(ttl time.Duration, exists func(string) bool) *serveShellManager {
+	if ttl <= 0 {
+		ttl = 30 * time.Minute
+	}
+	m := &serveShellManager{ttl: ttl, exists: exists, shells: make(map[string]*serveShell), stopCh: make(chan struct{})}
+	go m.janitor()
+	return m
+}
+
+func (m *serveShellManager) janitor() {
+	interval := m.ttl / 2
+	if interval > 30*time.Second {
+		interval = 30 * time.Second
+	}
+	if interval < time.Second {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.evictExpired()
+		case <-m.stopCh:
+			return
+		}
+	}
+}
+
+func (m *serveShellManager) evictExpired() {
+	now := time.Now()
+	m.mu.Lock()
+	candidates := make(map[string]*serveShell, len(m.shells))
+	for sessionID, shell := range m.shells {
+		candidates[sessionID] = shell
+	}
+	m.mu.Unlock()
+
+	var stale []*serveShell
+	for sessionID, shell := range candidates {
+		missing := m.exists != nil && !m.exists(sessionID)
+		if !missing && now.Sub(shell.idleSince()) <= m.ttl {
+			continue
+		}
+		m.mu.Lock()
+		if m.shells[sessionID] == shell {
+			delete(m.shells, sessionID)
+			stale = append(stale, shell)
+		}
+		m.mu.Unlock()
+	}
+	for _, shell := range stale {
+		shell.close()
+	}
+}
+
+func (m *serveShellManager) create(sessionID, cwd string, cols, rows int) (*serveShell, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil, false, errServeShellClosed
+	}
+	if current := m.shells[sessionID]; current != nil && current.alive() {
+		if err := current.resize(cols, rows); err != nil {
+			return nil, false, fmt.Errorf("resize attached shell: %w", err)
+		}
+		return current, false, nil
+	}
+	if current := m.shells[sessionID]; current != nil {
+		delete(m.shells, sessionID)
+		current.close()
+	}
+	id, err := newServeShellID()
+	if err != nil {
+		return nil, false, err
+	}
+	shell := newServeShell(id, sessionID, cwd)
+	process, err := startServeShellProcess(cwd, cols, rows, shell.appendOutput)
+	if err != nil {
+		return nil, false, err
+	}
+	shell.process = process
+	m.shells[sessionID] = shell
+	go shell.watchExit()
+	return shell, true, nil
+}
+
+func newServeShellID() (string, error) {
+	var value [18]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate shell ID: %w", err)
+	}
+	return "sh_" + base64.RawURLEncoding.EncodeToString(value[:]), nil
+}
+
+func (m *serveShellManager) get(sessionID, shellID string) (*serveShell, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil, errServeShellClosed
+	}
+	shell := m.shells[sessionID]
+	if shell == nil || shell.id != shellID {
+		return nil, errServeShellStale
+	}
+	shell.touch()
+	return shell, nil
+}
+
+func (m *serveShellManager) closeShell(sessionID, shellID string) error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return errServeShellClosed
+	}
+	shell := m.shells[sessionID]
+	if shell == nil || shell.id != shellID {
+		m.mu.Unlock()
+		return errServeShellStale
+	}
+	delete(m.shells, sessionID)
+	m.mu.Unlock()
+	shell.close()
+	return nil
+}
+
+func (m *serveShellManager) closeSession(sessionID string) {
+	m.mu.Lock()
+	shell := m.shells[sessionID]
+	delete(m.shells, sessionID)
+	m.mu.Unlock()
+	if shell != nil {
+		shell.close()
+	}
+}
+
+func (m *serveShellManager) Close() {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	m.closeCh.Do(func() { close(m.stopCh) })
+	shells := make([]*serveShell, 0, len(m.shells))
+	for _, shell := range m.shells {
+		shells = append(shells, shell)
+	}
+	m.shells = map[string]*serveShell{}
+	m.mu.Unlock()
+	for _, shell := range shells {
+		shell.close()
+	}
+}
+
+type serveShellCreateRequest struct {
+	Cols int `json:"cols"`
+	Rows int `json:"rows"`
+}
+
+type serveShellIDRequest struct {
+	ShellID string `json:"shell_id"`
+}
+
+type serveShellInputRequest struct {
+	ShellID string `json:"shell_id"`
+	Data    string `json:"data"`
+}
+
+type serveShellResizeRequest struct {
+	ShellID string `json:"shell_id"`
+	Cols    int    `json:"cols"`
+	Rows    int    `json:"rows"`
+}
+
+func validServeShellSize(cols, rows int) bool {
+	return cols >= serveShellMinCols && cols <= serveShellMaxCols && rows >= serveShellMinRows && rows <= serveShellMaxRows
+}
+
+func (s *serveServer) shellManager() (*serveShellManager, error) {
+	s.shellsMu.Lock()
+	defer s.shellsMu.Unlock()
+	if s.shellsClosed {
+		return nil, errServeShellClosed
+	}
+	if s.shells == nil {
+		s.shells = newServeShellManager(30*time.Minute, s.shellSessionExists)
+	}
+	return s.shells, nil
+}
+
+func (s *serveServer) closeSessionShell(sessionID string) {
+	s.shellsMu.Lock()
+	manager := s.shells
+	s.shellsMu.Unlock()
+	if manager != nil {
+		manager.closeSession(sessionID)
+	}
+}
+
+func (s *serveServer) closeShellManager() {
+	s.shellsMu.Lock()
+	if s.shellsClosed {
+		s.shellsMu.Unlock()
+		return
+	}
+	s.shellsClosed = true
+	manager := s.shells
+	s.shells = nil
+	s.shellsMu.Unlock()
+	if manager != nil {
+		manager.Close()
+	}
+}
+
+func (s *serveServer) shellSessionExists(sessionID string) bool {
+	if s == nil || s.store == nil {
+		return false
+	}
+	sess, err := s.store.Get(context.Background(), sessionID)
+	return err == nil && sess != nil
+}
+
+func (s *serveServer) resolveShellCWD(ctx context.Context, sessionID string) (string, error) {
+	if s.store == nil {
+		return "", os.ErrNotExist
+	}
+	sess, err := s.store.Get(ctx, sessionID)
+	if err != nil {
+		return "", err
+	}
+	if sess == nil {
+		return "", os.ErrNotExist
+	}
+	var binding serveWorkspaceBinding
+	if strings.TrimSpace(sess.ProjectID) != "" {
+		binding, err = s.resolvePersistedProjectWorkspace(ctx, *sess)
+	} else {
+		binding, err = s.resolveWorkspace(ctx, serveWorkspaceRequest{
+			SessionID: sessionID, FirstPartyUI: true, AllowNoProject: true,
+		})
+	}
+	if err != nil {
+		return "", err
+	}
+	cwd := strings.TrimSpace(binding.RuntimeDir)
+	if cwd == "" {
+		cwd = strings.TrimSpace(sess.WorktreeDir)
+	}
+	if cwd == "" {
+		cwd = strings.TrimSpace(sess.CWD)
+	}
+	if cwd == "" {
+		cwd = strings.TrimSpace(s.startupDir)
+	}
+	if cwd == "" {
+		return "", errors.New("session workspace is unavailable")
+	}
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", fmt.Errorf("inspect session workspace: %w", err)
+	}
+	if !info.IsDir() {
+		return "", errors.New("session workspace is not a directory")
+	}
+	absolute, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve session workspace: %w", err)
+	}
+	return absolute, nil
+}
+
+func sameOriginShellRequest(r *http.Request) bool {
+	fetchSite := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
+	if fetchSite == "cross-site" {
+		return false
+	}
+	// Direct, Hub-proxied, reverse-Hub, and WebRTC requests all originate as a
+	// same-origin browser fetch. Hub transports deliberately replace the backend
+	// Host, so the browser-owned Fetch Metadata signal is authoritative there.
+	if fetchSite == "same-origin" {
+		return true
+	}
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	scheme := "http"
+	if r.TLS != nil || strings.EqualFold(strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")), "https") {
+		scheme = "https"
+	}
+	return origin == scheme+"://"+r.Host
+}
+
+func (s *serveServer) handleSessionShell(w http.ResponseWriter, r *http.Request, sessionID, suffix string) {
+	if !platformServeShellSupported() || !s.cfg.ui {
+		writeOpenAIError(w, http.StatusNotImplemented, "unsupported_error", "interactive shells are unavailable")
+		return
+	}
+	if !sameOriginShellRequest(r) {
+		writeOpenAIError(w, http.StatusForbidden, "invalid_origin", "shell requests must come from the first-party UI origin")
+		return
+	}
+	switch suffix {
+	case "shell":
+		if r.Method == http.MethodPost {
+			s.handleShellCreate(w, r, sessionID)
+			return
+		}
+		if r.Method == http.MethodDelete {
+			s.handleShellDelete(w, r, sessionID)
+			return
+		}
+		w.Header().Set("Allow", "POST, DELETE")
+	case "shell/stream":
+		if r.Method == http.MethodGet {
+			s.handleShellStream(w, r, sessionID)
+			return
+		}
+		w.Header().Set("Allow", "GET")
+	case "shell/input":
+		if r.Method == http.MethodPost {
+			s.handleShellInput(w, r, sessionID)
+			return
+		}
+		w.Header().Set("Allow", "POST")
+	case "shell/resize":
+		if r.Method == http.MethodPost {
+			s.handleShellResize(w, r, sessionID)
+			return
+		}
+		w.Header().Set("Allow", "POST")
+	}
+	writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+}
+
+func decodeServeShellJSON(w http.ResponseWriter, r *http.Request, value any) bool {
+	if err := requireJSONContentType(r); err != nil {
+		writeOpenAIError(w, http.StatusUnsupportedMediaType, "invalid_request_error", err.Error())
+		return false
+	}
+	decoder := json.NewDecoder(io.LimitReader(r.Body, serveShellInputBytes*2))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid shell request")
+		return false
+	}
+	return true
+}
+
+func (s *serveServer) handleShellCreate(w http.ResponseWriter, r *http.Request, sessionID string) {
+	var req serveShellCreateRequest
+	if !decodeServeShellJSON(w, r, &req) {
+		return
+	}
+	if !validServeShellSize(req.Cols, req.Rows) {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid terminal size")
+		return
+	}
+	cwd, err := s.resolveShellCWD(r.Context(), sessionID)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.NotFound(w, r)
+		} else {
+			writeWorkspaceError(w, err)
+		}
+		return
+	}
+	manager, err := s.shellManager()
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	shell, created, err := manager.create(sessionID, cwd, req.Cols, req.Rows)
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	writeJSON(w, status, map[string]any{"shell_id": shell.id, "cwd": shell.cwd, "created": created, "state": "running"})
+}
+
+func writeServeShellError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errServeShellClosed):
+		writeOpenAIError(w, http.StatusServiceUnavailable, "shell_unavailable", "shell service is shutting down")
+	case errors.Is(err, errServeShellStale):
+		writeOpenAIError(w, http.StatusConflict, "stale_shell", "shell generation is stale")
+	case errors.Is(err, io.ErrClosedPipe):
+		writeOpenAIError(w, http.StatusConflict, "shell_exited", "shell has exited")
+	default:
+		writeOpenAIError(w, http.StatusInternalServerError, "shell_error", err.Error())
+	}
+}
+
+func (s *serveServer) handleShellInput(w http.ResponseWriter, r *http.Request, sessionID string) {
+	var req serveShellInputRequest
+	if !decodeServeShellJSON(w, r, &req) {
+		return
+	}
+	data, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil || len(data) == 0 || len(data) > serveShellInputBytes {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid shell input")
+		return
+	}
+	manager, err := s.shellManager()
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	shell, err := manager.get(sessionID, strings.TrimSpace(req.ShellID))
+	if err == nil {
+		err = shell.write(data)
+	}
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"accepted": len(data)})
+}
+
+func (s *serveServer) handleShellResize(w http.ResponseWriter, r *http.Request, sessionID string) {
+	var req serveShellResizeRequest
+	if !decodeServeShellJSON(w, r, &req) {
+		return
+	}
+	if !validServeShellSize(req.Cols, req.Rows) {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid terminal size")
+		return
+	}
+	manager, err := s.shellManager()
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	shell, err := manager.get(sessionID, strings.TrimSpace(req.ShellID))
+	if err == nil {
+		err = shell.resize(req.Cols, req.Rows)
+	}
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *serveServer) handleShellDelete(w http.ResponseWriter, r *http.Request, sessionID string) {
+	var req serveShellIDRequest
+	if !decodeServeShellJSON(w, r, &req) {
+		return
+	}
+	manager, err := s.shellManager()
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	if err := manager.closeShell(sessionID, strings.TrimSpace(req.ShellID)); err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func writeShellSSE(w io.Writer, event string, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	return err
+}
+
+func (s *serveServer) handleShellStream(w http.ResponseWriter, r *http.Request, sessionID string) {
+	shellID := strings.TrimSpace(r.URL.Query().Get("shell_id"))
+	offset, err := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("offset")), 10, 64)
+	if err != nil || offset < 0 || shellID == "" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "shell_id and a non-negative offset are required")
+		return
+	}
+	manager, err := s.shellManager()
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	shell, err := manager.get(sessionID, shellID)
+	if err != nil {
+		writeServeShellError(w, err)
+		return
+	}
+	ctx, cancel := s.contextWithShutdown(r.Context())
+	defer cancel()
+	stream := newStreamingResponseWriter(w, serveStreamWriteTimeout)
+	flusher, ok := stream.(http.Flusher)
+	if !ok {
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "streaming is unsupported")
+		return
+	}
+	setSSEHeaders(stream)
+	stream.Header().Set("Cache-Control", "no-cache, no-transform")
+	initial := shell.snapshot(offset)
+	if err := writeShellSSE(stream, "ready", map[string]any{
+		"shell_id": shell.id, "cwd": shell.cwd, "offset": offset,
+		"base_offset": initial.baseOffset, "next_offset": initial.nextOffset,
+		"heartbeat_ms": serveShellHeartbeat.Milliseconds(), "replay_bytes": serveShellReplayBytes,
+	}); err != nil {
+		return
+	}
+	flusher.Flush()
+	heartbeat := time.NewTicker(serveShellHeartbeat)
+	defer heartbeat.Stop()
+	exitSent := false
+	for {
+		snapshot := shell.snapshot(offset)
+		if snapshot.reset {
+			if err := writeShellSSE(stream, "reset", map[string]any{"offset": snapshot.baseOffset, "reason": "replay_window"}); err != nil {
+				return
+			}
+			offset = snapshot.baseOffset
+			flusher.Flush()
+			continue
+		}
+		if len(snapshot.data) > 0 {
+			next := snapshot.dataOffset + int64(len(snapshot.data))
+			if err := writeShellSSE(stream, "output", map[string]any{
+				"offset": snapshot.dataOffset, "next_offset": next,
+				"data": base64.StdEncoding.EncodeToString(snapshot.data),
+			}); err != nil {
+				return
+			}
+			offset = next
+			flusher.Flush()
+			continue
+		}
+		if snapshot.exited && !exitSent {
+			if err := writeShellSSE(stream, "exit", map[string]any{"offset": snapshot.nextOffset, "exit_code": snapshot.exitCode}); err != nil {
+				return
+			}
+			flusher.Flush()
+			exitSent = true
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-snapshot.changed:
+		case <-heartbeat.C:
+			if _, err := io.WriteString(stream, ": heartbeat\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/cmd/serve_shell_session_linux.go
+++ b/cmd/serve_shell_session_linux.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// signalServeShellSession reaches job-control groups that an interactive shell
+// moved out of its own process group. Every process in the PTY login session is
+// owned by this shell generation.
+func signalServeShellSession(sessionID int, signal syscall.Signal) error {
+	entries, err := filepath.Glob("/proc/[0-9]*/stat")
+	if err != nil {
+		return err
+	}
+	var result error
+	for _, entry := range entries {
+		data, readErr := os.ReadFile(entry)
+		if readErr != nil {
+			continue
+		}
+		line := string(data)
+		closeParen := strings.LastIndexByte(line, ')')
+		if closeParen < 0 || closeParen+2 >= len(line) {
+			continue
+		}
+		fields := strings.Fields(line[closeParen+2:])
+		// Fields after comm begin with state, ppid, pgrp, session.
+		if len(fields) < 4 || fields[3] != strconv.Itoa(sessionID) {
+			continue
+		}
+		pidText := filepath.Base(filepath.Dir(entry))
+		pid, parseErr := strconv.Atoi(pidText)
+		if parseErr != nil || pid <= 0 {
+			continue
+		}
+		if killErr := syscall.Kill(pid, signal); killErr != nil && !errors.Is(killErr, syscall.ESRCH) {
+			result = errors.Join(result, fmt.Errorf("signal shell session process %d: %w", pid, killErr))
+		}
+	}
+	return result
+}

--- a/cmd/serve_shell_session_other.go
+++ b/cmd/serve_shell_session_other.go
@@ -1,0 +1,9 @@
+//go:build (aix || android || darwin || dragonfly || freebsd || illumos || ios || netbsd || openbsd || solaris) && !linux
+
+package cmd
+
+import "syscall"
+
+// SIGHUP plus process-group signaling is the portable fallback. Linux also
+// enumerates the owning login session so job-control groups cannot survive.
+func signalServeShellSession(_ int, _ syscall.Signal) error { return nil }

--- a/cmd/serve_shell_test.go
+++ b/cmd/serve_shell_test.go
@@ -1,0 +1,619 @@
+//go:build !windows && !plan9 && !js && !wasip1
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/worktree"
+)
+
+func newShellTestServer(t *testing.T, requireAuth bool) (*serveServer, session.Store, string) {
+	t.Helper()
+	t.Setenv("SHELL", "/bin/sh")
+	store, err := session.NewStore(session.Config{Enabled: true, Path: t.TempDir() + "/sessions.db"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	cwd := t.TempDir()
+	now := time.Now().UTC()
+	if err := store.Create(context.Background(), &session.Session{
+		ID: "shell-session", Provider: "test", Model: "test", Mode: session.ModeChat,
+		Origin: session.OriginWeb, Status: session.StatusActive, CWD: cwd, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv := &serveServer{
+		cfg:   serveServerConfig{ui: true, basePath: "/ui", requireAuth: requireAuth, token: "secret"},
+		store: store, startupDir: cwd,
+	}
+	srv.shutdownCh = make(chan struct{})
+	srv.shells = newServeShellManager(time.Minute, srv.shellSessionExists)
+	t.Cleanup(srv.closeShellManager)
+	return srv, store, cwd
+}
+
+func shellJSONRequest(t *testing.T, client *http.Client, method, target, token string, body any) *http.Response {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, target, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func decodeShellResponse[T any](t *testing.T, response *http.Response) T {
+	t.Helper()
+	defer response.Body.Close()
+	var value T
+	if err := json.NewDecoder(response.Body).Decode(&value); err != nil {
+		t.Fatalf("decode status %d: %v", response.StatusCode, err)
+	}
+	return value
+}
+
+type shellCreateResponse struct {
+	ShellID string `json:"shell_id"`
+	CWD     string `json:"cwd"`
+	Created bool   `json:"created"`
+}
+
+type shellSSEEvent struct {
+	Event string
+	Data  map[string]any
+}
+
+func readShellSSE(t *testing.T, reader *bufio.Reader) shellSSEEvent {
+	t.Helper()
+	event := shellSSEEvent{Data: map[string]any{}}
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read SSE: %v", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			if event.Event != "" {
+				return event
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "event: ") {
+			event.Event = strings.TrimPrefix(line, "event: ")
+		}
+		if strings.HasPrefix(line, "data: ") {
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event.Data); err != nil {
+				t.Fatalf("decode SSE data: %v", err)
+			}
+		}
+	}
+}
+
+func TestServeShellHTTPCreateInputOutputResizeAttachDeleteAndStaleID(t *testing.T) {
+	srv, _, cwd := newShellTestServer(t, true)
+	ts := httptest.NewServer(srv.httpHandler())
+	defer ts.Close()
+	base := ts.URL + "/ui/v1/sessions/shell-session/shell"
+
+	createdResp := shellJSONRequest(t, ts.Client(), http.MethodPost, base, "secret", map[string]any{"cols": 80, "rows": 24})
+	if createdResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createdResp.Body)
+		createdResp.Body.Close()
+		t.Fatalf("create status=%d body=%s", createdResp.StatusCode, body)
+	}
+	created := decodeShellResponse[shellCreateResponse](t, createdResp)
+	if !created.Created || created.ShellID == "" || created.CWD != cwd {
+		t.Fatalf("create response = %+v, cwd %q", created, cwd)
+	}
+
+	attachedResp := shellJSONRequest(t, ts.Client(), http.MethodPost, base, "secret", map[string]any{"cols": 81, "rows": 25})
+	attached := decodeShellResponse[shellCreateResponse](t, attachedResp)
+	if attachedResp.StatusCode != http.StatusOK || attached.Created || attached.ShellID != created.ShellID {
+		t.Fatalf("attach status=%d response=%+v", attachedResp.StatusCode, attached)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	streamURL := fmt.Sprintf("%s/stream?shell_id=%s&offset=0", base, created.ShellID)
+	streamReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
+	streamReq.Header.Set("Authorization", "Bearer secret")
+	streamReq.Header.Set("Accept", "text/event-stream")
+	streamResp, err := ts.Client().Do(streamReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer streamResp.Body.Close()
+	if streamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(streamResp.Body)
+		t.Fatalf("stream status=%d body=%s", streamResp.StatusCode, body)
+	}
+	reader := bufio.NewReader(streamResp.Body)
+	if ready := readShellSSE(t, reader); ready.Event != "ready" || ready.Data["shell_id"] != created.ShellID {
+		t.Fatalf("ready event = %+v", ready)
+	}
+
+	resizeResp := shellJSONRequest(t, ts.Client(), http.MethodPost, base+"/resize", "secret", map[string]any{
+		"shell_id": created.ShellID, "cols": 91, "rows": 37,
+	})
+	if resizeResp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resizeResp.Body)
+		t.Fatalf("resize status=%d body=%s", resizeResp.StatusCode, body)
+	}
+	resizeResp.Body.Close()
+
+	command := "printf '__shell_pwd__%s\\n' \"$PWD\"; stty size; printf '__shell_'done'__\\n'\n"
+	inputResp := shellJSONRequest(t, ts.Client(), http.MethodPost, base+"/input", "secret", map[string]any{
+		"shell_id": created.ShellID, "data": base64.StdEncoding.EncodeToString([]byte(command)),
+	})
+	if inputResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(inputResp.Body)
+		t.Fatalf("input status=%d body=%s", inputResp.StatusCode, body)
+	}
+	inputResp.Body.Close()
+
+	var output strings.Builder
+	var nextOffset int64
+	for !strings.Contains(output.String(), "__shell_done__") {
+		event := readShellSSE(t, reader)
+		if event.Event != "output" {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(fmt.Sprint(event.Data["data"]))
+		if err != nil {
+			t.Fatal(err)
+		}
+		output.Write(data)
+		nextOffset = int64(event.Data["next_offset"].(float64))
+	}
+	if !strings.Contains(output.String(), "__shell_pwd__"+cwd) || !strings.Contains(output.String(), "37 91") {
+		t.Fatalf("shell output did not use bound cwd/resize: %q", output.String())
+	}
+	if nextOffset <= 0 {
+		t.Fatal("stream did not advance its monotonic offset")
+	}
+
+	deleteResp := shellJSONRequest(t, ts.Client(), http.MethodDelete, base, "secret", map[string]any{"shell_id": created.ShellID})
+	if deleteResp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(deleteResp.Body)
+		t.Fatalf("delete status=%d body=%s", deleteResp.StatusCode, body)
+	}
+	deleteResp.Body.Close()
+	staleResp := shellJSONRequest(t, ts.Client(), http.MethodPost, base+"/input", "secret", map[string]any{
+		"shell_id": created.ShellID, "data": base64.StdEncoding.EncodeToString([]byte("echo stale\n")),
+	})
+	defer staleResp.Body.Close()
+	if staleResp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(staleResp.Body)
+		t.Fatalf("stale input status=%d body=%s", staleResp.StatusCode, body)
+	}
+}
+
+func TestServeShellReplayResetAndExit(t *testing.T) {
+	shell := newServeShell("sh_test", "session", t.TempDir())
+	payload := bytes.Repeat([]byte("x"), serveShellReplayBytes+123)
+	shell.appendOutput(payload)
+	snapshot := shell.snapshot(0)
+	if !snapshot.reset || snapshot.baseOffset != 123 || snapshot.nextOffset != int64(len(payload)) {
+		t.Fatalf("reset snapshot = %+v", snapshot)
+	}
+	snapshot = shell.snapshot(snapshot.baseOffset)
+	if snapshot.reset || snapshot.dataOffset != 123 || len(snapshot.data) != serveShellChunkBytes {
+		t.Fatalf("replay snapshot = offset %d len %d reset %t", snapshot.dataOffset, len(snapshot.data), snapshot.reset)
+	}
+	shell.mu.Lock()
+	shell.exited = true
+	shell.exitCode = 7
+	shell.notifyLocked()
+	shell.mu.Unlock()
+	exit := shell.snapshot(shell.nextOffset)
+	if !exit.exited || exit.exitCode != 7 {
+		t.Fatalf("exit snapshot = %+v", exit)
+	}
+}
+
+func TestResolveShellCWDUsesPersistedProjectBindings(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	ctx := context.Background()
+	srv, store := newServeProjectTestServer(t)
+	now := time.Now().UTC()
+
+	root := newGitRepoForBindingTest(t)
+	project := &session.Project{Name: "Shell project", CanonicalDir: root}
+	if err := store.CreateProject(ctx, project); err != nil {
+		t.Fatal(err)
+	}
+	managed, err := worktree.Create(ctx, root, worktree.CreateOptions{Name: "shell-cwd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = worktree.Remove(context.Background(), managed.Dir, worktree.RemoveOptions{Force: true})
+	})
+
+	for _, tc := range []struct {
+		name        string
+		sessionID   string
+		cwd         string
+		worktreeDir string
+	}{
+		{name: "project root", sessionID: "shell-project-root", cwd: root},
+		{name: "managed worktree", sessionID: "shell-project-worktree", cwd: managed.Dir, worktreeDir: managed.Dir},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			persisted := &session.Session{
+				ID: tc.sessionID, Provider: "mock", Model: "mock", Mode: session.ModeChat,
+				Origin: session.OriginWeb, Status: session.StatusActive, CreatedAt: now, UpdatedAt: now,
+			}
+			if err := store.Create(ctx, persisted); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.BindSessionWorkspace(ctx, tc.sessionID, session.SessionWorkspaceBinding{
+				ProjectID: project.ID, CWD: tc.cwd, WorktreeDir: tc.worktreeDir,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			got, err := srv.resolveShellCWD(ctx, tc.sessionID)
+			if err != nil {
+				t.Fatalf("resolveShellCWD: %v", err)
+			}
+			if !sameServePath(got, tc.cwd) {
+				t.Fatalf("resolveShellCWD() = %q, want %q", got, tc.cwd)
+			}
+		})
+	}
+}
+
+func TestResolveShellCWDUsesPersistedNoProjectWorkspace(t *testing.T) {
+	srv, store := newServeProjectTestServer(t)
+	cwd := t.TempDir()
+	now := time.Now().UTC()
+	if err := store.Create(context.Background(), &session.Session{
+		ID: "shell-no-project", Provider: "mock", Model: "mock", Mode: session.ModeChat,
+		Origin: session.OriginWeb, Status: session.StatusActive, CWD: cwd, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := srv.resolveShellCWD(context.Background(), "shell-no-project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameServePath(got, cwd) {
+		t.Fatalf("resolveShellCWD() = %q, want %q", got, cwd)
+	}
+}
+
+func TestServeShellProcessDrainsHighVolumeOutputBeforeExit(t *testing.T) {
+	dir := t.TempDir()
+	const repetitions = 4_096
+	const block = "0123456789abcdef0123456789abcdef"
+	script := filepath.Join(dir, "write-and-exit.sh")
+	contents := fmt.Sprintf("#!/bin/sh\ni=0\nwhile [ \"$i\" -lt %d ]; do\n  printf '%s'\n  i=$((i + 1))\ndone\n", repetitions, block)
+	if err := os.WriteFile(script, []byte(contents), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHELL", script)
+
+	var outputMu sync.Mutex
+	var output bytes.Buffer
+	process, err := startServeShellProcess(dir, 80, 24, func(data []byte) {
+		// Simulate a temporarily busy consumer so output can still be queued in
+		// the PTY when the producer exits.
+		time.Sleep(125 * time.Millisecond)
+		outputMu.Lock()
+		_, _ = output.Write(data)
+		outputMu.Unlock()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(process.Close)
+	select {
+	case exit := <-process.Done():
+		if exit.Code != 0 {
+			t.Fatalf("exit = %+v", exit)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("shell process did not finish")
+	}
+	outputMu.Lock()
+	got := output.Len()
+	outputMu.Unlock()
+	if want := repetitions * len(block); got != want {
+		t.Fatalf("drained output bytes = %d, want %d", got, want)
+	}
+}
+
+func TestServeShellManagerShutdownPermanentlyDisablesLazyCreation(t *testing.T) {
+	srv := &serveServer{}
+	const callers = 32
+	start := make(chan struct{})
+	results := make(chan *serveShellManager, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			manager, err := srv.shellManager()
+			if err == nil {
+				results <- manager
+				return
+			}
+			if !errors.Is(err, errServeShellClosed) {
+				t.Errorf("shellManager error = %v", err)
+			}
+		}()
+	}
+	close(start)
+	srv.closeShellManager()
+	wg.Wait()
+	close(results)
+
+	for manager := range results {
+		manager.mu.Lock()
+		closed := manager.closed
+		manager.mu.Unlock()
+		if !closed {
+			t.Fatal("manager returned during shutdown remained open")
+		}
+	}
+	if manager, err := srv.shellManager(); manager != nil || !errors.Is(err, errServeShellClosed) {
+		t.Fatalf("shellManager after shutdown = (%p, %v), want nil shell manager closed", manager, err)
+	}
+	srv.shellsMu.Lock()
+	closed, manager := srv.shellsClosed, srv.shells
+	srv.shellsMu.Unlock()
+	if !closed || manager != nil {
+		t.Fatalf("shutdown state = closed %t manager %p", closed, manager)
+	}
+}
+
+func TestServeShellCleanupOnIdleSessionDeletionAndShutdown(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	var exists atomic.Bool
+	exists.Store(true)
+	manager := newServeShellManager(10*time.Millisecond, func(string) bool { return exists.Load() })
+	cwd := t.TempDir()
+	first, _, err := manager.create("idle", cwd, 80, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.mu.Lock()
+	first.lastUsed = time.Now().Add(-time.Hour)
+	first.mu.Unlock()
+	manager.evictExpired()
+	waitForShellExit(t, first)
+
+	second, _, err := manager.create("deleted", cwd, 80, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exists.Store(false)
+	manager.evictExpired()
+	waitForShellExit(t, second)
+
+	exists.Store(true)
+	third, _, err := manager.create("shutdown", cwd, 80, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.Close()
+	waitForShellExit(t, third)
+	if _, _, err := manager.create("late", cwd, 80, 24); !errors.Is(err, errServeShellClosed) {
+		t.Fatalf("create after shutdown error = %v", err)
+	}
+}
+
+func waitForShellExit(t *testing.T, shell *serveShell) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !shell.alive() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("shell process did not exit")
+}
+
+func TestServeShellServerStopTerminatesProcess(t *testing.T) {
+	srv, _, cwd := newShellTestServer(t, false)
+	manager, err := srv.shellManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	shell, _, err := manager.create("shell-session", cwd, 80, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	waitForShellExit(t, shell)
+}
+
+func TestServeShellProcessGroupCleanup(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	manager := newServeShellManager(time.Minute, nil)
+	defer manager.Close()
+	shell, _, err := manager.create("group", t.TempDir(), 80, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shell.write([]byte("sleep 30 & printf '__child__%s\\n' \"$!\"\n")); err != nil {
+		t.Fatal(err)
+	}
+	var childPID int
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := shell.snapshot(0)
+		text := string(snapshot.data)
+		if marker := strings.LastIndex(text, "__child__"); marker >= 0 {
+			_, _ = fmt.Sscanf(text[marker:], "__child__%d", &childPID)
+			if childPID > 0 {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if childPID <= 0 {
+		t.Fatal("did not capture background child PID")
+	}
+	manager.closeSession("group")
+	waitForShellExit(t, shell)
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !serveShellTestProcessRunning(childPID) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("background process %d survived shell cleanup", childPID)
+}
+
+func serveShellTestProcessRunning(pid int) bool {
+	if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+		return false
+	}
+	// Linux keeps a killed orphan visible briefly as a zombie until PID 1
+	// reaps it. It can no longer execute and therefore counts as terminated.
+	if stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
+		fields := strings.Fields(string(stat))
+		if len(fields) > 2 && fields[2] == "Z" {
+			return false
+		}
+	}
+	return true
+}
+
+func TestServeShellMethodsAuthOriginAndPathBinding(t *testing.T) {
+	srv, _, cwd := newShellTestServer(t, true)
+	ts := httptest.NewServer(srv.httpHandler())
+	defer ts.Close()
+	base := ts.URL + "/ui/v1/sessions/shell-session/shell"
+
+	unauthorized := shellJSONRequest(t, ts.Client(), http.MethodPost, base, "", map[string]any{"cols": 80, "rows": 24})
+	unauthorized.Body.Close()
+	if unauthorized.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status=%d", unauthorized.StatusCode)
+	}
+
+	request, _ := http.NewRequest(http.MethodPost, base, strings.NewReader(`{"cols":80,"rows":24}`))
+	request.Header.Set("Authorization", "Bearer secret")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Origin", "https://evil.example")
+	request.Header.Set("Sec-Fetch-Site", "cross-site")
+	crossOrigin, err := ts.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crossOrigin.Body.Close()
+	if crossOrigin.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin status=%d", crossOrigin.StatusCode)
+	}
+
+	arbitrary := shellJSONRequest(t, ts.Client(), http.MethodPost, base, "secret", map[string]any{"cols": 80, "rows": 24, "cwd": t.TempDir()})
+	arbitrary.Body.Close()
+	if arbitrary.StatusCode != http.StatusBadRequest {
+		t.Fatalf("client path status=%d", arbitrary.StatusCode)
+	}
+
+	missing := shellJSONRequest(t, ts.Client(), http.MethodPost, strings.Replace(base, "shell-session", "missing", 1), "secret", map[string]any{"cols": 80, "rows": 24})
+	missing.Body.Close()
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing session status=%d", missing.StatusCode)
+	}
+
+	method := shellJSONRequest(t, ts.Client(), http.MethodPatch, base, "secret", nil)
+	method.Body.Close()
+	if method.StatusCode != http.StatusMethodNotAllowed || method.Header.Get("Allow") != "POST, DELETE" {
+		t.Fatalf("method status=%d allow=%q", method.StatusCode, method.Header.Get("Allow"))
+	}
+
+	created := shellJSONRequest(t, ts.Client(), http.MethodPost, base, "secret", map[string]any{"cols": 80, "rows": 24})
+	payload := decodeShellResponse[shellCreateResponse](t, created)
+	if payload.CWD != cwd {
+		t.Fatalf("shell cwd=%q want authoritative %q", payload.CWD, cwd)
+	}
+}
+
+func TestServeShellCapabilityAdvertisesSupportedFirstPartyUI(t *testing.T) {
+	srv, _, _ := newShellTestServer(t, false)
+	recorder := httptest.NewRecorder()
+	srv.handleCapabilities(recorder, httptest.NewRequest(http.MethodGet, "/v1/capabilities", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	shell, _ := payload["shell"].(map[string]any)
+	if shell["enabled"] != true || shell["transport"] != "http_sse" {
+		t.Fatalf("shell capability = %#v", shell)
+	}
+
+	srv.cfg.ui = false
+	recorder = httptest.NewRecorder()
+	srv.handleCapabilities(recorder, httptest.NewRequest(http.MethodGet, "/v1/capabilities", nil))
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	shell, _ = payload["shell"].(map[string]any)
+	if shell["enabled"] != false {
+		t.Fatalf("API-only shell capability = %#v", shell)
+	}
+}
+
+func TestSameOriginShellRequestAcceptsHubBackendHost(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://reverse.local/v1/sessions/s1/shell", nil)
+	req.Header.Set("Origin", "https://hub.example")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	if !sameOriginShellRequest(req) {
+		t.Fatal("same-origin Hub browser request was rejected because the transport replaced Host")
+	}
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	if sameOriginShellRequest(req) {
+		t.Fatal("cross-site browser request was accepted")
+	}
+}

--- a/cmd/serve_shell_unix.go
+++ b/cmd/serve_shell_unix.go
@@ -1,0 +1,125 @@
+//go:build !windows && !plan9 && !js && !wasip1
+
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+type unixServeShellProcess struct {
+	file      *os.File
+	cmd       *exec.Cmd
+	done      chan serveShellExit
+	stopped   chan struct{}
+	closeOnce sync.Once
+}
+
+func platformServeShellSupported() bool { return true }
+
+func startServeShellProcess(cwd string, cols, rows int, output func([]byte)) (serveShellProcess, error) {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+	cmd := exec.Command(shell)
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color", "COLORTERM=truecolor", "TERM_PROGRAM=term-llm")
+	file, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)})
+	if err != nil {
+		return nil, err
+	}
+	process := &unixServeShellProcess{file: file, cmd: cmd, done: make(chan serveShellExit, 1), stopped: make(chan struct{})}
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		buffer := make([]byte, 32<<10)
+		for {
+			n, readErr := file.Read(buffer)
+			if n > 0 {
+				output(append([]byte(nil), buffer[:n]...))
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+	go func() {
+		waitErr := cmd.Wait()
+		// A shell can exit while descendants retain the PTY. Its process group is
+		// owned by this explicit user shell, so terminate any survivors, including
+		// job-control groups in the same login session where the OS exposes them.
+		_ = signalServeShellSession(cmd.Process.Pid, syscall.SIGKILL)
+		_ = signalServeShellGroup(cmd.Process.Pid, syscall.SIGKILL)
+		select {
+		case <-readDone:
+		case <-time.After(serveShellDrainWait):
+			// The slave side should close after every session process is gone. Keep
+			// shutdown bounded if a platform or driver fails to deliver EOF.
+			_ = file.Close()
+			<-readDone
+		}
+		_ = file.Close()
+		code := 0
+		if cmd.ProcessState != nil {
+			code = cmd.ProcessState.ExitCode()
+		} else if waitErr != nil {
+			code = -1
+		}
+		process.done <- serveShellExit{Code: code, Err: waitErr}
+		close(process.done)
+		close(process.stopped)
+	}()
+	return process, nil
+}
+
+func signalServeShellGroup(pid int, signal syscall.Signal) error {
+	if pid <= 0 {
+		return nil
+	}
+	err := syscall.Kill(-pid, signal)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+func (p *unixServeShellProcess) Write(data []byte) (int, error) { return p.file.Write(data) }
+
+func (p *unixServeShellProcess) Resize(cols, rows int) error {
+	return pty.Setsize(p.file, &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)})
+}
+
+func (p *unixServeShellProcess) Done() <-chan serveShellExit { return p.done }
+
+func (p *unixServeShellProcess) Close() {
+	p.closeOnce.Do(func() {
+		select {
+		case <-p.stopped:
+			return
+		default:
+		}
+		_ = signalServeShellSession(p.cmd.Process.Pid, syscall.SIGHUP)
+		_ = signalServeShellGroup(p.cmd.Process.Pid, syscall.SIGHUP)
+		_ = signalServeShellSession(p.cmd.Process.Pid, syscall.SIGTERM)
+		_ = signalServeShellGroup(p.cmd.Process.Pid, syscall.SIGTERM)
+		select {
+		case <-p.stopped:
+			return
+		case <-time.After(750 * time.Millisecond):
+		}
+		_ = signalServeShellSession(p.cmd.Process.Pid, syscall.SIGKILL)
+		_ = signalServeShellGroup(p.cmd.Process.Pid, syscall.SIGKILL)
+		_ = p.file.Close()
+		select {
+		case <-p.stopped:
+		case <-time.After(750 * time.Millisecond):
+		}
+	})
+}

--- a/cmd/serve_shell_unsupported.go
+++ b/cmd/serve_shell_unsupported.go
@@ -1,0 +1,9 @@
+//go:build windows || plan9 || js || wasip1
+
+package cmd
+
+func platformServeShellSupported() bool { return false }
+
+func startServeShellProcess(_ string, _, _ int, _ func([]byte)) (serveShellProcess, error) {
+	return nil, errServeShellUnsupported
+}

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -71,6 +71,10 @@ With the default base path of `/ui`, the web runtime exposes:
 - `GET /ui/v1/sessions?project_id=prj_...&cursor=...`
 - `GET /ui/v1/sessions/search?q=...&project_id=prj_...`
 - `POST /ui/v1/sessions/:id/project` (validated one-time historical assignment)
+- `POST|DELETE /ui/v1/sessions/:id/shell`
+- `GET /ui/v1/sessions/:id/shell/stream` (SSE)
+- `POST /ui/v1/sessions/:id/shell/input`
+- `POST /ui/v1/sessions/:id/shell/resize`
 - `GET /ui/healthz`
 - `GET /ui/` for the browser UI
 - `GET /ui/images/:file` for generated images
@@ -80,6 +84,14 @@ If the jobs platform is also enabled, the jobs API is mounted under the same bas
 The Web UI discovers local applications under `<base-path>/widgets/` by default. A clean installation ships with none, and widget controls remain hidden until at least one valid manifest is found. Use `--disable-widgets` to turn discovery and the widget routes off. See [Web UI widgets](/guides/widgets/) for the directory layout, manifest format, proxy behavior, lifecycle, and security model.
 
 LLM job runs now expose a `session_id` and persist to the same sessions store by default, which makes web/API integrations much easier to inspect while a progressive run is still executing.
+
+## Interactive shell
+
+On supported Unix servers, enter `/shell` in an existing Web UI conversation to open a full-screen terminal in that conversation's authoritative project or worktree. **Back to chat** detaches the browser while leaving the one session shell running; opening `/shell` again reattaches and replays bounded output. **Close shell** explicitly terminates the shell and its process group.
+
+The browser never sends a filesystem path. The server resolves the persisted session binding without creating or pinning an LLM runtime, and advertises support as `shell.enabled` from `GET /ui/v1/capabilities`. Unsupported platforms and API-only servers leave the command hidden. Shell input is explicit direct operator execution—it does not use the model shell-tool approval flow.
+
+Shell control uses authenticated HTTP mutations plus a resumable SSE response rather than WebSockets, so the same protocol works through direct serve, Hub proxying, reverse-connected Hub nodes, and WebRTC HTTP transport. Shell endpoints additionally require the first-party browser origin and are not opened to configured cross-origin API callers.
 
 ## Project-aware Responses and worktrees
 

--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -16,7 +16,13 @@ const session = (id: string, title: string, number: number) => ({
 
 async function mockAPI(
   page: Page,
-  options: { holdStream?: boolean; media?: boolean; model?: string; attention?: boolean } = {},
+  options: {
+    holdStream?: boolean;
+    media?: boolean;
+    model?: string;
+    attention?: boolean;
+    shell?: boolean;
+  } = {},
 ) {
   const requests: Array<{ method: string; url: string }> = [];
   const model = options.model || 'gpt-test';
@@ -30,6 +36,7 @@ async function mockAPI(
     if (path.endsWith('/v1/capabilities'))
       return json({
         projects: { enabled: true },
+        shell: { enabled: options.shell === true, version: 1, transport: 'http_sse' },
         widgets: [{ id: 'status', name: 'Status', url: '../widgets/status/' }],
       });
     if (path.endsWith('/v1/providers'))
@@ -108,6 +115,29 @@ async function mockAPI(
         },
       });
     }
+    if (options.shell && /\/v1\/sessions\/[^/]+\/shell$/.test(path) && request.method() === 'POST')
+      return json(
+        { shell_id: 'sh_browser', cwd: '/workspace/project', created: true, state: 'running' },
+        201,
+      );
+    if (options.shell && /\/v1\/sessions\/[^/]+\/shell\/stream$/.test(path))
+      return route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: [
+          'event: ready\ndata: {"shell_id":"sh_browser","offset":0,"base_offset":0,"next_offset":0}\n\n',
+          'event: output\ndata: {"offset":0,"next_offset":5,"data":"aGVsbG8="}\n\n',
+          'event: exit\ndata: {"offset":5,"exit_code":0}\n\n',
+        ].join(''),
+      });
+    if (options.shell && /\/v1\/sessions\/[^/]+\/shell\/(?:input|resize)$/.test(path))
+      return request.method() === 'POST' ? json({ accepted: 1 }) : json({});
+    if (
+      options.shell &&
+      /\/v1\/sessions\/[^/]+\/shell$/.test(path) &&
+      request.method() === 'DELETE'
+    )
+      return route.fulfill({ status: 204, body: '' });
     if (/\/v1\/sessions\/s1\/attention\/seen$/.test(path) && request.method() === 'POST')
       return json({
         store_instance_id: 'store-a',
@@ -190,13 +220,57 @@ async function mockAPI(
 async function open(
   page: Page,
   suffix = '',
-  options: { holdStream?: boolean; media?: boolean; model?: string; attention?: boolean } = {},
+  options: {
+    holdStream?: boolean;
+    media?: boolean;
+    model?: string;
+    attention?: boolean;
+    shell?: boolean;
+  } = {},
 ) {
   const requests = await mockAPI(page, options);
   await page.goto(`./${suffix}`);
   await expect(page.locator('#startupSplash')).toBeHidden({ timeout: 10_000 });
   return requests;
 }
+
+test('lazy-loads the capability-gated interactive shell overlay', async ({ page }) => {
+  const requests = await open(page, '', { shell: true });
+  const composer = page.getByRole('textbox', { name: 'Message' });
+  await composer.fill('/shell');
+  await composer.press('Enter');
+
+  await expect(page.getByRole('region', { name: 'Interactive shell' })).toBeVisible();
+  await expect(page.getByText('/workspace/project')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Back to chat' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Close shell' })).toBeVisible();
+
+  await page.evaluate(() => {
+    history.pushState({}, '', new URL('/ui/chat/1', location.origin));
+    dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await expect(page.getByRole('region', { name: 'Interactive shell' })).toBeHidden();
+  await expect(page.getByText('First question')).toBeVisible();
+
+  await composer.fill('/shell');
+  await composer.press('Enter');
+  await expect(page.getByRole('region', { name: 'Interactive shell' })).toBeVisible();
+  await page.getByRole('button', { name: 'Back to chat' }).click();
+  await expect(page.getByRole('region', { name: 'Interactive shell' })).toBeHidden();
+
+  await composer.fill('/shell');
+  await composer.press('Enter');
+  await expect(page.getByRole('region', { name: 'Interactive shell' })).toBeVisible();
+  await page.evaluate(() => {
+    history.pushState({}, '', new URL('/ui/', location.origin));
+    dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await expect(page.getByRole('region', { name: 'Interactive shell' })).toBeHidden();
+  expect(requests.some((entry) => /\/v1\/sessions\/[^/]+\/shell$/.test(entry.url))).toBe(true);
+  expect(requests.some((entry) => /\/v1\/sessions\/[^/]+\/shell\/stream$/.test(entry.url))).toBe(
+    true,
+  );
+});
 
 test('loads, navigates sessions, opens settings and preserves normal namespace hygiene', async ({
   page,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@preact/signals": "2.11.1",
         "@taga3s/highlightjs-terraform": "1.0.7",
+        "@xterm/addon-fit": "0.11.0",
+        "@xterm/xterm": "6.0.0",
         "dompurify": "3.4.14",
         "highlight.js": "11.12.0",
         "katex": "0.18.4",
@@ -2480,6 +2482,21 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/acorn": {
       "version": "8.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@preact/signals": "2.11.1",
     "@taga3s/highlightjs-terraform": "1.0.7",
+    "@xterm/addon-fit": "0.11.0",
+    "@xterm/xterm": "6.0.0",
     "dompurify": "3.4.14",
     "highlight.js": "11.12.0",
     "katex": "0.18.4",

--- a/frontend/src/api/endpoints.test.ts
+++ b/frontend/src/api/endpoints.test.ts
@@ -2,6 +2,39 @@ import { describe, expect, it, vi } from 'vitest';
 import type { APIClient } from './client';
 import { endpoints } from './endpoints';
 
+describe('shell endpoints', () => {
+  it('uses authenticated HTTP/SSE session routes with encoded generation state', async () => {
+    const json = vi.fn(async () => ({ shell_id: 'sh/one' }));
+    const request = vi.fn(async () => new Response());
+    const routes = endpoints({ json, request } as unknown as APIClient);
+    const controller = new AbortController();
+
+    await routes.shellCreate('session/one', 100, 30);
+    expect(json).toHaveBeenLastCalledWith(
+      '/v1/sessions/session%2Fone/shell',
+      {
+        method: 'POST',
+        headers: { 'X-Term-LLM-Session-ID': 'session/one' },
+        body: JSON.stringify({ cols: 100, rows: 30 }),
+      },
+      { policy: 'mutation', auth: 'session' },
+    );
+
+    await routes.shellStream('session/one', 'sh/one', 42, controller.signal);
+    expect(request).toHaveBeenLastCalledWith(
+      '/v1/sessions/session%2Fone/shell/stream?shell_id=sh%2Fone&offset=42',
+      {
+        signal: controller.signal,
+        headers: {
+          'X-Term-LLM-Session-ID': 'session/one',
+          Accept: 'text/event-stream',
+        },
+      },
+      { policy: 'stream', retries: 0, timeoutMs: 0, auth: 'session' },
+    );
+  });
+});
+
 describe('file change endpoints', () => {
   it('fetches encoded raw text with version pinning and cancellation', async () => {
     const response = new Response('# Plan\n', {

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -2,6 +2,17 @@ import type { APIClient } from './client';
 import type { Goal, MCPOAuthFlow, MCPResponse } from '../domain/types';
 import type { MentionSearchResponse } from '../domain/completions';
 
+export interface ShellCreateResponse {
+  shell_id: string;
+  cwd: string;
+  created: boolean;
+  state: 'running';
+}
+
+export interface ShellInputResponse {
+  accepted: number;
+}
+
 const encoded = (value: string): string => encodeURIComponent(value);
 const sessionHeaders = (id: string): Record<string, string> => ({ 'X-Term-LLM-Session-ID': id });
 // Review data may come from the session's node rather than the shell host. The
@@ -165,6 +176,52 @@ export const endpoints = (api: APIClient) => ({
         : { policy: 'mutation', retries: 0, timeoutMs: 0, auth: 'session' },
     );
   },
+  shellCreate: (id: string, cols: number, rows: number) =>
+    api.json<ShellCreateResponse>(
+      `/v1/sessions/${encoded(id)}/shell`,
+      {
+        method: 'POST',
+        headers: sessionHeaders(id),
+        body: JSON.stringify({ cols, rows }),
+      },
+      { policy: 'mutation', auth: 'session' },
+    ),
+  shellStream: (id: string, shellId: string, offset: number, signal: AbortSignal) =>
+    api.request(
+      `/v1/sessions/${encoded(id)}/shell/stream?shell_id=${encoded(shellId)}&offset=${offset}`,
+      { signal, headers: { ...sessionHeaders(id), Accept: 'text/event-stream' } },
+      { policy: 'stream', retries: 0, timeoutMs: 0, auth: 'session' },
+    ),
+  shellInput: (id: string, shellId: string, data: string) =>
+    api.json<ShellInputResponse>(
+      `/v1/sessions/${encoded(id)}/shell/input`,
+      {
+        method: 'POST',
+        headers: sessionHeaders(id),
+        body: JSON.stringify({ shell_id: shellId, data }),
+      },
+      { policy: 'mutation', auth: 'session' },
+    ),
+  shellResize: (id: string, shellId: string, cols: number, rows: number) =>
+    api.json<void>(
+      `/v1/sessions/${encoded(id)}/shell/resize`,
+      {
+        method: 'POST',
+        headers: sessionHeaders(id),
+        body: JSON.stringify({ shell_id: shellId, cols, rows }),
+      },
+      { policy: 'mutation', auth: 'session' },
+    ),
+  shellClose: (id: string, shellId: string) =>
+    api.json<void>(
+      `/v1/sessions/${encoded(id)}/shell`,
+      {
+        method: 'DELETE',
+        headers: sessionHeaders(id),
+        body: JSON.stringify({ shell_id: shellId }),
+      },
+      { policy: 'mutation', auth: 'session' },
+    ),
   response: (id: string, signal?: AbortSignal) =>
     api.get<Record<string, unknown>>(`/v1/responses/${encoded(id)}`, signal),
   responseEvents: (id: string, after: number, signal: AbortSignal) =>

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,5 +1,5 @@
-import { Component, type ComponentChildren } from 'preact';
-import { useEffect } from 'preact/hooks';
+import { Component, type ComponentChildren, type ComponentType } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 import { StoreContext } from './context';
 import type { AppStore, Toast } from '../stores/app-store';
 import { Sidebar } from '../components/Sidebar';
@@ -35,6 +35,49 @@ class ErrorBoundary extends Component<{ children: ComponentChildren }, { error: 
       props.children
     );
   }
+}
+
+function ShellOverlayLoader({ store }: { store: AppStore }) {
+  const [Overlay, setOverlay] = useState<ComponentType<{ store: AppStore }> | null>(null);
+  const [error, setError] = useState('');
+  useEffect(() => {
+    let current = true;
+    void import('../components/ShellOverlay')
+      .then((module) => {
+        if (current) setOverlay(() => module.ShellOverlay);
+      })
+      .catch((reason: unknown) => {
+        if (current)
+          setError(reason instanceof Error ? reason.message : 'Could not load terminal.');
+      });
+    return () => {
+      current = false;
+    };
+  }, []);
+  if (error)
+    return (
+      <section class="shell-overlay" role="alert">
+        <header class="shell-overlay-header">
+          <strong>Terminal could not load</strong>
+          <button class="btn" type="button" onClick={() => store.shellStore.back()}>
+            Back to chat
+          </button>
+        </header>
+        <div class="shell-error">{error}</div>
+      </section>
+    );
+  return Overlay ? (
+    <Overlay store={store} />
+  ) : (
+    <section class="shell-overlay" aria-label="Interactive shell" aria-busy="true">
+      <header class="shell-overlay-header">
+        <strong>Loading terminal…</strong>
+        <button class="btn" type="button" onClick={() => store.shellStore.back()}>
+          Back to chat
+        </button>
+      </header>
+    </section>
+  );
 }
 
 export function App({ store }: { store: AppStore }) {
@@ -122,6 +165,7 @@ export function App({ store }: { store: AppStore }) {
         </div>
         <Modals />
         <Lightbox />
+        {store.shellStore.visible.value && <ShellOverlayLoader store={store} />}
       </StoreContext.Provider>
     </ErrorBoundary>
   );

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -151,6 +151,7 @@ export function Composer() {
     store.config.agentNames,
     store.skills.value,
     runActive,
+    store.shellStore.enabled.value,
   );
   const combined = mention ? [...local, ...mentionCompletions(projectMentions)] : local;
   const completions =
@@ -204,6 +205,10 @@ export function Composer() {
       return;
     }
     if (command === '/new') return store.newChat();
+    if (command === '/shell') {
+      store.openShell();
+      return;
+    }
     if (command === '/goal') {
       store.modal.value = 'goal';
       return;

--- a/frontend/src/components/ShellOverlay.test.tsx
+++ b/frontend/src/components/ShellOverlay.test.tsx
@@ -1,0 +1,145 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppStore } from '../stores/app-store';
+import { ShellOverlay } from './ShellOverlay';
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon = vi.fn();
+    open = vi.fn();
+    focus = vi.fn();
+    write = vi.fn();
+    reset = vi.fn();
+    dispose = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+  },
+}));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn();
+  },
+}));
+
+const config = {
+  prefix: '/ui',
+  version: 'test',
+  sidebarCategories: ['all'],
+  agentName: '',
+  agentNames: [],
+  title: 'term-llm',
+  locationSharing: true,
+  worktrees: false,
+  hub: null,
+  vapidKey: '',
+  pushSupported: false,
+  webRTC: false,
+  signalingURL: '',
+};
+
+const stores: AppStore[] = [];
+afterEach(() => {
+  for (const store of stores.splice(0)) store.dispose();
+  vi.restoreAllMocks();
+});
+
+function shellStore(): AppStore {
+  const store = new AppStore(config);
+  stores.push(store);
+  store.shellStore.enabled.value = true;
+  store.sessions.value = [
+    {
+      id: 'session-one',
+      title: 'First',
+      name: '',
+      mode: 'chat',
+      origin: 'web',
+      archived: false,
+      pinned: false,
+      created: 1,
+      lastMessageAt: 1,
+      messages: [],
+    },
+  ];
+  store.activeSessionId.value = 'session-one';
+  store.draftActive.value = false;
+  store.shellStore.visible.value = true;
+  store.shellStore.sessionId.value = 'session-one';
+  store.shellStore.cwd.value = '/workspace/project';
+  store.shellStore.status.value = 'running';
+  store.shellStore.connect = vi.fn(async () => undefined);
+  store.shellStore.resize = vi.fn();
+  store.shellStore.detach = vi.fn();
+  return store;
+}
+
+describe('ShellOverlay', () => {
+  it('presents visible chat/close controls and does not steal Escape', async () => {
+    const store = shellStore();
+    store.shellStore.back = vi.fn();
+    store.shellStore.close = vi.fn(async () => undefined);
+    render(<ShellOverlay store={store} />);
+
+    expect(screen.getByText('/workspace/project')).toBeVisible();
+    expect(screen.getByText('Connected')).toBeVisible();
+    await userEvent.click(screen.getByRole('button', { name: 'Back to chat' }));
+    expect(store.shellStore.back).toHaveBeenCalledOnce();
+
+    let prevented = false;
+    const observe = (event: KeyboardEvent) => {
+      prevented = event.defaultPrevented;
+    };
+    window.addEventListener('keydown', observe);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    window.removeEventListener('keydown', observe);
+    expect(prevented).toBe(false);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close shell' }));
+    expect(store.shellStore.close).toHaveBeenCalledOnce();
+  });
+
+  it('offers restart after exit and binds the terminal at its fitted dimensions', async () => {
+    const store = shellStore();
+    store.shellStore.status.value = 'exited';
+    store.shellStore.exitCode.value = 7;
+    store.shellStore.restart = vi.fn(async () => undefined);
+    render(<ShellOverlay store={store} />);
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+
+    expect(screen.getByText('Exited (7)')).toBeVisible();
+    expect(store.shellStore.connect).toHaveBeenCalledWith(80, 24, expect.any(Object));
+    await userEvent.click(screen.getByRole('button', { name: 'Restart' }));
+    expect(store.shellStore.restart).toHaveBeenCalledWith(80, 24, expect.any(Object));
+  });
+
+  it('hides and disables session-owned controls when the active conversation changes', async () => {
+    const store = shellStore();
+    const back = vi.spyOn(store.shellStore, 'back');
+    store.shellStore.status.value = 'exited';
+    store.shellStore.restart = vi.fn(async () => undefined);
+    store.shellStore.close = vi.fn(async () => undefined);
+    render(<ShellOverlay store={store} />);
+
+    act(() => {
+      store.sessions.value = [
+        ...store.sessions.value,
+        { ...store.sessions.value[0], id: 'session-two', title: 'Second' },
+      ];
+      store.activeSessionId.value = 'session-two';
+    });
+
+    await waitFor(() => expect(back).toHaveBeenCalled());
+    const restart = screen.getByRole('button', { name: 'Restart' });
+    const close = screen.getByRole('button', { name: 'Close shell' });
+    expect(restart).toBeDisabled();
+    expect(close).toBeDisabled();
+    await userEvent.click(restart);
+    await userEvent.click(close);
+    expect(store.shellStore.restart).not.toHaveBeenCalled();
+    expect(store.shellStore.close).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ShellOverlay.tsx
+++ b/frontend/src/components/ShellOverlay.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import '../styles/features/shell-terminal.css';
+import type { AppStore } from '../stores/app-store';
+import type { ShellSink } from '../stores/shell-store';
+
+const statusLabel = (
+  status: AppStore['shellStore']['status']['value'],
+  exitCode: number | null,
+) => {
+  switch (status) {
+    case 'idle':
+    case 'connecting':
+      return 'Opening terminal…';
+    case 'reconnecting':
+      return 'Reconnecting…';
+    case 'exited':
+      return `Exited${exitCode === null ? '' : ` (${exitCode})`}`;
+    case 'error':
+      return 'Connection error';
+    default:
+      return 'Connected';
+  }
+};
+
+const shellBindingActive = (store: AppStore, sessionId: string) =>
+  Boolean(
+    sessionId &&
+    store.shellStore.visible.peek() &&
+    store.shellStore.sessionId.peek() === sessionId &&
+    store.activeSession.peek()?.id === sessionId,
+  );
+
+export function ShellOverlay({ store }: { store: AppStore }) {
+  const host = useRef<HTMLDivElement>(null);
+  const terminal = useRef<Terminal | null>(null);
+  const fitAddon = useRef<FitAddon | null>(null);
+  const sink = useRef<ShellSink | null>(null);
+  const [closing, setClosing] = useState(false);
+  const boundSessionId = store.shellStore.sessionId.value;
+  const activeSessionId = store.activeSession.value?.id || '';
+  const matchesActiveSession = Boolean(
+    boundSessionId && boundSessionId === activeSessionId && store.shellStore.visible.value,
+  );
+
+  useEffect(() => {
+    if (!matchesActiveSession) store.shellStore.back();
+  }, [activeSessionId, boundSessionId, matchesActiveSession, store]);
+
+  useEffect(() => {
+    if (!matchesActiveSession) return;
+    const target = host.current;
+    if (!target) return;
+    const instance = new Terminal({
+      allowProposedApi: false,
+      convertEol: false,
+      cursorBlink: true,
+      cursorStyle: 'bar',
+      fontFamily: '"SFMono-Regular", Consolas, "Liberation Mono", monospace',
+      fontSize: 14,
+      lineHeight: 1.15,
+      scrollback: 10_000,
+      theme: {
+        background: '#111418',
+        foreground: '#dce2e8',
+        cursor: '#eef2f5',
+        cursorAccent: '#111418',
+        selectionBackground: '#42546699',
+        black: '#171b20',
+        red: '#e06c75',
+        green: '#98c379',
+        yellow: '#e5c07b',
+        blue: '#61afef',
+        magenta: '#c678dd',
+        cyan: '#56b6c2',
+        white: '#d7dae0',
+        brightBlack: '#5c6370',
+        brightWhite: '#ffffff',
+      },
+    });
+    const fit = new FitAddon();
+    instance.loadAddon(fit);
+    instance.open(target);
+    terminal.current = instance;
+    fitAddon.current = fit;
+    sink.current = {
+      write: (data) => instance.write(data),
+      reset: () => instance.reset(),
+    };
+    const resize = () => {
+      if (!shellBindingActive(store, boundSessionId)) return;
+      try {
+        fit.fit();
+        if (instance.cols > 1 && instance.rows > 0)
+          store.shellStore.resize(instance.cols, instance.rows);
+      } catch {
+        // The overlay may be between layout and teardown.
+      }
+    };
+    const frame = requestAnimationFrame(() => {
+      if (!shellBindingActive(store, boundSessionId)) return;
+      resize();
+      instance.focus();
+      void store.shellStore.connect(instance.cols, instance.rows, sink.current!);
+    });
+    const input = instance.onData((data) => {
+      if (shellBindingActive(store, boundSessionId)) store.shellStore.input(data);
+    });
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(resize);
+    observer?.observe(target);
+    addEventListener('resize', resize);
+    return () => {
+      cancelAnimationFrame(frame);
+      removeEventListener('resize', resize);
+      observer?.disconnect();
+      input.dispose();
+      store.shellStore.detach();
+      instance.dispose();
+      terminal.current = null;
+      fitAddon.current = null;
+      sink.current = null;
+    };
+  }, [activeSessionId, boundSessionId, matchesActiveSession, store]);
+
+  const restart = () => {
+    if (!shellBindingActive(store, boundSessionId)) return;
+    const instance = terminal.current;
+    const output = sink.current;
+    if (!instance || !output) return;
+    void store.shellStore
+      .restart(instance.cols, instance.rows, output)
+      .then(() => instance.focus());
+  };
+  const close = async () => {
+    if (!shellBindingActive(store, boundSessionId)) return;
+    setClosing(true);
+    await store.shellStore.close();
+  };
+  const status = store.shellStore.status.value;
+  return (
+    <section class="shell-overlay" aria-label="Interactive shell">
+      <header class="shell-overlay-header">
+        <div class="shell-overlay-heading">
+          <strong>Terminal</strong>
+          <span class={`shell-status shell-status-${status}`}>
+            {statusLabel(status, store.shellStore.exitCode.value)}
+          </span>
+          {store.shellStore.cwd.value && (
+            <span class="shell-cwd" title={store.shellStore.cwd.value}>
+              {store.shellStore.cwd.value}
+            </span>
+          )}
+        </div>
+        <div class="shell-overlay-actions">
+          {status === 'exited' && (
+            <button class="btn" type="button" disabled={!matchesActiveSession} onClick={restart}>
+              Restart
+            </button>
+          )}
+          <button class="btn" type="button" onClick={() => store.shellStore.back()}>
+            Back to chat
+          </button>
+          <button
+            class="btn shell-close"
+            type="button"
+            disabled={closing || !matchesActiveSession}
+            onClick={close}
+          >
+            {closing ? 'Closing…' : 'Close shell'}
+          </button>
+        </div>
+      </header>
+      {store.shellStore.error.value && (
+        <div class="shell-error" role="alert">
+          {store.shellStore.error.value}
+        </div>
+      )}
+      <div class="shell-terminal" ref={host} aria-label="Terminal output" />
+    </section>
+  );
+}

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -3159,6 +3159,25 @@ describe('Preact-owned chat surfaces', () => {
     expect(screen.getByRole('option', { name: /compact/ })).toBeInTheDocument();
   });
 
+  it('discovers and dispatches the capability-gated shell command locally', async () => {
+    const store = createStore();
+    store.shellStore.enabled.value = true;
+    store.openShell = vi.fn();
+    store.send = vi.fn(async () => undefined);
+    render(
+      <StoreContext.Provider value={store}>
+        <Composer />
+      </StoreContext.Provider>,
+    );
+    const input = screen.getByRole('textbox', { name: 'Message' });
+    await userEvent.type(input, '/sh');
+    expect(screen.getByRole('option', { name: /shell/ })).toBeInTheDocument();
+    await userEvent.type(input, 'ell');
+    await userEvent.keyboard('{Enter}');
+    expect(store.openShell).toHaveBeenCalledOnce();
+    expect(store.send).not.toHaveBeenCalled();
+  });
+
   it('dispatches restored branch and live skill commands instead of sending them as chat', async () => {
     const branchStore = createStore();
     branchStore.branchCommand = vi.fn(async () => undefined);

--- a/frontend/src/domain/completions.ts
+++ b/frontend/src/domain/completions.ts
@@ -56,6 +56,11 @@ export const SLASH_COMMANDS = [
     description: 'Ask a side question without interrupting the main run',
     streamingSafe: true,
   },
+  {
+    command: '/shell',
+    description: 'Open an interactive terminal for this conversation',
+    streamingSafe: true,
+  },
   { command: '/skills', description: 'Browse available skills' },
   {
     command: '/thread',
@@ -117,6 +122,7 @@ export function composerCompletions(
   agents: string[],
   skills: SkillCommand[] = [],
   streaming = false,
+  shellEnabled = false,
 ): Completion[] {
   const slash = value.match(/^\/[\w-]*$/);
   if (slash) {
@@ -131,7 +137,12 @@ export function composerCompletions(
       ...skillCompletions(skills),
     ];
     return entries
-      .filter((entry) => entry.value.startsWith(slash[0]) && (!streaming || entry.streamingSafe))
+      .filter(
+        (entry) =>
+          entry.value.startsWith(slash[0]) &&
+          (!streaming || entry.streamingSafe) &&
+          (entry.value !== '/shell' || shellEnabled),
+      )
       .sort((left, right) => left.value.localeCompare(right.value));
   }
   const mention = activeMentionAtCursor(value, value.length);

--- a/frontend/src/domain/rendering.test.ts
+++ b/frontend/src/domain/rendering.test.ts
@@ -216,6 +216,15 @@ describe('composer completion', () => {
     expect(applyCompletion('please /co', '/compact')).toBe('please /compact ');
   });
 
+  it('gates the interactive shell command on the server capability', () => {
+    expect(composerCompletions('/sh', [], [], false, false).map((entry) => entry.value)).toEqual(
+      [],
+    );
+    expect(composerCompletions('/sh', [], [], false, true).map((entry) => entry.value)).toEqual([
+      '/shell',
+    ]);
+  });
+
   it('restores branch commands and live skill filtering while streaming', () => {
     const skills = [
       {

--- a/frontend/src/stores/app-store.test.ts
+++ b/frontend/src/stores/app-store.test.ts
@@ -255,6 +255,36 @@ describe('AppStore compatibility behavior', () => {
     store.dispose();
   });
 
+  it('detaches and hides a bound shell before selecting or creating a conversation', async () => {
+    const store = new AppStore(config);
+    const first = session();
+    const second = { ...session(), id: 's2', title: 'Second' };
+    store.sessions.value = [first, second];
+    store.activeSessionId.value = first.id;
+    store.draftActive.value = false;
+    store.shellStore.enabled.value = true;
+    expect(store.shellStore.show(first.id)).toBe(true);
+    store.shellStore.status.value = 'running';
+    store.endpoints.sessionState = vi.fn(async () => ({}));
+    store.endpoints.selectedSession = vi.fn(async (id: string) => ({
+      selected_session: { id },
+      selected_transcript: { bodies: { messages: [] } },
+    }));
+    store.endpoints.skills = vi.fn(async () => ({ skills: [] }));
+    store.endpoints.tree = vi.fn(async () => ({}));
+
+    const selecting = store.selectSession(second);
+    expect(store.shellStore.visible.value).toBe(false);
+    expect(store.activeSessionId.value).toBe(second.id);
+    await selecting;
+
+    expect(store.shellStore.show(second.id)).toBe(true);
+    store.newChat();
+    expect(store.shellStore.visible.value).toBe(false);
+    expect(store.activeSessionId.value).toBe('');
+    store.dispose();
+  });
+
   it('moves the active session to root after worktree cleanup', async () => {
     const store = new AppStore(config);
     try {

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -49,6 +49,7 @@ import { StatusReconciler } from './status-reconciler';
 import { RunEngine } from './run-engine';
 import { SelectionStore } from './selection-store';
 import { CommitStore } from './commit-store';
+import { ShellStore } from './shell-store';
 import type {
   DiffState,
   HubAgent,
@@ -113,6 +114,7 @@ export class AppStore {
   readonly runEngine: RunEngine;
   readonly selectionStore: SelectionStore;
   readonly commitStore: CommitStore;
+  readonly shellStore: ShellStore;
   readonly keys: StorageKeys;
   readonly api: APIClient;
   readonly endpoints: Endpoints;
@@ -274,6 +276,11 @@ export class AppStore {
     this.renameTarget = this.sessionStore.renameTarget;
     this.projectTarget = this.sessionStore.projectTarget;
     this.activeSession = this.sessionStore.activeSession;
+    this.shellStore = new ShellStore(
+      this.endpoints,
+      (message, kind) => this.services.toast(message, kind),
+      () => this.activeSession.peek()?.id || '',
+    );
     this.showWidgets = signal(storage.getItem(this.keys.showWidgetsSidebar) !== '0');
     // The legacy boolean was optimistic and is never authoritative. Enrollment
     // is reconstructed from browser and server state below.
@@ -825,6 +832,7 @@ export class AppStore {
     const worktreesEnabled =
       worktrees.enabled === true || (worktrees.enabled === undefined && this.config.worktrees);
     this.sessionStore.applyCapabilities(projectsEnabled, worktreesEnabled);
+    this.shellStore.enabled.value = recordValue(data.shell)?.enabled === true;
     const attachments = recordValue(data.attachments);
     if (attachments) {
       const maxCount = Number(attachments.max_count);
@@ -919,12 +927,14 @@ export class AppStore {
   }
 
   async selectSession(session: Session, replace = false): Promise<void> {
+    if (session.id !== this.activeSessionId.peek()) this.shellStore.back();
     await this.selectionStore.selectSession(session, replace);
     this.serverEventCoordinator.updateInterest(this.activeSessionId.peek());
     void this.acknowledgeSelectedAttention();
   }
 
   newChat(replace = false, projectId?: string, persistCurrent = true): void {
+    this.shellStore.back();
     this.selectionStore.newChat(replace, projectId, persistCurrent);
     this.serverEventCoordinator.updateInterest('');
   }
@@ -950,6 +960,7 @@ export class AppStore {
   }
 
   async resolveAndSelectSession(id: string, replace = false): Promise<void> {
+    this.shellStore.back();
     await this.selectionStore.resolveAndSelectSession(id, replace);
   }
 
@@ -1426,7 +1437,17 @@ export class AppStore {
     this.composer.dispose();
     this.tabSyncCoordinator.dispose();
     this.serverEventCoordinator.dispose();
+    this.shellStore.dispose();
     this.services.dispose();
+  }
+
+  openShell(): void {
+    const session = this.activeSession.peek();
+    if (!session || this.draftActive.peek()) {
+      this.toast('Start the conversation before opening a shell.', 'error');
+      return;
+    }
+    if (this.shellStore.show(session.id)) this.prompt.value = '';
   }
 
   toast(value: unknown, kind: Toast['kind'] = 'info'): void {

--- a/frontend/src/stores/shell-store.test.ts
+++ b/frontend/src/stores/shell-store.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Endpoints } from '../api/endpoints';
+import { ShellStore, type ShellSink } from './shell-store';
+
+const sse = (...events: Array<{ event: string; data: unknown }>): Response => {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const event of events)
+          controller.enqueue(
+            encoder.encode(`event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`),
+          );
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+  );
+};
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+};
+
+function setup() {
+  const endpoints = {
+    shellCreate: vi.fn(async () => ({
+      shell_id: 'sh_one',
+      cwd: '/workspace',
+      created: true,
+      state: 'running' as const,
+    })),
+    shellStream: vi
+      .fn()
+      .mockResolvedValueOnce(
+        sse(
+          { event: 'ready', data: { shell_id: 'sh_one', next_offset: 0 } },
+          { event: 'output', data: { offset: 0, next_offset: 2, data: btoa('hi') } },
+        ),
+      )
+      .mockResolvedValueOnce(sse({ event: 'exit', data: { offset: 2, exit_code: 0 } })),
+    shellInput: vi.fn(async () => ({ accepted: 2 })),
+    shellResize: vi.fn(async () => undefined),
+    shellClose: vi.fn(async () => undefined),
+  } as unknown as Endpoints;
+  const toast = vi.fn();
+  let activeSessionId = 'session-one';
+  const store = new ShellStore(endpoints, toast, () => activeSessionId);
+  store.enabled.value = true;
+  const sink: ShellSink = { write: vi.fn(), reset: vi.fn() };
+  return {
+    store,
+    endpoints,
+    toast,
+    sink,
+    setActiveSession: (sessionId: string) => {
+      activeSessionId = sessionId;
+    },
+  };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe('ShellStore', () => {
+  it('attaches, reconnects from the consumed offset, decodes output, and reports exit', async () => {
+    const { store, endpoints, sink } = setup();
+    expect(store.show('session-one')).toBe(true);
+
+    await store.connect(100, 30, sink);
+
+    expect(endpoints.shellCreate).toHaveBeenCalledWith('session-one', 100, 30);
+    expect(endpoints.shellStream).toHaveBeenNthCalledWith(
+      1,
+      'session-one',
+      'sh_one',
+      0,
+      expect.any(AbortSignal),
+    );
+    expect(endpoints.shellStream).toHaveBeenNthCalledWith(
+      2,
+      'session-one',
+      'sh_one',
+      2,
+      expect.any(AbortSignal),
+    );
+    expect(sink.write).toHaveBeenCalledWith(new Uint8Array([104, 105]));
+    expect(store.offset.value).toBe(2);
+    expect(store.status.value).toBe('exited');
+    expect(store.exitCode.value).toBe(0);
+  });
+
+  it('serializes and batches input without closing the shell when returning to chat', async () => {
+    vi.useFakeTimers();
+    const { store, endpoints } = setup();
+    store.show('session-one');
+    store.shellId.value = 'sh_one';
+    store.status.value = 'running';
+
+    store.input('a');
+    store.input('b');
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(endpoints.shellInput).toHaveBeenCalledTimes(1);
+    expect(endpoints.shellInput).toHaveBeenCalledWith('session-one', 'sh_one', btoa('ab'));
+    store.back();
+    expect(store.visible.value).toBe(false);
+    expect(endpoints.shellClose).not.toHaveBeenCalled();
+  });
+
+  it('explicitly closes the bound generation and hides unsupported servers', async () => {
+    const { store, endpoints, toast } = setup();
+    store.enabled.value = false;
+    expect(store.show('session-one')).toBe(false);
+    expect(toast).toHaveBeenCalledWith('Interactive shell is unavailable on this server.', 'error');
+
+    store.enabled.value = true;
+    store.show('session-one');
+    store.shellId.value = 'sh_one';
+    await store.close();
+    expect(endpoints.shellClose).toHaveBeenCalledWith('session-one', 'sh_one');
+    expect(store.visible.value).toBe(false);
+  });
+
+  it('applies replay resets before writing replacement output', async () => {
+    const { store, endpoints, sink } = setup();
+    vi.mocked(endpoints.shellStream)
+      .mockReset()
+      .mockResolvedValueOnce(
+        sse(
+          { event: 'reset', data: { offset: 40, reason: 'replay_window' } },
+          { event: 'output', data: { offset: 40, next_offset: 42, data: btoa('ok') } },
+          { event: 'exit', data: { offset: 42, exit_code: 0 } },
+        ),
+      );
+    store.show('session-one');
+    await store.connect(80, 24, sink);
+    expect(sink.reset).toHaveBeenCalled();
+    expect(sink.write).toHaveBeenCalledWith(new Uint8Array([111, 107]));
+    expect(store.offset.value).toBe(42);
+  });
+
+  it('discards pending input batches when detaching, rebinding, restarting, or closing', async () => {
+    vi.useFakeTimers();
+    for (const action of ['detach', 'rebind', 'restart', 'close'] as const) {
+      const { store, endpoints, sink, setActiveSession } = setup();
+      store.show('session-one');
+      store.shellId.value = 'sh_one';
+      store.status.value = 'running';
+      store.input(`stale-${action}`);
+
+      if (action === 'detach') store.detach();
+      if (action === 'rebind') {
+        setActiveSession('session-two');
+        store.show('session-two');
+      }
+      if (action === 'restart') {
+        const restarting = store.restart(80, 24, sink);
+        store.dispose();
+        await restarting;
+      }
+      if (action === 'close') await store.close();
+      await vi.advanceTimersByTimeAsync(8);
+
+      expect(endpoints.shellInput, action).not.toHaveBeenCalled();
+      store.dispose();
+    }
+  });
+
+  it('does not let stale queued input or its error mutate a replacement binding', async () => {
+    vi.useFakeTimers();
+    const pending = deferred<{ accepted: number }>();
+    const { store, endpoints, setActiveSession } = setup();
+    vi.mocked(endpoints.shellInput).mockImplementation(() => pending.promise);
+    store.show('session-one');
+    store.shellId.value = 'sh_one';
+    store.status.value = 'running';
+    store.input('x'.repeat(60 * 1024));
+    vi.advanceTimersByTime(8);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(endpoints.shellInput).toHaveBeenCalledTimes(1);
+
+    setActiveSession('session-two');
+    store.show('session-two');
+    store.shellId.value = 'sh_two';
+    store.status.value = 'running';
+    store.error.value = '';
+    pending.reject(new Error('old shell failed'));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(endpoints.shellInput).toHaveBeenCalledTimes(1);
+    expect(store.status.value).toBe('running');
+    expect(store.error.value).toBe('');
+    store.dispose();
+  });
+
+  it.each(['detach', 'restart', 'close'] as const)(
+    'ignores an old input error after %s invalidates its generation',
+    async (action) => {
+      vi.useFakeTimers();
+      const pendingInput = deferred<{ accepted: number }>();
+      const pendingCreate = deferred<{
+        shell_id: string;
+        cwd: string;
+        created: boolean;
+        state: 'running';
+      }>();
+      const { store, endpoints, sink } = setup();
+      vi.mocked(endpoints.shellInput).mockImplementation(() => pendingInput.promise);
+      store.show('session-one');
+      store.shellId.value = 'sh_one';
+      store.status.value = 'running';
+      store.input('old input');
+      vi.advanceTimersByTime(8);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(endpoints.shellInput).toHaveBeenCalledOnce();
+
+      let restarting: Promise<void> | undefined;
+      if (action === 'detach') store.detach();
+      if (action === 'restart') {
+        vi.mocked(endpoints.shellCreate).mockImplementation(() => pendingCreate.promise);
+        restarting = store.restart(80, 24, sink);
+      }
+      if (action === 'close') await store.close();
+      const replacementStatus = store.status.value;
+      pendingInput.reject(new Error('stale input failure'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(store.status.value).toBe(replacementStatus);
+      expect(store.error.value).toBe('');
+      store.dispose();
+      if (restarting) {
+        pendingCreate.resolve({
+          shell_id: 'sh_two',
+          cwd: '/workspace',
+          created: true,
+          state: 'running',
+        });
+        await restarting;
+      }
+    },
+  );
+
+  it('guards transport controls after the active conversation no longer matches', async () => {
+    vi.useFakeTimers();
+    const { store, endpoints, sink, setActiveSession } = setup();
+    store.show('session-one');
+    store.shellId.value = 'sh_one';
+    store.status.value = 'running';
+    setActiveSession('session-two');
+
+    store.input('stale');
+    store.resize(100, 30);
+    await store.restart(100, 30, sink);
+    await store.close();
+    await vi.runAllTimersAsync();
+
+    expect(endpoints.shellInput).not.toHaveBeenCalled();
+    expect(endpoints.shellResize).not.toHaveBeenCalled();
+    expect(endpoints.shellCreate).not.toHaveBeenCalled();
+    expect(endpoints.shellClose).not.toHaveBeenCalled();
+    expect(store.visible.value).toBe(false);
+    expect(store.sessionId.value).toBe('');
+    store.dispose();
+  });
+});

--- a/frontend/src/stores/shell-store.ts
+++ b/frontend/src/stores/shell-store.ts
@@ -1,0 +1,353 @@
+import { signal, type Signal } from '@preact/signals';
+import { decodeSSE } from '../api/client';
+import type { Endpoints } from '../api/endpoints';
+
+export type ShellStatus = 'idle' | 'connecting' | 'running' | 'reconnecting' | 'exited' | 'error';
+
+export interface ShellSink {
+  write(data: Uint8Array): void;
+  reset(): void;
+}
+
+interface ShellEventData {
+  shell_id?: string;
+  offset?: number;
+  next_offset?: number;
+  exit_code?: number;
+  data?: string;
+}
+
+const delay = (milliseconds: number, signal: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, milliseconds);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+
+function decodeBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 8192) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 8192));
+  }
+  return btoa(binary);
+}
+
+function abortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === 'AbortError'
+    : (error as { name?: string } | null)?.name === 'AbortError';
+}
+
+/** Owns the detachable browser shell transport; terminal rendering stays in the lazy overlay chunk. */
+export class ShellStore {
+  readonly enabled = signal(false);
+  readonly visible = signal(false);
+  readonly status: Signal<ShellStatus> = signal('idle');
+  readonly sessionId = signal('');
+  readonly shellId = signal('');
+  readonly cwd = signal('');
+  readonly offset = signal(0);
+  readonly exitCode = signal<number | null>(null);
+  readonly error = signal('');
+
+  private generation = 0;
+  private streamAbort: AbortController | null = null;
+  private inputTimer = 0;
+  private resizeTimer = 0;
+  private inputChunks: Uint8Array[] = [];
+  private inputChain: Promise<void> = Promise.resolve();
+  private cols = 80;
+  private rows = 24;
+
+  constructor(
+    private readonly endpoints: Endpoints,
+    private readonly toast: (message: unknown, kind?: 'info' | 'success' | 'error') => void,
+    private readonly activeSessionId: () => string,
+  ) {}
+
+  show(sessionId: string): boolean {
+    if (!this.enabled.peek()) {
+      this.toast('Interactive shell is unavailable on this server.', 'error');
+      return false;
+    }
+    if (!sessionId || sessionId !== this.activeSessionId()) {
+      this.toast('Start the conversation before opening a shell.', 'error');
+      return false;
+    }
+    if (this.sessionId.peek() !== sessionId) this.resetBinding(sessionId);
+    this.visible.value = true;
+    return true;
+  }
+
+  back(): void {
+    this.visible.value = false;
+    this.detach();
+  }
+
+  async connect(cols: number, rows: number, sink: ShellSink): Promise<void> {
+    const sessionId = this.sessionId.peek();
+    if (!this.bindingActive(sessionId)) return;
+    this.cols = cols;
+    this.rows = rows;
+    const generation = this.invalidateGeneration();
+    const controller = new AbortController();
+    this.streamAbort = controller;
+    this.status.value = 'connecting';
+    this.error.value = '';
+    try {
+      const created = await this.endpoints.shellCreate(sessionId, cols, rows);
+      if (!this.current(generation, sessionId)) return;
+      if (this.shellId.peek() && this.shellId.peek() !== created.shell_id) {
+        this.offset.value = 0;
+        sink.reset();
+      }
+      this.shellId.value = created.shell_id;
+      this.cwd.value = created.cwd;
+      this.exitCode.value = null;
+      this.status.value = 'running';
+      await this.superviseStream(generation, sessionId, sink, controller);
+    } catch (error) {
+      if (!this.current(generation, sessionId) || abortError(error)) return;
+      this.status.value = 'error';
+      this.error.value = error instanceof Error ? error.message : 'Could not open the shell.';
+    }
+  }
+
+  async restart(cols: number, rows: number, sink: ShellSink): Promise<void> {
+    if (!this.bindingActive()) return;
+    this.shellId.value = '';
+    this.offset.value = 0;
+    this.exitCode.value = null;
+    sink.reset();
+    await this.connect(cols, rows, sink);
+  }
+
+  private async superviseStream(
+    generation: number,
+    sessionId: string,
+    sink: ShellSink,
+    controller: AbortController,
+  ): Promise<void> {
+    let retry = 250;
+    while (this.current(generation, sessionId) && !controller.signal.aborted) {
+      try {
+        const response = await this.endpoints.shellStream(
+          sessionId,
+          this.shellId.peek(),
+          this.offset.peek(),
+          controller.signal,
+        );
+        if (!this.current(generation, sessionId)) {
+          await response.body?.cancel();
+          return;
+        }
+        if (response.status === 409) {
+          await response.body?.cancel();
+          const attached = await this.endpoints.shellCreate(sessionId, this.cols, this.rows);
+          if (!this.current(generation, sessionId)) return;
+          if (attached.shell_id !== this.shellId.peek()) {
+            this.shellId.value = attached.shell_id;
+            this.cwd.value = attached.cwd;
+            this.offset.value = 0;
+            sink.reset();
+          }
+          continue;
+        }
+        if (!response.ok || !response.body) {
+          const body = await response.text();
+          throw new Error(body || `Shell stream returned ${response.status}`);
+        }
+        this.status.value = 'running';
+        this.error.value = '';
+        retry = 250;
+        for await (const message of decodeSSE(response.body, controller.signal)) {
+          if (!this.current(generation, sessionId)) return;
+          let data: ShellEventData;
+          try {
+            data = JSON.parse(message.data) as ShellEventData;
+          } catch {
+            continue;
+          }
+          if (message.event === 'reset') {
+            this.offset.value = Math.max(0, Number(data.offset) || 0);
+            sink.reset();
+            continue;
+          }
+          if (message.event === 'output' && data.data) {
+            const start = Math.max(0, Number(data.offset) || 0);
+            const next = Math.max(start, Number(data.next_offset) || start);
+            if (next <= this.offset.peek()) continue;
+            if (start !== this.offset.peek()) {
+              this.offset.value = start;
+              sink.reset();
+            }
+            sink.write(decodeBase64(data.data));
+            this.offset.value = next;
+            continue;
+          }
+          if (message.event === 'exit') {
+            this.offset.value = Math.max(this.offset.peek(), Number(data.offset) || 0);
+            this.exitCode.value = Number.isFinite(data.exit_code) ? Number(data.exit_code) : -1;
+            this.status.value = 'exited';
+            return;
+          }
+        }
+      } catch (error) {
+        if (!this.current(generation, sessionId) || controller.signal.aborted || abortError(error))
+          return;
+        this.error.value = error instanceof Error ? error.message : 'Shell stream disconnected.';
+      }
+      if (!this.current(generation, sessionId) || controller.signal.aborted) return;
+      this.status.value = 'reconnecting';
+      await delay(retry, controller.signal);
+      retry = Math.min(5000, retry * 2);
+    }
+  }
+
+  input(data: string): void {
+    if (!data || this.status.peek() !== 'running' || !this.bindingActive()) return;
+    const generation = this.generation;
+    this.inputChunks.push(new TextEncoder().encode(data));
+    if (this.inputTimer) return;
+    this.inputTimer = window.setTimeout(() => {
+      this.inputTimer = 0;
+      this.flushInput(generation);
+    }, 8);
+  }
+
+  private flushInput(generation: number): void {
+    if (generation !== this.generation || !this.bindingActive() || !this.inputChunks.length) return;
+    const size = this.inputChunks.reduce((total, chunk) => total + chunk.length, 0);
+    const bytes = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of this.inputChunks.splice(0)) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const sessionId = this.sessionId.peek();
+    const shellId = this.shellId.peek();
+    for (let start = 0; start < bytes.length; start += 48 * 1024) {
+      const payload = encodeBase64(bytes.subarray(start, start + 48 * 1024));
+      this.inputChain = this.inputChain
+        .then(async () => {
+          if (!this.inputCurrent(generation, sessionId, shellId)) return;
+          await this.endpoints.shellInput(sessionId, shellId, payload);
+        })
+        .catch((error: unknown) => {
+          if (!this.inputCurrent(generation, sessionId, shellId)) return;
+          this.status.value = 'error';
+          this.error.value = error instanceof Error ? error.message : 'Shell input failed.';
+        });
+    }
+  }
+
+  resize(cols: number, rows: number): void {
+    if (!this.bindingActive()) return;
+    this.cols = cols;
+    this.rows = rows;
+    const generation = this.generation;
+    clearTimeout(this.resizeTimer);
+    this.resizeTimer = window.setTimeout(() => {
+      this.resizeTimer = 0;
+      const sessionId = this.sessionId.peek();
+      const shellId = this.shellId.peek();
+      if (
+        generation !== this.generation ||
+        !this.bindingActive(sessionId) ||
+        !shellId ||
+        this.status.peek() === 'exited'
+      )
+        return;
+      void this.endpoints.shellResize(sessionId, shellId, cols, rows).catch(() => {
+        // Stream reconnection or a replacement generation will reconcile size.
+      });
+    }, 80);
+  }
+
+  async close(): Promise<void> {
+    if (!this.bindingActive()) {
+      this.visible.value = false;
+      this.resetBinding('');
+      return;
+    }
+    const sessionId = this.sessionId.peek();
+    const shellId = this.shellId.peek();
+    this.visible.value = false;
+    this.resetBinding('');
+    const closeGeneration = this.generation;
+    if (!sessionId || !shellId) return;
+    try {
+      await this.endpoints.shellClose(sessionId, shellId);
+    } catch (error) {
+      if (closeGeneration === this.generation) this.toast(error, 'error');
+    }
+  }
+
+  detach(): void {
+    this.invalidateGeneration();
+  }
+
+  dispose(): void {
+    this.detach();
+  }
+
+  private invalidateGeneration(): number {
+    this.generation += 1;
+    this.streamAbort?.abort();
+    this.streamAbort = null;
+    clearTimeout(this.inputTimer);
+    clearTimeout(this.resizeTimer);
+    this.inputTimer = 0;
+    this.resizeTimer = 0;
+    this.inputChunks = [];
+    this.inputChain = Promise.resolve();
+    return this.generation;
+  }
+
+  private bindingActive(sessionId = this.sessionId.peek()): boolean {
+    return Boolean(
+      sessionId &&
+      this.visible.peek() &&
+      sessionId === this.sessionId.peek() &&
+      sessionId === this.activeSessionId(),
+    );
+  }
+
+  private inputCurrent(generation: number, sessionId: string, shellId: string): boolean {
+    return (
+      generation === this.generation &&
+      shellId !== '' &&
+      shellId === this.shellId.peek() &&
+      this.status.peek() === 'running' &&
+      this.bindingActive(sessionId)
+    );
+  }
+
+  private current(generation: number, sessionId: string): boolean {
+    return generation === this.generation && this.bindingActive(sessionId);
+  }
+
+  private resetBinding(sessionId: string): void {
+    this.detach();
+    this.sessionId.value = sessionId;
+    this.shellId.value = '';
+    this.cwd.value = '';
+    this.offset.value = 0;
+    this.exitCode.value = null;
+    this.error.value = '';
+    this.status.value = 'idle';
+  }
+}

--- a/frontend/src/styles/features/shell-terminal.css
+++ b/frontend/src/styles/features/shell-terminal.css
@@ -1,0 +1,134 @@
+.shell-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  background: #111418;
+  color: #dce2e8;
+}
+
+.shell-overlay-header {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 10px 16px;
+  border-bottom: 1px solid #30363d;
+  background: #f7f7f5;
+  color: var(--text-primary);
+}
+
+.shell-overlay-heading,
+.shell-overlay-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.shell-overlay-heading strong {
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.shell-status {
+  flex: none;
+  padding: 3px 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.shell-status-running {
+  border-color: #b9d5c2;
+  color: #356543;
+}
+
+.shell-status-error,
+.shell-status-exited {
+  border-color: #dec5c0;
+  color: #8a4338;
+}
+
+.shell-cwd {
+  overflow: hidden;
+  max-width: min(48vw, 680px);
+  color: var(--text-secondary);
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shell-overlay-actions .btn {
+  min-height: 34px;
+  white-space: nowrap;
+}
+
+.shell-overlay-actions .shell-close {
+  border-color: #d9b9b4;
+  color: #873b32;
+}
+
+.shell-error {
+  padding: 8px 16px;
+  border-bottom: 1px solid #5d2d2d;
+  background: #321d1d;
+  color: #f1c7c2;
+  font-size: 12px;
+}
+
+.shell-terminal {
+  min-width: 0;
+  min-height: 0;
+  padding: 12px 10px 10px;
+  overflow: hidden;
+  background: #111418;
+}
+
+.shell-terminal .xterm {
+  height: 100%;
+}
+
+.shell-terminal .xterm-viewport {
+  scrollbar-color: #4f5862 #111418;
+}
+
+@media (width <= 680px) {
+  .shell-overlay-header {
+    min-height: 0;
+    align-items: flex-start;
+    padding: max(8px, env(safe-area-inset-top)) 10px 8px;
+  }
+
+  .shell-overlay-heading {
+    flex-wrap: wrap;
+    gap: 5px 8px;
+  }
+
+  .shell-cwd {
+    order: 3;
+    width: 100%;
+    max-width: 50vw;
+  }
+
+  .shell-overlay-actions {
+    gap: 6px;
+  }
+
+  .shell-overlay-actions .btn {
+    min-height: 38px;
+    padding-inline: 9px;
+    font-size: 12px;
+  }
+
+  .shell-terminal {
+    padding: 8px 5px max(5px, env(safe-area-inset-bottom));
+  }
+}

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -17,8 +17,8 @@ func TestGeneratedBundleAssets(t *testing.T) {
 		"dist/chunks/rich-highlight.js", "dist/chunks/rich-katex.js",
 		"dist/chunks/highlight.js", "dist/chunks/katex.js", "dist/chunks/katex.css", "dist/chunks/webrtc.js", "dist/chunks/mcp.js",
 		"dist/chunks/MarkdownFilePreview.js", "dist/chunks/markdown-preview-store.js",
-		"dist/chunks/markdown-document.js", "dist/chunks/file-text.js",
-		"dist/assets/MarkdownFilePreview.css",
+		"dist/chunks/ShellOverlay.js", "dist/chunks/markdown-document.js", "dist/chunks/file-text.js",
+		"dist/assets/MarkdownFilePreview.css", "dist/assets/ShellOverlay.css",
 	} {
 		body, err := StaticAsset(name)
 		if err != nil {
@@ -67,13 +67,13 @@ func TestProductionBundleSizeBudgets(t *testing.T) {
 		// presentation buffer, explicit response authority/transport state,
 		// authoritative mobile stream recovery, widget process lifecycle controls,
 		// model capability-aware runtime controls, durable terminal/input-required
-		// attention reconciliation, native commit review/editor controls, and the
-		// small eager Markdown review toggle/loader are first-party shell code. The
-		// preview body, parser, source transport, and preview CSS remain in bounded
-		// lazy chunks. Keep bounded headroom while still failing meaningful accidental
-		// regressions.
-		"dist/app.js":  {raw: 455_000, gzip: 132_000},
-		"dist/app.css": {raw: 174_000, gzip: 32_000},
+		// attention reconciliation, native commit review/editor controls, the
+		// resumable shell transport/store, and the small eager Markdown review
+		// toggle/loader are first-party shell code. The xterm terminal, preview body,
+		// parser, source transport, and feature CSS remain in bounded lazy chunks.
+		// Keep bounded headroom while still failing meaningful accidental regressions.
+		"dist/app.js":  {raw: 465_000, gzip: 135_000},
+		"dist/app.css": {raw: 174_000, gzip: 33_000},
 	}
 	for name, budget := range budgets {
 		body, err := StaticAsset(name)
@@ -95,7 +95,7 @@ func TestBundlePolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, forbidden := range []string{"window.TermLLMApp", "preact/compat", "legacy-bridge", "./assets/highlight.css", "./assets/katex.css"} {
+	for _, forbidden := range []string{"window.TermLLMApp", "preact/compat", "legacy-bridge", "./assets/highlight.css", "./assets/katex.css", "@xterm/xterm", "xterm-rows"} {
 		if bytes.Contains(js, []byte(forbidden)) {
 			t.Errorf("production bundle contains forbidden compatibility path %q", forbidden)
 		}


### PR DESCRIPTION
## Summary

Adds an interactive, PTY-backed `/shell` terminal to the web UI, rendered with a lazy-loaded xterm.js chunk. Typing `/shell` in the composer opens a full-screen terminal bound to the conversation's project/worktree.

Demo video (18 s, real server, real PTY) was recorded against this branch and shared with Sam directly; not attached here.

## Design

**Transport: streamed HTTP + POST, deliberately no WebSocket.** None of the Hub paths carry WebSocket upgrades — the Hub proxy strips `Upgrade`, the reverse-Hub tunnel is a request/streamed-response frame protocol, and the WebRTC bridge is an HTTP-over-datachannel fetch shim. An SSE output stream plus batched input POSTs works identically across direct serve, Hub proxy, reverse Hub and WebRTC with zero changes to any of those layers.

**Endpoints** (all under the existing authenticated `/v1/sessions/{id}/` prefix):

| Method | Path | Purpose |
|---|---|---|
| `POST` | `shell` | create or idempotently attach; returns `shell_id`, `cwd` |
| `GET` | `shell/stream?shell_id=&offset=` | SSE `ready` / `output` (base64) / `reset` / `exit`, 8 s heartbeats |
| `POST` | `shell/input` | base64 keystrokes, size-bounded |
| `POST` | `shell/resize` | `pty.Setsize` |
| `DELETE` | `shell` | terminate |

**Backend**
- One live shell per session; generation IDs protect replacement shells from stale tabs.
- cwd comes only from persisted session/project/worktree state via the normal workspace resolver. Client-supplied paths are rejected (`DisallowUnknownFields`).
- Opening a shell does not hydrate or pin an LLM runtime.
- 1 MiB bounded replay ring with monotonic offsets; reconnect past the ring gets `reset` + tail.
- Cleanup on explicit close, process exit, idle expiry, session delete, MCP draft delete and server shutdown. Linux enumerates the PTY login session to kill separate job-control groups; other Unix uses SIGHUP + TERM/KILL on the process group. PTY is drained to EOF (3 s ceiling) before `exit` is emitted.
- Lazy manager creation is permanently disabled once shutdown starts (no shell can be spawned after `Stop`).
- Cross-site browser requests rejected via Fetch Metadata; same-origin allowed even when Hub rewrites `Host`.
- Capability advertised in `/healthz` and `/v1/capabilities`; non-Unix platforms advertise it disabled and return 501.

**Frontend**
- `/shell` is capability-gated in completions and dispatched locally in the composer.
- Overlay: **Back to chat** detaches without killing the shell; **Close shell** terminates; restart after exit; cwd + connection status shown. Escape is not intercepted.
- Stream supervision reuses `APIClient`, the fetch reader and the SSE decoder. Input is serialized, UTF-8 encoded, batched (~16 ms) and generation-scoped so late responses from an old shell cannot mutate a new one. Resize is debounced.
- Selecting another conversation, resolving a route or starting a new chat detaches the shell first; the overlay also self-hides on binding mismatch.
- `@xterm/xterm` 6.0.0 and `@xterm/addon-fit` 0.11.0 pinned exactly; the chunk and its CSS load only when the overlay opens. Verified xterm does not leak into eager `app.js`.

## Size impact (deterministic build vs `ae000342`, same toolchain/flags)

| Artifact | Baseline | This PR | Delta |
|---|---:|---:|---:|
| Eager `app.js` (raw / gzip) | 447,937 / 125,296 | 455,401 / 127,282 | +7,464 / +1,986 |
| Eager `app.css` | 170,204 / 30,248 | 170,204 / 30,248 | 0 |
| Lazy `ShellOverlay.js` | — | 345,527 / 88,625 | lazy only |
| Lazy `ShellOverlay.css` | — | 5,807 / 1,670 | lazy only |
| Root binary | 92,809,183 | 93,243,334 | **+434,151 (+0.47%)** |

For comparison, the alternatives measured with the same esbuild: wterm 62.9 KB raw (too young, created Apr 2026), ghostty-web 1.06 MB, rioterm 1.17 MB. xterm.js was the right trade.

## Review history

Plan reviewed by a separate developer pass before implementation (surfaced that WebSocket fails on *every* Hub path, not just reverse — shaped the transport choice). Post-implementation code review found and fixed five issues, each now covered by a regression test:

1. Project-bound sessions could not resolve a workspace (`AllowNoProject` combined with a `ProjectID`).
2. Switching conversations left the shell attached to the previous session.
3. Output truncated on exit (fixed 100 ms drain reproducibly captured 114,692/131,072 bytes).
4. Queued input from an old shell generation could mutate new UI state.
5. Server shutdown could race lazy shell-manager creation.

Final re-review: no remaining blocking or high-severity findings.

## Verification

- `go test ./...`, `go build ./...`, `go vet ./...` — pass
- `go test -race ./cmd` — pass (includes `TestServeShell*`, `TestSameOriginShellRequest`, `TestHubReverseNodeProxyStreamsShellSSEIncrementally`)
- `go test ./internal/serveui` — embedded asset checks and bundle budgets pass
- Frontend: format, lint (eslint + stylelint), typecheck, `vitest` — **510 tests pass**
- Playwright shell smoke via `scripts/browser_lifecycle_smoke.sh` — desktop and mobile pass (covers open, conversation switch, new chat, Back to chat)
- `make build` — pass
- Darwin cross-compile of `./cmd` — pass
- `git diff --check` — clean
- Manual: real PTY session recorded end-to-end against `term-llm serve web --no-projects` on this branch

## Known limitations

- Replay is bounded to 1 MiB; a tab reconnecting after more output gets a reset and the retained tail.
- Resuming at an arbitrary ring offset can land mid-escape-sequence; the `reset` path handles the common case.
- Windows: shell reports unsupported. A Windows package cross-compile of `./cmd` is blocked by pre-existing Unix-only code in `internal/procutil`, unrelated to this change.
- Security posture is unchanged from other authenticated routes: any bearer-token holder can open a shell. Worth a conscious decision on whether an opt-in serve flag is wanted before this ships broadly.
