### PR TITLE
feat(share): support custom publishing helpers

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -26,6 +26,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/serve"
 	servehttp "github.com/samsaffron/term-llm/internal/serve/http"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/share"
 	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/samsaffron/term-llm/internal/skills"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -1314,7 +1315,15 @@ type serveServer struct {
 	cfgRef                   *config.Config
 	store                    session.Store
 	approvalDefault          tools.ApprovalMode
-	shareClientFactory       func() (serveGistCreator, error)
+	sharePublisherFactory    func() (share.Publisher, error)
+	shareMu                  sync.Mutex
+	shareCacheKey            string
+	shareCachedPublisher     share.Publisher
+	shareCachedCapabilities  share.Capabilities
+	shareCachedErr           error
+	shareCacheUntil          time.Time
+	shareBuildFlight         chan struct{}
+	shareInvocation          chan struct{}
 	projectsEnabled          bool
 	bootstrapProjectID       string
 	startupDir               string
@@ -1497,6 +1506,7 @@ func (s *serveServer) httpHandler() http.Handler {
 		s.registerWidgetRoutes(inner)
 	}
 	inner.HandleFunc("/v1/capabilities", s.auth(s.cors(s.handleCapabilities)))
+	inner.HandleFunc("/v1/sharing/capabilities", s.auth(s.cors(s.handleSharingCapabilities)))
 	inner.HandleFunc("/v1/project-directories", s.auth(s.cors(s.handleProjectDirectories)))
 	inner.HandleFunc("/v1/projects", s.auth(s.cors(s.handleProjects)))
 	inner.HandleFunc("/v1/projects/", s.auth(s.cors(s.handleProjectByID)))

--- a/cmd/serve_share.go
+++ b/cmd/serve_share.go
@@ -1,32 +1,172 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
-	"github.com/samsaffron/term-llm/internal/agents/gist"
 	"github.com/samsaffron/term-llm/internal/config"
 	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/share"
 )
-
-type serveGistCreator interface {
-	Create(description string, public bool, files map[string]string) (*gist.Gist, error)
-}
 
 type sessionShareRequest struct {
 	AnchorMessageID int64              `json:"anchor_message_id"`
 	Scope           session.ShareScope `json:"scope"`
-	Public          bool               `json:"public"`
+	Visibility      share.Visibility   `json:"visibility,omitempty"`
+	Public          *bool              `json:"public,omitempty"`
 }
 
 type sessionShareResponse struct {
-	GistID     string `json:"gist_id"`
-	GistURL    string `json:"gist_url"`
-	PreviewURL string `json:"preview_url"`
-	Public     bool   `json:"public"`
+	Provider   share.ProviderID   `json:"provider"`
+	ID         string             `json:"id"`
+	URL        string             `json:"url"`
+	SourceURL  string             `json:"source_url,omitempty"`
+	Visibility share.Visibility   `json:"visibility"`
+	Ready      bool               `json:"ready"`
+	Scope      session.ShareScope `json:"scope"`
+
+	GistID     string `json:"gist_id,omitempty"`
+	GistURL    string `json:"gist_url,omitempty"`
+	PreviewURL string `json:"preview_url,omitempty"`
+	Public     *bool  `json:"public,omitempty"`
+}
+
+type sharingCapabilitiesResponse struct {
+	Enabled           bool               `json:"enabled"`
+	Provider          share.Provider     `json:"provider"`
+	Operations        []share.Operation  `json:"operations"`
+	Visibilities      []share.Visibility `json:"visibilities"`
+	DefaultVisibility share.Visibility   `json:"default_visibility"`
+	Help              string             `json:"help,omitempty"`
+	Notes             []string           `json:"notes,omitempty"`
+	Limits            map[string]any     `json:"limits,omitempty"`
+}
+
+const (
+	sharingCacheTTL      = time.Minute
+	sharingErrorCacheTTL = 5 * time.Second
+)
+
+func (s *serveServer) shareConfigSnapshot() config.ShareConfig {
+	if s.cfgRef == nil {
+		return config.ShareConfig{}
+	}
+	return s.cfgRef.Share
+}
+
+func shareConfigCacheKey(cfg config.ShareConfig) string {
+	encoded, _ := json.Marshal(cfg)
+	return string(encoded)
+}
+
+func (s *serveServer) buildSharingPublisher() (share.Publisher, error) {
+	if s.sharePublisherFactory != nil {
+		return s.sharePublisherFactory()
+	}
+	return share.NewPublisher(s.shareConfigSnapshot())
+}
+
+// sharingProvider caches both the publisher and validated capabilities. The
+// config-derived key invalidates the cache if an embedding reloads cfgRef in
+// place, while the TTL bounds stale provider state. A shared flight prevents
+// concurrent modal/API requests from spawning duplicate capability helpers.
+func (s *serveServer) sharingProvider(ctx context.Context) (share.Publisher, share.Capabilities, error) {
+	key := shareConfigCacheKey(s.shareConfigSnapshot())
+	for {
+		now := time.Now()
+		s.shareMu.Lock()
+		if s.shareCacheKey == key && now.Before(s.shareCacheUntil) {
+			publisher, capabilities, err := s.shareCachedPublisher, s.shareCachedCapabilities, s.shareCachedErr
+			s.shareMu.Unlock()
+			return publisher, capabilities, err
+		}
+		if flight := s.shareBuildFlight; flight != nil {
+			s.shareMu.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil, share.Capabilities{}, share.NewError(share.ErrorProvider, "sharing was canceled")
+			case <-flight:
+				continue
+			}
+		}
+		flight := make(chan struct{})
+		s.shareBuildFlight = flight
+		s.shareMu.Unlock()
+
+		publisher, err := s.buildSharingPublisher()
+		var capabilities share.Capabilities
+		if err == nil {
+			err = s.withShareInvocation(ctx, func() error {
+				var capabilityErr error
+				capabilities, capabilityErr = publisher.Capabilities(ctx)
+				return capabilityErr
+			})
+		}
+		if err == nil {
+			if capabilityErr := share.ValidateCapabilities(capabilities); capabilityErr != nil {
+				err = share.NewError(share.ErrorProtocol, "sharing provider returned invalid capabilities")
+			}
+		}
+		ttl := sharingCacheTTL
+		if err != nil {
+			ttl = sharingErrorCacheTTL
+		}
+		s.shareMu.Lock()
+		s.shareCacheKey = key
+		s.shareCachedPublisher = publisher
+		s.shareCachedCapabilities = capabilities
+		s.shareCachedErr = err
+		s.shareCacheUntil = time.Now().Add(ttl)
+		close(flight)
+		s.shareBuildFlight = nil
+		s.shareMu.Unlock()
+		return publisher, capabilities, err
+	}
+}
+
+func (s *serveServer) withShareInvocation(ctx context.Context, fn func() error) error {
+	s.shareMu.Lock()
+	if s.shareInvocation == nil {
+		s.shareInvocation = make(chan struct{}, 1)
+	}
+	slot := s.shareInvocation
+	s.shareMu.Unlock()
+	select {
+	case slot <- struct{}{}:
+		defer func() { <-slot }()
+		return fn()
+	case <-ctx.Done():
+		return share.NewError(share.ErrorProvider, "sharing was canceled")
+	}
+}
+
+func (s *serveServer) handleSharingCapabilities(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeProjectError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	if s.store == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
+		return
+	}
+	_, capabilities, err := s.sharingProvider(r.Context())
+	if err != nil {
+		writeShareError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, sharingCapabilitiesResponse{
+		Enabled: true, Provider: capabilities.Provider, Operations: capabilities.Operations,
+		Visibilities: capabilities.Visibilities, DefaultVisibility: capabilities.DefaultVisibility,
+		Help: capabilities.Provider.Help, Notes: capabilities.Notes, Limits: capabilities.Limits,
+	})
 }
 
 func (s *serveServer) handleCreateSessionShare(w http.ResponseWriter, r *http.Request, sessionID string) {
@@ -43,6 +183,7 @@ func (s *serveServer) handleCreateSessionShare(w http.ResponseWriter, r *http.Re
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "scope must be response or conversation")
 		return
 	}
