### PR TITLE
fix(web): allow dedicated agent in fresh threads

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1180,6 +1180,18 @@ func (c serveServerConfig) imagesRoute() string { return c.basePath + "/images/"
 // filesRoute returns the files sub-route, e.g. "/ui/files/" or "/chat/files/".
 func (c serveServerConfig) filesRoute() string { return c.basePath + "/files/" }
 
+func (c serveServerConfig) agentAvailable(name string) bool {
+	if name == c.agentName {
+		return name != ""
+	}
+	for _, available := range c.agentNames {
+		if name == available {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveFilesDir returns the files-dir from the flag if set, otherwise from config.
 func resolveFilesDir(flagVal string, cfg *config.Config) string {
 	if flagVal != "" {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1180,9 +1180,10 @@ func (c serveServerConfig) imagesRoute() string { return c.basePath + "/images/"
 // filesRoute returns the files sub-route, e.g. "/ui/files/" or "/chat/files/".
 func (c serveServerConfig) filesRoute() string { return c.basePath + "/files/" }
 
+// agentAvailable reports whether a first-party request may select name.
 func (c serveServerConfig) agentAvailable(name string) bool {
-	if name == c.agentName {
-		return name != ""
+	if name != "" && name == c.agentName {
+		return true
 	}
 	for _, available := range c.agentNames {
 		if name == available {

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -186,18 +186,9 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid agent name")
 		return
 	}
-	if req.Agent != "" {
-		available := false
-		for _, name := range s.cfg.agentNames {
-			if req.Agent == name {
-				available = true
-				break
-			}
-		}
-		if !available {
-			writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "agent is not available")
-			return
-		}
+	if req.Agent != "" && !s.cfg.agentAvailable(req.Agent) {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "agent is not available")
+		return
 	}
 	if req.NoProject && strings.TrimSpace(req.ProjectID) != "" {
 		writeProjectError(w, http.StatusBadRequest, "invalid_project_selection", "no_project and project_id are mutually exclusive")

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -481,6 +481,46 @@ func TestServeServerConfig_RouteHelpers(t *testing.T) {
 	}
 }
 
+func TestServeServerConfigAgentAvailableIncludesDedicatedAgent(t *testing.T) {
+	cfg := serveServerConfig{
+		agentName:  "jarvis",
+		agentNames: []string{"developer", "reviewer"},
+	}
+	for _, name := range []string{"jarvis", "developer", "reviewer"} {
+		if !cfg.agentAvailable(name) {
+			t.Errorf("agentAvailable(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", "missing"} {
+		if cfg.agentAvailable(name) {
+			t.Errorf("agentAvailable(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestHandleResponsesAcceptsDedicatedAgentForFreshThread(t *testing.T) {
+	srv := newTestServeServer("thread response")
+	defer srv.sessionMgr.Close()
+	srv.cfg.agentName = "jarvis"
+	var createdAgent string
+	srv.agentRuntimeFactory = func(ctx context.Context, _, _, agentName string) (*serveRuntime, error) {
+		createdAgent = agentName
+		runtime, err := srv.sessionMgr.factory(ctx)
+		if runtime != nil {
+			runtime.agentName = agentName
+		}
+		return runtime, err
+	}
+
+	code, response := doResponsesFirstParty(t, srv, `{"input":"continue in a new thread","agent":"jarvis","client_message_id":"thread-message"}`, "thread-child")
+	if code != http.StatusOK {
+		t.Fatalf("response status = %d, want 200: %#v", code, response)
+	}
+	if createdAgent != "jarvis" {
+		t.Fatalf("created agent = %q, want jarvis", createdAgent)
+	}
+}
+
 func TestRuntimeForFreshAgentProviderRequestUsesSelectedAgent(t *testing.T) {
 	mgr := newServeSessionManager(time.Hour, 10, func(context.Context) (*serveRuntime, error) {
 		return &serveRuntime{}, nil

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -481,19 +481,26 @@ func TestServeServerConfig_RouteHelpers(t *testing.T) {
 	}
 }
 
-func TestServeServerConfigAgentAvailableIncludesDedicatedAgent(t *testing.T) {
-	cfg := serveServerConfig{
-		agentName:  "jarvis",
-		agentNames: []string{"developer", "reviewer"},
+func TestServeServerConfigAgentAvailable(t *testing.T) {
+	dedicated := serveServerConfig{agentName: "jarvis"}
+	if !dedicated.agentAvailable("jarvis") {
+		t.Fatal("dedicated agent was unavailable")
 	}
-	for _, name := range []string{"jarvis", "developer", "reviewer"} {
-		if !cfg.agentAvailable(name) {
-			t.Errorf("agentAvailable(%q) = false, want true", name)
+	for _, name := range []string{"", "developer", "missing"} {
+		if dedicated.agentAvailable(name) {
+			t.Errorf("dedicated agentAvailable(%q) = true, want false", name)
 		}
 	}
-	for _, name := range []string{"", "missing"} {
-		if cfg.agentAvailable(name) {
-			t.Errorf("agentAvailable(%q) = true, want false", name)
+
+	multiAgent := serveServerConfig{agentNames: []string{"developer", "reviewer"}}
+	for _, name := range []string{"developer", "reviewer"} {
+		if !multiAgent.agentAvailable(name) {
+			t.Errorf("multi-agent agentAvailable(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", "jarvis", "missing"} {
+		if multiAgent.agentAvailable(name) {
+			t.Errorf("multi-agent agentAvailable(%q) = true, want false", name)
 		}
 	}
 }
@@ -518,6 +525,11 @@ func TestHandleResponsesAcceptsDedicatedAgentForFreshThread(t *testing.T) {
 	}
 	if createdAgent != "jarvis" {
 		t.Fatalf("created agent = %q, want jarvis", createdAgent)
+	}
+
+	code, response = doResponsesFirstParty(t, srv, `{"input":"continue in a new thread","agent":"developer","client_message_id":"foreign-agent-message"}`, "foreign-agent-thread")
+	if code != http.StatusBadRequest || !strings.Contains(fmt.Sprint(response), "agent is not available") {
+		t.Fatalf("foreign agent status/response = %d %#v, want unavailable-agent 400", code, response)
 	}
 }
 

--- a/frontend/e2e/real-server.spec.ts
+++ b/frontend/e2e/real-server.spec.ts
@@ -143,10 +143,10 @@ test('sends a real uncommitted diff comment through the browser and Go protocol'
   await file.locator('.diff-file-row').click();
   await file.getByRole('button', { name: 'Comment on line 2' }).click();
   await file.getByRole('textbox', { name: 'Inline comment' }).fill('Keep this fixture change.');
+  const responseHeadings = page.getByRole('heading', { name: 'Debug Provider Output' });
+  const responseCount = await responseHeadings.count();
   await file.getByRole('button', { name: 'Send now' }).click();
-  await expect(page.getByRole('heading', { name: 'Debug Provider Output' }).last()).toBeVisible({
-    timeout: 15_000,
-  });
+  await expect(responseHeadings).toHaveCount(responseCount + 1, { timeout: 15_000 });
 
   const durable = await page.evaluate(async () => {
     const selected = decodeURIComponent(location.pathname.match(/\/chat\/([^/]+)/)?.[1] || '');


### PR DESCRIPTION
## Summary

- accept the fixed `--agent` identity as an available Web UI agent
- preserve the existing allowlist for multi-agent Web UI selection
- cover a fresh first-party thread request using the dedicated agent
- make the diff-comment browser smoke wait for the newly created response rather than an already-visible prior response

## Reproduction

On a Web UI server launched with `--agent jarvis`, `/thread` creates an empty child session. Its first request includes `agent: "jarvis"` because the new thread has no previous response ID. The server only checked `agentNames`, which is intentionally empty in dedicated-agent mode, and returned:

```text
400 {"error":{"message":"agent is not available","type":"invalid_request_error"}}
```

The fixed agent lives in `agentName`, not `agentNames`, so it must also be accepted.

## Validation

- `go test ./cmd -run 'TestServeServerConfigAgentAvailable|TestHandleResponsesAcceptsDedicatedAgentForFreshThread|TestRuntimeForFreshAgentProviderRequestUsesSelectedAgent' -count=1`
- `go build ./...`
- targeted diff-comment browser E2E repeated 5 times: 5/5 passed
- `go test ./...` reaches the full suite but fails two unrelated skill-discovery tests because the mounted Jarvis skill catalog is truncated by `max_visible_skills`; all other packages pass
