### PR TITLE
fix: OpenAI tool-parameter cache permanently retains every runtime's schema graphs

### DIFF
--- a/internal/llm/json_schema_lowering.go
+++ b/internal/llm/json_schema_lowering.go
@@ -71,6 +71,8 @@ func scrubUnsupportedOpenAISchemaKeywords(value interface{}) {
 	}
 }
 
+const maxOpenAIParametersCacheEntries = 4096
+
 type openAIParametersCacheKey struct {
 	schemaPtr uintptr
 	strict    bool
@@ -85,7 +87,16 @@ type openAIParametersCacheEntry struct {
 	params map[string]interface{}
 }
 
-var openAIParametersCache sync.Map
+// Keep identity caching bounded so short-lived runtimes do not pin every schema
+// and lowered copy for the lifetime of the process.
+var openAIParametersCache = struct {
+	mu      sync.Mutex
+	entries map[openAIParametersCacheKey]*openAIParametersCacheEntry
+	order   []openAIParametersCacheKey
+	next    int
+}{
+	entries: make(map[openAIParametersCacheKey]*openAIParametersCacheEntry),
+}
 
 func openAIParametersFromToolSchema(schema map[string]interface{}, strict bool) map[string]interface{} {
 	key := openAIParametersCacheKey{strict: strict}
@@ -93,8 +104,22 @@ func openAIParametersFromToolSchema(schema map[string]interface{}, strict bool) 
 		key.schemaPtr = reflect.ValueOf(schema).Pointer()
 	}
 
-	cached, _ := openAIParametersCache.LoadOrStore(key, &openAIParametersCacheEntry{schema: schema})
-	entry := cached.(*openAIParametersCacheEntry)
+	openAIParametersCache.mu.Lock()
+	entry := openAIParametersCache.entries[key]
+	if entry == nil {
+		entry = &openAIParametersCacheEntry{schema: schema}
+		if len(openAIParametersCache.order) < maxOpenAIParametersCacheEntries {
+			openAIParametersCache.order = append(openAIParametersCache.order, key)
+		} else {
+			oldest := openAIParametersCache.order[openAIParametersCache.next]
+			delete(openAIParametersCache.entries, oldest)
+			openAIParametersCache.order[openAIParametersCache.next] = key
+			openAIParametersCache.next = (openAIParametersCache.next + 1) % maxOpenAIParametersCacheEntries
+		}
+		openAIParametersCache.entries[key] = entry
+	}
+	openAIParametersCache.mu.Unlock()
+
 	entry.once.Do(func() {
 		parsed, err := ParseToolJSONSchemaMap(schema)
 		if err != nil {

--- a/internal/llm/json_schema_model_test.go
+++ b/internal/llm/json_schema_model_test.go
@@ -115,3 +115,60 @@ func TestOpenAIParametersFromToolSchema_CachesLoweredParametersBySchemaIdentityA
 		t.Fatalf("strict and non-strict schemas should be cached separately")
 	}
 }
+
+func TestOpenAIParametersCacheIsBounded(t *testing.T) {
+	resetOpenAIParametersCacheForTest(t)
+
+	schemas := make([]map[string]interface{}, maxOpenAIParametersCacheEntries+10)
+	for i := range schemas {
+		schemas[i] = map[string]interface{}{"type": "object", "x-index": i}
+		openAIParametersFromToolSchema(schemas[i], true)
+	}
+
+	firstKey := openAIParametersCacheKey{
+		schemaPtr: reflect.ValueOf(schemas[0]).Pointer(),
+		strict:    true,
+	}
+	lastKey := openAIParametersCacheKey{
+		schemaPtr: reflect.ValueOf(schemas[len(schemas)-1]).Pointer(),
+		strict:    true,
+	}
+
+	openAIParametersCache.mu.Lock()
+	entryCount := len(openAIParametersCache.entries)
+	orderCount := len(openAIParametersCache.order)
+	_, hasFirst := openAIParametersCache.entries[firstKey]
+	_, hasLast := openAIParametersCache.entries[lastKey]
+	openAIParametersCache.mu.Unlock()
+
+	if entryCount != maxOpenAIParametersCacheEntries || orderCount != maxOpenAIParametersCacheEntries {
+		t.Fatalf("cache size = entries %d order %d, want %d", entryCount, orderCount, maxOpenAIParametersCacheEntries)
+	}
+	if hasFirst {
+		t.Fatal("oldest schema was not evicted")
+	}
+	if !hasLast {
+		t.Fatal("newest schema was not cached")
+	}
+}
+
+func resetOpenAIParametersCacheForTest(t *testing.T) {
+	t.Helper()
+
+	openAIParametersCache.mu.Lock()
+	oldEntries := openAIParametersCache.entries
+	oldOrder := openAIParametersCache.order
+	oldNext := openAIParametersCache.next
+	openAIParametersCache.entries = make(map[openAIParametersCacheKey]*openAIParametersCacheEntry)
+	openAIParametersCache.order = nil
+	openAIParametersCache.next = 0
+	openAIParametersCache.mu.Unlock()
+
+	t.Cleanup(func() {
+		openAIParametersCache.mu.Lock()
+		openAIParametersCache.entries = oldEntries
+		openAIParametersCache.order = oldOrder
+		openAIParametersCache.next = oldNext
+		openAIParametersCache.mu.Unlock()
+	})
+}


### PR DESCRIPTION
## What changed

- Replaced the process-global, unbounded OpenAI parameter `sync.Map` with a mutex-protected identity cache capped at 4,096 entries.
- Added O(1) FIFO eviction with a circular cursor, so evicted entries release their strong references to both the source schema graph and its lowered copy.
- Kept `sync.Once` on each resident entry, preserving one lowering computation for concurrent callers that share a cached schema identity; returned parameter maps are still deep-copied.
- Added a boundedness/eviction test that inserts more than the maximum number of distinct schema maps and verifies the oldest entry is gone, the newest is resident, and both cache bookkeeping structures remain capped.

## Why this is high-value

OpenAI Responses and ChatGPT both use this cache for every tool-enabled request. Jarvis repeatedly creates short-lived web, Telegram, job, child-agent, and model-swap runtimes, and many built-in tools create fresh nested schema maps for each registry. The old global cache retained every source graph and lowered graph for the entire process lifetime, so heap retention and GC work grew with runtime churn.

The new fixed cap makes retained cache memory plateau instead of growing with every runtime. Hot schemas still avoid reparsing and normalization, while O(1) eviction avoids adding cache-size-dependent work once the cap is reached.

## Validation

- `gofmt -w internal/llm/json_schema_lowering.go internal/llm/json_schema_model_test.go`
- `go test ./internal/llm -run 'Test(OpenAIParameters|SanitizedResponsesParameters)' -count=1`
- `go test -race ./internal/llm -run 'Test(OpenAIParameters|SanitizedResponsesParameters)' -count=1`
- `go build ./...`
- `git diff --check`
- `go test ./...` ran; all `internal/llm` tests passed. The repository-wide run was blocked by unrelated existing environment/main failures: two `cmd` skill-discovery tests saw the host's configured skill list instead of their temporary fixtures, and `internal/serveui` reported the freshly generated main-branch bundles slightly above existing gzip budgets. No failing test exercises the changed cache.