+
 	sess, err := s.store.Get(r.Context(), sessionID)
 	if err != nil || sess == nil {
 		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
@@ -63,6 +204,28 @@ func (s *serveServer) handleCreateSessionShare(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	publisher, capabilities, err := s.sharingProvider(r.Context())
+	if err != nil {
+		writeShareError(w, err)
+		return
+	}
+	visibility := req.Visibility
+	if visibility == "" {
+		if req.Public != nil {
+			if *req.Public {
+				visibility = share.VisibilityPublic
+			} else {
+				visibility = share.VisibilityUnlisted
+			}
+		} else {
+			visibility = capabilities.DefaultVisibility
+		}
+	}
+	if !capabilities.SupportsVisibility(visibility) {
+		writeShareError(w, share.NewError(share.ErrorUnsupportedVisibility, fmt.Sprintf("%s visibility is not supported by %s", visibility, capabilities.Provider.Name)))
+		return
+	}
+
 	reasoningConfig := config.DefaultReasoningConfig()
 	if s.cfgRef != nil {
 		reasoningConfig = s.cfgRef.ResolveReasoning("chat")
@@ -71,25 +234,13 @@ func (s *serveServer) handleCreateSessionShare(w http.ResponseWriter, r *http.Re
 		IncludeReasoningSummaries: internalreasoning.ExportSummaries(reasoningConfig),
 		Partial:                   req.Scope == session.ShareScopeConversation,
 		ResponseOnly:              req.Scope == session.ShareScopeResponse,
-		// Point-in-time web shares deliberately never include raw reasoning.
+		// Point-in-time web shares deliberately never include raw reasoning and
+		// are never persisted, so a later whole-session update cannot widen them.
 		IncludeRawReasoning: false,
 	}
-	files, err := session.GistFiles(sess, selected, opts)
+	files, err := session.ShareFiles(sess, selected, opts)
 	if err != nil {
 		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "failed to render share")
-		return
-	}
-	factory := s.shareClientFactory
-	if factory == nil {
-		factory = func() (serveGistCreator, error) { return gist.NewClient() }
-	}
-	client, err := factory()
-	if err != nil {
-		message := strings.TrimSpace(err.Error())
-		if message == "" {
-			message = "GitHub CLI is unavailable"
-		}
-		writeOpenAIError(w, http.StatusServiceUnavailable, "dependency_error", message+". Sharing currently requires the gh CLI on the term-llm server.")
 		return
 	}
 	name := strings.TrimSpace(sess.PreferredShortTitle())
@@ -100,25 +251,47 @@ func (s *serveServer) handleCreateSessionShare(w http.ResponseWriter, r *http.Re
 	if req.Scope == session.ShareScopeResponse {
 		description = fmt.Sprintf("term-llm assistant response from %s", name)
 	}
-	created, err := client.Create(description, req.Public, files)
-	if err != nil {
-		writeOpenAIError(w, http.StatusBadGateway, "dependency_error", "failed to create GitHub Gist: "+strings.TrimSpace(err.Error()))
-		return
-	}
-	if created == nil || strings.TrimSpace(created.ID) == "" {
-		writeOpenAIError(w, http.StatusBadGateway, "dependency_error", "GitHub CLI returned an empty Gist result")
-		return
-	}
-	preview := session.GistPreviewURL(created.ID)
-	if preview == "" {
-		writeOpenAIError(w, http.StatusBadGateway, "dependency_error", "GitHub CLI returned an invalid Gist ID")
-		return
-	}
-	gistURL := strings.TrimSpace(created.URL)
-	if gistURL == "" {
-		gistURL = gist.GetURL(created.ID)
-	}
-	writeJSON(w, http.StatusCreated, sessionShareResponse{
-		GistID: created.ID, GistURL: gistURL, PreviewURL: preview, Public: req.Public,
+	var created share.Result
+	err = s.withShareInvocation(r.Context(), func() error {
+		var createErr error
+		created, createErr = publisher.Create(r.Context(), share.Request{
+			RequestID: share.NewRequestID(), Title: name, Description: description,
+			Visibility: visibility, Entrypoint: "index.html", Files: share.TranscriptFiles(files),
+		})
+		return createErr
 	})
+	if err != nil {
+		writeShareError(w, err)
+		return
+	}
+	if created.Provider == "" {
+		created.Provider = capabilities.Provider.ID
+	}
+	if created.Provider != capabilities.Provider.ID {
+		writeShareError(w, share.NewError(share.ErrorProtocol, "sharing provider returned a mismatched provider identity"))
+		return
+	}
+	response := sessionShareResponse{
+		Provider: created.Provider, ID: created.ID, URL: created.URL, SourceURL: created.SourceURL,
+		Visibility: created.Visibility, Ready: created.Ready, Scope: req.Scope,
+	}
+	if created.Provider == share.ProviderGitHub {
+		public := created.Visibility == share.VisibilityPublic
+		response.GistID, response.GistURL, response.PreviewURL, response.Public = created.ID, created.SourceURL, created.URL, &public
+	}
+	writeJSON(w, http.StatusCreated, response)
+}
+
+func writeShareError(w http.ResponseWriter, err error) {
+	typed := share.AsError(err)
+	status := http.StatusBadGateway
+	switch typed.Code {
+	case share.ErrorDependencyMissing, share.ErrorAuthRequired:
+		status = http.StatusServiceUnavailable
+	case share.ErrorTimeout:
+		status = http.StatusGatewayTimeout
+	case share.ErrorUnsupportedVisibility:
+		status = http.StatusBadRequest
+	}
+	writeProjectError(w, status, string(typed.Code), typed.Error())
 }

--- a/cmd/serve_share_test.go
+++ b/cmd/serve_share_test.go
@@ -2,33 +2,71 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/samsaffron/term-llm/internal/agents/gist"
+	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/share"
 )
 
-type serveShareGistMock struct {
-	public      bool
+type serveSharePublisherMock struct {
+	visibility  share.Visibility
 	description string
 	files       map[string]string
 	err         error
+	capErr      error
+	caps        share.Capabilities
+	result      share.Result
+	capCalls    int
+	createCalls int
 }
 
-func (m *serveShareGistMock) Create(description string, public bool, files map[string]string) (*gist.Gist, error) {
-	m.description, m.public, m.files = description, public, files
-	if m.err != nil {
-		return nil, m.err
+func (m *serveSharePublisherMock) Capabilities(context.Context) (share.Capabilities, error) {
+	m.capCalls++
+	if m.capErr != nil {
+		return share.Capabilities{}, m.capErr
 	}
-	return &gist.Gist{ID: "abc123", URL: "https://gist.github.com/test/abc123", Public: public}, nil
+	if m.caps.Protocol == "" {
+		m.caps = share.Capabilities{
+			Protocol: share.Protocol, Version: share.Version,
+			Provider:          share.Provider{ID: "github", Name: "GitHub Gist"},
+			Operations:        []share.Operation{share.OperationCreate, share.OperationUpdate},
+			Visibilities:      []share.Visibility{share.VisibilityUnlisted, share.VisibilityPublic},
+			DefaultVisibility: share.VisibilityUnlisted,
+		}
+	}
+	return m.caps, nil
+}
+
+func (m *serveSharePublisherMock) Create(_ context.Context, req share.Request) (share.Result, error) {
+	m.createCalls++
+	m.description, m.visibility = req.Description, req.Visibility
+	m.files = make(map[string]string, len(req.Files))
+	for _, file := range req.Files {
+		m.files[file.Name] = string(file.Content)
+	}
+	if m.err != nil {
+		return share.Result{}, m.err
+	}
+	if m.result.ID != "" {
+		return m.result, nil
+	}
+	return share.Result{Provider: "github", ID: "abc123", URL: "https://gisthost.github.io/?abc123/index.html", SourceURL: "https://gist.github.com/test/abc123", Visibility: req.Visibility, Ready: true}, nil
+}
+
+func (m *serveSharePublisherMock) Update(context.Context, string, share.Request) (share.Result, error) {
+	return share.Result{}, errors.New("unexpected update")
 }
 
 func newServeShareFixture(t *testing.T) (*serveServer, int64) {
@@ -74,14 +112,14 @@ func serveShareRequest(t *testing.T, server *serveServer, body string) *httptest
 
 func TestCreateSessionShareResponseUsesTextOnlyExport(t *testing.T) {
 	server, anchor := newServeShareFixture(t)
-	mock := &serveShareGistMock{}
-	server.shareClientFactory = func() (serveGistCreator, error) { return mock, nil }
+	mock := &serveSharePublisherMock{}
+	server.sharePublisherFactory = func() (share.Publisher, error) { return mock, nil }
 	rr := serveShareRequest(t, server, `{"anchor_message_id":`+formatInt64(anchor)+`,"scope":"response","public":true}`)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
 	}
-	if !mock.public || !strings.Contains(mock.description, "assistant response") {
-		t.Fatalf("gist request: public=%v description=%q", mock.public, mock.description)
+	if mock.visibility != share.VisibilityPublic || !strings.Contains(mock.description, "assistant response") {
+		t.Fatalf("share request: visibility=%v description=%q", mock.visibility, mock.description)
 	}
 	for name, content := range mock.files {
 		if !strings.Contains(content, "shareable answer") {
@@ -94,15 +132,21 @@ func TestCreateSessionShareResponseUsesTextOnlyExport(t *testing.T) {
 			t.Fatalf("%s included whole-session metrics", name)
 		}
 	}
-	if !strings.Contains(rr.Body.String(), `"preview_url":"https://gisthost.github.io/?abc123/index.html"`) {
-		t.Fatalf("response=%s", rr.Body.String())
+	for _, want := range []string{
+		`"provider":"github"`, `"id":"abc123"`, `"url":"https://gisthost.github.io/?abc123/index.html"`,
+		`"visibility":"public"`, `"ready":true`, `"scope":"response"`,
+		`"gist_id":"abc123"`, `"preview_url":"https://gisthost.github.io/?abc123/index.html"`, `"public":true`,
+	} {
+		if !strings.Contains(rr.Body.String(), want) {
+			t.Fatalf("response missing %s: %s", want, rr.Body.String())
+		}
 	}
 }
 
 func TestCreateSessionShareExplainsGitHubCLIDependency(t *testing.T) {
 	server, anchor := newServeShareFixture(t)
-	server.shareClientFactory = func() (serveGistCreator, error) {
-		return nil, errors.New("gh CLI not found. Install from: https://cli.github.com")
+	server.sharePublisherFactory = func() (share.Publisher, error) {
+		return nil, share.NewError(share.ErrorDependencyMissing, "GitHub sharing requires the gh CLI; install it from https://cli.github.com")
 	}
 	rr := serveShareRequest(t, server, `{"anchor_message_id":`+formatInt64(anchor)+`,"scope":"conversation"}`)
 	if rr.Code != http.StatusServiceUnavailable {
@@ -113,11 +157,261 @@ func TestCreateSessionShareExplainsGitHubCLIDependency(t *testing.T) {
 	}
 }
 
-func TestCreateSessionShareRejectsInvalidAnchorAndMethod(t *testing.T) {
+func TestGenericCapabilitiesDoesNotInvokeSharingHelper(t *testing.T) {
 	server, _ := newServeShareFixture(t)
+	called := false
+	server.sharePublisherFactory = func() (share.Publisher, error) {
+		called = true
+		return nil, errors.New("must not run")
+	}
+	rr := httptest.NewRecorder()
+	server.handleCapabilities(rr, httptest.NewRequest(http.MethodGet, "/v1/capabilities", nil))
+	if rr.Code != http.StatusOK || called || strings.Contains(rr.Body.String(), `"sharing"`) {
+		t.Fatalf("status=%d helperCalled=%v body=%s", rr.Code, called, rr.Body.String())
+	}
+}
+
+func TestSharingCapabilitiesAreAuthenticatedCuratedAndNoStore(t *testing.T) {
+	server, _ := newServeShareFixture(t)
+	caps := share.Capabilities{
+		Protocol: share.Protocol, Version: share.Version,
+		Provider:     share.Provider{ID: "acme", Name: "Acme Vault", Help: "Sign in to Acme."},
+		Operations:   []share.Operation{share.OperationCreate},
+		Visibilities: []share.Visibility{share.VisibilityPrivate}, DefaultVisibility: share.VisibilityPrivate,
+		Notes: []string{"Private links expire."},
+	}
+	server.sharePublisherFactory = func() (share.Publisher, error) { return &serveSharePublisherMock{caps: caps}, nil }
+	server.cfg.requireAuth, server.cfg.token = true, "secret"
+	handler := server.auth(server.handleSharingCapabilities)
+
+	unauthorized := httptest.NewRecorder()
+	handler(unauthorized, httptest.NewRequest(http.MethodGet, "/v1/sharing/capabilities", nil))
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status=%d", unauthorized.Code)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/sharing/capabilities", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	if rr.Code != http.StatusOK || rr.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("status=%d cache=%q body=%s", rr.Code, rr.Header().Get("Cache-Control"), rr.Body.String())
+	}
+	var response sharingCapabilitiesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if !response.Enabled || response.Provider.ID != "acme" || response.DefaultVisibility != share.VisibilityPrivate || response.Help != "Sign in to Acme." {
+		t.Fatalf("response=%+v", response)
+	}
+}
+
+func TestSharingProviderCachesCapabilitiesAndInvalidatesWhenConfigChanges(t *testing.T) {
+	server, _ := newServeShareFixture(t)
+	server.cfgRef = &config.Config{Share: config.ShareConfig{Provider: "command", Command: []string{"first"}}}
+	first := &serveSharePublisherMock{caps: share.Capabilities{
+		Protocol: share.Protocol, Version: share.Version, Provider: share.Provider{ID: "first", Name: "First"},
+		Operations: []share.Operation{share.OperationCreate}, Visibilities: []share.Visibility{share.VisibilityPrivate}, DefaultVisibility: share.VisibilityPrivate,
+	}}
+	second := &serveSharePublisherMock{caps: share.Capabilities{
+		Protocol: share.Protocol, Version: share.Version, Provider: share.Provider{ID: "second", Name: "Second"},
+		Operations: []share.Operation{share.OperationCreate}, Visibilities: []share.Visibility{share.VisibilityPrivate}, DefaultVisibility: share.VisibilityPrivate,
+	}}
+	factoryCalls := 0
+	server.sharePublisherFactory = func() (share.Publisher, error) {
+		factoryCalls++
+		if server.cfgRef.Share.Command[0] == "first" {
+			return first, nil
+		}
+		return second, nil
+	}
+	request := func() string {
+		rr := httptest.NewRecorder()
+		server.handleSharingCapabilities(rr, httptest.NewRequest(http.MethodGet, "/v1/sharing/capabilities", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		return rr.Body.String()
+	}
+	if body := request(); !strings.Contains(body, `"id":"first"`) {
+		t.Fatalf("first body=%s", body)
+	}
+	_ = request()
+	if factoryCalls != 1 || first.capCalls != 1 {
+		t.Fatalf("cache calls factory=%d capabilities=%d", factoryCalls, first.capCalls)
+	}
+	server.cfgRef.Share.Command[0] = "second"
+	if body := request(); !strings.Contains(body, `"id":"second"`) {
+		t.Fatalf("second body=%s", body)
+	}
+	if factoryCalls != 2 || second.capCalls != 1 {
+		t.Fatalf("rebuild calls factory=%d capabilities=%d", factoryCalls, second.capCalls)
+	}
+}
+
+type blockingServeSharePublisher struct {
+	started chan struct{}
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+func (p *blockingServeSharePublisher) Capabilities(context.Context) (share.Capabilities, error) {
+	if p.calls.Add(1) == 1 {
+		close(p.started)
+	}
+	<-p.release
+	return share.Capabilities{
+		Protocol: share.Protocol, Version: share.Version, Provider: share.Provider{ID: "blocking", Name: "Blocking"},
+		Operations: []share.Operation{share.OperationCreate}, Visibilities: []share.Visibility{share.VisibilityPrivate}, DefaultVisibility: share.VisibilityPrivate,
+	}, nil
+}
+
+func (p *blockingServeSharePublisher) Create(context.Context, share.Request) (share.Result, error) {
+	return share.Result{}, errors.New("not used")
+}
+
+func TestSharingProviderSingleflightsConcurrentCapabilities(t *testing.T) {
+	server, _ := newServeShareFixture(t)
+	publisher := &blockingServeSharePublisher{started: make(chan struct{}), release: make(chan struct{})}
+	var factoryCalls atomic.Int32
+	server.sharePublisherFactory = func() (share.Publisher, error) {
+		factoryCalls.Add(1)
+		return publisher, nil
+	}
+	const callers = 8
+	errorsCh := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			_, _, err := server.sharingProvider(context.Background())
+			errorsCh <- err
+		}()
+	}
+	<-publisher.started
+	close(publisher.release)
+	for i := 0; i < callers; i++ {
+		if err := <-errorsCh; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if factoryCalls.Load() != 1 || publisher.calls.Load() != 1 {
+		t.Fatalf("factory calls=%d capabilities calls=%d", factoryCalls.Load(), publisher.calls.Load())
+	}
+}
+
+func TestShareInvocationConcurrencyIsBounded(t *testing.T) {
+	server := &serveServer{}
+	var active atomic.Int32
+	var maximum atomic.Int32
+	start := make(chan struct{})
+	entered := make(chan struct{}, 8)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := server.withShareInvocation(context.Background(), func() error {
+				current := active.Add(1)
+				for {
+					old := maximum.Load()
+					if current <= old || maximum.CompareAndSwap(old, current) {
+						break
+					}
+				}
+				entered <- struct{}{}
+				<-start
+				active.Add(-1)
+				return nil
+			}); err != nil {
+				t.Errorf("withShareInvocation: %v", err)
+			}
+		}()
+	}
+	<-entered
+	close(start)
+	wg.Wait()
+	if maximum.Load() != 1 {
+		t.Fatalf("maximum concurrent invocations=%d, want 1", maximum.Load())
+	}
+}
+
+func TestCreateSessionShareUsesCustomProviderWithoutPersistenceOrGistFields(t *testing.T) {
+	server, anchor := newServeShareFixture(t)
+	caps := share.Capabilities{
+		Protocol: share.Protocol, Version: share.Version,
+		Provider:     share.Provider{ID: "acme", Name: "Acme Vault"},
+		Operations:   []share.Operation{share.OperationCreate},
+		Visibilities: []share.Visibility{share.VisibilityPrivate}, DefaultVisibility: share.VisibilityPrivate,
+	}
+	mock := &serveSharePublisherMock{caps: caps, result: share.Result{
+		Provider: "acme", ID: "opaque", URL: "https://share.example/opaque",
+		Visibility: share.VisibilityPrivate, Ready: true,
+	}}
+	server.sharePublisherFactory = func() (share.Publisher, error) { return mock, nil }
+	rr := serveShareRequest(t, server, `{"anchor_message_id":`+formatInt64(anchor)+`,"scope":"conversation","visibility":"private"}`)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, forbidden := range []string{"gist_id", "gist_url", "preview_url", `"public"`} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("custom response exposed legacy field %q: %s", forbidden, body)
+		}
+	}
+	persisted, err := server.store.Get(context.Background(), "share-session")
+	if err != nil || persisted.Share != nil {
+		t.Fatalf("point-in-time share was persisted: share=%+v err=%v", persisted.Share, err)
+	}
+}
+
+func TestCreateSessionShareGitHubPathIsAlsoNotPersisted(t *testing.T) {
+	server, anchor := newServeShareFixture(t)
+	mock := &serveSharePublisherMock{}
+	server.sharePublisherFactory = func() (share.Publisher, error) { return mock, nil }
+	rr := serveShareRequest(t, server, `{"anchor_message_id":`+formatInt64(anchor)+`,"scope":"response"}`)
+	if rr.Code != http.StatusCreated || !strings.Contains(rr.Body.String(), `"provider":"github"`) {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	persisted, err := server.store.Get(context.Background(), "share-session")
+	if err != nil || persisted.Share != nil {
+		t.Fatalf("GitHub point-in-time share was persisted: share=%+v err=%v", persisted.Share, err)
+	}
+}
+
+func TestCreateSessionShareRejectsUnsupportedVisibilityBeforeCreate(t *testing.T) {
+	server, anchor := newServeShareFixture(t)
+	caps := share.Capabilities{
+		Protocol: share.Protocol, Version: share.Version,
+		Provider:     share.Provider{ID: "acme", Name: "Acme Vault"},
+		Operations:   []share.Operation{share.OperationCreate},
+		Visibilities: []share.Visibility{share.VisibilityPrivate}, DefaultVisibility: share.VisibilityPrivate,
+	}
+	mock := &serveSharePublisherMock{caps: caps}
+	server.sharePublisherFactory = func() (share.Publisher, error) { return mock, nil }
+	rr := serveShareRequest(t, server, `{"anchor_message_id":`+formatInt64(anchor)+`,"scope":"response","visibility":"public"}`)
+	if rr.Code != http.StatusBadRequest || mock.createCalls != 0 || !strings.Contains(rr.Body.String(), string(share.ErrorUnsupportedVisibility)) {
+		t.Fatalf("status=%d calls=%d body=%s", rr.Code, mock.createCalls, rr.Body.String())
+	}
+}
+
+func TestCreateSessionShareCuratesProviderError(t *testing.T) {
+	server, anchor := newServeShareFixture(t)
+	mock := &serveSharePublisherMock{err: share.NewError(share.ErrorProvider, "sharing provider rejected the request")}
+	server.sharePublisherFactory = func() (share.Publisher, error) { return mock, nil }
+	rr := serveShareRequest(t, server, `{"anchor_message_id":`+formatInt64(anchor)+`,"scope":"response"}`)
+	if rr.Code != http.StatusBadGateway || !strings.Contains(rr.Body.String(), "sharing provider rejected") {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCreateSessionShareRejectsInvalidAnchorAndMethodBeforeStartingProvider(t *testing.T) {
+	server, _ := newServeShareFixture(t)
+	called := false
+	server.sharePublisherFactory = func() (share.Publisher, error) {
+		called = true
+		return nil, errors.New("must not run")
+	}
 	rr := serveShareRequest(t, server, `{"anchor_message_id":999999,"scope":"response"}`)
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("anchor status=%d body=%s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusBadRequest || called {
+		t.Fatalf("anchor status=%d helperCalled=%v body=%s", rr.Code, called, rr.Body.String())
 	}
 	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/share-session/shares", nil)
 	rr = httptest.NewRecorder()

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -38,6 +38,7 @@ Examples:
   term-llm sessions show 42               # By number
   term-llm sessions show #42              # By number (explicit)
   term-llm sessions delete 42
+  term-llm sessions share 42 --visibility unlisted
   term-llm sessions export 42 [path.md]`,
 	RunE: runSessionsList, // Default to list
 }
@@ -74,6 +75,19 @@ var sessionsExportCmd = &cobra.Command{
 	Short: "Export session as markdown",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE:  runSessionsExport,
+}
+
+var sessionsShareCmd = &cobra.Command{
+	Use:   "share <number|id>",
+	Short: "Share a complete saved session",
+	Long: `Share a complete saved session through the configured provider.
+
+Raw model reasoning is excluded unless --include-raw-reasoning is explicitly
+supplied. GitHub's default unlisted Gists are not private: anyone with the link
+can view them. GitHub sharing requires an authenticated gh CLI account.`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runSessionsShare,
+	SilenceUsage: true,
 }
 
 var sessionsResetCmd = &cobra.Command{
@@ -171,6 +185,10 @@ var (
 	sessionsGistIncludeSystem         bool
 	sessionsGistIncludeReasoning      bool
 	sessionsGistIncludeRawReasoning   bool
+	sessionsShareVisibility           string
+	sessionsShareNew                  bool
+	sessionsShareJSON                 bool
+	sessionsShareIncludeRawReasoning  bool
 	sessionsResetYes                  bool
 )
 
@@ -190,6 +208,12 @@ func init() {
 	sessionsExportCmd.Flags().BoolVar(&sessionsExportIncludeReasoning, "include-reasoning", false, "Include provider reasoning summaries in export")
 	sessionsExportCmd.Flags().BoolVar(&sessionsExportIncludeRawReasoning, "include-raw-reasoning", false, "Include raw reasoning when reasoning.raw is enabled")
 
+	// Share flags
+	sessionsShareCmd.Flags().StringVar(&sessionsShareVisibility, "visibility", "", "Share visibility: public, unlisted, or private (default: provider default)")
+	sessionsShareCmd.Flags().BoolVar(&sessionsShareNew, "new", false, "Create a new share instead of updating a compatible session share")
+	sessionsShareCmd.Flags().BoolVar(&sessionsShareJSON, "json", false, "Output the share result as JSON")
+	sessionsShareCmd.Flags().BoolVar(&sessionsShareIncludeRawReasoning, "include-raw-reasoning", false, "Include raw model reasoning (privacy-sensitive; requires reasoning.raw/source permission)")
+
 	// Reset flags
 	sessionsResetCmd.Flags().BoolVarP(&sessionsResetYes, "yes", "y", false, "Delete without interactive confirmation")
 
@@ -205,6 +229,7 @@ func init() {
 	sessionsCmd.AddCommand(sessionsShowCmd)
 	sessionsCmd.AddCommand(sessionsDeleteCmd)
 	sessionsCmd.AddCommand(sessionsExportCmd)
+	sessionsCmd.AddCommand(sessionsShareCmd)
 	sessionsCmd.AddCommand(sessionsResetCmd)
 	sessionsCmd.AddCommand(sessionsNameCmd)
 	sessionsCmd.AddCommand(sessionsTagCmd)

--- a/cmd/sessions_share.go
+++ b/cmd/sessions_share.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
+	"github.com/samsaffron/term-llm/internal/session"
+	sharepkg "github.com/samsaffron/term-llm/internal/share"
+	"github.com/spf13/cobra"
+)
+
+var newSessionSharePublisher = sharepkg.NewPublisher
+
+type sessionsShareOutput struct {
+	Provider   sharepkg.ProviderID `json:"provider"`
+	ID         string              `json:"id"`
+	URL        string              `json:"url"`
+	SourceURL  string              `json:"source_url,omitempty"`
+	Visibility sharepkg.Visibility `json:"visibility"`
+	Ready      bool                `json:"ready"`
+	Scope      session.ShareScope  `json:"scope"`
+	Updated    bool                `json:"updated"`
+}
+
+func runSessionsShare(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	storeCfg := sessionStoreConfig(cfg)
+	if !storeCfg.Enabled {
+		return fmt.Errorf("session storage is disabled (check sessions.enabled and --no-session)")
+	}
+	store, err := session.NewStore(storeCfg)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sess, err := store.GetByPrefix(ctx, args[0])
+	if err != nil {
+		return fmt.Errorf("failed to get session: %w", err)
+	}
+	if sess == nil {
+		return fmt.Errorf("session %q not found", args[0])
+	}
+
+	requestedVisibility := sharepkg.Visibility(strings.ToLower(strings.TrimSpace(sessionsShareVisibility)))
+	if requestedVisibility != "" && !sharepkg.ValidVisibility(requestedVisibility) {
+		return fmt.Errorf("invalid visibility %q: expected public, unlisted, or private", sessionsShareVisibility)
+	}
+	publisher, err := newSessionSharePublisher(cfg.Share)
+	if err != nil {
+		return err
+	}
+	capabilities, err := publisher.Capabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if err := sharepkg.ValidateCapabilities(capabilities); err != nil {
+		return sharepkg.NewError(sharepkg.ErrorProtocol, "sharing provider returned invalid capabilities")
+	}
+	visibility := requestedVisibility
+	if visibility == "" {
+		visibility = capabilities.DefaultVisibility
+		if sess.Share != nil {
+			sess.Share.Normalize()
+			if sess.Share.Provider == string(capabilities.Provider.ID) && sess.Share.Scope == session.ShareScopeSession && sharepkg.ValidVisibility(sharepkg.Visibility(sess.Share.Visibility)) {
+				visibility = sharepkg.Visibility(sess.Share.Visibility)
+			}
+		}
+	}
+	if !capabilities.SupportsVisibility(visibility) {
+		return sharepkg.NewError(sharepkg.ErrorUnsupportedVisibility, fmt.Sprintf("%s visibility is not supported by %s", visibility, capabilities.Provider.Name))
+	}
+	if !sessionsShareJSON {
+		for _, note := range capabilities.Notes {
+			fmt.Fprintf(cmd.OutOrStdout(), "Note: %s\n", note)
+		}
+		if capabilities.Provider.Help != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Help: %s\n", capabilities.Provider.Help)
+		}
+	}
+
+	messages, _, err := session.LoadScrollbackWithBoundary(ctx, store, sess)
+	if err != nil {
+		return fmt.Errorf("failed to get messages: %w", err)
+	}
+	exportOptions, err := sessionShareExportOptions(cfg, sess, sessionsShareIncludeRawReasoning)
+	if err != nil {
+		return err
+	}
+	if sessionsShareIncludeRawReasoning {
+		fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: raw model reasoning was explicitly requested and may contain private or sensitive information.")
+	}
+	files, err := session.ShareFiles(sess, session.VisibleExportMessages(messages), exportOptions)
+	if err != nil {
+		return err
+	}
+	name := strings.TrimSpace(sess.PreferredShortTitle())
+	if name == "" {
+		name = fmt.Sprintf("#%d", sess.Number)
+	}
+	request := sharepkg.Request{
+		RequestID: sharepkg.NewRequestID(), Title: name,
+		Description: "term-llm session: " + name, Visibility: visibility,
+		Entrypoint: "index.html", Files: sharepkg.TranscriptFiles(files),
+	}
+
+	updated := false
+	var result sharepkg.Result
+	hadExistingShare := sess.Share != nil && sess.Share.Exists()
+	if hadExistingShare {
+		sess.Share.Normalize()
+	}
+	if !sessionsShareNew && hadExistingShare {
+		updater, canUpdate := publisher.(sharepkg.Updater)
+		compatible := canUpdate && sess.Share.Provider == string(capabilities.Provider.ID) &&
+			sess.Share.Scope == session.ShareScopeSession && capabilities.Supports(sharepkg.OperationUpdate)
+		if compatible {
+			result, err = updater.Update(ctx, sess.Share.ID, request)
+			updated = err == nil
+		}
+	}
+	if !updated && err == nil {
+		if hadExistingShare {
+			fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: creating a new %s share will replace the saved share state; the previous %s link may remain active and must be managed with that provider.\n", capabilities.Provider.Name, sess.Share.Provider)
+		}
+		result, err = publisher.Create(ctx, request)
+	}
+	if err != nil {
+		return err
+	}
+	if result.Provider == "" {
+		result.Provider = capabilities.Provider.ID
+	}
+
+	now := time.Now()
+	sharedAt := now
+	if updated && sess.Share != nil && !sess.Share.SharedAt.IsZero() {
+		sharedAt = sess.Share.SharedAt
+	}
+	state := &session.ShareState{
+		Provider: string(result.Provider), ID: result.ID, URL: result.URL, SourceURL: result.SourceURL,
+		Visibility: string(result.Visibility), Scope: session.ShareScopeSession,
+		SharedAt: sharedAt, UpdatedAt: now,
+	}
+	state.Normalize()
+	if err := session.UpdateShare(ctx, store, sess.ID, state); err != nil {
+		return fmt.Errorf("share created, but saving share state failed: %w", err)
+	}
+
+	output := sessionsShareOutput{
+		Provider: result.Provider, ID: result.ID, URL: result.URL, SourceURL: result.SourceURL,
+		Visibility: result.Visibility, Ready: result.Ready, Scope: session.ShareScopeSession, Updated: updated,
+	}
+	if sessionsShareJSON {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(output)
+	}
+	action := "Created share"
+	if updated {
+		action = "Updated share"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s with %s\n%s\n", action, capabilities.Provider.Name, result.URL)
+	if result.SourceURL != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Source: %s\n", result.SourceURL)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Visibility: %s\n", result.Visibility)
+	if updated && requestedVisibility != "" && requestedVisibility != result.Visibility {
+		fmt.Fprintf(cmd.OutOrStdout(), "Visibility unchanged: the provider kept this share %s instead of %s.\n", result.Visibility, requestedVisibility)
+	}
+	if !result.Ready {
+		fmt.Fprintln(cmd.OutOrStdout(), "The share was created, but anonymous readiness could not be confirmed yet.")
+	}
+	return nil
+}
+
+func sessionShareExportOptions(cfg *config.Config, sess *session.Session, includeRaw bool) (session.ExportOptions, error) {
+	reasoningCfg := config.DefaultReasoningConfig()
+	if cfg != nil {
+		reasoningCfg = cfg.ResolveReasoning(sessionExportReasoningSurface(sess))
+	}
+	opts := session.ExportOptions{IncludeReasoningSummaries: internalreasoning.ExportSummaries(reasoningCfg)}
+	if !includeRaw {
+		return opts, nil
+	}
+	opts.IncludeReasoningSummaries = true
+	switch {
+	case !reasoningCfg.Raw:
+		return session.ExportOptions{}, fmt.Errorf("raw reasoning sharing is disabled; set reasoning.raw=true or TERM_LLM_SHOW_RAW_REASONING=1")
+	case !internalreasoning.SourceAllowsRaw(reasoningCfg):
+		return session.ExportOptions{}, fmt.Errorf("raw reasoning sharing is disabled by reasoning.source; set reasoning.source=all")
+	default:
+		opts.IncludeRawReasoning = true
+	}
+	return opts, nil
+}

--- a/cmd/sessions_share_test.go
+++ b/cmd/sessions_share_test.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	sharepkg "github.com/samsaffron/term-llm/internal/share"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type sessionsSharePublisherMock struct {
+	createCalls int
+	updateCalls int
+	lastRequest sharepkg.Request
+	help        string
+	notes       []string
+}
+
+func (m *sessionsSharePublisherMock) Capabilities(context.Context) (sharepkg.Capabilities, error) {
+	return sharepkg.Capabilities{
+		Protocol: sharepkg.Protocol, Version: sharepkg.Version,
+		Provider:     sharepkg.Provider{ID: "acme", Name: "Acme Vault", Help: m.help},
+		Operations:   []sharepkg.Operation{sharepkg.OperationCreate, sharepkg.OperationUpdate},
+		Visibilities: []sharepkg.Visibility{sharepkg.VisibilityPrivate}, DefaultVisibility: sharepkg.VisibilityPrivate,
+		Notes: append([]string(nil), m.notes...),
+	}, nil
+}
+
+func (m *sessionsSharePublisherMock) Create(_ context.Context, req sharepkg.Request) (sharepkg.Result, error) {
+	m.createCalls++
+	m.lastRequest = req
+	return sharepkg.Result{Provider: "acme", ID: "opaque", URL: "https://share.example/opaque", Visibility: sharepkg.VisibilityPrivate, Ready: true}, nil
+}
+
+func (m *sessionsSharePublisherMock) Update(_ context.Context, _ string, req sharepkg.Request) (sharepkg.Result, error) {
+	m.updateCalls++
+	m.lastRequest = req
+	return sharepkg.Result{Provider: "acme", ID: "opaque", URL: "https://share.example/opaque", Visibility: sharepkg.VisibilityPrivate, Ready: true}, nil
+}
+
+func TestSessionsShareCreatesThenUpdatesAndPersistsWholeSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	oldDBPath, oldNoSession := sessionDBPath, noSession
+	oldVisibility, oldNew, oldJSON, oldRaw := sessionsShareVisibility, sessionsShareNew, sessionsShareJSON, sessionsShareIncludeRawReasoning
+	oldFactory := newSessionSharePublisher
+	t.Cleanup(func() {
+		sessionDBPath, noSession = oldDBPath, oldNoSession
+		sessionsShareVisibility, sessionsShareNew, sessionsShareJSON, sessionsShareIncludeRawReasoning = oldVisibility, oldNew, oldJSON, oldRaw
+		newSessionSharePublisher = oldFactory
+	})
+	sessionDBPath, noSession = filepath.Join(t.TempDir(), "sessions.db"), false
+	sessionsShareVisibility, sessionsShareNew, sessionsShareJSON, sessionsShareIncludeRawReasoning = "private", false, true, false
+
+	store, err := session.NewStore(session.Config{Enabled: true, Path: sessionDBPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	sess := &session.Session{ID: "session-share-cli", Name: "CLI share", Provider: "mock", Model: "mock", Mode: session.ModeChat, CreatedAt: now, UpdatedAt: now}
+	if err := store.Create(context.Background(), sess); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddMessage(context.Background(), sess.ID, session.NewMessage(sess.ID, llm.UserText("hello"), -1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	publisher := &sessionsSharePublisherMock{}
+	newSessionSharePublisher = func(config.ShareConfig) (sharepkg.Publisher, error) { return publisher, nil }
+	run := func() sessionsShareOutput {
+		t.Helper()
+		var output bytes.Buffer
+		command := &cobra.Command{}
+		command.SetOut(&output)
+		if err := runSessionsShare(command, []string{sess.ID}); err != nil {
+			t.Fatal(err)
+		}
+		var decoded sessionsShareOutput
+		if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+			t.Fatalf("decode output %q: %v", output.String(), err)
+		}
+		return decoded
+	}
+	first := run()
+	if first.Updated || publisher.createCalls != 1 || publisher.updateCalls != 0 || first.Scope != session.ShareScopeSession {
+		t.Fatalf("first=%+v calls=%d/%d", first, publisher.createCalls, publisher.updateCalls)
+	}
+
+	check, err := session.NewStore(session.Config{Enabled: true, Path: sessionDBPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, err := check.Get(context.Background(), sess.ID)
+	_ = check.Close()
+	if err != nil || persisted.Share == nil || persisted.Share.Provider != "acme" || persisted.Share.Scope != session.ShareScopeSession {
+		t.Fatalf("persisted share=%+v error=%v", persisted.Share, err)
+	}
+
+	second := run()
+	if !second.Updated || publisher.createCalls != 1 || publisher.updateCalls != 1 {
+		t.Fatalf("second=%+v calls=%d/%d", second, publisher.createCalls, publisher.updateCalls)
+	}
+
+	sessionsShareNew = true
+	var output, warnings bytes.Buffer
+	command := &cobra.Command{}
+	command.SetOut(&output)
+	command.SetErr(&warnings)
+	if err := runSessionsShare(command, []string{sess.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if publisher.createCalls != 2 || !strings.Contains(warnings.String(), "replace the saved share state") || !strings.Contains(warnings.String(), "may remain active") {
+		t.Fatalf("new share warning=%q createCalls=%d", warnings.String(), publisher.createCalls)
+	}
+
+	publisher.notes = []string{"Private links expire."}
+	publisher.help = "Run acme login."
+	sessionsShareNew, sessionsShareJSON = false, false
+	output.Reset()
+	command.SetOut(&output)
+	if err := runSessionsShare(command, []string{sess.ID}); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "Note: Private links expire.") || !strings.Contains(text, "Help: Run acme login.") || strings.Index(text, "Note:") > strings.Index(text, "Updated share") {
+		t.Fatalf("provider guidance was not shown before publishing: %q", text)
+	}
+}
+
+func TestSessionShareExportOptionsRequireExplicitRawReasoning(t *testing.T) {
+	cfg := &config.Config{Reasoning: config.ReasoningConfig{Raw: true, Source: config.ReasoningSourceAll, Export: config.ReasoningExportRaw}}
+	sess := &session.Session{ID: "share-raw", Mode: session.ModeChat, Provider: "mock", Model: "mock", CreatedAt: time.Now()}
+	messages := []session.Message{{
+		SessionID: sess.ID, Role: llm.RoleAssistant, TextContent: "Final answer.",
+		Parts: []llm.Part{{Type: llm.PartText, Text: "Final answer.", ReasoningContent: "private raw chain", ReasoningKind: llm.ReasoningKindRaw}},
+	}}
+	withoutOptions, err := sessionShareExportOptions(cfg, sess, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	without := session.ExportToMarkdown(sess, messages, withoutOptions)
+	if strings.Contains(without, "private raw chain") {
+		t.Fatalf("generic session share implicitly included raw reasoning: %q", without)
+	}
+	withOptions, err := sessionShareExportOptions(cfg, sess, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	with := session.ExportToMarkdown(sess, messages, withOptions)
+	if !strings.Contains(with, "private raw chain") {
+		t.Fatalf("explicit raw share omitted reasoning: %q", with)
+	}
+	if _, err := sessionShareExportOptions(&config.Config{}, sess, true); err == nil || !strings.Contains(err.Error(), "reasoning.raw") {
+		t.Fatalf("disabled explicit raw error=%v", err)
+	}
+}
+
+func TestSessionsShareCommandRegistered(t *testing.T) {
+	for _, command := range sessionsCmd.Commands() {
+		if command.Name() == "share" {
+			if command.Flag("visibility") == nil || command.Flag("new") == nil || command.Flag("json") == nil || command.Flag("include-raw-reasoning") == nil {
+				t.Fatalf("share flags incomplete")
+			}
+			return
+		}
+	}
+	t.Fatal("sessions share command is not registered")
+}

--- a/docs-site/content/guides/usage.md
+++ b/docs-site/content/guides/usage.md
@@ -113,7 +113,7 @@ Set `TERM_LLM_AT_MENTIONS=0` to disable `@` autocomplete and submit-time textual
 | `/goal` | Set, edit, pause, resume, clear, or show the persistent session goal |
 | `/side <question>` | Ask a private, tool-less one-turn question without interrupting or changing the main conversation |
 | `/commit [intent]` | Review, stage, draft, and create a Git commit in the active checkout |
-| `/share [new] [public]` | Share the session as a GitHub Gist; repeat to update or create a new gist |
+| `/share [new] [raw] [public\|unlisted\|private]` | Share the complete session through the configured provider; `raw` explicitly opts into privacy-sensitive raw reasoning |
 | `/quit` | Exit chat |
 
 When web search is enabled, the chat status line shows `web`; when fast service tier is enabled, it shows `fast`.

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -34,6 +34,7 @@ A typical config has a few major parts:
 - `providers` for model-specific credentials and routing
 - per-command blocks such as `exec`, `ask`, and `edit`
 - `commit.message_agent` for the native commit workflow's scope/message agent
+- `share` for the built-in GitHub or custom command transcript publisher
 - feature-specific blocks such as `image`, `audio`, `music`, `embed`, `search`, `sessions`, `file_tracking`, `tools`, and `skills`
 
 ## Example
@@ -101,6 +102,11 @@ lifecycle:
   adapters: [auto] # environment-detected Herdr/cmux only
   osc: off         # no terminal progress without explicit opt-in
   commands: []     # no custom process without explicit configuration
+
+share:
+  provider: github # or command
+  command: []      # direct argv; required only for provider: command
+  timeout: 120s    # create/update; maximum 600s
 
 # Optional global approval override. When omitted, chat, ask, and ordinary
 # serve platforms use auto; edit, exec, loop, and serve mcp use prompt.
@@ -373,6 +379,21 @@ printf '\033]9;4;3\a'; sleep 10; printf '\033]9;4;0\a'
 ```
 
 If the title changes only during `sleep` and resets afterward, Ghostty shell integration is overwriting it at the prompt. If it never changes, check for a fixed `title`, `title-command`, or a manual surface/tab title override.
+
+## Transcript sharing
+
+`share.provider` defaults to `github`, which publishes through the authenticated `gh` CLI. Set it to `command` to use a Share Helper Protocol v1 executable:
+
+```yaml
+share:
+  provider: command
+  command: [/usr/local/bin/acme-share, --tenant, engineering]
+  timeout: 120s
+```
+
+`share.command` is an argv list, not shell text, and may include prefix arguments. The operation name is appended by term-llm. The timeout must be greater than zero and no more than `600s`; capability discovery is separately capped at ten seconds. A command is rejected under the GitHub provider so an ignored helper configuration cannot look active.
+
+See [Sharing](/reference/sharing/) for TUI/CLI behavior and the complete helper JSON protocol.
 
 ## Terminal-host lifecycle
 

--- a/docs-site/content/reference/sessions.md
+++ b/docs-site/content/reference/sessions.md
@@ -19,13 +19,20 @@ term-llm sessions untag 42 auth
 term-llm sessions autotitle
 term-llm sessions autotitle --dry-run
 term-llm sessions browse
-term-llm sessions gist 42
+term-llm sessions share 42 --visibility unlisted
+term-llm sessions export gist 42
 term-llm sessions delete 42
 term-llm sessions reset
 term-llm chat --resume=42
 ```
 
 Sessions are numbered sequentially for convenience, so `42` and `#42` both work.
+
+## Sharing sessions
+
+`term-llm sessions share <id> [--visibility public|unlisted|private] [--new] [--include-raw-reasoning] [--json]` publishes the complete visible session through the configured generic sharing provider. It updates a persisted compatible whole-session share unless `--new` is supplied. Raw reasoning is excluded unless `--include-raw-reasoning` is explicitly supplied; the flag prints a privacy warning and still respects the reasoning source policy. Human-readable output includes provider notes and help, such as GitHub authentication guidance and the warning that unlisted Gists are not private. The TUI equivalent is `/share [new] [raw] [public|unlisted|private]`.
+
+Web response/conversation shares capture a point in time and are not persisted. `term-llm sessions export gist` remains the explicit GitHub-only export path. See [Sharing](/reference/sharing/) for provider configuration and the custom helper protocol.
 
 ## Conversation paths
 

--- a/docs-site/content/reference/sharing.md
+++ b/docs-site/content/reference/sharing.md
@@ -1,0 +1,249 @@
+---
+title: "Sharing"
+weight: 8
+description: "Share session transcripts through the built-in GitHub publisher or a custom Share Helper Protocol v1 command."
+kicker: "Transcripts"
+---
+
+term-llm can publish rendered transcript bundles without coupling the Web UI, TUI, or session store to one hosting service.
+
+## User commands
+
+From the chat TUI:
+
+```text
+/share [new] [raw] [public|unlisted|private]
+```
+
+From the CLI, for a complete saved session:
+
+```bash
+term-llm sessions share 42
+term-llm sessions share 42 --visibility private
+term-llm sessions share 42 --include-raw-reasoning
+term-llm sessions share 42 --new --json
+```
+
+A compatible whole-session share is updated by default. `new` or `--new` always creates another share. An update is offered only when the stored share has `scope: session`, belongs to the currently configured provider, and that provider advertises `update`. Replacing saved state warns that the old provider link may remain active.
+
+Raw model reasoning is never included implicitly, even when `reasoning.export: raw` is configured. It requires the explicit `/share raw` or `--include-raw-reasoning` opt-in, remains subject to `reasoning.raw` and `reasoning.source`, and is accompanied by a privacy warning because it may contain sensitive information.
+
+The Web UI shares either one response or the visible conversation through that response. These point-in-time Web shares are deliberately **not persisted**. A later whole-session update therefore cannot add broader content to a response-only URL.
+
+The older `agents export/import gist` and `sessions export gist` commands remain GitHub-specific and do not use this protocol.
+
+## Providers
+
+GitHub Gist is the default provider and uses the existing `gh` authentication:
+
+```yaml
+share:
+  provider: github
+  timeout: 120s
+```
+
+It supports `unlisted` and `public` shares. Unlisted Gists are accessible to anyone with the URL; they are not private. After creating or updating a Gist, term-llm makes at most five anonymous readiness requests to the primary `https://gisthost.github.io/` transcript URL within ten seconds. A `403`, `429`, network failure, or exhausted probe does not turn an already-created or updated Gist into a failure; the result instead has `ready: false`. Updates query GitHub for the Gist's existing visibility because GitHub cannot change visibility in place.
+
+To use a custom executable:
+
+```yaml
+share:
+  provider: command
+  command: [/usr/local/bin/acme-share, --tenant, engineering]
+  timeout: 120s
+```
+
+The configured array is an argv vector, not shell text. term-llm resolves `argv[0]` once (including through `PATH`) and stores an absolute executable path before changing to a bundle directory. It appends `capabilities`, `create`, or `update` as the final argument. Prefix arguments are preserved exactly. `share.timeout` controls create/update and must be greater than zero and at most `600s`; its default is `120s`. Capabilities always has a maximum timeout of ten seconds.
+
+## Share Helper Protocol v1
+
+### Process contract
+
+The protocol identifier is `term-llm-share` and the version is JSON number `1`.
+
+Each operation is one process invocation:
+
+```text
+COMMAND [PREFIX_ARG ...] capabilities
+COMMAND [PREFIX_ARG ...] create
+COMMAND [PREFIX_ARG ...] update
+```
+
+term-llm executes the argv directly without a shell. The helper reads exactly one JSON object from standard input and writes exactly one JSON object to standard output. Standard error is diagnostic-only: it is captured with a 64 KiB process bound, quoted and truncated again to 4 KiB on the operator log surface, and is never included in Web or TUI errors or their wrapped error chains. Standard output is limited to 1 MiB. Extra non-JSON standard output makes the response invalid.
+
+The process runs in a detached process group. Cancellation and timeout kill the group. After any completed invocation, term-llm also cleans up background descendants; a successful zero-exit helper whose descendant retains inherited pipes is accepted after the bounded wait delay and its completed stdout response is still parsed.
+
+### Capabilities request
+
+The `capabilities` working directory is unspecified. Input:
+
+```json
+{
+  "protocol": "term-llm-share",
+  "version": 1,
+  "request_id": "7de40dd4ff5347af93e2187df9c4ef83"
+}
+```
+
+`request_id` is unique per invocation and should be included in provider-side diagnostics or idempotency records. It is not a persistent share ID.
+
+A successful capabilities response has this schema:
+
+```json
+{
+  "protocol": "term-llm-share",
+  "version": 1,
+  "provider": {
+    "id": "acme-vault",
+    "name": "Acme Vault",
+    "help": "Run acme-share login if authentication is required."
+  },
+  "operations": ["create", "update"],
+  "visibilities": ["private", "unlisted"],
+  "default_visibility": "private",
+  "notes": ["Private links expire after 30 days."],
+  "limits": {
+    "expires_after_days": 30
+  }
+}
+```
+
+Required fields and semantics:
+
+| Field | Requirement |
+|---|---|
+| `protocol` | Exactly `term-llm-share`. |
+| `version` | Exactly `1`. |
+| `provider.id` | Stable identifier containing 1–64 printable ASCII bytes without whitespace. It is persisted with whole-session shares and gates future updates. `github` is reserved for the built-in provider and is rejected from command helpers. |
+| `provider.name` | Non-empty human-readable name, at most 128 UTF-8 bytes and without control characters. |
+| `provider.help` | Optional user guidance, at most 2048 UTF-8 bytes and without control characters. It may mention provider-specific installation or authentication. |
+| `operations` | Must contain `create`; may also contain `update`. No other v1 operation is valid. |
+| `visibilities` | Non-empty unique list drawn only from `public`, `unlisted`, and `private`. |
+| `default_visibility` | Must be one of `visibilities`. |
+| `notes` | At most 16 non-empty entries. Each is at most 1024 UTF-8 bytes and cannot contain control characters. Clients show these notes to users. |
+| `limits` | Optional JSON object with at most 32 keys, at most four nested levels, bounded arrays/objects, and an encoded size of at most 16 KiB. |
+
+Advertising `update` means the helper can replace the bundle associated with its own opaque ID. A helper that cannot safely preserve an existing URL must omit `update`.
+
+### Create and update bundle
+
+For `create` and `update`, term-llm creates a fresh private temporary directory with mode `0700`, writes bundle files with mode `0600`, sets that directory as the helper's working directory, and removes it after every success or failure.
+
+Version 1 transcript bundles contain at most 32 files, with a 16 MiB per-file limit and a 32 MiB total-content limit. The standard bundle contains:
+
+- `index.html` — standalone rendered transcript and the entrypoint;
+- `session.md` — Markdown source transcript.
+
+The JSON manifest names files relative to the working directory. Helpers must reject absolute paths, traversal, or files not declared by the manifest. File content is read from the working directory and is not duplicated in JSON.
+
+Create input:
+
+```json
+{
+  "protocol": "term-llm-share",
+  "version": 1,
+  "request_id": "39b843c39b624315b80e04297c67ef09",
+  "title": "Investigate latency",
+  "description": "term-llm session: Investigate latency",
+  "visibility": "private",
+  "entrypoint": "index.html",
+  "files": [
+    {
+      "name": "index.html",
+      "media_type": "text/html; charset=utf-8",
+      "role": "entrypoint"
+    },
+    {
+      "name": "session.md",
+      "media_type": "text/markdown; charset=utf-8",
+      "role": "transcript"
+    }
+  ]
+}
+```
+
+Update input is identical and adds the helper's previously returned opaque ID:
+
+```json
+{
+  "protocol": "term-llm-share",
+  "version": 1,
+  "request_id": "becf0f36c9224cfd8a8976af1037914d",
+  "id": "share_Y2hhbmdlLW1l",
+  "title": "Investigate latency",
+  "description": "term-llm session: Investigate latency",
+  "visibility": "private",
+  "entrypoint": "index.html",
+  "files": [
+    {"name": "index.html", "media_type": "text/html; charset=utf-8", "role": "entrypoint"},
+    {"name": "session.md", "media_type": "text/markdown; charset=utf-8", "role": "transcript"}
+  ]
+}
+```
+
+`title` and `description` are display metadata. `visibility` has already been checked against capabilities. On update, the helper must return the actual resulting visibility; it must not claim a requested visibility that the remote object could not adopt.
+
+### Success response and readiness
+
+A successful create or update exits zero and returns:
+
+```json
+{
+  "protocol": "term-llm-share",
+  "version": 1,
+  "id": "share_Y2hhbmdlLW1l",
+  "url": "https://shares.example.test/s/share_Y2hhbmdlLW1l",
+  "source_url": "https://shares.example.test/s/share_Y2hhbmdlLW1l/source",
+  "visibility": "private"
+}
+```
+
+`source_url` is optional. All returned URLs must be absolute HTTPS URLs. Plain HTTP is accepted only for loopback hosts such as `localhost`, `127.0.0.1`, or `::1`. A URL is at most 2048 bytes and cannot contain whitespace, control characters, or embedded user information. `id` is 1–256 printable ASCII bytes without whitespace. `visibility` must be one of the three v1 values.
+
+**A zero exit is a readiness promise:** `url` must already be usable when the helper exits. term-llm does not probe custom URLs, because they may require authentication and probing could disclose credentials or create load. Successful custom-provider results therefore have `ready: true`.
+
+### Failure response
+
+A failed operation exits nonzero. It may return this structured object on stdout:
+
+```json
+{
+  "error": {
+    "code": "auth_required",
+    "message": "Sign in with acme-share login and try again."
+  }
+}
+```
+
+Stable v1 codes are:
+
+| Code | Meaning |
+|---|---|
+| `dependency_missing` | The helper or one of its required programs is unavailable. |
+| `auth_required` | Provider authentication is missing or expired. |
+| `timeout` | The provider operation timed out. term-llm also generates this code when it kills an overdue helper. |
+| `provider_error` | The remote provider rejected or could not complete the operation. |
+| `protocol_error` | Input/output does not satisfy this protocol. |
+| `unsupported_visibility` | The requested visibility cannot be provided. Normally term-llm rejects this before create/update using capabilities. |
+
+The message must be safe for an end user: valid UTF-8, non-empty, no control characters, and at most 1024 bytes. Do not put tokens, raw HTTP bodies, stack traces, or command diagnostics in it. Put diagnostics on stderr; term-llm never forwards arbitrary stderr to Web or TUI users. Unknown error codes are normalized to `provider_error`; an invalid message is replaced with `share helper failed`. A nonzero exit without a valid structured error becomes the same curated message.
+
+## Web API
+
+Authenticated clients can discover the active provider with:
+
+```text
+GET /v1/sharing/capabilities
+```
+
+The response uses `Cache-Control: no-store` and returns `enabled`, `provider`, `operations`, `visibilities`, `default_visibility`, `help`, `notes`, and optional `limits`. Unlike generic `GET /v1/capabilities`, this endpoint may invoke a configured helper. Generic capabilities deliberately omits sharing details so it never waits for or implies readiness of a subprocess.
+
+Point-in-time creation remains:
+
+```text
+POST /v1/sessions/{id}/shares
+```
+
+Request fields are `anchor_message_id`, `scope` (`response` or `conversation`), and `visibility`. For one compatibility release, `public: true|false` is accepted only when `visibility` is absent. The generic response fields are `provider`, `id`, `url`, optional `source_url`, `visibility`, `ready`, and `scope`. GitHub responses additionally include legacy `gist_id`, `gist_url`, `preview_url`, and `public` fields for one compatibility release.
+
+Errors use a stable `error.code` and curated `error.message`; helper stderr is never returned.

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -10,11 +10,31 @@ export interface ApprovalPolicyResponse {
   guardian_auto_suspended: boolean;
 }
 
+export type ShareVisibility = 'public' | 'unlisted' | 'private';
+
+export interface SharingCapabilitiesResponse {
+  enabled: boolean;
+  provider: { id: string; name: string };
+  operations: Array<'create' | 'update'>;
+  visibilities: ShareVisibility[];
+  default_visibility: ShareVisibility;
+  help?: string;
+  notes?: string[];
+  limits?: Record<string, unknown>;
+}
+
 export interface SessionShareResponse {
-  gist_id: string;
-  gist_url: string;
-  preview_url: string;
-  public: boolean;
+  provider: string;
+  id: string;
+  url: string;
+  source_url?: string;
+  visibility: ShareVisibility;
+  ready: boolean;
+  scope: 'response' | 'conversation' | 'session';
+  gist_id?: string;
+  gist_url?: string;
+  preview_url?: string;
+  public?: boolean;
 }
 
 export interface ShellCreateResponse {
@@ -35,6 +55,7 @@ const sessionHeaders = (id: string): Record<string, string> => ({ 'X-Term-LLM-Se
 const sessionReviewRead = { auth: 'session', versionCheck: false } as const;
 export const endpoints = (api: APIClient) => ({
   capabilities: () => api.get<Record<string, unknown>>('/v1/capabilities'),
+  sharingCapabilities: () => api.get<SharingCapabilitiesResponse>('/v1/sharing/capabilities'),
   providers: () => api.get<Record<string, unknown>>('/v1/providers'),
   models: (provider = '', signal?: AbortSignal) =>
     api.get<Record<string, unknown>>(

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useStore } from '../app/context';
+import type {
+  SessionShareResponse,
+  SharingCapabilitiesResponse,
+  ShareVisibility,
+} from '../api/endpoints';
 import { errorMessage } from '../domain/text';
 import { copyText } from '../platform/browser';
 import { Overlay } from './Overlay';
@@ -8,19 +13,27 @@ import '../styles/features/share.css';
 type ShareScope = 'response' | 'conversation';
 type SharePhase = 'form' | 'submitting' | 'success';
 
+const visibilityLabel = (visibility: ShareVisibility): string =>
+  visibility === 'public' ? 'Public' : visibility === 'private' ? 'Private' : 'Unlisted';
+
+const visibilityDescription = (visibility: ShareVisibility): string => {
+  if (visibility === 'public') return 'Discoverable by anyone through the sharing provider.';
+  if (visibility === 'private') return 'Access is restricted by the sharing provider.';
+  return 'Anyone with the link may be able to view it, but it is not publicly listed.';
+};
+
 export function ShareModal() {
   const store = useStore();
   const target = store.shareTarget.value;
   const [scope, setScope] = useState<ShareScope>('response');
-  const [isPublic, setIsPublic] = useState(false);
+  const [visibility, setVisibility] = useState<ShareVisibility | ''>('');
+  const [capabilities, setCapabilities] = useState<SharingCapabilitiesResponse | null>(null);
+  const [capabilityLoading, setCapabilityLoading] = useState(true);
+  const [capabilityError, setCapabilityError] = useState('');
   const [phase, setPhase] = useState<SharePhase>('form');
   const [error, setError] = useState('');
   const [copied, setCopied] = useState(false);
-  const [result, setResult] = useState<{
-    previewURL: string;
-    gistURL: string;
-    public: boolean;
-  } | null>(null);
+  const [result, setResult] = useState<SessionShareResponse | null>(null);
   const success = useRef<HTMLDivElement>(null);
 
   const close = () => {
@@ -28,6 +41,33 @@ export function ShareModal() {
     store.shareTarget.value = null;
     store.modal.value = '';
   };
+
+  useEffect(() => {
+    let active = true;
+    setCapabilityLoading(true);
+    setCapabilityError('');
+    setCapabilities(null);
+    setVisibility('');
+    void store.endpoints
+      .sharingCapabilities()
+      .then((loaded) => {
+        if (!active) return;
+        if (!loaded.enabled || !loaded.visibilities.length) {
+          throw new Error('Sharing is not enabled on this server.');
+        }
+        setCapabilities(loaded);
+        setVisibility(loaded.default_visibility);
+      })
+      .catch((cause) => {
+        if (active) setCapabilityError(errorMessage(cause));
+      })
+      .finally(() => {
+        if (active) setCapabilityLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [store, target?.sessionId]);
 
   useEffect(() => {
     if (phase === 'submitting' || !target || store.activeSession.value?.id === target.sessionId)
@@ -44,9 +84,8 @@ export function ShareModal() {
 
   if (!target) return null;
   const submitting = phase === 'submitting';
-  const githubCLIProblem = /\bgh\b|GitHub CLI/i.test(error);
   const create = async () => {
-    if (submitting) return;
+    if (submitting || !capabilities || !visibility) return;
     setError('');
     setCopied(false);
     setPhase('submitting');
@@ -54,13 +93,9 @@ export function ShareModal() {
       const response = await store.endpoints.createSessionShare(target.sessionId, {
         anchor_message_id: target.anchorMessageId,
         scope,
-        public: isPublic,
+        visibility,
       });
-      setResult({
-        previewURL: response.preview_url,
-        gistURL: response.gist_url,
-        public: response.public,
-      });
+      setResult(response);
       setPhase('success');
     } catch (cause) {
       setError(errorMessage(cause));
@@ -82,34 +117,41 @@ export function ShareModal() {
             ✓
           </div>
           <h3>Share created</h3>
-          <p>{result.public ? 'Public' : 'Secret (unlisted)'}</p>
-          <label class="share-url-label" for="sharePreviewURL">
-            Preview link
+          <p>{visibilityLabel(result.visibility)}</p>
+          {!result.ready && (
+            <p class="share-ready-note">
+              The link was created, but readiness was not confirmed yet.
+            </p>
+          )}
+          <label class="share-url-label" for="shareURL">
+            Share link
           </label>
           <input
-            id="sharePreviewURL"
+            id="shareURL"
             class="share-url"
-            value={result.previewURL}
+            value={result.url}
             readOnly
             onFocus={(event) => event.currentTarget.select()}
           />
-          <a class="share-gist-link" href={result.gistURL} target="_blank" rel="noreferrer">
-            View Gist ↗
-          </a>
+          {result.source_url && (
+            <a class="share-source-link" href={result.source_url} target="_blank" rel="noreferrer">
+              View source ↗
+            </a>
+          )}
           <div class="modal-actions share-success-actions">
-            <a class="btn primary" href={result.previewURL} target="_blank" rel="noreferrer">
-              Open preview
+            <a class="btn primary" href={result.url} target="_blank" rel="noreferrer">
+              Open link
             </a>
             <button
               class="btn"
               type="button"
               onClick={() => {
-                void copyText(result.previewURL)
+                void copyText(result.url)
                   .then(() => setCopied(true))
                   .catch((cause) => store.toast(cause, 'error'));
               }}
             >
-              {copied ? 'Copied' : 'Copy preview link'}
+              {copied ? 'Copied' : 'Copy link'}
             </button>
             <button class="btn" type="button" onClick={close}>
               Done
@@ -123,112 +165,121 @@ export function ShareModal() {
             void create();
           }}
         >
-          <p>Create a GitHub Gist with a polished, standalone transcript.</p>
-
-          <fieldset class="share-fieldset" disabled={submitting}>
-            <legend>What do you want to share?</legend>
-            <label class={`share-choice ${scope === 'response' ? 'is-selected' : ''}`}>
-              <input
-                type="radio"
-                name="share-scope"
-                value="response"
-                checked={scope === 'response'}
-                onChange={() => setScope('response')}
-              />
-              <span>
-                <strong>This response</strong>
-                <small>
-                  Just the assistant’s complete reply text. No prompts or tool activity.
-                </small>
-              </span>
-            </label>
-            <label class={`share-choice ${scope === 'conversation' ? 'is-selected' : ''}`}>
-              <input
-                type="radio"
-                name="share-scope"
-                value="conversation"
-                checked={scope === 'conversation'}
-                onChange={() => setScope('conversation')}
-              />
-              <span>
-                <strong>Conversation up to here</strong>
-                <small>
-                  The visible transcript, including your messages and tool activity, up to and
-                  including this response.
-                </small>
-              </span>
-            </label>
-          </fieldset>
-
-          <fieldset class="share-fieldset share-visibility" disabled={submitting}>
-            <legend>Visibility</legend>
-            <label class={`share-choice ${!isPublic ? 'is-selected' : ''}`}>
-              <input
-                type="radio"
-                name="share-visibility"
-                checked={!isPublic}
-                onChange={() => setIsPublic(false)}
-              />
-              <span>
-                <strong>Secret (unlisted)</strong>
-                <small>Anyone with the link can view it. Secret Gists are not private.</small>
-              </span>
-            </label>
-            <label class={`share-choice ${isPublic ? 'is-selected' : ''}`}>
-              <input
-                type="radio"
-                name="share-visibility"
-                checked={isPublic}
-                onChange={() => setIsPublic(true)}
-              />
-              <span>
-                <strong>Public</strong>
-                <small>Visible on your GitHub Gist profile and discoverable by anyone.</small>
-              </span>
-            </label>
-          </fieldset>
-
-          <div class="share-included">
-            <strong>What’s included</strong>
-            <p>
-              {scope === 'response'
-                ? 'The assistant reply text only. Prompts, tool activity, and raw reasoning are excluded.'
-                : 'The conversation through this response. Prompts, code, tool output, filenames, and images may be included; raw reasoning is excluded.'}
-            </p>
-          </div>
-          <p class="share-privacy">
-            Review sensitive content before sharing—the Gist is created on your GitHub account.
-          </p>
-          {error && (
+          {capabilityLoading && <p role="status">Loading sharing options…</p>}
+          {!capabilityLoading && capabilityError && (
             <div class="modal-error share-error" role="alert">
-              <strong>Couldn’t create the Gist.</strong> {error}
-              {githubCLIProblem && (
-                <span class="share-error-help">
-                  Sharing currently uses the GitHub CLI on the machine running term-llm. Install{' '}
-                  <a href="https://cli.github.com/" target="_blank" rel="noreferrer">
-                    <code>gh</code>
-                  </a>{' '}
-                  and run <code>gh auth login</code>, then try again.
-                </span>
-              )}
+              <strong>Sharing unavailable.</strong> {capabilityError}
             </div>
           )}
-          <div class="modal-actions">
-            {!submitting && (
-              <button class="btn" type="button" onClick={close}>
-                Cancel
-              </button>
-            )}
-            <button
-              class={`btn primary ${submitting ? 'is-loading' : ''}`}
-              type="submit"
-              disabled={submitting}
-            >
-              <span aria-live="polite">
-                {submitting ? 'Creating Gist…' : error ? 'Try again' : 'Create share'}
-              </span>
-            </button>
-          </div>
+          {!capabilityLoading && capabilities && (
+            <>
+              <p>
+                {capabilities.provider.id === 'github'
+                  ? 'Create a GitHub Gist with a polished, standalone transcript.'
+                  : `Create a share with ${capabilities.provider.name}.`}
+              </p>
+
+              <fieldset class="share-fieldset" disabled={submitting}>
+                <legend>What do you want to share?</legend>
+                <label class={`share-choice ${scope === 'response' ? 'is-selected' : ''}`}>
+                  <input
+                    type="radio"
+                    name="share-scope"
+                    value="response"
+                    checked={scope === 'response'}
+                    onChange={() => setScope('response')}
+                  />
+                  <span>
+                    <strong>This response</strong>
+                    <small>
+                      Just the assistant’s complete reply text. No prompts or tool activity.
+                    </small>
+                  </span>
+                </label>
+                <label class={`share-choice ${scope === 'conversation' ? 'is-selected' : ''}`}>
+                  <input
+                    type="radio"
+                    name="share-scope"
+                    value="conversation"
+                    checked={scope === 'conversation'}
+                    onChange={() => setScope('conversation')}
+                  />
+                  <span>
+                    <strong>Conversation up to here</strong>
+                    <small>
+                      The visible transcript, including your messages and tool activity, up to and
+                      including this response.
+                    </small>
+                  </span>
+                </label>
+              </fieldset>
+
+              <fieldset class="share-fieldset share-visibility" disabled={submitting}>
+                <legend>Visibility</legend>
+                {capabilities.visibilities.length === 1 ? (
+                  <div class="share-included">
+                    <strong>{visibilityLabel(capabilities.visibilities[0])}</strong>
+                    <span>{visibilityDescription(capabilities.visibilities[0])}</span>
+                  </div>
+                ) : (
+                  capabilities.visibilities.map((option) => (
+                    <label
+                      key={option}
+                      class={`share-choice ${visibility === option ? 'is-selected' : ''}`}
+                    >
+                      <input
+                        type="radio"
+                        name="share-visibility"
+                        value={option}
+                        checked={visibility === option}
+                        onChange={() => setVisibility(option)}
+                      />
+                      <span>
+                        <strong>{visibilityLabel(option)}</strong>
+                        <small>{visibilityDescription(option)}</small>
+                      </span>
+                    </label>
+                  ))
+                )}
+              </fieldset>
+
+              <div class="share-included">
+                <strong>What’s included</strong>
+                <p>
+                  {scope === 'response'
+                    ? 'The assistant reply text only. Prompts, tool activity, and raw reasoning are excluded.'
+                    : 'The conversation through this response. Prompts, code, tool output, filenames, and images may be included; raw reasoning is excluded.'}
+                </p>
+              </div>
+              {capabilities.notes?.map((note) => (
+                <p class="share-privacy" key={note}>
+                  {note}
+                </p>
+              ))}
+              {capabilities.help && <p class="share-provider-help">{capabilities.help}</p>}
+              {error && (
+                <div class="modal-error share-error" role="alert">
+                  <strong>Couldn’t create share.</strong> {error}
+                </div>
+              )}
+              <div class="modal-actions">
+                {!submitting && (
+                  <button class="btn" type="button" onClick={close}>
+                    Cancel
+                  </button>
+                )}
+                <button
+                  class={`btn primary ${submitting ? 'is-loading' : ''}`}
+                  type="submit"
+                  disabled={submitting || !visibility}
+                >
+                  <span aria-live="polite">
+                    {submitting ? 'Creating share…' : error ? 'Try again' : 'Create share'}
+                  </span>
+                </button>
+              </div>
+            </>
+          )}
         </form>
       )}
     </Overlay>

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -5,6 +5,7 @@ import { StoreContext } from '../app/context';
 import { App } from '../app/App';
 import { AppStore } from '../stores/app-store';
 import { APIError } from '../api/client';
+import type { SessionShareResponse } from '../api/endpoints';
 import { Transcript } from './Transcript';
 import { Composer } from './Composer';
 import { Markdown } from './Markdown';
@@ -4564,24 +4565,23 @@ describe('Preact-owned chat surfaces', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('session is temporarily busy');
   });
 
-  it('creates a point-in-time share with explicit scope and visibility', async () => {
+  it('creates a point-in-time share with provider capabilities and explicit visibility', async () => {
     const store = createStore();
     store.shareTarget.value = { sessionId: store.sessions.value[0].id, anchorMessageId: 42 };
     store.modal.value = 'share';
-    let resolveShare!: (value: {
-      gist_id: string;
-      gist_url: string;
-      preview_url: string;
-      public: boolean;
-    }) => void;
+    store.endpoints.sharingCapabilities = vi.fn(async () => ({
+      enabled: true,
+      provider: { id: 'github', name: 'GitHub Gist' },
+      operations: ['create', 'update'] as Array<'create' | 'update'>,
+      visibilities: ['unlisted', 'public'] as Array<'unlisted' | 'public'>,
+      default_visibility: 'unlisted' as const,
+      help: 'Use the active GitHub account.',
+      notes: ['Unlisted Gists are not private.'],
+    }));
+    let resolveShare!: (value: SessionShareResponse) => void;
     store.endpoints.createSessionShare = vi.fn(
       () =>
-        new Promise<{
-          gist_id: string;
-          gist_url: string;
-          preview_url: string;
-          public: boolean;
-        }>((resolve) => {
+        new Promise<SessionShareResponse>((resolve) => {
           resolveShare = resolve;
         }),
     );
@@ -4592,9 +4592,8 @@ describe('Preact-owned chat surfaces', () => {
     );
 
     expect(await screen.findByRole('heading', { name: 'Share transcript' })).toBeInTheDocument();
-    expect(screen.queryByText('GitHub CLI required for now.')).not.toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /This response/ })).toBeChecked();
-    expect(screen.getByRole('radio', { name: /Secret \(unlisted\)/ })).toBeChecked();
+    expect(await screen.findByRole('radio', { name: /This response/ })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Unlisted/ })).toBeChecked();
 
     await userEvent.click(screen.getByRole('radio', { name: /Conversation up to here/ }));
     await userEvent.click(screen.getByRole('radio', { name: /Public/ }));
@@ -4603,9 +4602,9 @@ describe('Preact-owned chat surfaces', () => {
     expect(store.endpoints.createSessionShare).toHaveBeenCalledWith(store.sessions.value[0].id, {
       anchor_message_id: 42,
       scope: 'conversation',
-      public: true,
+      visibility: 'public',
     });
-    expect(screen.getByText('Creating Gist…')).toBeVisible();
+    expect(screen.getByText('Creating share…')).toBeVisible();
     expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Close Share transcript' }),
@@ -4617,53 +4616,81 @@ describe('Preact-owned chat surfaces', () => {
 
     await act(async () =>
       resolveShare({
-        gist_id: 'abc123',
-        gist_url: 'https://gist.github.com/test/abc123',
-        preview_url: 'https://gisthost.github.io/?abc123/index.html',
-        public: true,
+        provider: 'github',
+        id: 'abc123',
+        url: 'https://share.example/abc123',
+        source_url: 'https://source.example/abc123',
+        visibility: 'public',
+        ready: true,
+        scope: 'conversation',
       }),
     );
     expect(await screen.findByRole('heading', { name: 'Share created' })).toBeVisible();
-    expect(screen.getByRole('link', { name: 'Open preview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Open link' })).toHaveAttribute(
       'href',
-      'https://gisthost.github.io/?abc123/index.html',
+      'https://share.example/abc123',
     );
-    expect(screen.getByRole('link', { name: 'View Gist ↗' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'View source ↗' })).toHaveAttribute(
       'href',
-      'https://gist.github.com/test/abc123',
+      'https://source.example/abc123',
     );
   });
 
-  it('preserves share choices and explains GitHub CLI failures', async () => {
+  it('uses generic wording and a statement for a command provider with one visibility', async () => {
     const store = createStore();
     store.shareTarget.value = { sessionId: store.sessions.value[0].id, anchorMessageId: 42 };
     store.modal.value = 'share';
-    store.endpoints.createSessionShare = vi.fn(async () => {
-      throw new Error('gh CLI not found; install it and run gh auth login');
-    });
-    render(
+    store.endpoints.sharingCapabilities = vi.fn(async () => ({
+      enabled: true,
+      provider: { id: 'acme', name: 'Acme Vault' },
+      operations: ['create'] as Array<'create'>,
+      visibilities: ['private'] as Array<'private'>,
+      default_visibility: 'private' as const,
+      notes: ['Only invited teammates can open this link.'],
+    }));
+    const { container } = render(
       <StoreContext.Provider value={store}>
         <Modals />
       </StoreContext.Provider>,
     );
 
-    await screen.findByRole('heading', { name: 'Share transcript' });
+    expect(await screen.findByText('Create a share with Acme Vault.')).toBeVisible();
+    expect(screen.getByText('Private')).toBeVisible();
+    expect(screen.queryByRole('radio', { name: /Private/ })).not.toBeInTheDocument();
+    expect(container).not.toHaveTextContent(/GitHub|Gist|\bgh\b|gisthost/i);
+  });
+
+  it('preserves share choices and shows a curated generic provider failure', async () => {
+    const store = createStore();
+    store.shareTarget.value = { sessionId: store.sessions.value[0].id, anchorMessageId: 42 };
+    store.modal.value = 'share';
+    store.endpoints.sharingCapabilities = vi.fn(async () => ({
+      enabled: true,
+      provider: { id: 'acme', name: 'Acme Vault' },
+      operations: ['create'] as Array<'create'>,
+      visibilities: ['private'] as Array<'private'>,
+      default_visibility: 'private' as const,
+      help: 'Sign in to Acme Vault and try again.',
+    }));
+    store.endpoints.createSessionShare = vi.fn(async () => {
+      throw new Error('Authentication is required by the sharing provider.');
+    });
+    const { container } = render(
+      <StoreContext.Provider value={store}>
+        <Modals />
+      </StoreContext.Provider>,
+    );
+
+    await screen.findByRole('radio', { name: /Conversation up to here/ });
     await userEvent.click(screen.getByRole('radio', { name: /Conversation up to here/ }));
     await userEvent.click(screen.getByRole('button', { name: 'Create share' }));
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      'gh CLI not found; install it and run gh auth login',
-    );
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      'Sharing currently uses the GitHub CLI on the machine running term-llm',
-    );
-    expect(screen.getByRole('link', { name: 'gh' })).toHaveAttribute(
-      'href',
-      'https://cli.github.com/',
+      'Authentication is required by the sharing provider.',
     );
     expect(screen.getByRole('radio', { name: /Conversation up to here/ })).toBeChecked();
     expect(screen.getByRole('button', { name: 'Try again' })).toBeEnabled();
+    expect(container).not.toHaveTextContent(/GitHub|Gist|\bgh\b|gisthost/i);
   });
-
   it('offers legacy branch-context choices before creating a path', async () => {
     const store = createStore();
     store.branchTarget.value = '42';

--- a/frontend/src/styles/features/share.css
+++ b/frontend/src/styles/features/share.css
@@ -13,6 +13,11 @@
   line-height: 1.45;
 }
 
+.share-visibility .share-included {
+  display: grid;
+  gap: 0.14rem;
+}
+
 .share-included strong {
   color: var(--text);
 }

--- a/frontend/src/styles/features/share.css
+++ b/frontend/src/styles/features/share.css
@@ -99,13 +99,6 @@
   margin-top: 0.75rem;
 }
 
-.share-error-help {
-  display: block;
-  margin-top: 0.35rem;
-  color: var(--text-muted);
-  line-height: 1.45;
-}
-
 .share-modal .btn.is-loading {
   display: inline-flex;
   align-items: center;
@@ -162,7 +155,7 @@
   font-size: 0.78rem;
 }
 
-.share-gist-link {
+.share-source-link {
   display: inline-block;
   margin-top: 0.55rem;
   font-size: 0.8rem;

--- a/internal/agents/gist/client.go
+++ b/internal/agents/gist/client.go
@@ -1,17 +1,29 @@
-// Package gist provides GitHub Gist operations for agent sharing.
-// It uses the gh CLI tool for authentication and API access.
+// Package gist provides GitHub Gist operations through the gh CLI.
+// It is used by explicit Gist import/export and the built-in sharing provider.
 package gist
 
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/samsaffron/term-llm/internal/procutil"
 )
+
+var (
+	ErrDependencyMissing = errors.New("gist dependency missing")
+	ErrAuthRequired      = errors.New("gist authentication required")
+	ErrProvider          = errors.New("gist provider error")
+)
+
+const ProviderID = "github"
 
 // Gist represents a GitHub Gist.
 type Gist struct {
@@ -50,9 +62,9 @@ func (c *Client) checkGH() error {
 	cmd := c.execCommand("gh", "api", "user", "--silent")
 	if err := cmd.Run(); err != nil {
 		if _, ok := err.(*exec.ExitError); !ok {
-			return fmt.Errorf("gh CLI not found. Install from: https://cli.github.com")
+			return fmt.Errorf("%w: gh CLI not found. Install from: https://cli.github.com", ErrDependencyMissing)
 		}
-		return fmt.Errorf("gh CLI not authenticated. Run: gh auth login --hostname github.com")
+		return fmt.Errorf("%w: gh CLI not authenticated. Run: gh auth login --hostname github.com", ErrAuthRequired)
 	}
 
 	return nil
@@ -94,12 +106,15 @@ func (c *Client) Create(description string, public bool, files map[string]string
 		return nil, fmt.Errorf("create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
+	if err := os.Chmod(tmpDir, 0o700); err != nil {
+		return nil, fmt.Errorf("secure temp dir: %w", err)
+	}
 
 	// Write files to temp directory
 	var filePaths []string
 	for name, content := range files {
 		path := filepath.Join(tmpDir, name)
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			return nil, fmt.Errorf("write temp file %s: %w", name, err)
 		}
 		filePaths = append(filePaths, path)
@@ -116,12 +131,14 @@ func (c *Client) Create(description string, public bool, files map[string]string
 	args = append(args, filePaths...)
 
 	cmd := c.execCommand("gh", args...)
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
+	stderr := procutil.NewLimitedBuffer(64 << 10)
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stderr = stderr
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh gist create failed: %w\n%s", err, stderr.String())
+		logGistDiagnostic("create", stderr.String())
+		return nil, fmt.Errorf("%w: gh gist create failed", ErrProvider)
 	}
 
 	// Parse output URL
@@ -152,20 +169,24 @@ func (c *Client) Update(gistID string, files map[string]string) error {
 		return fmt.Errorf("create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
+	if err := os.Chmod(tmpDir, 0o700); err != nil {
+		return fmt.Errorf("secure temp dir: %w", err)
+	}
 
 	// Update each file using gh gist edit --add
 	for name, content := range files {
 		path := filepath.Join(tmpDir, name)
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			return fmt.Errorf("write temp file %s: %w", name, err)
 		}
 
 		cmd := c.execCommand("gh", "gist", "edit", gistID, "--add", path)
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
+		stderr := procutil.NewLimitedBuffer(64 << 10)
+		cmd.Stderr = stderr
 
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("gh gist edit failed for %s: %w\n%s", name, err, stderr.String())
+			logGistDiagnostic("update", stderr.String())
+			return fmt.Errorf("%w: gh gist edit failed for %s", ErrProvider, name)
 		}
 	}
 
@@ -187,12 +208,14 @@ type gistAPIResponse struct {
 // Get fetches a gist by ID.
 func (c *Client) Get(gistID string) (*Gist, error) {
 	cmd := c.execCommand("gh", "api", fmt.Sprintf("/gists/%s", gistID))
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
+	stderr := procutil.NewLimitedBuffer(64 << 10)
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stderr = stderr
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api failed: %w\n%s", err, stderr.String())
+		logGistDiagnostic("get", stderr.String())
+		return nil, fmt.Errorf("%w: gh api failed", ErrProvider)
 	}
 
 	var resp gistAPIResponse
@@ -214,7 +237,26 @@ func (c *Client) Get(gistID string) (*Gist, error) {
 	}, nil
 }
 
+func logGistDiagnostic(operation, diagnostic string) {
+	if diagnostic == "" {
+		return
+	}
+	const maxBytes = 4096
+	if len(diagnostic) > maxBytes {
+		diagnostic = diagnostic[:maxBytes] + "…(truncated)"
+	}
+	log.Printf("[gist] gh %s diagnostic: %q", operation, diagnostic)
+}
+
 // GetURL returns the web URL for a gist ID.
 func GetURL(gistID string) string {
 	return fmt.Sprintf("https://gist.github.com/%s", gistID)
+}
+
+// PreviewURL returns the first-party rich transcript URL for a valid Gist ID.
+func PreviewURL(gistID string) string {
+	if matched, _ := regexp.MatchString(`^[a-f0-9]+$`, gistID); !matched {
+		return ""
+	}
+	return "https://gisthost.github.io/?" + gistID + "/index.html"
 }

--- a/internal/agents/gist/client.go
+++ b/internal/agents/gist/client.go
@@ -42,19 +42,17 @@ func NewClient() (*Client, error) {
 	return c, nil
 }
 
-// checkGH verifies gh CLI is installed and authenticated.
+// checkGH verifies gh CLI is installed and the active account can access GitHub.
 func (c *Client) checkGH() error {
-	cmd := c.execCommand("gh", "auth", "status")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
+	// Checking the API mirrors the account selection used by "gh gist". In
+	// contrast, "gh auth status" fails when any configured account is invalid,
+	// including inactive accounts that will not be used for the Gist operation.
+	cmd := c.execCommand("gh", "api", "user", "--silent")
 	if err := cmd.Run(); err != nil {
-		// Check if gh is not installed
 		if _, ok := err.(*exec.ExitError); !ok {
 			return fmt.Errorf("gh CLI not found. Install from: https://cli.github.com")
 		}
-		// gh is installed but not authenticated
-		return fmt.Errorf("gh CLI not authenticated. Run: gh auth login\n%s", stderr.String())
+		return fmt.Errorf("gh CLI not authenticated. Run: gh auth login --hostname github.com")
 	}
 
 	return nil

--- a/internal/agents/gist/client_test.go
+++ b/internal/agents/gist/client_test.go
@@ -1,6 +1,7 @@
 package gist
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -82,6 +83,34 @@ func TestGistCommandHelper(t *testing.T) {
 	}
 	fmt.Fprint(os.Stderr, os.Getenv("TERM_LLM_GIST_HELPER_STDERR"))
 	os.Exit(exitCode)
+}
+
+func TestGistWriteFailuresDoNotExposeStderr(t *testing.T) {
+	const diagnostic = "SECRET ghp_example remote diagnostic"
+	client := &Client{execCommand: func(string, ...string) *exec.Cmd {
+		return gistTestCommand(t, 1, diagnostic)
+	}}
+	for name, run := range map[string]func() error{
+		"create": func() error {
+			_, err := client.Create("description", false, map[string]string{"index.html": "hello"})
+			return err
+		},
+		"update": func() error {
+			return client.Update("abc123", map[string]string{"index.html": "hello"})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := run()
+			if err == nil {
+				t.Fatal("write succeeded unexpectedly")
+			}
+			for current := err; current != nil; current = errors.Unwrap(current) {
+				if strings.Contains(current.Error(), diagnostic) || strings.Contains(current.Error(), "ghp_example") {
+					t.Fatalf("error chain exposed stderr: %v", current)
+				}
+			}
+		})
+	}
 }
 
 func TestParseGistRef(t *testing.T) {

--- a/internal/agents/gist/client_test.go
+++ b/internal/agents/gist/client_test.go
@@ -1,8 +1,88 @@
 package gist
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 )
+
+func TestCheckGHUsesActiveAccountAPI(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	client := &Client{execCommand: func(name string, args ...string) *exec.Cmd {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return gistTestCommand(t, 0, "")
+	}}
+
+	if err := client.checkGH(); err != nil {
+		t.Fatal(err)
+	}
+	if gotName != "gh" {
+		t.Fatalf("command = %q, want gh", gotName)
+	}
+	if want := []string{"api", "user", "--silent"}; !reflect.DeepEqual(gotArgs, want) {
+		t.Fatalf("arguments = %q, want %q", gotArgs, want)
+	}
+}
+
+func TestCheckGHAuthenticationFailureIsConcise(t *testing.T) {
+	const diagnostic = "token ghp_example and unrelated inactive account details"
+	client := &Client{execCommand: func(string, ...string) *exec.Cmd {
+		return gistTestCommand(t, 1, diagnostic)
+	}}
+
+	err := client.checkGH()
+	if err == nil {
+		t.Fatal("checkGH succeeded, want authentication error")
+	}
+	if !strings.Contains(err.Error(), "gh auth login --hostname github.com") {
+		t.Fatalf("error lacks login guidance: %v", err)
+	}
+	if strings.Contains(err.Error(), diagnostic) || strings.Contains(err.Error(), "ghp_example") {
+		t.Fatalf("error exposed gh diagnostic: %v", err)
+	}
+}
+
+func TestCheckGHReportsMissingCLI(t *testing.T) {
+	client := &Client{execCommand: func(string, ...string) *exec.Cmd {
+		return exec.Command(filepath.Join(t.TempDir(), "missing-gh"))
+	}}
+
+	err := client.checkGH()
+	if err == nil || !strings.Contains(err.Error(), "gh CLI not found") {
+		t.Fatalf("error = %v, want missing CLI guidance", err)
+	}
+}
+
+func gistTestCommand(t *testing.T, exitCode int, stderr string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestGistCommandHelper$")
+	cmd.Env = append(os.Environ(),
+		"TERM_LLM_GIST_HELPER=1",
+		fmt.Sprintf("TERM_LLM_GIST_HELPER_EXIT=%d", exitCode),
+		"TERM_LLM_GIST_HELPER_STDERR="+stderr,
+	)
+	return cmd
+}
+
+func TestGistCommandHelper(t *testing.T) {
+	if os.Getenv("TERM_LLM_GIST_HELPER") != "1" {
+		return
+	}
+	exitCode, err := strconv.Atoi(os.Getenv("TERM_LLM_GIST_HELPER_EXIT"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	fmt.Fprint(os.Stderr, os.Getenv("TERM_LLM_GIST_HELPER_STDERR"))
+	os.Exit(exitCode)
+}
 
 func TestParseGistRef(t *testing.T) {
 	tests := []struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -473,6 +473,7 @@ type Config struct {
 	Ask             AskConfig                 `mapstructure:"ask"`
 	Chat            ChatConfig                `mapstructure:"chat"`
 	Lifecycle       LifecycleConfig           `mapstructure:"lifecycle"`
+	Share           ShareConfig               `mapstructure:"share" yaml:"share,omitempty"`
 	Edit            EditConfig                `mapstructure:"edit"`
 	Loop            LoopConfig                `mapstructure:"loop"`
 	Image           ImageConfig               `mapstructure:"image"`
@@ -759,6 +760,57 @@ type ChatConfig struct {
 	TerminalTitleFormat string `mapstructure:"terminal_title_format"`                        // Optional custom terminal title template
 	TerminalProgress    bool   `mapstructure:"terminal_progress"`                            // Deprecated compatibility opt-in for automatic OSC progress
 	ApprovalMode        string `mapstructure:"approval_mode" yaml:"approval_mode,omitempty"` // Optional approval mode: prompt or auto
+}
+
+// ShareConfig selects the provider used by generic transcript sharing.
+type ShareConfig struct {
+	Provider string   `mapstructure:"provider" yaml:"provider,omitempty"`
+	Command  []string `mapstructure:"command" yaml:"command,omitempty"`
+	Timeout  string   `mapstructure:"timeout" yaml:"timeout,omitempty"`
+}
+
+// ValidateShare rejects ignored, shell-like, or unbounded helper configuration
+// before any sharing subprocess can be started.
+func (c *Config) ValidateShare() error {
+	if c == nil {
+		return nil
+	}
+	provider := strings.ToLower(strings.TrimSpace(c.Share.Provider))
+	if provider == "" {
+		provider = DefaultShareProvider
+	}
+	switch provider {
+	case "github":
+		if len(c.Share.Command) != 0 {
+			return fmt.Errorf("invalid share.command: command is only valid when share.provider is command")
+		}
+	case "command":
+		if len(c.Share.Command) == 0 || strings.TrimSpace(c.Share.Command[0]) == "" {
+			return fmt.Errorf("invalid share.command: executable cannot be empty when share.provider is command")
+		}
+	default:
+		return fmt.Errorf("invalid share.provider %q: expected github or command", c.Share.Provider)
+	}
+	if len(c.Share.Command) > 64 {
+		return fmt.Errorf("invalid share.command: at most 64 argv entries are allowed")
+	}
+	for i, arg := range c.Share.Command {
+		if strings.IndexByte(arg, 0) >= 0 {
+			return fmt.Errorf("invalid share.command[%d]: contains NUL", i)
+		}
+		if len(arg) > 4096 {
+			return fmt.Errorf("invalid share.command[%d]: must be at most 4096 bytes", i)
+		}
+	}
+	timeoutValue := strings.TrimSpace(c.Share.Timeout)
+	if timeoutValue == "" {
+		timeoutValue = DefaultShareTimeout
+	}
+	timeout, err := time.ParseDuration(timeoutValue)
+	if err != nil || timeout <= 0 || timeout > 600*time.Second {
+		return fmt.Errorf("invalid share.timeout %q: expected a duration greater than zero and at most 600s", c.Share.Timeout)
+	}
+	return nil
 }
 
 // LifecycleConfig controls terminal-host lifecycle publication.
@@ -1177,6 +1229,9 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	if err := cfg.ValidateLifecycle(); err != nil {
+		return nil, err
+	}
+	if err := cfg.ValidateShare(); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -57,6 +57,8 @@ const (
 	DefaultChatTerminalTitle     = "smart"
 	DefaultLifecycleOSC          = "off"
 	DefaultLifecycleSinkTimeout  = "2s"
+	DefaultShareProvider         = "github"
+	DefaultShareTimeout          = "120s"
 	DefaultEditContextLines      = 3
 	DefaultEditDiffFormat        = "auto"
 
@@ -192,6 +194,10 @@ var keySpecs = []KeySpec{
 	def("lifecycle.adapters", []string{"auto"}),
 	def("lifecycle.osc", DefaultLifecycleOSC),
 	def("lifecycle.commands", []map[string]any{}),
+
+	def("share.provider", DefaultShareProvider),
+	def("share.command", []string{}),
+	def("share.timeout", DefaultShareTimeout),
 
 	optional("edit.provider"),
 	optional("edit.model"),

--- a/internal/config/share_test.go
+++ b/internal/config/share_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestShareConfigDefaultsAndLoad(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Share.Provider != DefaultShareProvider || cfg.Share.Timeout != DefaultShareTimeout || len(cfg.Share.Command) != 0 {
+		t.Fatalf("default share config=%+v", cfg.Share)
+	}
+
+	configDir, err := GetConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte("share:\n  provider: command\n  command: [/opt/share-helper, --tenant, demo]\n  timeout: 45s\n")
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	viper.Reset()
+	cfg, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Share.Provider != "command" || cfg.Share.Timeout != "45s" || strings.Join(cfg.Share.Command, "|") != "/opt/share-helper|--tenant|demo" {
+		t.Fatalf("loaded share config=%+v", cfg.Share)
+	}
+}
+
+func TestValidateShare(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cfg  ShareConfig
+		want string
+	}{
+		{name: "github", cfg: ShareConfig{Provider: "github", Timeout: "120s"}},
+		{name: "command", cfg: ShareConfig{Provider: "command", Command: []string{"helper", "--prefix"}, Timeout: "10s"}},
+		{name: "unknown provider", cfg: ShareConfig{Provider: "other"}, want: "expected github or command"},
+		{name: "command missing argv", cfg: ShareConfig{Provider: "command"}, want: "executable cannot be empty"},
+		{name: "github ignored command", cfg: ShareConfig{Provider: "github", Command: []string{"helper"}}, want: "only valid"},
+		{name: "nul argument", cfg: ShareConfig{Provider: "command", Command: []string{"helper", "bad\x00arg"}}, want: "contains NUL"},
+		{name: "invalid timeout", cfg: ShareConfig{Provider: "github", Timeout: "forever"}, want: "greater than zero"},
+		{name: "long timeout", cfg: ShareConfig{Provider: "github", Timeout: "601s"}, want: "at most 600s"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := (&Config{Share: test.cfg}).ValidateShare()
+			if test.want == "" && err != nil {
+				t.Fatalf("ValidateShare error=%v", err)
+			}
+			if test.want != "" && (err == nil || !strings.Contains(err.Error(), test.want)) {
+				t.Fatalf("ValidateShare error=%v, want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/session/export_gist.go
+++ b/internal/session/export_gist.go
@@ -2,13 +2,12 @@ package session
 
 import (
 	"fmt"
-	"regexp"
+
+	"github.com/samsaffron/term-llm/internal/agents/gist"
 )
 
-var gistIDPattern = regexp.MustCompile(`^[a-f0-9]+$`)
-
-// GistFiles builds the canonical HTML and Markdown transcript files.
-func GistFiles(sess *Session, messages []Message, opts ExportOptions) (map[string]string, error) {
+// ShareFiles builds the canonical HTML and Markdown transcript bundle.
+func ShareFiles(sess *Session, messages []Message, opts ExportOptions) (map[string]string, error) {
 	markdown := ExportToMarkdown(sess, messages, opts)
 	html, err := ExportToHTML(sess, messages, opts)
 	if err != nil {
@@ -17,10 +16,12 @@ func GistFiles(sess *Session, messages []Message, opts ExportOptions) (map[strin
 	return map[string]string{"index.html": html, "session.md": markdown}, nil
 }
 
+// GistFiles is retained for the explicit GitHub-only export commands.
+func GistFiles(sess *Session, messages []Message, opts ExportOptions) (map[string]string, error) {
+	return ShareFiles(sess, messages, opts)
+}
+
 // GistPreviewURL returns the gisthost preview URL for a valid gist ID.
 func GistPreviewURL(id string) string {
-	if !gistIDPattern.MatchString(id) {
-		return ""
-	}
-	return "https://gisthost.github.io/?" + id + "/index.html"
+	return gist.PreviewURL(id)
 }

--- a/internal/session/share.go
+++ b/internal/session/share.go
@@ -1,27 +1,87 @@
 package session
 
-import "time"
+import (
+	"time"
 
-// ShareState records the current external share for a session.
+	"github.com/samsaffron/term-llm/internal/agents/gist"
+)
+
+// ShareState records the current external share for a session. The generic
+// fields are authoritative; legacy Gist fields remain for one compatibility
+// path and are normalized/dual-written without a database migration.
 type ShareState struct {
-	GistID     string    `json:"gist_id,omitempty"`
-	GistURL    string    `json:"gist_url,omitempty"`
-	PreviewURL string    `json:"preview_url,omitempty"`
-	Public     bool      `json:"public,omitempty"`
-	SharedAt   time.Time `json:"shared_at,omitempty"`
-	UpdatedAt  time.Time `json:"updated_at,omitempty"`
+	Provider   string     `json:"provider,omitempty"`
+	ID         string     `json:"id,omitempty"`
+	URL        string     `json:"url,omitempty"`
+	SourceURL  string     `json:"source_url,omitempty"`
+	Visibility string     `json:"visibility,omitempty"`
+	Scope      ShareScope `json:"scope,omitempty"`
+
+	GistID     string `json:"gist_id,omitempty"`
+	GistURL    string `json:"gist_url,omitempty"`
+	PreviewURL string `json:"preview_url,omitempty"`
+	Public     bool   `json:"public,omitempty"`
+
+	SharedAt  time.Time `json:"shared_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
-// Clone returns a copy that callers may mutate safely.
+// Normalize upgrades legacy Gist state in memory and dual-writes compatibility
+// fields for GitHub shares. It intentionally performs no database rewrite.
+func (s *ShareState) Normalize() {
+	if s == nil {
+		return
+	}
+	if s.ID == "" && s.GistID != "" {
+		s.Provider = gist.ProviderID
+		s.ID = s.GistID
+		s.URL = s.PreviewURL
+		if s.URL == "" {
+			s.URL = gist.PreviewURL(s.GistID)
+		}
+		s.SourceURL = s.GistURL
+		if s.Public {
+			s.Visibility = "public"
+		} else {
+			s.Visibility = "unlisted"
+		}
+		s.Scope = ShareScopeSession
+	}
+	if s.Provider == gist.ProviderID && s.ID != "" {
+		if s.Visibility == "" {
+			if s.Public {
+				s.Visibility = "public"
+			} else {
+				s.Visibility = "unlisted"
+			}
+		}
+		s.GistID = s.ID
+		if s.URL == "" {
+			s.URL = gist.PreviewURL(s.ID)
+		}
+		s.PreviewURL = s.URL
+		if s.SourceURL == "" {
+			s.SourceURL = gist.GetURL(s.ID)
+		}
+		s.GistURL = s.SourceURL
+		s.Public = s.Visibility == "public"
+	}
+	if s.Scope == "" && s.ID != "" {
+		s.Scope = ShareScopeSession
+	}
+}
+
+// Clone returns a normalized copy that callers may mutate safely.
 func (s *ShareState) Clone() *ShareState {
 	if s == nil {
 		return nil
 	}
 	clone := *s
+	clone.Normalize()
 	return &clone
 }
 
-// Exists reports whether this state identifies a share.
+// Exists reports whether this state identifies a generic or legacy share.
 func (s *ShareState) Exists() bool {
-	return s != nil && s.GistID != ""
+	return s != nil && (s.ID != "" || s.GistID != "")
 }

--- a/internal/session/share_export.go
+++ b/internal/session/share_export.go
@@ -8,10 +8,11 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 )
 
-// ShareScope identifies the point-in-time transcript content exported to a Gist.
+// ShareScope identifies the transcript content included in a share.
 type ShareScope string
 
 const (
+	ShareScopeSession      ShareScope = "session"
 	ShareScopeResponse     ShareScope = "response"
 	ShareScopeConversation ShareScope = "conversation"
 )

--- a/internal/session/share_persistence_test.go
+++ b/internal/session/share_persistence_test.go
@@ -3,7 +3,9 @@ package session
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,8 +28,8 @@ func TestSessionSharePersistenceRoundTrip(t *testing.T) {
 		t.Fatalf("Get share = %+v, err = %v", got, err)
 	}
 	updated := got.Share.Clone()
-	updated.PreviewURL = "https://example.test/preview"
-	updated.Public = true
+	updated.URL = "https://example.test/preview"
+	updated.Visibility = "public"
 	if err := UpdateShare(context.Background(), store, sess.ID, updated); err != nil {
 		t.Fatal(err)
 	}
@@ -41,6 +43,53 @@ func TestSessionSharePersistenceRoundTrip(t *testing.T) {
 	got, err = store.Get(context.Background(), sess.ID)
 	if err != nil || got.Share != nil {
 		t.Fatalf("cleared share = %+v, err = %v", got.Share, err)
+	}
+}
+
+func TestShareStateLegacyNormalizationAndGitHubDualWrite(t *testing.T) {
+	legacy := parseShareJSONString(sql.NullString{Valid: true, String: `{"gist_id":"abc123","gist_url":"https://gist.github.com/u/abc123","preview_url":"https://preview.example/abc123","public":true}`})
+	if legacy == nil || legacy.Provider != "github" || legacy.ID != "abc123" || legacy.URL != "https://preview.example/abc123" || legacy.SourceURL != "https://gist.github.com/u/abc123" || legacy.Visibility != "public" || legacy.Scope != ShareScopeSession {
+		t.Fatalf("normalized legacy state=%+v", legacy)
+	}
+	if !legacy.Exists() {
+		t.Fatal("normalized legacy state does not exist")
+	}
+	withoutPreview := parseShareJSONString(sql.NullString{Valid: true, String: `{"gist_id":"def456","gist_url":"https://gist.github.com/u/def456"}`})
+	if withoutPreview == nil || withoutPreview.URL != GistPreviewURL("def456") || withoutPreview.PreviewURL != GistPreviewURL("def456") || withoutPreview.SourceURL != "https://gist.github.com/u/def456" || withoutPreview.Visibility != "unlisted" {
+		t.Fatalf("legacy state without preview=%+v", withoutPreview)
+	}
+	genericEmptyVisibility := (&ShareState{Provider: "github", ID: "feed123", Public: true}).Clone()
+	if genericEmptyVisibility == nil || genericEmptyVisibility.Visibility != "public" || genericEmptyVisibility.URL != GistPreviewURL("feed123") {
+		t.Fatalf("GitHub state with empty legacy visibility=%+v", genericEmptyVisibility)
+	}
+
+	generic := &ShareState{
+		Provider: "github", ID: "def456", URL: "https://preview.example/def456",
+		SourceURL: "https://gist.github.com/u/def456", Visibility: "unlisted", Scope: ShareScopeSession,
+	}
+	raw := shareJSONString(generic)
+	if !raw.Valid {
+		t.Fatal("generic GitHub state was not serialized")
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(raw.String), &fields); err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{
+		"provider": "github", "id": "def456", "url": "https://preview.example/def456",
+		"source_url": "https://gist.github.com/u/def456", "visibility": "unlisted", "scope": "session",
+		"gist_id": "def456", "gist_url": "https://gist.github.com/u/def456", "preview_url": "https://preview.example/def456",
+	} {
+		if fields[key] != want {
+			t.Fatalf("serialized %s=%v, want %q: %s", key, fields[key], want, raw.String)
+		}
+	}
+}
+
+func TestShareStateCommandProviderDoesNotWriteLegacyGistFields(t *testing.T) {
+	raw := shareJSONString(&ShareState{Provider: "acme", ID: "opaque", URL: "https://share.example/opaque", Visibility: "private", Scope: ShareScopeSession})
+	if !raw.Valid || strings.Contains(raw.String, "gist_id") || strings.Contains(raw.String, "preview_url") || strings.Contains(raw.String, `"public"`) {
+		t.Fatalf("custom provider serialization=%q", raw.String)
 	}
 }
 

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -5917,6 +5917,7 @@ func parseShareJSONString(raw sql.NullString) *ShareState {
 	if err := json.Unmarshal([]byte(raw.String), &share); err != nil || !share.Exists() {
 		return nil
 	}
+	share.Normalize()
 	return &share
 }
 

--- a/internal/share/command.go
+++ b/internal/share/command.go
@@ -1,0 +1,273 @@
+package share
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/procutil"
+)
+
+const (
+	DefaultCommandTimeout = 120 * time.Second
+	MaxCommandTimeout     = 600 * time.Second
+	capabilitiesTimeout   = 10 * time.Second
+	commandStdoutLimit    = int64(1 << 20)
+	commandStderrLimit    = int64(64 << 10)
+	commandWaitDelay      = time.Second
+)
+
+type CommandPublisher struct {
+	argv    []string
+	timeout time.Duration
+
+	capabilitiesMu sync.Mutex
+	capabilities   *Capabilities
+	runMu          sync.Mutex
+}
+
+func NewCommandPublisher(argv []string, timeout time.Duration) (*CommandPublisher, error) {
+	if len(argv) == 0 || strings.TrimSpace(argv[0]) == "" {
+		return nil, fmt.Errorf("share helper executable cannot be empty")
+	}
+	if len(argv) > 64 {
+		return nil, fmt.Errorf("share helper command accepts at most 64 argv entries")
+	}
+	for i, arg := range argv {
+		if strings.IndexByte(arg, 0) >= 0 {
+			return nil, fmt.Errorf("share helper argv[%d] contains NUL", i)
+		}
+		if len(arg) > 4096 {
+			return nil, fmt.Errorf("share helper argv[%d] must be at most 4096 bytes", i)
+		}
+	}
+	if timeout == 0 {
+		timeout = DefaultCommandTimeout
+	}
+	if timeout < 0 || timeout > MaxCommandTimeout {
+		return nil, fmt.Errorf("share helper timeout must be greater than zero and at most %s", MaxCommandTimeout)
+	}
+	resolved, err := exec.LookPath(argv[0])
+	if err != nil && !(errors.Is(err, exec.ErrDot) && resolved != "") {
+		return nil, errorWithDiagnostic(ErrorDependencyMissing, "share helper executable was not found", err.Error(), err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return nil, errorWithDiagnostic(ErrorProvider, "could not resolve share helper executable", err.Error(), err)
+	}
+	command := append([]string(nil), argv...)
+	command[0] = resolved
+	return &CommandPublisher{argv: command, timeout: timeout}, nil
+}
+
+type helperEnvelope struct {
+	Protocol  string `json:"protocol"`
+	Version   int    `json:"version"`
+	RequestID string `json:"request_id"`
+}
+
+type helperRequest struct {
+	helperEnvelope
+	ID          string     `json:"id,omitempty"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Visibility  Visibility `json:"visibility"`
+	Entrypoint  string     `json:"entrypoint"`
+	Files       []File     `json:"files"`
+}
+
+type helperResponse struct {
+	Protocol   string     `json:"protocol"`
+	Version    int        `json:"version"`
+	ID         string     `json:"id"`
+	URL        string     `json:"url"`
+	SourceURL  string     `json:"source_url,omitempty"`
+	Visibility Visibility `json:"visibility"`
+	Error      *Error     `json:"error,omitempty"`
+}
+
+func (p *CommandPublisher) Capabilities(ctx context.Context) (Capabilities, error) {
+	p.capabilitiesMu.Lock()
+	defer p.capabilitiesMu.Unlock()
+	if p.capabilities != nil {
+		return *p.capabilities, nil
+	}
+
+	payload := helperEnvelope{Protocol: Protocol, Version: Version, RequestID: NewRequestID()}
+	var capabilities Capabilities
+	if err := p.run(ctx, OperationCapabilities, capabilitiesTimeout, "", payload, &capabilities); err != nil {
+		return Capabilities{}, err
+	}
+	if err := ValidateHelperCapabilities(capabilities); err != nil {
+		return Capabilities{}, errorWithDiagnostic(ErrorProtocol, "share helper returned invalid capabilities", err.Error(), err)
+	}
+	copy := capabilities
+	p.capabilities = &copy
+	return capabilities, nil
+}
+
+func (p *CommandPublisher) Create(ctx context.Context, req Request) (Result, error) {
+	return p.publish(ctx, OperationCreate, "", req)
+}
+
+func (p *CommandPublisher) Update(ctx context.Context, id string, req Request) (Result, error) {
+	if !validID(id) {
+		return Result{}, NewError(ErrorProtocol, "stored share ID is invalid")
+	}
+	return p.publish(ctx, OperationUpdate, id, req)
+}
+
+func (p *CommandPublisher) publish(ctx context.Context, operation Operation, id string, req Request) (Result, error) {
+	if err := ValidateRequest(req); err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProtocol, "share request is invalid", err.Error(), err)
+	}
+	capabilities, err := p.Capabilities(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	if !capabilities.Supports(operation) {
+		return Result{}, NewError(ErrorProvider, fmt.Sprintf("sharing provider does not support %s", operation))
+	}
+	if !capabilities.SupportsVisibility(req.Visibility) {
+		return Result{}, NewError(ErrorUnsupportedVisibility, fmt.Sprintf("sharing provider does not support %s visibility", req.Visibility))
+	}
+
+	dir, err := os.MkdirTemp("", "term-llm-share-")
+	if err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProvider, "could not prepare share bundle", err.Error(), err)
+	}
+	defer os.RemoveAll(dir)
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProvider, "could not prepare share bundle", err.Error(), err)
+	}
+	for _, file := range req.Files {
+		path := filepath.Join(dir, file.Name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return Result{}, errorWithDiagnostic(ErrorProvider, "could not prepare share bundle", err.Error(), err)
+		}
+		if err := os.WriteFile(path, file.Content, 0o600); err != nil {
+			return Result{}, errorWithDiagnostic(ErrorProvider, "could not prepare share bundle", err.Error(), err)
+		}
+	}
+
+	payload := helperRequest{
+		helperEnvelope: helperEnvelope{Protocol: Protocol, Version: Version, RequestID: req.RequestID},
+		ID:             id,
+		Title:          req.Title,
+		Description:    req.Description,
+		Visibility:     req.Visibility,
+		Entrypoint:     req.Entrypoint,
+		Files:          req.Files,
+	}
+	var response helperResponse
+	if err := p.run(ctx, operation, p.timeout, dir, payload, &response); err != nil {
+		return Result{}, err
+	}
+	if response.Protocol != Protocol || response.Version != Version {
+		return Result{}, NewError(ErrorProtocol, "share helper returned an incompatible protocol response")
+	}
+	result := Result{
+		Provider: capabilities.Provider.ID, ID: response.ID, URL: response.URL,
+		SourceURL: response.SourceURL, Visibility: response.Visibility, Ready: true,
+	}
+	if err := ValidateResult(result); err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProtocol, "share helper returned an invalid result", err.Error(), err)
+	}
+	if !capabilities.SupportsVisibility(result.Visibility) {
+		return Result{}, NewError(ErrorProtocol, "share helper returned a visibility it did not advertise")
+	}
+	return result, nil
+}
+
+func (p *CommandPublisher) run(ctx context.Context, operation Operation, timeout time.Duration, dir string, input, output any) error {
+	p.runMu.Lock()
+	defer p.runMu.Unlock()
+
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return errorWithDiagnostic(ErrorProtocol, "could not encode share helper request", err.Error(), err)
+	}
+	payload = append(payload, '\n')
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := append(append([]string(nil), p.argv[1:]...), string(operation))
+	cmd := exec.CommandContext(timeoutCtx, p.argv[0], args...)
+	cmd.Dir = dir
+	cmd.Stdin = bytes.NewReader(payload)
+	cmd.WaitDelay = commandWaitDelay
+	stdout := procutil.NewLimitedBuffer(commandStdoutLimit)
+	stderr := procutil.NewLimitedBuffer(commandStderrLimit)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cleanup, err := procutil.PrepareCommand(cmd)
+	if err != nil {
+		return errorWithDiagnostic(ErrorProvider, "could not start share helper", err.Error(), err)
+	}
+	defer cleanup()
+	defer func() {
+		// A successful helper may have left descendants holding inherited pipes.
+		// Run's WaitDelay closes those pipes, and this group cancellation prevents
+		// the detached descendants from surviving the completed invocation.
+		if cmd.Cancel != nil {
+			_ = cmd.Cancel()
+		}
+	}()
+
+	runErr := cmd.Run()
+	if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+		return errorWithDiagnostic(ErrorTimeout, "share helper timed out", stderr.String(), context.DeadlineExceeded)
+	}
+	if errors.Is(timeoutCtx.Err(), context.Canceled) {
+		return errorWithDiagnostic(ErrorProvider, "sharing was canceled", stderr.String(), context.Canceled)
+	}
+	if stdout.Truncated() {
+		return errorWithDiagnostic(ErrorProtocol, "share helper stdout exceeded 1 MiB", stderr.String(), runErr)
+	}
+	// A helper may successfully exit after writing its complete response while a
+	// background descendant still retains inherited pipe descriptors. os/exec
+	// reports ErrWaitDelay after closing those pipes; the helper's zero exit code
+	// remains authoritative, so parse the bounded stdout response normally.
+	if errors.Is(runErr, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 0 {
+		runErr = nil
+	}
+	if runErr != nil {
+		var response helperResponse
+		if json.Unmarshal([]byte(stdout.String()), &response) == nil && response.Error != nil {
+			code := response.Error.Code
+			if !slicesContainsErrorCode(code) {
+				code = ErrorProvider
+			}
+			message := strings.TrimSpace(response.Error.Message)
+			if validateStructuredErrorMessage(message) != nil {
+				message = "share helper failed"
+			}
+			return errorWithDiagnostic(code, message, stderr.String(), runErr)
+		}
+		if errors.Is(runErr, exec.ErrNotFound) || errors.Is(runErr, os.ErrNotExist) {
+			return errorWithDiagnostic(ErrorDependencyMissing, "share helper executable was not found", stderr.String(), runErr)
+		}
+		return errorWithDiagnostic(ErrorProvider, "share helper failed", stderr.String(), runErr)
+	}
+	if err := json.Unmarshal([]byte(stdout.String()), output); err != nil {
+		return errorWithDiagnostic(ErrorProtocol, "share helper returned malformed JSON", stderr.String(), err)
+	}
+	return nil
+}
+
+func slicesContainsErrorCode(code ErrorCode) bool {
+	for _, stable := range stableErrorCodes {
+		if code == stable {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/share/command_test.go
+++ b/internal/share/command_test.go
@@ -1,0 +1,511 @@
+package share
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func commandTestPublisher(t *testing.T, mode string, timeout time.Duration) *CommandPublisher {
+	t.Helper()
+	publisher, err := NewCommandPublisher([]string{os.Args[0], "-test.run=^TestCommandHelperProcess$", "--", "prefix argument"}, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TERM_LLM_SHARE_HELPER", "1")
+	t.Setenv("TERM_LLM_SHARE_HELPER_MODE", mode)
+	return publisher
+}
+
+func commandTestRequest() Request {
+	return Request{
+		RequestID: "request-1", Title: "A title", Description: "A description",
+		Visibility: VisibilityPrivate, Entrypoint: "index.html",
+		Files: []File{
+			{Name: "index.html", MediaType: "text/html; charset=utf-8", Role: "entrypoint", Content: []byte("<h1>hello</h1>")},
+			{Name: "session.md", MediaType: "text/markdown; charset=utf-8", Role: "transcript", Content: []byte("# hello")},
+		},
+	}
+}
+
+func TestCommandPublisherCapabilitiesValidation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		mode string
+		code ErrorCode
+	}{
+		{name: "valid", mode: "valid"},
+		{name: "bad protocol", mode: "bad-protocol", code: ErrorProtocol},
+		{name: "missing create", mode: "missing-create", code: ErrorProtocol},
+		{name: "missing visibility", mode: "missing-visibility", code: ErrorProtocol},
+		{name: "reserved github id", mode: "github-id", code: ErrorProtocol},
+		{name: "oversized provider name", mode: "long-provider-name", code: ErrorProtocol},
+		{name: "control in provider help", mode: "control-provider-help", code: ErrorProtocol},
+		{name: "too many notes", mode: "too-many-notes", code: ErrorProtocol},
+		{name: "oversized limits", mode: "oversized-limits", code: ErrorProtocol},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			publisher := commandTestPublisher(t, test.mode, time.Second)
+			capabilities, err := publisher.Capabilities(context.Background())
+			if test.code == "" {
+				if err != nil || capabilities.Provider.ID != "test-helper" || !capabilities.Supports(OperationUpdate) {
+					t.Fatalf("capabilities=%+v error=%v", capabilities, err)
+				}
+				return
+			}
+			if err == nil || AsError(err).Code != test.code {
+				t.Fatalf("error=%v code=%q, want %q", err, AsError(err).Code, test.code)
+			}
+		})
+	}
+}
+
+func TestCommandPublisherReportsMissingExecutable(t *testing.T) {
+	_, err := NewCommandPublisher([]string{filepath.Join(t.TempDir(), "missing-helper")}, time.Second)
+	if err == nil || AsError(err).Code != ErrorDependencyMissing || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestCommandPublisherStructuredFailureRoutesBoundedDiagnosticWithoutErrorExposure(t *testing.T) {
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	publisher := commandTestPublisher(t, "structured-error", time.Second)
+	_, err := publisher.Create(context.Background(), commandTestRequest())
+	if err == nil || AsError(err).Code != ErrorAuthRequired || !strings.Contains(err.Error(), "sign in") {
+		t.Fatalf("error=%v", err)
+	}
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if strings.Contains(current.Error(), "SECRET-STDERR") {
+			t.Fatalf("stderr leaked through error chain: %v", current)
+		}
+	}
+	if !strings.Contains(logs.String(), "SECRET-STDERR") || logs.Len() > maxDiagnosticLogBytes+512 || !strings.Contains(logs.String(), "truncated") {
+		t.Fatalf("diagnostic log was not routed with a bound: bytes=%d log=%q", logs.Len(), logs.String())
+	}
+}
+
+func TestCommandPublisherRejectsMalformedAndOversizedStdout(t *testing.T) {
+	for _, test := range []struct {
+		mode string
+		want string
+	}{
+		{mode: "malformed", want: "malformed JSON"},
+		{mode: "oversized", want: "exceeded 1 MiB"},
+	} {
+		t.Run(test.mode, func(t *testing.T) {
+			publisher := commandTestPublisher(t, test.mode, time.Second)
+			_, err := publisher.Capabilities(context.Background())
+			if err == nil || AsError(err).Code != ErrorProtocol || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
+func TestCommandPublisherRejectsInvalidHelperResult(t *testing.T) {
+	for _, mode := range []string{"bad-result-id", "bad-result-url"} {
+		t.Run(mode, func(t *testing.T) {
+			publisher := commandTestPublisher(t, mode, time.Second)
+			_, err := publisher.Create(context.Background(), commandTestRequest())
+			if err == nil || AsError(err).Code != ErrorProtocol {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
+func TestCommandPublisherCreatesPrivateBundleAndAlwaysCleansIt(t *testing.T) {
+	capture := filepath.Join(t.TempDir(), "capture.json")
+	t.Setenv("TERM_LLM_SHARE_HELPER_CAPTURE", capture)
+	publisher := commandTestPublisher(t, "bundle", time.Second)
+	result, err := publisher.Create(context.Background(), commandTestRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Ready || result.Provider != "test-helper" || result.Visibility != VisibilityPrivate {
+		t.Fatalf("result=%+v", result)
+	}
+	var got struct {
+		CWD        string            `json:"cwd"`
+		DirMode    uint32            `json:"dir_mode"`
+		FileModes  map[string]uint32 `json:"file_modes"`
+		Contents   map[string]string `json:"contents"`
+		Entrypoint string            `json:"entrypoint"`
+		Names      []string          `json:"names"`
+		Prefix     string            `json:"prefix"`
+	}
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.DirMode != 0o700 || got.FileModes["index.html"] != 0o600 || got.FileModes["session.md"] != 0o600 {
+		t.Fatalf("permissions=%#o files=%#v", got.DirMode, got.FileModes)
+	}
+	if got.Contents["index.html"] != "<h1>hello</h1>" || got.Contents["session.md"] != "# hello" {
+		t.Fatalf("contents=%#v", got.Contents)
+	}
+	if got.Entrypoint != "index.html" || strings.Join(got.Names, ",") != "index.html,session.md" || got.Prefix != "prefix argument" {
+		t.Fatalf("manifest=%+v", got)
+	}
+	if _, err := os.Stat(got.CWD); !os.IsNotExist(err) {
+		t.Fatalf("temporary bundle still exists: stat error=%v", err)
+	}
+}
+
+func TestCommandPublisherResolvesRelativePATHExecutableBeforeBundleCWD(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relative executable symlink test is Unix-specific")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	helper := filepath.Join(binDir, "term-llm-relative-share-helper")
+	if err := os.Symlink(os.Args[0], helper); err != nil {
+		t.Skipf("cannot create helper symlink: %v", err)
+	}
+	relativeBin, err := filepath.Rel(cwd, binDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", relativeBin)
+	t.Setenv("TERM_LLM_SHARE_HELPER", "1")
+	t.Setenv("TERM_LLM_SHARE_HELPER_MODE", "valid")
+	publisher, err := NewCommandPublisher([]string{filepath.Base(helper), "-test.run=^TestCommandHelperProcess$", "--", "prefix argument"}, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(publisher.argv[0]) {
+		t.Fatalf("resolved argv[0] = %q, want absolute", publisher.argv[0])
+	}
+	created, err := publisher.Create(context.Background(), commandTestRequest())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	updated, err := publisher.Update(context.Background(), created.ID, commandTestRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if created.ID != "opaque-1" || updated.ID != created.ID {
+		t.Fatalf("create/update results = %+v / %+v", created, updated)
+	}
+}
+
+func TestCommandPublisherAcceptsZeroExitAfterWaitDelayAndParsesStdout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pipe-retaining descendant test is Unix-specific")
+	}
+	publisher := commandTestPublisher(t, "background-pipes", 3*time.Second)
+	pidFile := filepath.Join(t.TempDir(), "background.pid")
+	t.Setenv("TERM_LLM_SHARE_HELPER_CAPTURE", pidFile)
+	started := time.Now()
+	capabilities, err := publisher.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	if capabilities.Provider.ID != "test-helper" || time.Since(started) >= 4*time.Second {
+		t.Fatalf("capabilities=%+v elapsed=%s", capabilities, time.Since(started))
+	}
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for processAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if processAlive(pid) {
+		t.Fatalf("background descendant %d survived successful helper cleanup", pid)
+	}
+}
+
+func TestCommandPublisherRejectsUnsafeStructuredErrorMessages(t *testing.T) {
+	for _, mode := range []string{"control-error", "long-error"} {
+		t.Run(mode, func(t *testing.T) {
+			publisher := commandTestPublisher(t, mode, time.Second)
+			_, err := publisher.Create(context.Background(), commandTestRequest())
+			if err == nil || err.Error() != "share helper failed" || strings.Contains(err.Error(), "unsafe") {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
+func TestCommandPublisherRemovesBundleAfterProviderFailure(t *testing.T) {
+	capture := filepath.Join(t.TempDir(), "capture.json")
+	t.Setenv("TERM_LLM_SHARE_HELPER_CAPTURE", capture)
+	publisher := commandTestPublisher(t, "bundle-error", time.Second)
+	_, err := publisher.Create(context.Background(), commandTestRequest())
+	if err == nil || AsError(err).Code != ErrorProvider {
+		t.Fatalf("error=%v", err)
+	}
+	var got struct {
+		CWD string `json:"cwd"`
+	}
+	data, readErr := os.ReadFile(capture)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if json.Unmarshal(data, &got) != nil || got.CWD == "" {
+		t.Fatalf("capture=%s", data)
+	}
+	if _, statErr := os.Stat(got.CWD); !os.IsNotExist(statErr) {
+		t.Fatalf("temporary bundle still exists after failure: %v", statErr)
+	}
+}
+
+func TestCommandPublisherTimeoutKillsProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group assertion is Unix-specific")
+	}
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	t.Setenv("TERM_LLM_SHARE_HELPER_CAPTURE", pidFile)
+	publisher := commandTestPublisher(t, "timeout", 100*time.Millisecond)
+	_, err := publisher.Create(context.Background(), commandTestRequest())
+	if err == nil || AsError(err).Code != ErrorTimeout {
+		t.Fatalf("error=%v", err)
+	}
+	data, readErr := os.ReadFile(pidFile)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+	if parseErr != nil {
+		t.Fatal(parseErr)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("descendant process %d survived timeout cleanup", pid)
+}
+
+func processAlive(pid int) bool {
+	if killErr := syscall.Kill(pid, 0); killErr != nil {
+		return false
+	}
+	// A killed orphan may remain briefly as a zombie until PID 1 reaps it; it
+	// can no longer execute and therefore counts as cleaned up.
+	if stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
+		fields := strings.Fields(string(stat))
+		if len(fields) > 2 && fields[2] == "Z" {
+			return false
+		}
+	}
+	return true
+}
+
+func TestValidateResultURLAndIDRules(t *testing.T) {
+	valid := Result{ID: "opaque-123", URL: "https://example.test/share", SourceURL: "http://127.0.0.1:8080/source", Visibility: VisibilityPrivate}
+	if err := ValidateResult(valid); err != nil {
+		t.Fatalf("valid result rejected: %v", err)
+	}
+	for _, test := range []struct {
+		name string
+		edit func(*Result)
+	}{
+		{name: "space in id", edit: func(r *Result) { r.ID = "bad id" }},
+		{name: "long id", edit: func(r *Result) { r.ID = strings.Repeat("x", 257) }},
+		{name: "relative url", edit: func(r *Result) { r.URL = "/share" }},
+		{name: "public http", edit: func(r *Result) { r.URL = "http://example.test/share" }},
+		{name: "url whitespace", edit: func(r *Result) { r.URL = "https://example.test/a b" }},
+		{name: "long url", edit: func(r *Result) { r.URL = "https://example.test/" + strings.Repeat("x", 2049) }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := valid
+			test.edit(&result)
+			if err := ValidateResult(result); err == nil {
+				t.Fatalf("invalid result accepted: %+v", result)
+			}
+		})
+	}
+}
+
+func TestValidateRequestBounds(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		edit func(*Request)
+	}{
+		{name: "too many files", edit: func(r *Request) {
+			for len(r.Files) <= MaxRequestFiles {
+				r.Files = append(r.Files, File{Name: fmt.Sprintf("extra-%d.txt", len(r.Files)), MediaType: "text/plain", Role: "attachment"})
+			}
+		}},
+		{name: "oversized file", edit: func(r *Request) { r.Files[0].Content = make([]byte, MaxRequestFileBytes+1) }},
+		{name: "oversized bundle", edit: func(r *Request) {
+			r.Files[0].Content = make([]byte, MaxRequestFileBytes)
+			r.Files[1].Content = make([]byte, MaxRequestFileBytes)
+			r.Files = append(r.Files, File{Name: "extra.txt", MediaType: "text/plain", Role: "attachment", Content: []byte{1}})
+		}},
+		{name: "control title", edit: func(r *Request) { r.Title = "bad\ntitle" }},
+		{name: "control file name", edit: func(r *Request) { r.Files[0].Name = "bad\nname" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := commandTestRequest()
+			test.edit(&req)
+			if err := ValidateRequest(req); err == nil {
+				t.Fatalf("invalid request accepted")
+			}
+		})
+	}
+}
+
+func TestCommandHelperProcess(t *testing.T) {
+	if os.Getenv("TERM_LLM_SHARE_HELPER") != "1" {
+		return
+	}
+	operation := os.Args[len(os.Args)-1]
+	mode := os.Getenv("TERM_LLM_SHARE_HELPER_MODE")
+	var input struct {
+		Protocol   string `json:"protocol"`
+		Version    int    `json:"version"`
+		RequestID  string `json:"request_id"`
+		Entrypoint string `json:"entrypoint"`
+		Files      []File `json:"files"`
+	}
+	_ = json.NewDecoder(os.Stdin).Decode(&input)
+	if input.Protocol != Protocol || input.Version != Version || input.RequestID == "" {
+		fmt.Fprintln(os.Stderr, "bad protocol input")
+		os.Exit(3)
+	}
+
+	if operation == "capabilities" {
+		switch mode {
+		case "malformed":
+			fmt.Print("not-json")
+			os.Exit(0)
+		case "oversized":
+			fmt.Print(strings.Repeat("x", int(commandStdoutLimit)+1))
+			os.Exit(0)
+		}
+		capabilities := Capabilities{
+			Protocol: Protocol, Version: Version,
+			Provider:     Provider{ID: "test-helper", Name: "Test Helper"},
+			Operations:   []Operation{OperationCreate, OperationUpdate},
+			Visibilities: []Visibility{VisibilityPrivate}, DefaultVisibility: VisibilityPrivate,
+		}
+		if mode == "bad-protocol" {
+			capabilities.Protocol = "other"
+		}
+		if mode == "missing-create" {
+			capabilities.Operations = []Operation{OperationUpdate}
+		}
+		if mode == "missing-visibility" {
+			capabilities.Visibilities = nil
+		}
+		if mode == "github-id" {
+			capabilities.Provider.ID = ProviderGitHub
+		}
+		if mode == "long-provider-name" {
+			capabilities.Provider.Name = strings.Repeat("n", maxProviderNameBytes+1)
+		}
+		if mode == "control-provider-help" {
+			capabilities.Provider.Help = "unsafe\nhelp"
+		}
+		if mode == "too-many-notes" {
+			capabilities.Notes = make([]string, maxCapabilityNotes+1)
+			for i := range capabilities.Notes {
+				capabilities.Notes[i] = "note"
+			}
+		}
+		if mode == "oversized-limits" {
+			capabilities.Limits = map[string]any{"description": strings.Repeat("x", maxCapabilityLimitsBytes)}
+		}
+		if mode == "background-pipes" {
+			child := exec.Command("sh", "-c", "sleep 30")
+			child.Stdout = os.Stdout
+			child.Stderr = os.Stderr
+			if err := child.Start(); err != nil {
+				os.Exit(8)
+			}
+			_ = os.WriteFile(os.Getenv("TERM_LLM_SHARE_HELPER_CAPTURE"), []byte(strconv.Itoa(child.Process.Pid)), 0o600)
+		}
+		_ = json.NewEncoder(os.Stdout).Encode(capabilities)
+		os.Exit(0)
+	}
+
+	switch mode {
+	case "structured-error":
+		fmt.Fprint(os.Stderr, strings.Repeat("SECRET-STDERR", 7000))
+		fmt.Print(`{"error":{"code":"auth_required","message":"sign in to the helper"}}`)
+		os.Exit(7)
+	case "control-error":
+		fmt.Print("{\"error\":{\"code\":\"provider_error\",\"message\":\"unsafe\\nmessage\"}}")
+		os.Exit(7)
+	case "long-error":
+		_ = json.NewEncoder(os.Stdout).Encode(map[string]any{"error": map[string]any{"code": ErrorProvider, "message": strings.Repeat("unsafe", maxStructuredErrorBytes)}})
+		os.Exit(7)
+	case "timeout":
+		capture := os.Getenv("TERM_LLM_SHARE_HELPER_CAPTURE")
+		child := exec.Command("sh", "-c", "echo $$ > \"$1\"; exec sleep 30", "share-child", capture)
+		if err := child.Start(); err != nil {
+			os.Exit(8)
+		}
+		_ = child.Wait()
+		return
+	case "bundle", "bundle-error":
+		info, _ := os.Stat(".")
+		capture := struct {
+			CWD        string            `json:"cwd"`
+			DirMode    uint32            `json:"dir_mode"`
+			FileModes  map[string]uint32 `json:"file_modes"`
+			Contents   map[string]string `json:"contents"`
+			Entrypoint string            `json:"entrypoint"`
+			Names      []string          `json:"names"`
+			Prefix     string            `json:"prefix"`
+		}{DirMode: uint32(info.Mode().Perm()), FileModes: map[string]uint32{}, Contents: map[string]string{}, Entrypoint: input.Entrypoint, Prefix: os.Args[len(os.Args)-2]}
+		capture.CWD, _ = os.Getwd()
+		for _, file := range input.Files {
+			fileInfo, _ := os.Stat(file.Name)
+			content, _ := os.ReadFile(file.Name)
+			capture.FileModes[file.Name] = uint32(fileInfo.Mode().Perm())
+			capture.Contents[file.Name] = string(content)
+			capture.Names = append(capture.Names, file.Name)
+		}
+		data, _ := json.Marshal(capture)
+		_ = os.WriteFile(os.Getenv("TERM_LLM_SHARE_HELPER_CAPTURE"), data, 0o600)
+		if mode == "bundle-error" {
+			fmt.Print(`{"error":{"code":"provider_error","message":"provider rejected bundle"}}`)
+			os.Exit(9)
+		}
+	}
+	response := helperResponse{
+		Protocol: Protocol, Version: Version, ID: "opaque-1", URL: "https://example.test/share/1",
+		SourceURL: "http://localhost:8080/source/1", Visibility: VisibilityPrivate,
+	}
+	if mode == "bad-result-id" {
+		response.ID = "bad id"
+	}
+	if mode == "bad-result-url" {
+		response.URL = "http://example.test/not-loopback"
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(response)
+	os.Exit(0)
+}

--- a/internal/share/factory.go
+++ b/internal/share/factory.go
@@ -1,0 +1,27 @@
+package share
+
+import (
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func NewPublisher(cfg config.ShareConfig) (Publisher, error) {
+	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
+	case "", config.DefaultShareProvider:
+		return NewGitHubPublisher(), nil
+	case "command":
+		timeoutValue := strings.TrimSpace(cfg.Timeout)
+		if timeoutValue == "" {
+			timeoutValue = config.DefaultShareTimeout
+		}
+		timeout, err := time.ParseDuration(timeoutValue)
+		if err != nil {
+			return nil, NewError(ErrorProtocol, "sharing provider timeout configuration is invalid")
+		}
+		return NewCommandPublisher(cfg.Command, timeout)
+	default:
+		return nil, NewError(ErrorProtocol, "sharing provider configuration selects an unsupported provider")
+	}
+}

--- a/internal/share/factory_test.go
+++ b/internal/share/factory_test.go
@@ -1,0 +1,26 @@
+package share
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func TestNewPublisherReturnsActionableSafeConfigurationErrors(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cfg  config.ShareConfig
+		want string
+	}{
+		{name: "timeout", cfg: config.ShareConfig{Provider: "command", Command: []string{"helper"}, Timeout: "not-a-duration\nSECRET"}, want: "timeout configuration is invalid"},
+		{name: "provider", cfg: config.ShareConfig{Provider: "unknown\nSECRET"}, want: "unsupported provider"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewPublisher(test.cfg)
+			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), "SECRET") {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}

--- a/internal/share/github.go
+++ b/internal/share/github.go
@@ -1,0 +1,186 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/agents/gist"
+)
+
+type githubGistClient interface {
+	Create(description string, public bool, files map[string]string) (*gist.Gist, error)
+	Get(gistID string) (*gist.Gist, error)
+	Update(gistID string, files map[string]string) error
+}
+
+type GitHubPublisher struct {
+	newClient  func() (githubGistClient, error)
+	http       *http.Client
+	sleep      func(context.Context, time.Duration) bool
+	previewURL func(string) string
+}
+
+func NewGitHubPublisher() *GitHubPublisher {
+	return &GitHubPublisher{
+		newClient:  func() (githubGistClient, error) { return gist.NewClient() },
+		http:       &http.Client{Timeout: 2 * time.Second},
+		sleep:      sleepContext,
+		previewURL: gist.PreviewURL,
+	}
+}
+
+func (p *GitHubPublisher) Capabilities(context.Context) (Capabilities, error) {
+	return Capabilities{
+		Protocol: Protocol,
+		Version:  Version,
+		Provider: Provider{
+			ID:   ProviderGitHub,
+			Name: "GitHub Gist",
+			Help: "Requires the gh CLI authenticated to github.com (run: gh auth login --hostname github.com).",
+		},
+		Operations:        []Operation{OperationCreate, OperationUpdate},
+		Visibilities:      []Visibility{VisibilityUnlisted, VisibilityPublic},
+		DefaultVisibility: VisibilityUnlisted,
+		Notes: []string{
+			"Unlisted Gists are accessible to anyone with the link; they are not private.",
+			"Shares are created on the active GitHub account selected by gh.",
+		},
+	}, nil
+}
+
+func (p *GitHubPublisher) Create(ctx context.Context, req Request) (Result, error) {
+	if err := ValidateRequest(req); err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProtocol, "share request is invalid", err.Error(), err)
+	}
+	if req.Visibility != VisibilityUnlisted && req.Visibility != VisibilityPublic {
+		return Result{}, NewError(ErrorUnsupportedVisibility, "GitHub Gist supports unlisted and public visibility")
+	}
+	client, err := p.newClient()
+	if err != nil {
+		return Result{}, githubClientError(err)
+	}
+	files := make(map[string]string, len(req.Files))
+	for _, file := range req.Files {
+		files[file.Name] = string(file.Content)
+	}
+	created, err := client.Create(req.Description, req.Visibility == VisibilityPublic, files)
+	if err != nil {
+		return Result{}, githubClientError(err)
+	}
+	if created == nil {
+		return Result{}, NewError(ErrorProvider, "GitHub returned an empty share result")
+	}
+	sourceURL := strings.TrimSpace(created.URL)
+	if sourceURL == "" {
+		sourceURL = gist.GetURL(created.ID)
+	}
+	result := Result{
+		Provider: ProviderGitHub, ID: created.ID, URL: p.previewURL(created.ID), SourceURL: sourceURL,
+		Visibility: req.Visibility,
+	}
+	if err := ValidateResult(result); err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProtocol, "GitHub returned an invalid share result", err.Error(), err)
+	}
+	result.Ready = p.probeReady(ctx, result.URL)
+	return result, nil
+}
+
+func (p *GitHubPublisher) Update(ctx context.Context, id string, req Request) (Result, error) {
+	if gist.PreviewURL(id) == "" {
+		return Result{}, NewError(ErrorProtocol, "stored GitHub share ID is invalid")
+	}
+	if err := ValidateRequest(req); err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProtocol, "share request is invalid", err.Error(), err)
+	}
+	if req.Visibility != VisibilityUnlisted && req.Visibility != VisibilityPublic {
+		return Result{}, NewError(ErrorUnsupportedVisibility, "GitHub Gist supports unlisted and public visibility")
+	}
+	client, err := p.newClient()
+	if err != nil {
+		return Result{}, githubClientError(err)
+	}
+	existing, err := client.Get(id)
+	if err != nil {
+		return Result{}, githubClientError(err)
+	}
+	if existing == nil {
+		return Result{}, NewError(ErrorProvider, "GitHub returned an empty share result")
+	}
+	files := make(map[string]string, len(req.Files))
+	for _, file := range req.Files {
+		files[file.Name] = string(file.Content)
+	}
+	if err := client.Update(id, files); err != nil {
+		return Result{}, githubClientError(err)
+	}
+	visibility := VisibilityUnlisted
+	if existing.Public {
+		visibility = VisibilityPublic
+	}
+	sourceURL := strings.TrimSpace(existing.URL)
+	if sourceURL == "" {
+		sourceURL = gist.GetURL(id)
+	}
+	result := Result{
+		Provider: ProviderGitHub, ID: id, URL: p.previewURL(id), SourceURL: sourceURL,
+		Visibility: visibility,
+	}
+	if err := ValidateResult(result); err != nil {
+		return Result{}, errorWithDiagnostic(ErrorProtocol, "GitHub returned an invalid share result", err.Error(), err)
+	}
+	result.Ready = p.probeReady(ctx, result.URL)
+	return result, nil
+}
+
+func githubClientError(err error) error {
+	switch {
+	case errors.Is(err, gist.ErrDependencyMissing):
+		return errorWithDiagnostic(ErrorDependencyMissing, "GitHub sharing requires the gh CLI; install it from https://cli.github.com", err.Error(), err)
+	case errors.Is(err, gist.ErrAuthRequired):
+		return errorWithDiagnostic(ErrorAuthRequired, "GitHub authentication is required; run gh auth login --hostname github.com", err.Error(), err)
+	default:
+		return errorWithDiagnostic(ErrorProvider, "GitHub could not create or update the share", err.Error(), err)
+	}
+}
+
+func (p *GitHubPublisher) probeReady(parent context.Context, target string) bool {
+	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
+	defer cancel()
+	backoff := 200 * time.Millisecond
+	for attempt := 0; attempt < 5; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		if err != nil {
+			return false
+		}
+		req.Header.Set("User-Agent", "term-llm-share-readiness/1")
+		resp, err := p.http.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			switch {
+			case resp.StatusCode >= 200 && resp.StatusCode < 300:
+				return true
+			case resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests:
+				return false
+			}
+		}
+		if attempt == 4 || !p.sleep(ctx, backoff) {
+			return false
+		}
+		backoff *= 2
+	}
+	return false
+}
+
+func sleepContext(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/share/github_test.go
+++ b/internal/share/github_test.go
@@ -1,0 +1,143 @@
+package share
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/agents/gist"
+)
+
+type fakeGistClient struct {
+	gist        *gist.Gist
+	createErr   error
+	getErr      error
+	updateErr   error
+	createCalls int
+	getCalls    int
+	updateCalls int
+}
+
+func (f *fakeGistClient) Create(string, bool, map[string]string) (*gist.Gist, error) {
+	f.createCalls++
+	return f.gist, f.createErr
+}
+
+func (f *fakeGistClient) Get(string) (*gist.Gist, error) {
+	f.getCalls++
+	return f.gist, f.getErr
+}
+
+func (f *fakeGistClient) Update(string, map[string]string) error {
+	f.updateCalls++
+	return f.updateErr
+}
+
+func TestGitHubPublisherCapabilities(t *testing.T) {
+	capabilities, err := NewGitHubPublisher().Capabilities(context.Background())
+	if err != nil || ValidateCapabilities(capabilities) != nil {
+		t.Fatalf("capabilities=%+v error=%v", capabilities, err)
+	}
+	if capabilities.Provider.ID != "github" || !capabilities.Supports(OperationUpdate) || capabilities.SupportsVisibility(VisibilityPrivate) {
+		t.Fatalf("capabilities=%+v", capabilities)
+	}
+}
+
+func TestGitHubPublisherReadinessProbe(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		statuses     []int
+		wantReady    bool
+		wantRequests int
+	}{
+		{name: "becomes ready", statuses: []int{http.StatusNotFound, http.StatusOK}, wantReady: true, wantRequests: 2},
+		{name: "forbidden stops", statuses: []int{http.StatusForbidden, http.StatusOK}, wantRequests: 1},
+		{name: "rate limited stops", statuses: []int{http.StatusTooManyRequests, http.StatusOK}, wantRequests: 1},
+		{name: "bounded failures", statuses: []int{500, 500, 500, 500, 500, 200}, wantRequests: 5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				status := test.statuses[requests]
+				requests++
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+			client := &fakeGistClient{gist: &gist.Gist{ID: "abc123", URL: "https://gist.github.com/test/abc123"}}
+			publisher := NewGitHubPublisher()
+			publisher.newClient = func() (githubGistClient, error) { return client, nil }
+			publisher.http = server.Client()
+			publisher.sleep = func(context.Context, time.Duration) bool { return true }
+			publisher.previewURL = func(string) string { return server.URL }
+
+			request := commandTestRequest()
+			request.Visibility = VisibilityUnlisted
+			result, err := publisher.Create(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Create error=%v", err)
+			}
+			if result.Ready != test.wantReady || requests != test.wantRequests || client.createCalls != 1 {
+				t.Fatalf("result=%+v requests=%d createCalls=%d", result, requests, client.createCalls)
+			}
+		})
+	}
+}
+
+func TestGitHubPublisherUpdateUsesStoredVisibilityAndProbesPrimaryPreview(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	client := &fakeGistClient{gist: &gist.Gist{ID: "abc123", URL: "", Public: false}}
+	publisher := NewGitHubPublisher()
+	publisher.newClient = func() (githubGistClient, error) { return client, nil }
+	publisher.http = server.Client()
+	publisher.previewURL = func(string) string { return server.URL }
+
+	request := commandTestRequest()
+	request.Visibility = VisibilityPublic // Existing Gist visibility is immutable.
+	result, err := publisher.Update(context.Background(), "abc123", request)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if result.Visibility != VisibilityUnlisted || !result.Ready || result.URL != server.URL || result.SourceURL != gist.GetURL("abc123") {
+		t.Fatalf("result=%+v", result)
+	}
+	if client.getCalls != 1 || client.updateCalls != 1 || requests != 1 {
+		t.Fatalf("calls get=%d update=%d readiness=%d", client.getCalls, client.updateCalls, requests)
+	}
+}
+
+func TestGitHubPublisherUpdateReadinessFailureDoesNotFailUpdate(t *testing.T) {
+	client := &fakeGistClient{gist: &gist.Gist{ID: "abc123", URL: gist.GetURL("abc123"), Public: true}}
+	publisher := NewGitHubPublisher()
+	publisher.newClient = func() (githubGistClient, error) { return client, nil }
+	publisher.http = &http.Client{Timeout: time.Millisecond}
+	publisher.sleep = func(context.Context, time.Duration) bool { return true }
+	publisher.previewURL = func(string) string { return "https://127.0.0.1:1/unreachable" }
+	request := commandTestRequest()
+	request.Visibility = VisibilityUnlisted
+	result, err := publisher.Update(context.Background(), "abc123", request)
+	if err != nil || result.Visibility != VisibilityPublic || result.Ready {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+}
+
+func TestGitHubPublisherDoesNotFailCreatedShareWhenProbeFails(t *testing.T) {
+	client := &fakeGistClient{gist: &gist.Gist{ID: "abc123", URL: "https://gist.github.com/test/abc123"}}
+	publisher := NewGitHubPublisher()
+	publisher.newClient = func() (githubGistClient, error) { return client, nil }
+	publisher.http = &http.Client{Timeout: time.Millisecond}
+	publisher.sleep = func(context.Context, time.Duration) bool { return true }
+	publisher.previewURL = func(string) string { return "https://127.0.0.1:1/unreachable" }
+	request := commandTestRequest()
+	request.Visibility = VisibilityPublic
+	result, err := publisher.Create(context.Background(), request)
+	if err != nil || result.ID != "abc123" || result.Ready {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -1,0 +1,529 @@
+// Package share defines provider-neutral transcript sharing.
+package share
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/samsaffron/term-llm/internal/agents/gist"
+)
+
+const (
+	Protocol = "term-llm-share"
+	Version  = 1
+
+	ProviderGitHub ProviderID = ProviderID(gist.ProviderID)
+
+	MaxRequestFiles      = 32
+	MaxRequestFileBytes  = 16 << 20
+	MaxRequestTotalBytes = 32 << 20
+
+	maxProviderNameBytes     = 128
+	maxProviderHelpBytes     = 2048
+	maxCapabilityNotes       = 16
+	maxCapabilityNoteBytes   = 1024
+	maxCapabilityLimitsBytes = 16 << 10
+	maxStructuredErrorBytes  = 1024
+	maxDiagnosticLogBytes    = 4096
+)
+
+type ProviderID string
+
+type Visibility string
+
+const (
+	VisibilityPublic   Visibility = "public"
+	VisibilityUnlisted Visibility = "unlisted"
+	VisibilityPrivate  Visibility = "private"
+)
+
+type Operation string
+
+const (
+	OperationCapabilities Operation = "capabilities"
+	OperationCreate       Operation = "create"
+	OperationUpdate       Operation = "update"
+)
+
+type Provider struct {
+	ID   ProviderID `json:"id"`
+	Name string     `json:"name"`
+	Help string     `json:"help,omitempty"`
+}
+
+type Capabilities struct {
+	Protocol          string         `json:"protocol"`
+	Version           int            `json:"version"`
+	Provider          Provider       `json:"provider"`
+	Operations        []Operation    `json:"operations"`
+	Visibilities      []Visibility   `json:"visibilities"`
+	DefaultVisibility Visibility     `json:"default_visibility"`
+	Notes             []string       `json:"notes,omitempty"`
+	Limits            map[string]any `json:"limits,omitempty"`
+}
+
+func (c Capabilities) Supports(operation Operation) bool {
+	return slices.Contains(c.Operations, operation)
+}
+
+func (c Capabilities) SupportsVisibility(visibility Visibility) bool {
+	return slices.Contains(c.Visibilities, visibility)
+}
+
+type File struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Role      string `json:"role"`
+	Content   []byte `json:"-"`
+}
+
+type Request struct {
+	RequestID   string     `json:"request_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Visibility  Visibility `json:"visibility"`
+	Entrypoint  string     `json:"entrypoint"`
+	Files       []File     `json:"files"`
+}
+
+type Result struct {
+	Provider   ProviderID `json:"provider"`
+	ID         string     `json:"id"`
+	URL        string     `json:"url"`
+	SourceURL  string     `json:"source_url,omitempty"`
+	Visibility Visibility `json:"visibility"`
+	Ready      bool       `json:"ready"`
+}
+
+type ErrorCode string
+
+const (
+	ErrorDependencyMissing     ErrorCode = "dependency_missing"
+	ErrorAuthRequired          ErrorCode = "auth_required"
+	ErrorTimeout               ErrorCode = "timeout"
+	ErrorProvider              ErrorCode = "provider_error"
+	ErrorProtocol              ErrorCode = "protocol_error"
+	ErrorUnsupportedVisibility ErrorCode = "unsupported_visibility"
+)
+
+var stableErrorCodes = []ErrorCode{
+	ErrorDependencyMissing,
+	ErrorAuthRequired,
+	ErrorTimeout,
+	ErrorProvider,
+	ErrorProtocol,
+	ErrorUnsupportedVisibility,
+}
+
+type Error struct {
+	Code       ErrorCode `json:"code"`
+	Message    string    `json:"message"`
+	diagnostic string
+	cause      error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	return "sharing failed"
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func NewError(code ErrorCode, message string) *Error {
+	if !slices.Contains(stableErrorCodes, code) {
+		code = ErrorProvider
+	}
+	return &Error{Code: code, Message: strings.TrimSpace(message)}
+}
+
+func errorWithDiagnostic(code ErrorCode, message, diagnostic string, cause error) *Error {
+	err := NewError(code, message)
+	err.diagnostic = boundedDiagnostic(diagnostic)
+	err.cause = cause
+	if err.diagnostic != "" {
+		// Diagnostics stay on the operator log surface. Quoting prevents helper
+		// control bytes from affecting terminals, and Error() never exposes them
+		// to Web or TUI users.
+		log.Printf("[share] provider diagnostic: %q", err.diagnostic)
+	}
+	return err
+}
+
+func boundedDiagnostic(value string) string {
+	if len(value) <= maxDiagnosticLogBytes {
+		return value
+	}
+	return value[:maxDiagnosticLogBytes] + "…(truncated)"
+}
+
+func AsError(err error) *Error {
+	var typed *Error
+	if errors.As(err, &typed) {
+		return typed
+	}
+	return errorWithDiagnostic(ErrorProvider, "sharing provider failed", "", err)
+}
+
+type Publisher interface {
+	Capabilities(context.Context) (Capabilities, error)
+	Create(context.Context, Request) (Result, error)
+}
+
+// Updater is implemented only by publishers that can replace an existing share.
+// Callers must also require the update operation in Capabilities.
+type Updater interface {
+	Update(context.Context, string, Request) (Result, error)
+}
+
+func ValidateCapabilities(c Capabilities) error {
+	if c.Protocol != Protocol {
+		return fmt.Errorf("protocol must be %q", Protocol)
+	}
+	if c.Version != Version {
+		return fmt.Errorf("version must be %d", Version)
+	}
+	if !validProviderID(c.Provider.ID) {
+		return fmt.Errorf("provider.id must be 1 to 64 printable ASCII bytes without whitespace")
+	}
+	if err := validateDisplayText("provider.name", c.Provider.Name, maxProviderNameBytes, false); err != nil {
+		return err
+	}
+	if err := validateDisplayText("provider.help", c.Provider.Help, maxProviderHelpBytes, true); err != nil {
+		return err
+	}
+	if len(c.Operations) > 2 {
+		return fmt.Errorf("operations must contain at most create and update")
+	}
+	if !c.Supports(OperationCreate) {
+		return fmt.Errorf("operations must include create")
+	}
+	if len(c.Visibilities) == 0 {
+		return fmt.Errorf("visibilities cannot be empty")
+	}
+	seen := make(map[Visibility]bool, len(c.Visibilities))
+	for _, visibility := range c.Visibilities {
+		if !ValidVisibility(visibility) {
+			return fmt.Errorf("unsupported visibility %q", visibility)
+		}
+		if seen[visibility] {
+			return fmt.Errorf("duplicate visibility %q", visibility)
+		}
+		seen[visibility] = true
+	}
+	if !seen[c.DefaultVisibility] {
+		return fmt.Errorf("default_visibility must be one of visibilities")
+	}
+	operationSeen := make(map[Operation]bool, len(c.Operations))
+	for _, operation := range c.Operations {
+		if operation != OperationCreate && operation != OperationUpdate {
+			return fmt.Errorf("unsupported operation %q", operation)
+		}
+		if operationSeen[operation] {
+			return fmt.Errorf("duplicate operation %q", operation)
+		}
+		operationSeen[operation] = true
+	}
+	if len(c.Notes) > maxCapabilityNotes {
+		return fmt.Errorf("notes must contain at most %d entries", maxCapabilityNotes)
+	}
+	for i, note := range c.Notes {
+		if err := validateDisplayText(fmt.Sprintf("notes[%d]", i), note, maxCapabilityNoteBytes, false); err != nil {
+			return err
+		}
+	}
+	if err := validateLimits(c.Limits); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateHelperCapabilities applies the protocol's generic validation and
+// prevents external helpers from claiming a built-in provider identity.
+func ValidateHelperCapabilities(c Capabilities) error {
+	if err := ValidateCapabilities(c); err != nil {
+		return err
+	}
+	if c.Provider.ID == ProviderGitHub {
+		return fmt.Errorf("provider.id %q is reserved for the built-in GitHub provider", ProviderGitHub)
+	}
+	return nil
+}
+
+func validateDisplayText(field, value string, maxBytes int, allowEmpty bool) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must be valid UTF-8", field)
+	}
+	if len(value) > maxBytes {
+		return fmt.Errorf("%s must be at most %d bytes", field, maxBytes)
+	}
+	if !allowEmpty && strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s cannot be empty", field)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%s must not contain control characters", field)
+		}
+	}
+	return nil
+}
+
+func validateStructuredErrorMessage(value string) error {
+	return validateDisplayText("error.message", value, maxStructuredErrorBytes, false)
+}
+
+func validateLimits(limits map[string]any) error {
+	if len(limits) == 0 {
+		return nil
+	}
+	if len(limits) > 32 {
+		return fmt.Errorf("limits must contain at most 32 entries")
+	}
+	encoded, err := json.Marshal(limits)
+	if err != nil {
+		return fmt.Errorf("limits must be valid JSON: %w", err)
+	}
+	if len(encoded) > maxCapabilityLimitsBytes {
+		return fmt.Errorf("limits must encode to at most %d bytes", maxCapabilityLimitsBytes)
+	}
+	return validateLimitValue("limits", limits, 0)
+}
+
+func validateLimitValue(field string, value any, depth int) error {
+	if depth > 4 {
+		return fmt.Errorf("%s exceeds maximum nesting depth", field)
+	}
+	switch typed := value.(type) {
+	case nil, bool, float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return nil
+	case string:
+		return validateDisplayText(field, typed, maxCapabilityNoteBytes, true)
+	case []any:
+		if len(typed) > 32 {
+			return fmt.Errorf("%s array must contain at most 32 entries", field)
+		}
+		for i, item := range typed {
+			if err := validateLimitValue(fmt.Sprintf("%s[%d]", field, i), item, depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]any:
+		if len(typed) > 32 {
+			return fmt.Errorf("%s object must contain at most 32 entries", field)
+		}
+		for key, item := range typed {
+			if err := validateDisplayText(field+" key", key, 64, false); err != nil {
+				return err
+			}
+			if err := validateLimitValue(field+"."+key, item, depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s contains unsupported value type %T", field, value)
+	}
+}
+
+func validProviderID(id ProviderID) bool {
+	if len(id) == 0 || len(id) > 64 {
+		return false
+	}
+	for _, b := range []byte(id) {
+		if b < 0x21 || b > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func ValidVisibility(visibility Visibility) bool {
+	switch visibility {
+	case VisibilityPublic, VisibilityUnlisted, VisibilityPrivate:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidateRequest(req Request) error {
+	if err := validateDisplayText("request_id", req.RequestID, 128, false); err != nil {
+		return err
+	}
+	if err := validateDisplayText("title", req.Title, 512, true); err != nil {
+		return err
+	}
+	if err := validateDisplayText("description", req.Description, 2048, true); err != nil {
+		return err
+	}
+	if !ValidVisibility(req.Visibility) {
+		return fmt.Errorf("visibility is invalid")
+	}
+	if req.Entrypoint != "index.html" {
+		return fmt.Errorf("entrypoint must be index.html")
+	}
+	if len(req.Files) == 0 {
+		return fmt.Errorf("files cannot be empty")
+	}
+	if len(req.Files) > MaxRequestFiles {
+		return fmt.Errorf("files must contain at most %d entries", MaxRequestFiles)
+	}
+	entrypointFound := false
+	seen := make(map[string]bool, len(req.Files))
+	totalBytes := 0
+	for _, file := range req.Files {
+		if !validRelativeName(file.Name) || len(file.Name) > 255 {
+			return fmt.Errorf("file name %q must be a relative path of at most 255 bytes", file.Name)
+		}
+		if seen[file.Name] {
+			return fmt.Errorf("duplicate file name %q", file.Name)
+		}
+		seen[file.Name] = true
+		if file.Name == req.Entrypoint {
+			entrypointFound = true
+		}
+		if err := validateDisplayText(fmt.Sprintf("file %q media_type", file.Name), file.MediaType, 128, false); err != nil {
+			return err
+		}
+		if err := validateDisplayText(fmt.Sprintf("file %q role", file.Name), file.Role, 128, false); err != nil {
+			return err
+		}
+		if len(file.Content) > MaxRequestFileBytes {
+			return fmt.Errorf("file %q exceeds the %d byte limit", file.Name, MaxRequestFileBytes)
+		}
+		totalBytes += len(file.Content)
+		if totalBytes > MaxRequestTotalBytes {
+			return fmt.Errorf("share bundle exceeds the %d byte limit", MaxRequestTotalBytes)
+		}
+	}
+	if !entrypointFound {
+		return fmt.Errorf("entrypoint is not present in files")
+	}
+	if !seen["session.md"] {
+		return fmt.Errorf("files must include session.md")
+	}
+	return nil
+}
+
+func validRelativeName(name string) bool {
+	if name == "" || !utf8.ValidString(name) || filepath.IsAbs(name) || strings.ContainsRune(name, '\x00') || strings.Contains(name, "\\") {
+		return false
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	clean := filepath.Clean(name)
+	return clean == name && clean != "." && clean != ".." && !strings.HasPrefix(clean, ".."+string(filepath.Separator))
+}
+
+func ValidateResult(result Result) error {
+	if !validID(result.ID) {
+		return fmt.Errorf("id must be 1 to 256 printable ASCII bytes without whitespace")
+	}
+	if err := validateURL(result.URL); err != nil {
+		return fmt.Errorf("url: %w", err)
+	}
+	if result.SourceURL != "" {
+		if err := validateURL(result.SourceURL); err != nil {
+			return fmt.Errorf("source_url: %w", err)
+		}
+	}
+	if !ValidVisibility(result.Visibility) {
+		return fmt.Errorf("visibility is invalid")
+	}
+	return nil
+}
+
+func validID(id string) bool {
+	if len(id) == 0 || len(id) > 256 {
+		return false
+	}
+	for _, b := range []byte(id) {
+		if b < 0x21 || b > 0x7e || unicode.IsSpace(rune(b)) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateURL(raw string) error {
+	if len(raw) == 0 || len(raw) > 2048 {
+		return fmt.Errorf("must be 1 to 2048 bytes")
+	}
+	for _, r := range raw {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf("must not contain whitespace or control characters")
+		}
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !parsed.IsAbs() || parsed.Host == "" || parsed.User != nil {
+		return fmt.Errorf("must be an absolute HTTP(S) URL without user information")
+	}
+	if parsed.Scheme == "https" {
+		return nil
+	}
+	if parsed.Scheme != "http" || !loopbackHost(parsed.Hostname()) {
+		return fmt.Errorf("must use HTTPS (HTTP is allowed only for loopback hosts)")
+	}
+	return nil
+}
+
+func loopbackHost(host string) bool {
+	if strings.EqualFold(strings.TrimSuffix(host, "."), "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+var fallbackRequestID atomic.Uint64
+
+func NewRequestID() string {
+	var data [16]byte
+	if _, err := rand.Read(data[:]); err == nil {
+		return hex.EncodeToString(data[:])
+	}
+	return fmt.Sprintf("fallback-%d-%d", time.Now().UnixNano(), fallbackRequestID.Add(1))
+}
+
+func TranscriptFiles(files map[string]string) []File {
+	result := make([]File, 0, len(files))
+	for name, content := range files {
+		mediaType, role := "text/plain; charset=utf-8", "attachment"
+		switch name {
+		case "index.html":
+			mediaType, role = "text/html; charset=utf-8", "entrypoint"
+		case "session.md":
+			mediaType, role = "text/markdown; charset=utf-8", "transcript"
+		}
+		result = append(result, File{Name: name, MediaType: mediaType, Role: role, Content: []byte(content)})
+	}
+	slices.SortFunc(result, func(a, b File) int { return strings.Compare(a.Name, b.Name) })
+	return result
+}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -2675,6 +2675,9 @@ func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 	case worktreeOperationDoneMsg:
 		return m.handleWorktreeOperationDone(msg)
 
+	case shareCapabilitiesMsg:
+		return m.handleShareCapabilities(msg)
+
 	case shareDoneMsg:
 		return m.handleShareDone(msg)
 

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -103,11 +103,14 @@ func AllCommands() []Command {
 		},
 		{
 			Name:        "share",
-			Description: "Share this session as a GitHub Gist",
-			Usage:       "/share [new] [public]",
+			Description: "Share this complete session (unlisted is not private)",
+			Usage:       "/share [new] [raw] [public|unlisted|private]",
 			Subcommands: []Subcommand{
-				{Name: "new", Description: "Create a new gist"},
-				{Name: "public", Description: "Make a new gist public"},
+				{Name: "new", Description: "Create a new share"},
+				{Name: "raw", Description: "Explicitly include privacy-sensitive raw model reasoning"},
+				{Name: "public", Description: "Request public visibility"},
+				{Name: "unlisted", Description: "Request unlisted visibility"},
+				{Name: "private", Description: "Request private visibility"},
 			},
 		},
 		{
@@ -732,6 +735,16 @@ func (m *Model) showFooterMessageWithToneFor(content string, tone string, durati
 	return m, tea.Tick(duration, func(time.Time) tea.Msg {
 		return footerMessageClearMsg{Seq: seq}
 	})
+}
+
+func (m *Model) showFooterPersistent(content string, tone string) (tea.Model, tea.Cmd) {
+	m.footerMessage = sanitizeFooterMessage(content)
+	m.footerMessageTone = tone
+	m.footerMessageSeq++ // Invalidate any older transient clear timer.
+	if m.footerMessage == "" {
+		m.footerMessageTone = ""
+	}
+	return m, nil
 }
 
 func (m *Model) showFooterMutedWithCmd(content string, cmd tea.Cmd) (tea.Model, tea.Cmd) {

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -20,13 +20,13 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/agents"
-	"github.com/samsaffron/term-llm/internal/agents/gist"
 	"github.com/samsaffron/term-llm/internal/clipboard"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
+	sharepkg "github.com/samsaffron/term-llm/internal/share"
 	"github.com/samsaffron/term-llm/internal/skills"
 	"github.com/samsaffron/term-llm/internal/testutil"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -5317,15 +5317,80 @@ func TestCmdShareRejectsUnknownArgument(t *testing.T) {
 	m.sess = &session.Session{ID: "share-test"}
 	result, cmd := m.ExecuteCommand("/share banana")
 	m = result.(*Model)
-	if cmd == nil || !strings.Contains(m.footerMessage, "Usage: /share [new] [public]") {
+	if cmd == nil || !strings.Contains(m.footerMessage, "Usage: /share [new] [raw] [public|unlisted|private]") {
 		t.Fatalf("footer = %q, cmd nil = %v", m.footerMessage, cmd == nil)
 	}
 }
 
-func TestCmdShareExistingGistOpensChoice(t *testing.T) {
+type recordingSharePublisher struct {
+	caps        sharepkg.Capabilities
+	result      sharepkg.Result
+	capCalls    int
+	createCalls int
+	updateCalls int
+	lastRequest sharepkg.Request
+}
+
+func defaultShareCapabilities() sharepkg.Capabilities {
+	return sharepkg.Capabilities{
+		Protocol: sharepkg.Protocol, Version: sharepkg.Version,
+		Provider:          sharepkg.Provider{ID: "test", Name: "Test helper"},
+		Operations:        []sharepkg.Operation{sharepkg.OperationCreate, sharepkg.OperationUpdate},
+		Visibilities:      []sharepkg.Visibility{sharepkg.VisibilityUnlisted, sharepkg.VisibilityPrivate},
+		DefaultVisibility: sharepkg.VisibilityUnlisted,
+	}
+}
+
+func (p *recordingSharePublisher) Capabilities(context.Context) (sharepkg.Capabilities, error) {
+	p.capCalls++
+	return p.caps, nil
+}
+
+func (p *recordingSharePublisher) Create(_ context.Context, req sharepkg.Request) (sharepkg.Result, error) {
+	p.createCalls++
+	p.lastRequest = req
+	return p.result, nil
+}
+
+func (p *recordingSharePublisher) Update(_ context.Context, _ string, req sharepkg.Request) (sharepkg.Result, error) {
+	p.updateCalls++
+	p.lastRequest = req
+	return p.result, nil
+}
+
+func installSharePublisher(t *testing.T, publisher sharepkg.Publisher) {
+	t.Helper()
+	old := newSharePublisher
+	newSharePublisher = func(config.ShareConfig) (sharepkg.Publisher, error) { return publisher, nil }
+	t.Cleanup(func() { newSharePublisher = old })
+}
+
+func lastBatchMessage(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(batch) == 0 {
+		t.Fatalf("command = %T, want non-empty batch", cmd())
+	}
+	return batch[len(batch)-1]()
+}
+
+func TestCmdShareLoadsCapabilitiesAsynchronouslyBeforeOfferingUpdate(t *testing.T) {
+	publisher := &recordingSharePublisher{caps: defaultShareCapabilities()}
+	installSharePublisher(t, publisher)
 	m := newCmdTestModel(&mockStore{})
-	m.sess = &session.Session{ID: "share-test", Share: &session.ShareState{GistID: "abc123"}}
+	m.sess = &session.Session{ID: "share-test", Share: &session.ShareState{
+		Provider: "test", ID: "opaque", URL: "https://example.test/share", Visibility: "unlisted", Scope: session.ShareScopeSession,
+	}}
 	result, cmd := m.ExecuteCommand("/share")
+	m = result.(*Model)
+	if cmd == nil || publisher.capCalls != 0 || !m.shareInFlight || m.dialog.Type() == DialogShareChoice {
+		t.Fatalf("capabilities ran synchronously or dialog opened early: calls=%d inFlight=%v dialog=%v", publisher.capCalls, m.shareInFlight, m.dialog.Type())
+	}
+	message, ok := lastBatchMessage(t, cmd).(shareCapabilitiesMsg)
+	if !ok {
+		t.Fatalf("capability command returned unexpected message")
+	}
+	result, cmd = m.handleShareCapabilities(message)
 	m = result.(*Model)
 	if cmd != nil || m.dialog.Type() != DialogShareChoice || m.pendingShare == nil {
 		t.Fatalf("dialog=%v pending=%v cmd nil=%v", m.dialog.Type(), m.pendingShare, cmd == nil)
@@ -5335,7 +5400,7 @@ func TestCmdShareExistingGistOpensChoice(t *testing.T) {
 func TestShareCommandRegistered(t *testing.T) {
 	for _, command := range AllCommands() {
 		if command.Name == "share" {
-			if command.Usage != "/share [new] [public]" || len(command.Subcommands) != 2 {
+			if command.Usage != "/share [new] [raw] [public|unlisted|private]" || len(command.Subcommands) != 5 {
 				t.Fatalf("share command = %+v", command)
 			}
 			return
@@ -5344,15 +5409,51 @@ func TestShareCommandRegistered(t *testing.T) {
 	t.Fatal("share command not registered")
 }
 
-func TestCmdShareNewSkipsExistingChoice(t *testing.T) {
-	store := &mockStore{sessions: map[string]*session.Session{}, messages: map[string][]session.Message{}}
-	m := newCmdTestModel(store)
-	m.sess = &session.Session{ID: "share-new", Share: &session.ShareState{GistID: "abc123"}}
-	store.sessions[m.sess.ID] = m.sess
-	result, cmd := m.ExecuteCommand("/share new")
+func TestShareCapabilitiesDoNotOfferUpdateWithoutCompatibleCapabilityAndScope(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		provider   string
+		scope      session.ShareScope
+		operations []sharepkg.Operation
+	}{
+		{name: "no update capability", provider: "test", scope: session.ShareScopeSession, operations: []sharepkg.Operation{sharepkg.OperationCreate}},
+		{name: "point in time scope", provider: "test", scope: session.ShareScopeResponse, operations: []sharepkg.Operation{sharepkg.OperationCreate, sharepkg.OperationUpdate}},
+		{name: "different provider", provider: "other", scope: session.ShareScopeSession, operations: []sharepkg.Operation{sharepkg.OperationCreate, sharepkg.OperationUpdate}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			caps := defaultShareCapabilities()
+			caps.Operations = test.operations
+			publisher := &recordingSharePublisher{caps: caps, result: sharepkg.Result{Provider: "test", ID: "new", URL: "https://example.test/new", Visibility: sharepkg.VisibilityUnlisted, Ready: true}}
+			sess := &session.Session{ID: "share-test", Share: &session.ShareState{
+				Provider: test.provider, ID: "old", URL: "https://example.test/old", Visibility: "unlisted", Scope: test.scope,
+			}}
+			store := &mockStore{sessions: map[string]*session.Session{sess.ID: sess}, messages: map[string][]session.Message{sess.ID: {}}}
+			m := newCmdTestModel(store)
+			m.sess = sess
+			result, cmd := m.handleShareCapabilities(shareCapabilitiesMsg{request: shareRequest{}, publisher: publisher, capabilities: caps})
+			m = result.(*Model)
+			if cmd != nil || m.shareInFlight || m.dialog.Type() != DialogShareChoice || m.pendingShare == nil {
+				t.Fatalf("cmd nil=%v inFlight=%v dialog=%v pending=%v", cmd == nil, m.shareInFlight, m.dialog.Type(), m.pendingShare)
+			}
+			if selected := m.dialog.Selected(); selected == nil || selected.ID != "create" || !strings.Contains(selected.Description, "previous provider link") {
+				t.Fatalf("incompatible share warning missing: selected=%+v", selected)
+			}
+		})
+	}
+}
+
+func TestShareCapabilitiesRejectUnsupportedVisibilityBeforeCreate(t *testing.T) {
+	caps := defaultShareCapabilities()
+	caps.Visibilities = []sharepkg.Visibility{sharepkg.VisibilityUnlisted}
+	publisher := &recordingSharePublisher{caps: caps}
+	m := newCmdTestModel(&mockStore{})
+	m.sess = &session.Session{ID: "share-test"}
+	result, _ := m.handleShareCapabilities(shareCapabilitiesMsg{
+		request: shareRequest{visibility: sharepkg.VisibilityPrivate, visibilitySet: true}, publisher: publisher, capabilities: caps,
+	})
 	m = result.(*Model)
-	if cmd == nil || m.dialog.Type() == DialogShareChoice || !m.shareInFlight {
-		t.Fatalf("dialog=%v inFlight=%v cmd nil=%v", m.dialog.Type(), m.shareInFlight, cmd == nil)
+	if publisher.createCalls != 0 || !strings.Contains(m.footerMessage, "not supported") {
+		t.Fatalf("create calls=%d footer=%q", publisher.createCalls, m.footerMessage)
 	}
 }
 
@@ -5374,36 +5475,9 @@ func TestCmdShareRejectsWhileStreamingOrInFlight(t *testing.T) {
 	}
 }
 
-type recordingGistSharer struct {
-	createResult *gist.Gist
-	createCalls  int
-	updateCalls  int
-}
-
-func (s *recordingGistSharer) Create(string, bool, map[string]string) (*gist.Gist, error) {
-	s.createCalls++
-	return s.createResult, nil
-}
-
-func (s *recordingGistSharer) Update(string, map[string]string) error {
-	s.updateCalls++
-	return nil
-}
-
-func installGistSharer(t *testing.T, sharer gistSharer) {
-	t.Helper()
-	old := newGistClient
-	newGistClient = func() (gistSharer, error) { return sharer, nil }
-	t.Cleanup(func() { newGistClient = old })
-}
-
 func shareWorkResult(t *testing.T, cmd tea.Cmd) shareDoneMsg {
 	t.Helper()
-	batch, ok := cmd().(tea.BatchMsg)
-	if !ok || len(batch) < 2 {
-		t.Fatalf("share command = %T, want batch with footer and work commands", cmd())
-	}
-	msg := batch[len(batch)-1]()
+	msg := lastBatchMessage(t, cmd)
 	result, ok := msg.(shareDoneMsg)
 	if !ok {
 		t.Fatalf("share work command returned %T", msg)
@@ -5411,7 +5485,73 @@ func shareWorkResult(t *testing.T, cmd tea.Cmd) shareDoneMsg {
 	return result
 }
 
-func TestStartShareCopiesPreviewExactlyOnceForCreateAndUpdate(t *testing.T) {
+func TestShareProviderGuidanceIncludesNotesHelpPrivacyAndOrphanWarning(t *testing.T) {
+	req := shareRequest{
+		includeRaw: true, visibility: sharepkg.VisibilityUnlisted,
+		capabilities: sharepkg.Capabilities{Provider: sharepkg.Provider{Name: "Acme", Help: "Run acme login."}, Notes: []string{"Links expire."}},
+	}
+	guidance := shareProviderGuidance(req, true)
+	for _, want := range []string{"Unlisted links are not private", "Links expire.", "Run acme login.", "raw model reasoning", "previous provider link"} {
+		if !strings.Contains(guidance, want) {
+			t.Fatalf("guidance missing %q: %q", want, guidance)
+		}
+	}
+}
+
+func TestShareProgressFooterPersistsPastTransientTimer(t *testing.T) {
+	publisher := &recordingSharePublisher{caps: defaultShareCapabilities()}
+	installSharePublisher(t, publisher)
+	m := newCmdTestModel(&mockStore{})
+	m.sess = &session.Session{ID: "share-progress"}
+	_, oldTimer := m.showFooterMuted("older notice")
+	oldClear := oldTimer().(footerMessageClearMsg)
+	result, cmd := m.ExecuteCommand("/share")
+	m = result.(*Model)
+	if cmd == nil || !m.shareInFlight || m.footerMessage != "Loading sharing provider…" {
+		t.Fatalf("progress state inFlight=%v footer=%q cmd=%v", m.shareInFlight, m.footerMessage, cmd != nil)
+	}
+	updated, _ := m.Update(oldClear)
+	m = updated.(*Model)
+	if m.footerMessage != "Loading sharing provider…" {
+		t.Fatalf("old transient timer cleared active progress: %q", m.footerMessage)
+	}
+}
+
+func TestShareRawReasoningRequiresExplicitRawArgument(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		includeRaw bool
+		wantRaw    bool
+	}{
+		{name: "config raw is not implicit"},
+		{name: "explicit raw", includeRaw: true, wantRaw: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			caps := defaultShareCapabilities()
+			publisher := &recordingSharePublisher{caps: caps, result: sharepkg.Result{Provider: "test", ID: "opaque", URL: "https://example.test/share", Visibility: sharepkg.VisibilityUnlisted, Ready: true}}
+			sess := &session.Session{ID: "share-raw", Name: "Raw privacy"}
+			message := session.Message{SessionID: sess.ID, Role: llm.RoleAssistant, Parts: []llm.Part{{Type: llm.PartText, Text: "Final answer.", ReasoningContent: "private raw chain", ReasoningKind: llm.ReasoningKindRaw}}, TextContent: "Final answer."}
+			store := &mockStore{sessions: map[string]*session.Session{sess.ID: sess}, messages: map[string][]session.Message{sess.ID: {message}}}
+			m := newCmdTestModel(store)
+			m.sess = sess
+			m.config = &config.Config{Reasoning: config.ReasoningConfig{Raw: true, Source: config.ReasoningSourceAll, Export: config.ReasoningExportRaw}}
+			_, cmd := m.startShare(shareRequest{publisher: publisher, capabilities: caps, visibility: sharepkg.VisibilityUnlisted, includeRaw: test.includeRaw}, false)
+			result := shareWorkResult(t, cmd)
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			containsRaw := false
+			for _, file := range publisher.lastRequest.Files {
+				containsRaw = containsRaw || strings.Contains(string(file.Content), "private raw chain")
+			}
+			if containsRaw != test.wantRaw || result.includedRaw != test.wantRaw {
+				t.Fatalf("containsRaw=%v includedRaw=%v want=%v", containsRaw, result.includedRaw, test.wantRaw)
+			}
+		})
+	}
+}
+
+func TestStartShareCopiesLinkExactlyOnceForCreateAndUpdate(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
 		update     bool
@@ -5422,9 +5562,13 @@ func TestStartShareCopiesPreviewExactlyOnceForCreateAndUpdate(t *testing.T) {
 		{name: "update", update: true, wantUpdate: 1},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			caps := defaultShareCapabilities()
+			publisher := &recordingSharePublisher{caps: caps, result: sharepkg.Result{
+				Provider: "test", ID: "opaque", URL: "https://example.test/share", Visibility: sharepkg.VisibilityUnlisted, Ready: true,
+			}}
 			sess := &session.Session{ID: "share-flow", Name: "Share flow"}
 			if tt.update {
-				sess.Share = &session.ShareState{GistID: "abc123", GistURL: "https://gist.github.com/u/abc123"}
+				sess.Share = &session.ShareState{Provider: "test", ID: "opaque", URL: "https://example.test/share", Visibility: "unlisted", Scope: session.ShareScopeSession}
 			}
 			store := &mockStore{
 				sessions: map[string]*session.Session{sess.ID: sess},
@@ -5432,8 +5576,6 @@ func TestStartShareCopiesPreviewExactlyOnceForCreateAndUpdate(t *testing.T) {
 			}
 			m := newCmdTestModel(store)
 			m.sess = sess
-			sharer := &recordingGistSharer{createResult: &gist.Gist{ID: "abc123", URL: "https://gist.github.com/u/abc123"}}
-			installGistSharer(t, sharer)
 			copyCalls := 0
 			var copied string
 			installCopyBackend(t, func(text string) (clipboard.CopyMethod, error) {
@@ -5442,22 +5584,16 @@ func TestStartShareCopiesPreviewExactlyOnceForCreateAndUpdate(t *testing.T) {
 				return clipboard.CopyMethodNative, nil
 			})
 
-			_, cmd := m.startShare(shareRequest{}, tt.update)
+			_, cmd := m.startShare(shareRequest{publisher: publisher, capabilities: caps, visibility: sharepkg.VisibilityUnlisted}, tt.update)
 			result := shareWorkResult(t, cmd)
 			if result.err != nil {
 				t.Fatalf("share result error = %v", result.err)
 			}
-			if copyCalls != 1 {
-				t.Fatalf("CopyTextBestEffort calls = %d, want 1", copyCalls)
+			if copyCalls != 1 || copied != "https://example.test/share" {
+				t.Fatalf("copy calls=%d value=%q", copyCalls, copied)
 			}
-			if copied != session.GistPreviewURL("abc123") {
-				t.Fatalf("copied preview = %q", copied)
-			}
-			if !result.copyAttempted || result.copyErr != nil || result.copyMethod != clipboard.CopyMethodNative {
-				t.Fatalf("copy result = %+v", result)
-			}
-			if sharer.createCalls != tt.wantCreate || sharer.updateCalls != tt.wantUpdate {
-				t.Fatalf("gist calls create=%d update=%d", sharer.createCalls, sharer.updateCalls)
+			if publisher.createCalls != tt.wantCreate || publisher.updateCalls != tt.wantUpdate {
+				t.Fatalf("share calls create=%d update=%d", publisher.createCalls, publisher.updateCalls)
 			}
 		})
 	}
@@ -5473,22 +5609,17 @@ func TestHandleShareDonePersistsOriginatingSession(t *testing.T) {
 	beforeMessages := len(m.messages)
 
 	result, _ := m.handleShareDone(shareDoneMsg{
-		store:     store,
-		sessionID: origin.ID,
-		gist:      &gist.Gist{ID: "abc123", URL: "https://gist.github.com/u/abc123"},
-		preview:   session.GistPreviewURL("abc123"),
+		store: store, sessionID: origin.ID,
+		result: sharepkg.Result{Provider: "test", ID: "opaque", URL: "https://example.test/share", Visibility: sharepkg.VisibilityPrivate, Ready: true},
 	})
 	m = result.(*Model)
-	if m.shareInFlight {
-		t.Fatal("share remained in flight")
+	if m.shareInFlight || store.updated == nil || store.updated.ID != origin.ID || store.updated.Share == nil {
+		t.Fatalf("inFlight=%v updated=%+v", m.shareInFlight, store.updated)
 	}
-	if store.updated == nil || store.updated.ID != origin.ID || store.updated.Share == nil {
-		t.Fatalf("updated session = %+v", store.updated)
+	if store.updated.Share.Scope != session.ShareScopeSession || current.Share != nil {
+		t.Fatalf("persisted/current share = %+v / %+v", store.updated.Share, current.Share)
 	}
-	if current.Share != nil {
-		t.Fatalf("current session was poisoned: %+v", current.Share)
-	}
-	if m.dialog.Type() != DialogContent || !strings.Contains(m.dialog.Content(), "abc123") {
+	if m.dialog.Type() != DialogContent || !strings.Contains(m.dialog.Content(), "example.test/share") {
 		t.Fatalf("result dialog type=%v content=%q", m.dialog.Type(), m.dialog.Content())
 	}
 	if len(m.messages) != beforeMessages {
@@ -5515,37 +5646,14 @@ func TestHandleShareDoneReportsClipboardDelivery(t *testing.T) {
 			m := newCmdTestModel(store)
 			m.sess = sess
 			result, _ := m.handleShareDone(shareDoneMsg{
-				store:         store,
-				sessionID:     sess.ID,
-				gist:          &gist.Gist{ID: "abc123", URL: "https://gist.github.com/u/abc123"},
-				preview:       session.GistPreviewURL("abc123"),
-				copyAttempted: tt.copyAttempted,
-				copyMethod:    tt.method,
-				copyErr:       tt.copyErr,
+				store: store, sessionID: sess.ID,
+				result:        sharepkg.Result{Provider: "test", ID: "opaque", URL: "https://example.test/share", Visibility: sharepkg.VisibilityUnlisted, Ready: true},
+				copyAttempted: tt.copyAttempted, copyMethod: tt.method, copyErr: tt.copyErr,
 			})
 			if got := result.(*Model).dialog.Content(); !strings.Contains(got, tt.wantDialog) {
 				t.Fatalf("dialog = %q, want %q", got, tt.wantDialog)
 			}
 		})
-	}
-}
-
-func TestHandleShareDonePublicUpdateExplainsVisibility(t *testing.T) {
-	sess := &session.Session{ID: "origin"}
-	store := &mockStore{sessions: map[string]*session.Session{"origin": sess}}
-	m := newCmdTestModel(store)
-	m.sess = sess
-	result, _ := m.handleShareDone(shareDoneMsg{
-		store:           store,
-		sessionID:       sess.ID,
-		gist:            &gist.Gist{ID: "abc123", URL: "https://gist.github.com/u/abc123"},
-		preview:         session.GistPreviewURL("abc123"),
-		updated:         true,
-		requestedPublic: true,
-	})
-	m = result.(*Model)
-	if !strings.Contains(m.dialog.Content(), "cannot make it public") {
-		t.Fatalf("dialog did not explain visibility: %q", m.dialog.Content())
 	}
 }
 

--- a/internal/tui/chat/dialog.go
+++ b/internal/tui/chat/dialog.go
@@ -353,16 +353,23 @@ func (d *DialogModel) ShowWorktreeConfirmation(title, question, yesLabel, noLabe
 	d.filtered = d.items
 }
 
-// ShowShareChoice asks how an already-shared session should be shared.
-func (d *DialogModel) ShowShareChoice() {
+// ShowShareChoice confirms a share and optionally offers an in-place update.
+func (d *DialogModel) ShowShareChoice(canUpdate bool, guidance string) {
 	d.dialogType = DialogShareChoice
 	d.title = "Share session"
 	d.cursor = 0
 	d.query = ""
-	d.items = []DialogItem{
-		{ID: "update", Label: "Update existing gist"},
-		{ID: "new", Label: "Create new gist"},
-		{ID: "cancel", Label: "Cancel"},
+	if canUpdate {
+		d.items = []DialogItem{
+			{ID: "update", Label: "Update existing share", Description: guidance},
+			{ID: "new", Label: "Create new share", Description: "Replaces the saved share state; the existing provider link may remain active and must be managed separately."},
+			{ID: "cancel", Label: "Cancel"},
+		}
+	} else {
+		d.items = []DialogItem{
+			{ID: "create", Label: "Create share", Description: guidance},
+			{ID: "cancel", Label: "Cancel"},
+		}
 	}
 	d.filtered = d.items
 }

--- a/internal/tui/chat/handlers.go
+++ b/internal/tui/chat/handlers.go
@@ -825,7 +825,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					if req == nil || selected.ID == "cancel" {
 						return m, nil
 					}
-					if selected.ID == "new" {
+					if selected.ID == "new" || selected.ID == "create" {
 						req.forceNew = true
 						return m.startShare(*req, false)
 					}

--- a/internal/tui/chat/share.go
+++ b/internal/tui/chat/share.go
@@ -7,50 +7,73 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/samsaffron/term-llm/internal/agents/gist"
 	"github.com/samsaffron/term-llm/internal/clipboard"
 	"github.com/samsaffron/term-llm/internal/config"
 	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
 	"github.com/samsaffron/term-llm/internal/session"
+	sharepkg "github.com/samsaffron/term-llm/internal/share"
 )
 
 type shareRequest struct {
-	forceNew bool
-	public   bool
+	forceNew      bool
+	includeRaw    bool
+	visibility    sharepkg.Visibility
+	visibilitySet bool
+	publisher     sharepkg.Publisher
+	capabilities  sharepkg.Capabilities
 }
 
-type gistSharer interface {
-	Create(string, bool, map[string]string) (*gist.Gist, error)
-	Update(string, map[string]string) error
+var newSharePublisher = func(cfg config.ShareConfig) (sharepkg.Publisher, error) {
+	return sharepkg.NewPublisher(cfg)
 }
 
-var newGistClient = func() (gistSharer, error) { return gist.NewClient() }
+type shareCapabilitiesMsg struct {
+	request      shareRequest
+	publisher    sharepkg.Publisher
+	capabilities sharepkg.Capabilities
+	err          error
+}
 
 type shareDoneMsg struct {
-	store           session.Store
-	sessionID       string
-	priorSharedAt   time.Time
-	gist            *gist.Gist
-	preview         string
-	updated         bool
-	public          bool
-	requestedPublic bool
-	copyAttempted   bool
-	copyMethod      clipboard.CopyMethod
-	copyErr         error
-	err             error
+	store               session.Store
+	sessionID           string
+	priorSharedAt       time.Time
+	result              sharepkg.Result
+	updated             bool
+	requestedVisibility sharepkg.Visibility
+	providerName        string
+	providerHelp        string
+	providerNotes       []string
+	includedRaw         bool
+	copyAttempted       bool
+	copyMethod          clipboard.CopyMethod
+	copyErr             error
+	err                 error
 }
 
 func (m *Model) cmdShare(args []string) (tea.Model, tea.Cmd) {
+	const usage = "Usage: /share [new] [raw] [public|unlisted|private]"
 	req := shareRequest{}
 	for _, arg := range args {
 		switch strings.ToLower(arg) {
 		case "new":
+			if req.forceNew {
+				return m.showFooterError(usage)
+			}
 			req.forceNew = true
-		case "public":
-			req.public = true
+		case "raw":
+			if req.includeRaw {
+				return m.showFooterError(usage)
+			}
+			req.includeRaw = true
+		case "public", "unlisted", "private":
+			if req.visibilitySet {
+				return m.showFooterError(usage)
+			}
+			req.visibility = sharepkg.Visibility(strings.ToLower(arg))
+			req.visibilitySet = true
 		default:
-			return m.showFooterError("Usage: /share [new] [public]")
+			return m.showFooterError(usage)
 		}
 	}
 	if m.sess == nil || m.store == nil {
@@ -62,12 +85,77 @@ func (m *Model) cmdShare(args []string) (tea.Model, tea.Cmd) {
 	if m.shareInFlight {
 		return m.showFooterError("A share is already in progress.")
 	}
-	if m.sess.Share != nil && m.sess.Share.GistID != "" && !req.forceNew {
-		m.pendingShare = &req
-		m.dialog.ShowShareChoice()
-		return m, nil
+
+	cfg := config.ShareConfig{}
+	if m.config != nil {
+		cfg = m.config.Share
 	}
-	return m.startShare(req, false)
+	ctx := m.rootCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.shareInFlight = true
+	updatedModel, _ := m.showFooterPersistent("Loading sharing provider…", "muted")
+	capabilityCmd := func() tea.Msg {
+		publisher, err := newSharePublisher(cfg)
+		if err != nil {
+			return shareCapabilitiesMsg{request: req, err: err}
+		}
+		capabilities, err := publisher.Capabilities(ctx)
+		return shareCapabilitiesMsg{request: req, publisher: publisher, capabilities: capabilities, err: err}
+	}
+	return updatedModel, tea.Batch(m.spinner.Tick, capabilityCmd)
+}
+
+func (m *Model) handleShareCapabilities(msg shareCapabilitiesMsg) (tea.Model, tea.Cmd) {
+	m.shareInFlight = false
+	if msg.err != nil {
+		return m.showFooterError("Share unavailable: " + msg.err.Error())
+	}
+	if err := sharepkg.ValidateCapabilities(msg.capabilities); err != nil {
+		return m.showFooterError("Share unavailable: provider returned invalid capabilities.")
+	}
+	req := msg.request
+	req.publisher = msg.publisher
+	req.capabilities = msg.capabilities
+	if !req.visibilitySet {
+		req.visibility = msg.capabilities.DefaultVisibility
+	}
+	if !msg.capabilities.SupportsVisibility(req.visibility) {
+		return m.showFooterError(fmt.Sprintf("%s visibility is not supported by %s.", req.visibility, msg.capabilities.Provider.Name))
+	}
+
+	compatibleUpdate := false
+	orphanWarning := false
+	if m.sess != nil && m.sess.Share != nil && m.sess.Share.Exists() {
+		m.sess.Share.Normalize()
+		_, canUpdate := msg.publisher.(sharepkg.Updater)
+		compatibleUpdate = !req.forceNew && canUpdate && m.sess.Share.Provider == string(msg.capabilities.Provider.ID) &&
+			m.sess.Share.Scope == session.ShareScopeSession && msg.capabilities.Supports(sharepkg.OperationUpdate)
+		orphanWarning = !compatibleUpdate
+	}
+	m.pendingShare = &req
+	m.dialog.ShowShareChoice(compatibleUpdate, shareProviderGuidance(req, orphanWarning))
+	m.clearFooterMessage()
+	return m, nil
+}
+
+func shareProviderGuidance(req shareRequest, orphanWarning bool) string {
+	parts := []string{fmt.Sprintf("Provider: %s. Visibility: %s.", req.capabilities.Provider.Name, req.visibility)}
+	if req.visibility == sharepkg.VisibilityUnlisted {
+		parts = append(parts, "Unlisted links are not private; anyone with the link may be able to view the transcript.")
+	}
+	parts = append(parts, req.capabilities.Notes...)
+	if help := strings.TrimSpace(req.capabilities.Provider.Help); help != "" {
+		parts = append(parts, "Help: "+help)
+	}
+	if req.includeRaw {
+		parts = append(parts, "WARNING: raw model reasoning was explicitly requested and may contain private or sensitive information.")
+	}
+	if orphanWarning {
+		parts = append(parts, "WARNING: creating this share replaces the saved share state; the previous provider link may remain active and must be managed separately.")
+	}
+	return strings.Join(parts, " ")
 }
 
 func (m *Model) startShare(req shareRequest, update bool) (tea.Model, tea.Cmd) {
@@ -77,6 +165,9 @@ func (m *Model) startShare(req shareRequest, update bool) (tea.Model, tea.Cmd) {
 	if m.sess == nil || m.store == nil {
 		return m.showFooterError("No saved session to share.")
 	}
+	if req.publisher == nil {
+		return m.showFooterError("Sharing provider is unavailable.")
+	}
 
 	sess := m.sess
 	sessSnapshot := *sess
@@ -85,90 +176,97 @@ func (m *Model) startShare(req shareRequest, update bool) (tea.Model, tea.Cmd) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cfg := config.DefaultReasoningConfig()
+	reasoningCfg := config.DefaultReasoningConfig()
 	if m.config != nil {
-		cfg = m.config.ResolveReasoning("chat")
+		reasoningCfg = m.config.ResolveReasoning("chat")
 	}
-	opts := session.ExportOptions{IncludeReasoningSummaries: internalreasoning.ExportSummaries(cfg)}
-	if cfg.Raw && internalreasoning.SourceAllowsRaw(cfg) && strings.EqualFold(strings.TrimSpace(cfg.Export), config.ReasoningExportRaw) {
-		opts.IncludeRawReasoning = true
-		opts.IncludeReasoningSummaries = true
+	opts := session.ExportOptions{IncludeReasoningSummaries: internalreasoning.ExportSummaries(reasoningCfg)}
+	if req.includeRaw {
+		switch {
+		case !reasoningCfg.Raw:
+			return m.showFooterError("Raw reasoning sharing is disabled; enable reasoning.raw before using /share raw.")
+		case !internalreasoning.SourceAllowsRaw(reasoningCfg):
+			return m.showFooterError("Raw reasoning sharing is blocked by reasoning.source; set it to all before using /share raw.")
+		default:
+			opts.IncludeRawReasoning = true
+			opts.IncludeReasoningSummaries = true
+		}
 	}
 
 	sessionID := sess.ID
-	name := sess.Name
+	name := strings.TrimSpace(sess.PreferredShortTitle())
 	if name == "" {
 		name = fmt.Sprintf("#%d", sess.Number)
 	}
-	var updateID, updateURL string
-	var updatePublic bool
+	requestedVisibility := sharepkg.Visibility("")
+	if req.visibilitySet {
+		requestedVisibility = req.visibility
+	}
+	var updateID string
+	var updater sharepkg.Updater
 	var priorSharedAt time.Time
 	if update {
-		if sess.Share == nil || sess.Share.GistID == "" {
-			return m.showFooterError("No existing gist to update.")
+		var ok bool
+		updater, ok = req.publisher.(sharepkg.Updater)
+		if !ok {
+			return m.showFooterError("The sharing provider does not support updates; create a new share instead.")
 		}
-		updateID = sess.Share.GistID
-		updateURL = sess.Share.GistURL
-		updatePublic = sess.Share.Public
+		if sess.Share == nil || !sess.Share.Exists() {
+			return m.showFooterError("No existing share to update.")
+		}
+		sess.Share.Normalize()
+		if sess.Share.Provider != string(req.capabilities.Provider.ID) || sess.Share.Scope != session.ShareScopeSession || !req.capabilities.Supports(sharepkg.OperationUpdate) {
+			return m.showFooterError("The existing share is not compatible with this provider; create a new share instead.")
+		}
+		updateID = sess.Share.ID
 		priorSharedAt = sess.Share.SharedAt
-		if session.GistPreviewURL(updateID) == "" {
-			return m.showFooterError("The stored gist ID is invalid; create a new gist instead.")
-		}
 	}
 
 	m.pendingShare = nil
 	m.shareInFlight = true
-	label := "Creating Gist…"
+	label := "Creating share…"
 	if update {
-		label = "Updating Gist…"
+		label = "Updating share…"
 	}
-	updatedModel, footerCmd := m.showFooterMuted(label)
+	updatedModel, _ := m.showFooterPersistent(label, "muted")
 	cmd := func() tea.Msg {
-		result := shareDoneMsg{store: store, sessionID: sessionID, priorSharedAt: priorSharedAt, updated: update, public: updatePublic, requestedPublic: req.public}
+		result := shareDoneMsg{
+			store: store, sessionID: sessionID, priorSharedAt: priorSharedAt, updated: update,
+			requestedVisibility: requestedVisibility, providerName: req.capabilities.Provider.Name,
+			providerHelp: req.capabilities.Provider.Help, providerNotes: append([]string(nil), req.capabilities.Notes...),
+			includedRaw: opts.IncludeRawReasoning,
+		}
 		messages, _, err := session.LoadScrollbackWithBoundary(ctx, store, &sessSnapshot)
 		if err != nil {
 			result.err = fmt.Errorf("load session messages: %w", err)
 			return result
 		}
-		files, err := session.GistFiles(&sessSnapshot, session.VisibleExportMessages(messages), opts)
+		files, err := session.ShareFiles(&sessSnapshot, session.VisibleExportMessages(messages), opts)
 		if err != nil {
 			result.err = err
 			return result
 		}
-		client, err := newGistClient()
-		if err != nil {
-			result.err = err
-			return result
+		request := sharepkg.Request{
+			RequestID: sharepkg.NewRequestID(), Title: name,
+			Description: "term-llm session: " + name, Visibility: req.visibility,
+			Entrypoint: "index.html", Files: sharepkg.TranscriptFiles(files),
 		}
 		if update {
-			if err := client.Update(updateID, files); err != nil {
-				result.err = fmt.Errorf("update gist: %w", err)
-				return result
-			}
-			result.gist = &gist.Gist{ID: updateID, URL: updateURL, Public: updatePublic}
-			result.preview = session.GistPreviewURL(updateID)
-			result.copyAttempted = true
-			result.copyMethod, result.copyErr = copyTextBestEffort(result.preview)
+			result.result, result.err = updater.Update(ctx, updateID, request)
+		} else {
+			result.result, result.err = req.publisher.Create(ctx, request)
+		}
+		if result.err != nil {
 			return result
 		}
-		g, err := client.Create("term-llm session: "+name, req.public, files)
-		if err != nil {
-			result.err = fmt.Errorf("create gist: %w", err)
-			return result
+		if result.result.Provider == "" {
+			result.result.Provider = req.capabilities.Provider.ID
 		}
-		preview := session.GistPreviewURL(g.ID)
-		if preview == "" {
-			result.err = fmt.Errorf("gist returned an invalid ID %q", g.ID)
-			return result
-		}
-		result.gist = g
-		result.preview = preview
-		result.public = req.public
 		result.copyAttempted = true
-		result.copyMethod, result.copyErr = copyTextBestEffort(result.preview)
+		result.copyMethod, result.copyErr = copyTextBestEffort(result.result.URL)
 		return result
 	}
-	return updatedModel, tea.Batch(footerCmd, cmd)
+	return updatedModel, tea.Batch(m.spinner.Tick, cmd)
 }
 
 func (m *Model) handleShareDone(msg shareDoneMsg) (tea.Model, tea.Cmd) {
@@ -176,37 +274,56 @@ func (m *Model) handleShareDone(msg shareDoneMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		return m.showFooterError("Share failed: " + msg.err.Error())
 	}
-	if msg.gist == nil || msg.sessionID == "" || msg.store == nil {
-		return m.showFooterError("Share failed: empty gist result.")
+	if msg.result.ID == "" || msg.result.URL == "" || msg.sessionID == "" || msg.store == nil {
+		return m.showFooterError("Share failed: empty provider result.")
 	}
 	now := time.Now()
 	sharedAt := now
 	if msg.updated && !msg.priorSharedAt.IsZero() {
 		sharedAt = msg.priorSharedAt
 	}
-	state := &session.ShareState{GistID: msg.gist.ID, GistURL: msg.gist.URL, PreviewURL: msg.preview, Public: msg.public, SharedAt: sharedAt, UpdatedAt: now}
+	state := &session.ShareState{
+		Provider: string(msg.result.Provider), ID: msg.result.ID, URL: msg.result.URL,
+		SourceURL: msg.result.SourceURL, Visibility: string(msg.result.Visibility), Scope: session.ShareScopeSession,
+		SharedAt: sharedAt, UpdatedAt: now,
+	}
+	state.Normalize()
 	ctx := m.rootCtx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := session.UpdateShare(ctx, msg.store, msg.sessionID, state); err != nil {
-		return m.showFooterError("Gist shared, but saving share state failed: " + err.Error())
+		return m.showFooterError("Share created, but saving share state failed: " + err.Error())
 	}
 	if m.sess != nil && m.sess.ID == msg.sessionID {
 		m.sess.Share = state
 	}
 	copied := msg.copyAttempted && msg.copyErr == nil
-	action := "Created new gist"
+	action := "Created new share"
 	if msg.updated {
-		action = "Updated existing gist"
+		action = "Updated existing share"
 	}
-	visibility := "Secret (unlisted, not private)"
-	if msg.public {
-		visibility = "Public"
+	content := fmt.Sprintf("%s\n\nLink:\n%s\n\nVisibility: %s", action, msg.result.URL, msg.result.Visibility)
+	if msg.providerName != "" {
+		content += "\n\nProvider: " + msg.providerName
 	}
-	content := fmt.Sprintf("%s\n\nPreview:\n%s\n\nGist/source:\n%s\n\nVisibility: %s", action, msg.preview, msg.gist.URL, visibility)
-	if msg.updated && msg.requestedPublic && !msg.public {
-		content += "\n\nVisibility unchanged: updating an existing gist cannot make it public. Create a new public gist instead."
+	for _, note := range msg.providerNotes {
+		content += "\n\nNote: " + note
+	}
+	if msg.providerHelp != "" {
+		content += "\n\nHelp: " + msg.providerHelp
+	}
+	if msg.includedRaw {
+		content += "\n\nWARNING: This share includes raw model reasoning, which may contain private or sensitive information."
+	}
+	if msg.result.SourceURL != "" {
+		content += "\n\nSource:\n" + msg.result.SourceURL
+	}
+	if !msg.result.Ready {
+		content += "\n\nThe share was created, but anonymous readiness could not be confirmed yet."
+	}
+	if msg.updated && msg.requestedVisibility != "" && msg.requestedVisibility != msg.result.Visibility {
+		content += fmt.Sprintf("\n\nVisibility unchanged: the provider kept this share %s instead of %s.", msg.result.Visibility, msg.requestedVisibility)
 	}
 	if copied {
 		if msg.copyMethod == clipboard.CopyMethodOSC52 {
@@ -215,7 +332,7 @@ func (m *Model) handleShareDone(msg shareDoneMsg) (tea.Model, tea.Cmd) {
 			content += "\n\nURL copied to clipboard."
 		}
 	} else {
-		content += "\n\nClipboard copy failed; copy the preview URL above."
+		content += "\n\nClipboard copy failed; copy the link above."
 	}
 	m.clearFooterMessage()
 	m.dialog.ShowContent("Session shared", content)


### PR DESCRIPTION
## Summary

- fix GitHub authentication checks to validate only the active account and keep CLI diagnostics out of user-facing errors
- introduce a provider-neutral transcript sharing layer with GitHub Gist as the zero-config default
- add the versioned `term-llm-share` command-helper protocol for private/custom publishers
- make Web, TUI, CLI, persistence, visibility, readiness, and error UX provider-aware
- retain legacy GitHub request/response and persisted-state compatibility
- add `sessions share` while leaving explicit session/agent Gist commands intact
- document the helper contract and configuration

## Safety and compatibility

- helper execution is argv-only, bounded, timed out, process-group cleaned, and isolated in a private temporary bundle
- helper IDs/URLs/capabilities are validated; `github` is reserved for the built-in provider
- helper and `gh` stderr is bounded and operator-only, never returned to Web/TUI users
- response/conversation Web shares remain non-persisted; only whole-session shares can be updated
- legacy GitHub share fields are normalized and dual-written without a database migration
- raw reasoning is opt-in for generic CLI/TUI sharing and remains excluded from Web sharing

## Review

- protocol/spec reviewed with Fable before implementation
- implementation reviewed with Opus; all blocking and practical medium findings were addressed, including `ErrWaitDelay`, relative helper paths, provider impersonation, readiness, capability caching, visibility correctness, diagnostics, raw-reasoning disclosure, and regression coverage

## Verification

- focused sharing/config/Gist/session/TUI/cmd Go suites pass
- `go vet ./...`
- frontend format, lint, typecheck, and all 581 tests pass
- `mise x node@24 -- make build`
- `git diff --check`

Local focused suites, frontend checks, vet, and the canonical build pass. GitHub CI’s `test` and `race` jobs currently fail in the pre-existing flaky `TestServeShellProcessGroupCleanup` test (the shell prints an empty background PID); `passkey-smoke` independently times out locating its second-key Rename button. The sharing packages/tests pass, and cross-build/frontend checks are green.

