### PR TITLE
fix: send claude-bin image tool results as MCP image content

### DIFF
--- a/internal/llm/claude_bin.go
+++ b/internal/llm/claude_bin.go
@@ -218,14 +218,11 @@ func (p *ClaudeBinProvider) SetEnv(env map[string]string) {
 // to satisfy the ToolExecutorSetter interface in engine.go.
 func (p *ClaudeBinProvider) SetToolExecutor(executor func(ctx context.Context, name string, args json.RawMessage) (ToolOutput, error)) {
 	// Wrap the ToolOutput executor to satisfy the mcphttp.ToolExecutor interface.
-	// For tool outputs with image data, materialise images to temp files and include their
-	// paths in the response text so Claude CLI can read them natively as vision inputs.
 	p.toolExecutor = func(ctx context.Context, name string, args json.RawMessage) (mcphttp.ToolResult, error) {
 		output, err := executor(ctx, name, args)
-		return mcphttp.ToolResult{
-			Content: p.formatToolOutputForClaude(output),
-			IsError: output.IsError || output.TimedOut,
-		}, err
+		result := p.formatToolResultForClaude(output)
+		result.IsError = output.IsError || output.TimedOut
+		return result, err
 	}
 }
 
@@ -1516,7 +1513,7 @@ func (p *ClaudeBinProvider) createHTTPMCPConfig(ctx context.Context, tools []Too
 		}
 	}
 
-	wrappedExecutor := p.cliToolBridgeState.wrappedExecutor(p.formatToolOutputForClaude)
+	wrappedExecutor := p.cliToolBridgeState.wrappedResultExecutor(p.formatToolResultForClaude)
 
 	// Create and start HTTP server
 	server := mcphttp.NewServer(wrappedExecutor)
@@ -1676,8 +1673,8 @@ func (p *ClaudeBinProvider) renderConversationParts(messages []Message) []string
 			// Format tool results
 			for _, part := range msg.Parts {
 				if part.Type == PartToolResult && part.ToolResult != nil {
-					// Process content to keep prompts compact for image tool results.
-					content := p.processToolResultContent(part.ToolResult)
+					// Keep flattened history textual; final-turn images are emitted as native blocks.
+					content := toolResultTextContent(part.ToolResult)
 					conversationParts = append(conversationParts,
 						fmt.Sprintf("Tool result (%s): %s", part.ToolResult.Name, content))
 				}
@@ -1711,42 +1708,6 @@ func mapClaudeToolName(claudeName string) string {
 		return strings.TrimPrefix(claudeName, "mcp__term-llm__")
 	}
 	return claudeName
-}
-
-// processToolResultContent formats tool result content for Claude CLI prompts.
-// Image data parts are written to temp files and their paths included inline so
-// Claude CLI can read them natively rather than receiving truncated base64.
-func (p *ClaudeBinProvider) processToolResultContent(result *ToolResult) string {
-	if result == nil {
-		return ""
-	}
-	if !toolResultHasImageData(result) {
-		return toolResultTextContent(result)
-	}
-
-	// Build combined output: text parts inline, image parts as file paths.
-	var parts []string
-	for _, contentPart := range toolResultContentParts(result) {
-		switch contentPart.Type {
-		case ToolContentPartText:
-			if contentPart.Text != "" {
-				parts = append(parts, contentPart.Text)
-			}
-		case ToolContentPartImageData:
-			mediaType, base64Data, ok := toolResultImageData(contentPart)
-			if !ok {
-				continue
-			}
-			path := p.imageDataToTempFile(mediaType, base64Data)
-			if path != "" {
-				parts = append(parts, path)
-			}
-		}
-	}
-	if len(parts) == 0 {
-		return toolResultTextContent(result)
-	}
-	return strings.Join(parts, "\n")
 }
 
 // mediaTypeToExt maps an image MIME type to a file extension.
@@ -1960,11 +1921,22 @@ func (p *ClaudeBinProvider) buildStreamJsonInput(messages []Message, sessionID s
 	return strings.Join(lines, "\n")
 }
 
