### PR TITLE
fix: hide workspace management in yolo mode

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -534,7 +534,13 @@ func runAsk(cmd *cobra.Command, args []string) error {
 
 	// Add tools to request if any are registered (local, MCP, or output tool)
 	if toolMgr != nil || mcpManager != nil || outputTool != nil {
-		if specs := llm.ToolSpecsForRequest(engine.Tools(), settings.Search); len(specs) > 0 {
+		specs := llm.ToolSpecsForRequest(engine.Tools(), settings.Search)
+		var approvalMgr *tools.ApprovalManager
+		if toolMgr != nil {
+			approvalMgr = toolMgr.ApprovalMgr
+		}
+		specs = tools.FilterToolSpecsForApprovalMode(specs, approvalMgr)
+		if len(specs) > 0 {
 			req.Tools = specs
 			req.ToolChoice = llm.ToolChoice{Mode: llm.ToolChoiceAuto}
 		}

--- a/cmd/loop.go
+++ b/cmd/loop.go
@@ -366,6 +366,11 @@ func runLoop(cmd *cobra.Command, args []string) error {
 	var toolSpecs []llm.ToolSpec
 	if toolMgr != nil || mcpManager != nil {
 		toolSpecs = llm.ToolSpecsForRequest(engine.Tools(), settings.Search)
+		var approvalMgr *tools.ApprovalManager
+		if toolMgr != nil {
+			approvalMgr = toolMgr.ApprovalMgr
+		}
+		toolSpecs = tools.FilterToolSpecsForApprovalMode(toolSpecs, approvalMgr)
 	}
 
 	// Force external search setting

--- a/cmd/serve_mcp.go
+++ b/cmd/serve_mcp.go
@@ -234,9 +234,11 @@ func runServeMCP(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Collect MCP tool specs.
+	// Collect MCP tool specs. Keep the executor registered for stale/in-flight
+	// calls, but do not advertise redundant workspace grants in yolo mode.
 	var mcpTools []mcphttp.ToolSpec
-	for _, spec := range registry.GetSpecs() {
+	localSpecs := tools.FilterToolSpecsForApprovalMode(registry.GetSpecs(), approvalMgr)
+	for _, spec := range localSpecs {
 		mcpTools = append(mcpTools, mcphttp.ToolSpec{
 			Name:        spec.Name,
 			Description: spec.Description,

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -1252,6 +1252,9 @@ const maxResponseIDs = 16
 
 func (rt *serveRuntime) selectTools(requested map[string]bool) []llm.ToolSpec {
 	all := rt.engine.Tools().AllSpecs()
+	if rt.toolMgr != nil {
+		all = tools.FilterToolSpecsForApprovalMode(all, rt.toolMgr.ApprovalMgr)
+	}
 	if len(requested) == 0 {
 		return all
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -13338,6 +13338,46 @@ func TestSelectTools_ResolvesToolMapNames(t *testing.T) {
 	}
 }
 
+func TestSelectTools_OmitsManageWorkspaceInYoloWithoutUnregisteringIt(t *testing.T) {
+	provider := llm.NewMockProvider("mock")
+	registry := llm.NewToolRegistry()
+	approval := tools.NewApprovalManager(tools.NewToolPermissions())
+	registry.Register(tools.NewManageWorkspaceTool(approval))
+	registry.Register(&echoTool{})
+	engine := llm.NewEngine(provider, registry)
+	rt := &serveRuntime{
+		provider: provider,
+		engine:   engine,
+		toolMgr:  &tools.ToolManager{ApprovalMgr: approval},
+	}
+
+	if got := rt.selectTools(nil); len(got) != 2 {
+		t.Fatalf("prompt tools = %v, want manage_workspace and echo", serveToolSpecNames(got))
+	}
+
+	approval.SetApprovalMode(tools.ModeYolo)
+	got := rt.selectTools(nil)
+	if len(got) != 1 || got[0].Name != "echo" {
+		t.Fatalf("yolo tools = %v, want only echo", serveToolSpecNames(got))
+	}
+	if _, ok := engine.Tools().Get(tools.ManageWorkspaceToolName); !ok {
+		t.Fatal("manage_workspace executor was unregistered in yolo mode")
+	}
+
+	approval.SetApprovalMode(tools.ModePrompt)
+	if got := rt.selectTools(nil); len(got) != 2 {
+		t.Fatalf("restored prompt tools = %v, want manage_workspace and echo", serveToolSpecNames(got))
+	}
+}
+
+func serveToolSpecNames(specs []llm.ToolSpec) []string {
+	names := make([]string, len(specs))
+	for i, spec := range specs {
+		names[i] = spec.Name
+	}
+	return names
+}
+
 func TestToolMap_ChatCompletions(t *testing.T) {
 	srv := newTestServeServerWithToolMap(
 		map[string]string{"MyEcho": "echo"},

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -520,9 +520,28 @@ func (m *ToolManager) SetupEngine(engine *llm.Engine) {
 	m.Registry.RegisterWithEngine(engine)
 }
 
-// GetSpecs returns all tool specs for the request.
+// FilterToolSpecsForApprovalMode removes tools that have no model-facing use in
+// the effective approval mode. Executors stay registered so an in-flight call
+// issued before a mode change can still complete safely.
+func FilterToolSpecsForApprovalMode(specs []llm.ToolSpec, approval *ApprovalManager) []llm.ToolSpec {
+	if approval == nil || !approval.YoloEnabled() {
+		return specs
+	}
+	filtered := make([]llm.ToolSpec, 0, len(specs))
+	for _, spec := range specs {
+		if spec.Name != ManageWorkspaceToolName {
+			filtered = append(filtered, spec)
+		}
+	}
+	return filtered
+}
+
+// GetSpecs returns all model-facing tool specs for the effective approval mode.
 func (m *ToolManager) GetSpecs() []llm.ToolSpec {
-	return m.Registry.GetSpecs()
+	if m == nil || m.Registry == nil {
+		return nil
+	}
+	return FilterToolSpecsForApprovalMode(m.Registry.GetSpecs(), m.ApprovalMgr)
 }
 
 // GetSpawnAgentTool returns the spawn_agent tool if enabled, for runner configuration.

--- a/internal/tools/registry_approval_mode_test.go
+++ b/internal/tools/registry_approval_mode_test.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func TestFilterToolSpecsForApprovalModeOmitsManageWorkspaceOnlyInYolo(t *testing.T) {
+	specs := []llm.ToolSpec{
+		{Name: ReadFileToolName},
+		{Name: ManageWorkspaceToolName},
+		{Name: ShellToolName},
+	}
+	approval := NewApprovalManager(NewToolPermissions())
+
+	if got := FilterToolSpecsForApprovalMode(specs, approval); len(got) != len(specs) {
+		t.Fatalf("prompt specs = %v, want all %v", toolSpecNames(got), toolSpecNames(specs))
+	}
+
+	approval.SetApprovalMode(ModeYolo)
+	got := FilterToolSpecsForApprovalMode(specs, approval)
+	if want := []string{ReadFileToolName, ShellToolName}; !equalToolSpecNames(got, want) {
+		t.Fatalf("yolo specs = %v, want %v", toolSpecNames(got), want)
+	}
+	if specs[1].Name != ManageWorkspaceToolName {
+		t.Fatalf("filter mutated input specs: %v", toolSpecNames(specs))
+	}
+
+	approval.SetApprovalMode(ModePrompt)
+	if got := FilterToolSpecsForApprovalMode(specs, approval); len(got) != len(specs) {
+		t.Fatalf("restored prompt specs = %v, want all %v", toolSpecNames(got), toolSpecNames(specs))
+	}
+}
+
+func toolSpecNames(specs []llm.ToolSpec) []string {
+	names := make([]string, len(specs))
+	for i, spec := range specs {
+		names[i] = spec.Name
+	}
+	return names
+}
+
+func equalToolSpecNames(specs []llm.ToolSpec, want []string) bool {
+	got := toolSpecNames(specs)
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -3165,6 +3165,7 @@ func (m *Model) newInspectorConfig() *inspector.Config {
 			}
 		}
 	}
+	toolSpecs = tools.FilterToolSpecsForApprovalMode(toolSpecs, m.approvalMgr)
 
 	cfg := &inspector.Config{
 		ProviderName:            m.providerName,

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -872,6 +872,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 		// tools (notably web_search/read_url) are registered so they can be injected
 		// when search is enabled, but they should not leak into ordinary chats.
 		reqTools = filterSearchToolSpecs(reqTools, m.searchEnabled)
+		reqTools = tools.FilterToolSpecsForApprovalMode(reqTools, m.approvalMgr)
 
 		serviceTier, serviceTierSet := m.currentServiceTier()
 		req := llm.Request{


### PR DESCRIPTION
## Summary

- omit `manage_workspace` from model-facing tool specs while the effective approval mode is yolo
- keep the executor registered so stale or in-flight calls remain safe across runtime mode changes
- apply the filtering consistently to CLI chat/ask/loop, the TUI inspector, serve APIs/runners, and `serve mcp`

In yolo mode, direct file/path checks already return `ProceedOnce`, so advertising `manage_workspace grant` only causes redundant bookkeeping and tool calls.

## Tests

- `go test ./internal/tools ./internal/tui/chat`
- `go test ./cmd -run 'Yolo|ApprovalMode|SelectTools|ServeMCP|ManageWorkspace' -count=1`
- `go build ./...`
- `git diff --check`

The full `go test ./cmd` run reached unrelated environment-sensitive skill discovery failures in `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir` and `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`; focused command-package tests pass.

## Review

Reviewed with `claude-bin:fable`. It found missing `ask` and `loop` coverage plus a TUI inspector inconsistency; all three were fixed in `73d920f6`. Its remaining Telegram fallback observation is unreachable because service construction requires a runner, whose path is already filtered.
