### PR TITLE
fix(mcp): report startup deadline as the cause when the transport fails first

### DIFF
--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -382,11 +382,18 @@ func (m *Manager) Enable(ctx context.Context, name string) error {
 		startupCancel()
 		if startupExpired {
 			processCancel()
-			if err == nil {
-				err = startupCtx.Err()
-				if err == nil {
-					err = context.Canceled
-				}
+			// Expiry cancels the process context, so the transport can report
+			// EOF or "client is closing" before the SDK observes the deadline.
+			// The startup context error is the cause; make it the reported one.
+			ctxErr := startupCtx.Err()
+			if ctxErr == nil {
+				ctxErr = context.Canceled
+			}
+			switch {
+			case err == nil:
+				err = ctxErr
+			case !errors.Is(err, ctxErr):
+				err = fmt.Errorf("%w: %v", ctxErr, err)
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
## Problem

`TestManagerEnable_TimesOutStartupWithBackgroundContext` failed on CI for #1099 (a PR that does not touch `internal/mcp`):

```
manager_test.go:183: status error = connect to MCP server sleepy: connection closed: calling "initialize": client is closing: EOF, want wrapped context deadline exceeded
```

Root cause in `manager.go`: when `mcpStartupTimeout` fires, `context.AfterFunc(startupCtx, processCancel)` kills the child process. The SDK's `initialize` call races between observing the transport EOF and observing the context deadline. When EOF wins, `client.start` returns a non-nil transport error, so the `err == nil` branch that substitutes `startupCtx.Err()` never runs. The reported error is a bare EOF rather than a wrapped `context.DeadlineExceeded` — misleading for users ("EOF" instead of "timed out") and flaky for the test.

## Fix

When startup has expired and the returned error does not already wrap the startup context error, wrap it: `fmt.Errorf("%w: %v", ctxErr, err)`. `errors.Is(err, context.DeadlineExceeded)` now holds on both sides of the race, and the transport detail is kept in the message.

One file, +12/−5.

## Verification

- `go build ./internal/mcp`, `go vet ./internal/mcp`, `gofmt` clean
- `go test ./internal/mcp -count=1` — pass
- `go test -race ./internal/mcp -run 'TestManagerEnable_' -count=30` — pass
- `GOMAXPROCS=1 go test ./internal/mcp -run TestManagerEnable_TimesOutStartupWithBackgroundContext -count=50` — pass
- `git diff --check` clean

I could not reproduce the EOF-first ordering locally (passed 10/10 before the fix too); it needs a loaded runner. The fix makes the outcome independent of the ordering rather than relying on reproduction.