-func (p *ClaudeBinProvider) formatToolOutputForClaude(output ToolOutput) string {
-	return p.appendInlineFlushNotice(p.processToolResultContent(&ToolResult{
-		Content:      output.Content,
-		ContentParts: output.ContentParts,
-	}))
+// formatToolResultForClaude builds the MCP tool result for Claude Code: all
+// text (plus any pending inline-flush notice) as one text block, followed by
+// image parts as MCP image blocks. Claude Code runs with --tools "" so it
+// cannot Read a temp-file path; images must travel inline over MCP.
+func (p *ClaudeBinProvider) formatToolResultForClaude(output ToolOutput) mcphttp.ToolResult {
+	text := p.appendInlineFlushNotice(toolResultTextContent(&ToolResult{Content: output.Content, ContentParts: output.ContentParts}))
+	images := mcpImageContentParts(output)
+	if len(images) == 0 {
+		return mcphttp.ToolResult{Content: text}
+	}
+	parts := make([]mcphttp.ContentPart, 0, len(images)+1)
+	if text != "" {
+		parts = append(parts, mcphttp.ContentPart{Type: mcphttp.ContentPartText, Text: text})
+	}
+	parts = append(parts, images...)
+	return mcphttp.ToolResult{Content: text, Parts: parts}
 }
 
 func buildSDKUserContentBlocks(parts []Part) []sdkContentBlock {

--- a/internal/llm/claude_bin_test.go
+++ b/internal/llm/claude_bin_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/mcphttp"
 )
 
 func TestClaudeBinProvider_ImplementsToolExecutorSetter(t *testing.T) {
@@ -46,9 +48,9 @@ func TestClaudeBinProvider_ImplementsInlineFlusher(t *testing.T) {
 	if !provider.inlineFlushRequested() {
 		t.Fatal("RequestInlineFlush did not mark the tool-result boundary")
 	}
-	formatted := provider.formatToolOutputForClaude(TextOutput("tool ok"))
+	formatted := provider.formatToolResultForClaude(TextOutput("tool ok")).Content
 	if !strings.Contains(formatted, strings.TrimSpace(inlineFlushToolNotice)) {
-		t.Fatalf("formatToolOutputForClaude = %q, want flush notice", formatted)
+		t.Fatalf("formatToolResultForClaude content = %q, want flush notice", formatted)
 	}
 }
 
@@ -2113,10 +2115,101 @@ func TestBuildStreamJsonInput_FramesHistoryEvenWhenFinalUserEmpty(t *testing.T) 
 	}
 }
 
