### PR TITLE
fix: A hung Git hook wedges commit operations and can survive server restart

### DIFF
--- a/internal/gitcommit/gitcommit_test.go
+++ b/internal/gitcommit/gitcommit_test.go
@@ -7,8 +7,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/testutil"
 )
 
 func gitTest(t *testing.T, dir string, args ...string) string {
@@ -241,6 +245,63 @@ func TestUnbornHookFailureIsRecoverableNotUncertain(t *testing.T) {
 	_, err = r.Commit(context.Background(), "initial", staged.Fingerprint)
 	if !IsKind(err, ErrCommit) || IsKind(err, ErrUncertain) {
 		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestCommitTimesOutHungHookAndReleasesCheckout(t *testing.T) {
+	r := repoTest(t)
+	writeTest(t, r.root, "base.txt", "changed\n")
+	state, err := r.Inspect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	staged, err := r.Stage(context.Background(), StageRequest{Mode: StageAll, StatusToken: state.StatusToken}, state.Fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pidPath := filepath.Join(t.TempDir(), "hook.pid")
+	t.Setenv("TERM_LLM_TEST_HOOK_PID", pidPath)
+	hook := filepath.Join(r.gitDir, "hooks", "pre-commit")
+	if err := os.WriteFile(hook, []byte("#!/bin/sh\nprintf '%s' $$ > \"$TERM_LLM_TEST_HOOK_PID\"\nsleep 60\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldTimeout, oldWaitDelay := commitTimeout, commitWaitDelay
+	commitTimeout, commitWaitDelay = time.Second, 100*time.Millisecond
+	t.Cleanup(func() {
+		commitTimeout, commitWaitDelay = oldTimeout, oldWaitDelay
+	})
+
+	started := time.Now()
+	_, err = r.Commit(context.Background(), "blocked", staged.Fingerprint)
+	if !IsKind(err, ErrCommit) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline-backed commit failure", err)
+	}
+	if elapsed := time.Since(started); elapsed > 3*time.Second {
+		t.Fatalf("hung commit returned after %s, want at most 3s", elapsed)
+	}
+
+	pidBytes, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read hook PID: %v", err)
+	}
+	hookPID, err := strconv.Atoi(string(pidBytes))
+	if err != nil {
+		t.Fatalf("parse hook PID %q: %v", pidBytes, err)
+	}
+	testutil.WaitForProcessExit(t, hookPID, 2*time.Second)
+
+	if err := os.Remove(hook); err != nil {
+		t.Fatal(err)
+	}
+	commitTimeout, commitWaitDelay = oldTimeout, oldWaitDelay
+	after, err := r.Inspect(context.Background())
+	if err != nil {
+		t.Fatalf("inspect after timed-out commit: %v", err)
+	}
+	if _, err := r.Commit(context.Background(), "after timeout", after.Fingerprint); err != nil {
+		t.Fatalf("commit after timed-out hook: %v", err)
 	}
 }
 

--- a/internal/gitcommit/process.go
+++ b/internal/gitcommit/process.go
@@ -11,6 +11,9 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/procutil"
 )
 
 var scrubGitEnvironment = map[string]struct{}{
@@ -157,15 +160,29 @@ func commandOutput(err error) string {
 	return ""
 }
 
+var (
+	commitTimeout   = 5 * time.Minute
+	commitWaitDelay = 2 * time.Second
+)
+
 // runCommit is deliberately not tied to ctx after the process starts. Callers may
-// abandon a request, but the host must drain Git to a known result.
+// abandon a request, but the host must drain Git to a known result within its
+// own deadline.
 func (r *Repository) runCommit(ctx context.Context, messageFile string) (string, string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", "", err
 	}
+	commitCtx, cancel := context.WithTimeout(context.Background(), commitTimeout)
+	defer cancel()
 	args := []string{"-C", r.root, "commit", "--cleanup=verbatim", "--file=" + messageFile}
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(commitCtx, "git", args...)
 	cmd.Env = gitEnvironment(nil)
+	cmd.WaitDelay = commitWaitDelay
+	cleanup, err := procutil.PrepareCommandProcessGroup(cmd)
+	if err != nil {
+		return "", "", err
+	}
+	defer cleanup()
 	stdout := &limitBuffer{max: maxCommitOutput}
 	stderr := &limitBuffer{max: maxCommitOutput}
 	outPipe, err := cmd.StdoutPipe()
@@ -185,6 +202,9 @@ func (r *Repository) runCommit(ctx context.Context, messageFile string) (string,
 	go func() { defer wg.Done(); _, _ = io.Copy(stderr, errPipe) }()
 	waitErr := cmd.Wait()
 	wg.Wait()
+	if deadlineErr := commitCtx.Err(); deadlineErr != nil {
+		waitErr = fmt.Errorf("Git commit exceeded %s: %w", commitTimeout, deadlineErr)
+	}
 	if stdout.truncated || stderr.truncated {
 		if waitErr == nil {
 			waitErr = &Error{Kind: ErrOutputLimit, Message: "Git commit output exceeded the display limit"}


### PR DESCRIPTION
## What changed

- Bound the host-owned `git commit` subprocess to a generous five-minute deadline without making an admitted commit depend on client cancellation.
- Run Git in its own process group so deadline cancellation kills hooks and helper descendants, and add a bounded `WaitDelay` so inherited output pipes cannot keep `Wait` blocked.
- Preserve the existing post-process HEAD verification, so a timeout racing with a completed commit is still reported as success when the resulting commit can be verified.
- Add an integration test with a blocking pre-commit hook. It verifies the deadline-backed failure, hook termination, checkout lease release, and a successful follow-up commit.

## Why this is high-value

Both web and TUI commit workflows use this host-owned transaction path, and it holds the checkout mutex plus the outer mutation lease while Git runs. Previously, a malformed hook or stuck signing/helper process could wait forever, permanently blocking later commits and coordinated root mutations for that checkout and preventing clean server shutdown. The bounded process-group execution turns that indefinite checkout outage into a classified, recoverable failure while retaining commit-outcome verification.

## Validation

- `gofmt -w internal/gitcommit/process.go internal/gitcommit/gitcommit_test.go`
- `go build ./...` (passed after generating the ignored frontend assets required by `go:embed`)
- `go test ./internal/gitcommit -run 'TestCommitTimesOutHungHookAndReleasesCheckout|TestUnbornHookFailureIsRecoverableNotUncertain' -count=1`
- `go test ./internal/gitcommit -count=3`
- `go test -race ./internal/gitcommit -count=1`
- `go test ./...` in a clean user environment: every package passed except the unrelated existing `internal/serveui.TestProductionBundleSizeBudgets`; current generated `app.js`/`app.css` gzip sizes exceed main's budgets by 130/291 bytes. This change does not touch frontend sources or bundle budgets.
- `git diff --check`