-func TestFormatToolOutputForClaude_UsesStructuredImageParts(t *testing.T) {
+func TestFormatToolResultForClaude_EmitsImageParts(t *testing.T) {
 	p := NewClaudeBinProvider("sonnet", nil)
 
-	formatted := p.formatToolOutputForClaude(ToolOutput{
+	result := p.formatToolResultForClaude(testClaudeImageToolOutput())
+
+	if result.Content != "Image loaded" {
+		t.Fatalf("Content = %q, want %q", result.Content, "Image loaded")
+	}
+	if len(result.Parts) != 2 {
+		t.Fatalf("Parts = %#v, want text and image blocks", result.Parts)
+	}
+	if result.Parts[0].Type != mcphttp.ContentPartText || result.Parts[0].Text != "Image loaded" {
+		t.Errorf("text part = %#v", result.Parts[0])
+	}
+	if image := result.Parts[1]; image.Type != mcphttp.ContentPartImage || image.MIMEType != "image/png" || string(image.Data) != "hello" {
+		t.Errorf("image part = %#v", image)
+	}
+
+	p.tempFilesMu.Lock()
+	trackedFiles := len(p.tempFiles)
+	p.tempFilesMu.Unlock()
+	if trackedFiles != 0 {
+		t.Fatalf("formatting tracked %d temp files, want none", trackedFiles)
+	}
+}
+
+func TestFormatToolResultForClaude_TextOnlyHasNoParts(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+
+	result := p.formatToolResultForClaude(TextOutput("tool ok"))
+
+	if result.Content != "tool ok" {
+		t.Fatalf("Content = %q, want %q", result.Content, "tool ok")
+	}
+	if result.Parts != nil {
+		t.Fatalf("Parts = %#v, want nil", result.Parts)
+	}
+}
+
+func TestFormatToolResultForClaude_FlushNoticeStaysInTextPart(t *testing.T) {
+	p := NewClaudeBinProvider("sonnet", nil)
+	p.requestInlineFlush()
+
+	result := p.formatToolResultForClaude(testClaudeImageToolOutput())
+
+	if len(result.Parts) != 2 {
+		t.Fatalf("Parts = %#v, want text and image blocks", result.Parts)
+	}
+	if result.Parts[0].Type != mcphttp.ContentPartText || !strings.HasSuffix(result.Parts[0].Text, inlineFlushToolNotice) {
+		t.Fatalf("text part = %#v, want inline flush notice", result.Parts[0])
+	}
+	if result.Parts[1].Type != mcphttp.ContentPartImage {
+		t.Fatalf("image part = %#v", result.Parts[1])
+	}
+
+	second := p.formatToolResultForClaude(testClaudeImageToolOutput())
+	if strings.Contains(second.Content, strings.TrimSpace(inlineFlushToolNotice)) {
+		t.Fatalf("second Content retained one-shot flush notice: %q", second.Content)
+	}
+}
+
+func TestClaudeBinProvider_SetToolExecutor_EmitsImageParts(t *testing.T) {
+	tests := []struct {
+		name      string
+		timedOut  bool
+		wantError bool
+	}{
+		{name: "success"},
+		{name: "timeout", timedOut: true, wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewClaudeBinProvider("sonnet", nil)
+			provider.SetToolExecutor(func(context.Context, string, json.RawMessage) (ToolOutput, error) {
+				output := testClaudeImageToolOutput()
+				output.TimedOut = tt.timedOut
+				return output, nil
+			})
+
+			result, err := provider.toolExecutor(context.Background(), "view_image", json.RawMessage("{}"))
+			if err != nil {
+				t.Fatalf("toolExecutor: %v", err)
+			}
+			if result.IsError != tt.wantError {
+				t.Errorf("IsError = %v, want %v", result.IsError, tt.wantError)
+			}
+			if len(result.Parts) != 2 || result.Parts[1].Type != mcphttp.ContentPartImage {
+				t.Fatalf("Parts = %#v, want text and image blocks", result.Parts)
+			}
+		})
+	}
+}
+
+func testClaudeImageToolOutput() ToolOutput {
+	return ToolOutput{
 		Content: "Image loaded",
 		ContentParts: []ToolContentPart{
 			{Type: ToolContentPartText, Text: "Image loaded"},
@@ -2125,20 +2218,6 @@ func TestFormatToolOutputForClaude_UsesStructuredImageParts(t *testing.T) {
 				Base64:    "aGVsbG8=",
 			}},
 		},
-	})
-
-	lines := strings.Split(strings.TrimSpace(formatted), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected formatted output to include text and image path, got %q", formatted)
-	}
-	if lines[0] != "Image loaded" {
-		t.Fatalf("expected first line to keep text output, got %q", lines[0])
-	}
-	if lines[1] == "" {
-		t.Fatal("expected second line to contain image path")
-	}
-	if _, err := os.Stat(lines[1]); err != nil {
-		t.Fatalf("expected materialized image path %q to exist: %v", lines[1], err)
 	}
 }
 

--- a/internal/llm/cli_bin_shared.go
+++ b/internal/llm/cli_bin_shared.go
@@ -270,9 +270,13 @@ func (s *cliToolBridgeState) deactivate(bridge *cliTurnBridge) {
 	s.eventsMu.Unlock()
 }
 
-// wrappedExecutor routes an HTTP MCP call through the active provider stream so
+// cliToolResultFormatter builds Content and Parts for an MCP tool result. The
+// bridge owns IsError so formatters cannot override execution status.
+type cliToolResultFormatter func(ToolOutput) mcphttp.ToolResult
+
+// wrappedResultExecutor routes an HTTP MCP call through the active provider stream so
 // the engine remains the sole owner of tool execution and event emission.
-func (s *cliToolBridgeState) wrappedExecutor(formatOutput func(ToolOutput) string) mcphttp.ToolExecutor {
+func (s *cliToolBridgeState) wrappedResultExecutor(format cliToolResultFormatter) mcphttp.ToolExecutor {
 	return func(ctx context.Context, name string, args json.RawMessage) (mcphttp.ToolResult, error) {
 		s.eventsMu.Lock()
 		bridge := s.currentBridge
@@ -315,20 +319,28 @@ func (s *cliToolBridgeState) wrappedExecutor(formatOutput func(ToolOutput) strin
 
 		select {
 		case response := <-responseChan:
-			content := response.Result.Content
-			if formatOutput != nil {
-				content = formatOutput(response.Result)
+			result := mcphttp.ToolResult{Content: response.Result.Content}
+			if format != nil {
+				result = format(response.Result)
 			}
-			return mcphttp.ToolResult{
-				Content: content,
-				IsError: response.Result.IsError || response.Result.TimedOut,
-			}, response.Err
+			result.IsError = response.Result.IsError || response.Result.TimedOut
+			return result, response.Err
 		case <-bridge.done:
 			return mcphttp.ToolResult{}, fmt.Errorf("tool execution rejected: stream closed during tool call %q", name)
 		case <-ctx.Done():
 			return mcphttp.ToolResult{}, ctx.Err()
 		}
 	}
+}
+
+func (s *cliToolBridgeState) wrappedExecutor(formatOutput func(ToolOutput) string) mcphttp.ToolExecutor {
+	return s.wrappedResultExecutor(func(output ToolOutput) mcphttp.ToolResult {
+		content := output.Content
+		if formatOutput != nil {
+			content = formatOutput(output)
+		}
+		return mcphttp.ToolResult{Content: content}
+	})
 }
 
 func handleCLIToolRequest(req cliToolRequest, send eventSender) {
@@ -736,4 +748,28 @@ func mcpToolSpecs(tools []ToolSpec) []mcphttp.ToolSpec {
 		out[i] = mcphttp.ToolSpec{Name: tool.Name, Description: tool.Description, Schema: tool.Schema}
 	}
 	return out
+}
+
+// mcpImageContentParts decodes the supported image parts of a tool output into
+// MCP image blocks. Unsupported media types and invalid base64 are skipped
+// (toolResultImageData already gates on png/jpeg/gif/webp).
+func mcpImageContentParts(output ToolOutput) []mcphttp.ContentPart {
+	result := &ToolResult{Content: output.Content, ContentParts: output.ContentParts}
+	var parts []mcphttp.ContentPart
+	for _, part := range toolResultContentParts(result) {
+		mediaType, base64Data, ok := toolResultImageData(part)
+		if !ok {
+			continue
+		}
+		raw, err := base64.StdEncoding.DecodeString(base64Data)
+		if err != nil || len(raw) == 0 {
+			continue
+		}
+		parts = append(parts, mcphttp.ContentPart{
+			Type:     mcphttp.ContentPartImage,
+			MIMEType: mediaType,
+			Data:     raw,
+		})
+	}
+	return parts
 }

--- a/internal/llm/cli_bin_shared_test.go
+++ b/internal/llm/cli_bin_shared_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"go/ast"
@@ -143,6 +144,140 @@ func TestCLIToolBridgePreservesToolFailureStatus(t *testing.T) {
 	}
 }
 
+func TestCLIToolBridgeForwardsImageParts(t *testing.T) {
+	tests := []struct {
+		name      string
+		isError   bool
+		wantError bool
+	}{
+		{name: "success"},
+		{name: "semantic error", isError: true, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			bridge := &cliTurnBridge{
+				toolReqCh: make(chan cliToolRequest, 1),
+				done:      make(chan struct{}),
+			}
+			events := make(chan Event, 1)
+			var state cliToolBridgeState
+			state.activate(bridge, events)
+			defer state.deactivate(bridge)
+
+			server := mcphttp.NewServer(state.wrappedResultExecutor(func(output ToolOutput) mcphttp.ToolResult {
+				return mcphttp.ToolResult{
+					Content: output.Content,
+					Parts: append([]mcphttp.ContentPart{{
+						Type: mcphttp.ContentPartText,
+						Text: output.Content,
+					}}, mcpImageContentParts(output)...),
+				}
+			}))
+			url, token, err := server.Start(testCtx, []mcphttp.ToolSpec{{
+				Name:   "view_image",
+				Schema: map[string]interface{}{"type": "object"},
+			}})
+			if err != nil {
+				t.Fatalf("start MCP server: %v", err)
+			}
+			defer func() {
+				stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer stopCancel()
+				if err := server.Stop(stopCtx); err != nil {
+					t.Errorf("stop MCP server: %v", err)
+				}
+			}()
+
+			go func() {
+				req := <-bridge.toolReqCh
+				req.ack <- nil
+				req.response <- ToolExecutionResponse{Result: ToolOutput{
+					Content: "Image loaded",
+					ContentParts: []ToolContentPart{
+						{Type: ToolContentPartText, Text: "Image loaded"},
+						{Type: ToolContentPartImageData, ImageData: &ToolImageData{
+							MediaType: "image/png",
+							Base64:    "aGVsbG8=",
+						}},
+					},
+					IsError: tt.isError,
+				}}
+			}()
+
+			body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"view_image","arguments":{}}}`)
+			req, err := http.NewRequestWithContext(testCtx, http.MethodPost, url, body)
+			if err != nil {
+				t.Fatalf("create MCP request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json, text/event-stream")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("call MCP tool: %v", err)
+			}
+			defer resp.Body.Close()
+			responseBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read MCP response: %v", err)
+			}
+			gotError, content := decodeMCPToolCallResponseBlocks(t, responseBody)
+			if gotError != tt.wantError {
+				t.Errorf("CallToolResult.IsError = %v, want %v; response: %s", gotError, tt.wantError, responseBody)
+			}
+			if len(content) != 2 {
+				t.Fatalf("MCP content = %#v, want two blocks", content)
+			}
+			if content[0].Type != "text" || content[0].Text != "Image loaded" {
+				t.Errorf("text block = %#v", content[0])
+			}
+			if content[1].Type != "image" || content[1].MIMEType != "image/png" {
+				t.Fatalf("image block = %#v", content[1])
+			}
+			decoded, err := base64.StdEncoding.DecodeString(content[1].Data)
+			if err != nil {
+				t.Fatalf("decode image data: %v", err)
+			}
+			if !bytes.Equal(decoded, []byte("hello")) {
+				t.Errorf("image data = %q, want %q", decoded, "hello")
+			}
+		})
+	}
+}
+
+type mcpToolCallContentBlock struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	MIMEType string `json:"mimeType"`
+	Data     string `json:"data"`
+}
+
+func decodeMCPToolCallResponseBlocks(t *testing.T, body []byte) (bool, []mcpToolCallContentBlock) {
+	t.Helper()
+	payload := bytes.TrimSpace(body)
+	for _, line := range bytes.Split(payload, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("data:")) {
+			payload = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+			break
+		}
+	}
+
+	var response struct {
+		Result struct {
+			Content []mcpToolCallContentBlock `json:"content"`
+			IsError bool                      `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(payload, &response); err != nil {
+		t.Fatalf("decode MCP response %q: %v", body, err)
+	}
+	return response.Result.IsError, response.Result.Content
+}
+
 func decodeMCPToolCallResponse(t *testing.T, body []byte) (bool, string) {
 	t.Helper()
 	payload := bytes.TrimSpace(body)
@@ -187,7 +322,9 @@ func TestInlineLoopCLIProvidersSupportInlineFlush(t *testing.T) {
 		state        *cliToolBridgeState
 		formatOutput func(ToolOutput) string
 	}{
-		{"claude_bin", claude, &claude.cliToolBridgeState, claude.formatToolOutputForClaude},
+		{"claude_bin", claude, &claude.cliToolBridgeState, func(output ToolOutput) string {
+			return claude.formatToolResultForClaude(output).Content
+		}},
 		{"grok_bin", grok, &grok.cliToolBridgeState, grok.formatToolOutput},
 		{"cursor_bin", cursor, &cursor.cliToolBridgeState, cursor.formatToolOutput},
 		{"agy_bin", agy, &agy.cliToolBridgeState, agy.formatToolOutput},

--- a/internal/mcphttp/http_server.go
+++ b/internal/mcphttp/http_server.go
@@ -22,10 +22,52 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// ToolResult is the text result exposed to an MCP client and its semantic status.
+// ContentPartType identifies an MCP tool-result content block.
+type ContentPartType string
+
+const (
+	ContentPartText  ContentPartType = "text"
+	ContentPartImage ContentPartType = "image"
+)
+
+// ContentPart is one MCP content block. Image Data holds raw (decoded) bytes;
+// the go-sdk base64-encodes it on the wire.
+type ContentPart struct {
+	Type     ContentPartType
+	Text     string
+	MIMEType string
+	Data     []byte
+}
+
+// ToolResult is the result exposed to an MCP client and its semantic status.
 type ToolResult struct {
-	Content string
+	Content string        // text-only result; used when Parts is empty
+	Parts   []ContentPart // optional structured blocks (text + images); takes precedence over Content
 	IsError bool
+}
+
+func toolResultContent(result ToolResult) []mcp.Content {
+	if len(result.Parts) == 0 {
+		return []mcp.Content{&mcp.TextContent{Text: result.Content}}
+	}
+
+	content := make([]mcp.Content, 0, len(result.Parts))
+	for _, part := range result.Parts {
+		switch part.Type {
+		case ContentPartText:
+			if part.Text != "" {
+				content = append(content, &mcp.TextContent{Text: part.Text})
+			}
+		case ContentPartImage:
+			if len(part.Data) > 0 && part.MIMEType != "" {
+				content = append(content, &mcp.ImageContent{Data: part.Data, MIMEType: part.MIMEType})
+			}
+		}
+	}
+	if len(content) == 0 {
+		return []mcp.Content{&mcp.TextContent{Text: result.Content}}
+	}
+	return content
 }
 
 // ToolExecutor is a function that executes a tool and returns the result.
@@ -147,9 +189,7 @@ func (s *Server) startInternal(host string, port int, token string, tools []Tool
 			}
 
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{Text: result.Content},
-				},
+				Content: toolResultContent(result),
 				IsError: result.IsError,
 			}, nil
 		})

--- a/internal/mcphttp/http_server_test.go
+++ b/internal/mcphttp/http_server_test.go
@@ -3,12 +3,15 @@ package mcphttp
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestServerStartStop(t *testing.T) {
@@ -128,6 +131,107 @@ func TestServerPropagatesToolResultIsError(t *testing.T) {
 	}
 	if !result.Result.IsError || len(result.Result.Content) != 1 || result.Result.Content[0].Text != "failed usefully" {
 		t.Fatalf("tool result = %#v", result.Result)
+	}
+}
+
+func TestServerEmitsImageContentParts(t *testing.T) {
+	server := NewServer(func(context.Context, string, json.RawMessage) (ToolResult, error) {
+		return ToolResult{
+			Content: "Image loaded",
+			Parts: []ContentPart{
+				{Type: ContentPartText, Text: "Image loaded"},
+				{Type: ContentPartImage, MIMEType: "image/png", Data: []byte("hello")},
+			},
+		}, nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	url, token, err := server.Start(ctx, []ToolSpec{{Name: "view_image", Schema: map[string]interface{}{"type": "object"}}})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+		defer stopCancel()
+		if err := server.Stop(stopCtx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	}()
+
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"view_image","arguments":{}}}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	for _, line := range bytes.Split(bytes.TrimSpace(payload), []byte("\n")) {
+		if bytes.HasPrefix(bytes.TrimSpace(line), []byte("data:")) {
+			payload = bytes.TrimSpace(bytes.TrimPrefix(bytes.TrimSpace(line), []byte("data:")))
+			break
+		}
+	}
+	var result struct {
+		Result struct {
+			Content []struct {
+				Type     string `json:"type"`
+				Text     string `json:"text"`
+				MIMEType string `json:"mimeType"`
+				Data     string `json:"data"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		t.Fatalf("decode response %q: %v", payload, err)
+	}
+	if len(result.Result.Content) != 2 {
+		t.Fatalf("content = %#v, want two blocks", result.Result.Content)
+	}
+	if got := result.Result.Content[0]; got.Type != "text" || got.Text != "Image loaded" {
+		t.Errorf("text block = %#v", got)
+	}
+	image := result.Result.Content[1]
+	if image.Type != "image" || image.MIMEType != "image/png" {
+		t.Fatalf("image block = %#v", image)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(image.Data)
+	if err != nil {
+		t.Fatalf("decode image data: %v", err)
+	}
+	if !bytes.Equal(decoded, []byte("hello")) {
+		t.Errorf("image data = %q, want %q", decoded, "hello")
+	}
+}
+
+func TestToolResultContentFallbacks(t *testing.T) {
+	tests := []struct {
+		name   string
+		result ToolResult
+	}{
+		{name: "plain text", result: ToolResult{Content: "plain"}},
+		{name: "invalid parts", result: ToolResult{Content: "fallback", Parts: []ContentPart{{Type: ContentPartImage, MIMEType: "image/png"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := toolResultContent(tt.result)
+			if len(content) != 1 {
+				t.Fatalf("content = %#v, want one text block", content)
+			}
+			text, ok := content[0].(*mcp.TextContent)
+			if !ok || text.Text != tt.result.Content {
+				t.Fatalf("content = %#v, want text %q", content, tt.result.Content)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

When the primary model runs through `claude-bin`, `view_image` results never reached the model as an image.

`view_image` (native mode) returns text + a base64 `image_data` content part. The claude-bin MCP bridge (`mcphttp.ToolResult`) was text-only, so `processToolResultContent` wrote the image to `/tmp/term-llm-img-*.png` and appended the *path* as text, assuming Claude Code would `Read` it. But `buildArgs` passes `--tools ""`, which disables every Claude Code built-in including `Read`. The model got a path it could not open (and the file was deleted at end of turn anyway).

Observed in a live session: five `view_image` calls each returned `Image loaded … Detail: auto`; the model eventually wrote "the image viewer isn't returning descriptions to me" and fell back to programmatic checks.

## Fix

- `internal/mcphttp`: `ToolResult` gains optional `Parts []ContentPart` (text / image). The server emits `mcp.TextContent` / `mcp.ImageContent` blocks for parts, falling back to the single text block when `Parts` is empty or yields nothing. `ImageContent.Data` carries raw decoded bytes (the go-sdk base64-encodes on the wire). `StructuredContent` is never set.
- `internal/llm/cli_bin_shared.go`: new `wrappedResultExecutor(cliToolResultFormatter)`; the existing string-based `wrappedExecutor` becomes a thin adapter so grok/agy/cursor call sites are unchanged. New `mcpImageContentParts` decodes supported image parts (png/jpeg/gif/webp, gated by `toolResultImageData`).
- `internal/llm/claude_bin.go`: `formatToolResultForClaude` replaces `formatToolOutputForClaude`; text (including any inline-flush notice) goes in one text block followed by image blocks. `processToolResultContent` and the tool-result temp-file path are removed; `renderConversationParts` uses `toolResultTextContent` for flattened history. `tempFileTracker` and cleanup plumbing are untouched (still used for user `PartImage` history and by cursor-bin). `--tools ""` stays.

## Tests

- `internal/mcphttp`: server emits text + image blocks; image data round-trips (raw bytes in, base64 on the wire); text-only and invalid-part fallbacks.
- `internal/llm`: `formatToolResultForClaude` emits image parts and tracks no temp files; text-only has no parts; inline-flush notice stays in the text part and is consumed once; `SetToolExecutor` path emits image parts and propagates `IsError` on timeout; end-to-end CLI bridge test over HTTP forwards image parts and keeps `IsError` bridge-owned.

Run: `gofmt -l` (clean), `go vet ./internal/mcphttp/... ./internal/llm/... ./internal/tools/...`, `go test ./internal/mcphttp/... ./internal/tools/... ./internal/llm/...`, `make build`, isolated-HOME `go test ./...`.

## Live verification (Claude Code 2.1.257, `claude-bin:fable`)

Same PNG, same prompt, same model:

- Before (installed v0.9.15): model reports only a load confirmation, retries on `/tmp/term-llm-img-1917911830.png`, answers **"CANNOT SEE IMAGE"**.
- After: accurate two-sentence description of the render, including the on-screen text ("pelican · sky bike · three.js", "Taking it for a ride.", "click to restart").

## Out of scope

`cmd/serve_mcp.go` (`serveMCPToolResult`, external MCP clients) stays text-only; it could reuse `mcpImageContentParts` in a follow-up.
