### PR TITLE
perf: reduce chat startup work

### DIFF
--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -41,21 +41,22 @@ type LocalToolRegistry struct {
 // NewLocalToolRegistry creates a new registry from configuration.
 // The approvalMgr parameter is used for interactive permission prompts.
 func NewLocalToolRegistry(toolConfig *ToolConfig, appConfig *config.Config, approvalMgr *ApprovalManager) (*LocalToolRegistry, error) {
-	// Build permissions from config
-	perms, err := toolConfig.BuildPermissions()
-	if err != nil {
-		return nil, err
-	}
-
-	// If no approval manager provided, create one (for backwards compatibility).
-	// Otherwise keep the registry and approval manager on the same permissions
-	// instance so dynamic updates like SetBaseDir are visible to tool checks.
-	if approvalMgr == nil {
-		approvalMgr = NewApprovalManager(perms)
-	} else if approvalMgr.permissions != nil {
+	var perms *ToolPermissions
+	if approvalMgr != nil && approvalMgr.permissions != nil {
+		// The caller owns these permissions; reuse the exact instance shared with
+		// its approval manager instead of rebuilding and discarding a duplicate.
 		perms = approvalMgr.permissions
 	} else {
-		approvalMgr.permissions = perms
+		var err error
+		perms, err = toolConfig.BuildPermissions()
+		if err != nil {
+			return nil, err
+		}
+		if approvalMgr == nil {
+			approvalMgr = NewApprovalManager(perms)
+		} else {
+			approvalMgr.permissions = perms
+		}
 	}
 
 	r := &LocalToolRegistry{

--- a/internal/tools/registry_permissions_test.go
+++ b/internal/tools/registry_permissions_test.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewToolManagerSharesBuiltPermissions(t *testing.T) {
+	dir := t.TempDir()
+	mgr, err := NewToolManager(&ToolConfig{
+		Enabled:  []string{ReadFileToolName},
+		ReadDirs: []string{dir},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewToolManager: %v", err)
+	}
+	defer mgr.ApprovalMgr.Close()
+
+	if mgr.Registry.permissions != mgr.ApprovalMgr.permissions {
+		t.Fatal("registry and approval manager do not share permissions")
+	}
+	readDirs, _, _ := mgr.Registry.permissions.Snapshot()
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if len(readDirs) != 1 || readDirs[0] != filepath.Clean(resolvedDir) {
+		t.Fatalf("read dirs = %v, want [%s]", readDirs, filepath.Clean(resolvedDir))
+	}
+}
+
+func TestNewLocalToolRegistryBuildsPermissionsWithoutManager(t *testing.T) {
+	dir := t.TempDir()
+	registry, err := NewLocalToolRegistry(&ToolConfig{
+		Enabled:  []string{ReadFileToolName},
+		ReadDirs: []string{dir},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewLocalToolRegistry: %v", err)
+	}
+	defer registry.approval.Close()
+
+	if registry.permissions != registry.approval.permissions {
+		t.Fatal("registry and generated approval manager do not share permissions")
+	}
+	allowed, err := registry.permissions.IsPathAllowedForRead(dir)
+	if err != nil {
+		t.Fatalf("IsPathAllowedForRead: %v", err)
+	}
+	if !allowed {
+		t.Fatalf("generated permissions do not allow configured read dir %s", dir)
+	}
+}
+
+func TestNewLocalToolRegistryReusesManagerPermissions(t *testing.T) {
+	managerDir := t.TempDir()
+	configDir := t.TempDir()
+	perms := NewToolPermissions()
+	if err := perms.AddReadDir(managerDir); err != nil {
+		t.Fatalf("AddReadDir: %v", err)
+	}
+	approvalMgr := NewApprovalManager(perms)
+	defer approvalMgr.Close()
+
+	registry, err := NewLocalToolRegistry(&ToolConfig{
+		Enabled:    []string{ReadFileToolName},
+		ReadDirs:   []string{configDir},
+		ShellAllow: []string{"echo ["}, // Rebuilding these permissions would fail.
+	}, nil, approvalMgr)
+	if err != nil {
+		t.Fatalf("NewLocalToolRegistry: %v", err)
+	}
+	if registry.permissions != perms {
+		t.Fatal("registry did not reuse the approval manager permissions")
+	}
+	allowed, err := registry.permissions.IsPathAllowedForRead(configDir)
+	if err != nil {
+		t.Fatalf("IsPathAllowedForRead: %v", err)
+	}
+	if allowed {
+		t.Fatalf("registry rebuilt permissions from config instead of reusing manager permissions")
+	}
+}

--- a/internal/tui/chat/approval_mode_persistence.go
+++ b/internal/tui/chat/approval_mode_persistence.go
@@ -22,6 +22,10 @@ func (m *Model) persistApprovalMode(mode tools.ApprovalMode) {
 	if m == nil || m.store == nil || m.sess == nil {
 		return
 	}
-	m.sess.ApprovalMode = sessionApprovalModeFromTools(mode)
+	persistedMode := sessionApprovalModeFromTools(mode)
+	if m.sess.ApprovalMode == persistedMode {
+		return
+	}
+	m.sess.ApprovalMode = persistedMode
 	_ = m.store.Update(context.Background(), m.sess)
 }

--- a/internal/tui/chat/approval_mode_persistence_test.go
+++ b/internal/tui/chat/approval_mode_persistence_test.go
@@ -124,6 +124,64 @@ func TestPersistRequestedApprovalModeSurvivesActualPromptFallback(t *testing.T) 
 	}
 }
 
+func TestPersistApprovalModeSkipsUnchangedSession(t *testing.T) {
+	store := &mockStore{}
+	sess := &session.Session{ID: session.NewID(), ApprovalMode: session.ApprovalModeAuto}
+	m := newTestChatModel(false)
+	m.store = store
+	m.sess = sess
+
+	m.PersistApprovalMode(tools.ModeAuto)
+	if store.updated != nil {
+		t.Fatal("unchanged approval mode wrote the session")
+	}
+	if got := m.ApprovalModeRequested(); got != tools.ModeAuto {
+		t.Fatalf("requested mode = %v, want auto", got)
+	}
+
+	m.PersistApprovalMode(tools.ModeYolo)
+	if store.updated != sess {
+		t.Fatal("changed approval mode did not write the session")
+	}
+	if sess.ApprovalMode != session.ApprovalModeYolo {
+		t.Fatalf("session approval mode = %q, want yolo", sess.ApprovalMode)
+	}
+}
+
+func TestNewChatSkipsScrollbackReadForFreshSession(t *testing.T) {
+	store := &mockStore{}
+	provider := llm.NewMockProvider("mock")
+	model := NewWithFastProviderAndApproval(
+		&config.Config{}, provider, nil, llm.NewEngine(provider, nil),
+		"mock", "mock", mcp.NewManager(), 1,
+		false, false, false, nil, "", "", false, "",
+		store, nil, false, nil, false, true, "", "", false,
+		tools.ModePrompt,
+	)
+	if model.sess == nil || len(store.created) != 1 {
+		t.Fatal("fresh chat session was not created")
+	}
+	if store.getMessagesCalls != 0 {
+		t.Fatalf("fresh chat read scrollback %d times, want 0", store.getMessagesCalls)
+	}
+}
+
+func TestNewChatLoadsScrollbackForExistingSession(t *testing.T) {
+	store := &mockStore{}
+	sess := &session.Session{ID: session.NewID(), Provider: "mock", Model: "mock", Mode: session.ModeChat}
+	provider := llm.NewMockProvider("mock")
+	NewWithFastProviderAndApproval(
+		&config.Config{}, provider, nil, llm.NewEngine(provider, nil),
+		"mock", "mock", mcp.NewManager(), 1,
+		false, false, false, nil, "", "", false, "",
+		store, sess, false, nil, false, true, "", "", false,
+		tools.ModePrompt,
+	)
+	if store.getMessagesCalls == 0 {
+		t.Fatal("existing chat session did not load scrollback")
+	}
+}
+
 func TestSetApprovalModePersistsToSession(t *testing.T) {
 	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
 	if err != nil {

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -949,7 +949,8 @@ func NewWithFastProviderAndApproval(cfg *config.Config, provider llm.Provider, f
 	}
 
 	// Use provided session or create a new one
-	if sess == nil {
+	newSession := sess == nil
+	if newSession {
 		sess = &session.Session{
 			ID:           session.NewID(),
 			Provider:     provider.Name(),
@@ -979,7 +980,7 @@ func NewWithFastProviderAndApproval(cfg *config.Config, provider llm.Provider, f
 	// window to the LLM.
 	var messages []session.Message
 	var compactionIdx int
-	if store != nil && sess.ID != "" {
+	if !newSession && store != nil && sess.ID != "" {
 		if loadedMsgs, idx, err := loadInitialSessionMessagesForScrollback(context.Background(), store, sess); err == nil {
 			messages = loadedMsgs
 			compactionIdx = idx

--- a/internal/tui/chat/commands_test.go
+++ b/internal/tui/chat/commands_test.go
@@ -412,6 +412,7 @@ type mockStore struct {
 	sessions         map[string]*session.Session
 	getErr           error
 	messages         map[string][]session.Message
+	getMessagesCalls int
 	summaries        []session.SessionSummary
 	searchOptions    []session.SearchOptions
 	msgErr           error
@@ -468,6 +469,7 @@ func (s *mockStore) GetByPrefix(_ context.Context, prefix string) (*session.Sess
 }
 
 func (s *mockStore) GetMessages(_ context.Context, sessionID string, _, _ int) ([]session.Message, error) {
+	s.getMessagesCalls++
 	if s.msgErr != nil {
 		return nil, s.msgErr
 	}


### PR DESCRIPTION
## Summary

Reduce redundant work while constructing a new interactive chat:

- reuse the `ToolPermissions` instance already owned by the approval manager instead of rebuilding and discarding a duplicate
- skip loading scrollback for a session created moments earlier
- skip persisting approval mode when the session already contains the requested value

The permission change also avoids emitting duplicate warnings for invalid or not-yet-existing configured directories.

## Performance

Measured from process start to first usable TUI render with isolated session databases, 40 interleaved warm runs:

| Build | Median |
|---|---:|
| `upstream/main` | 47.9 ms |
| this branch | 46.8 ms |

That is 1.1 ms, or about 2.3%, off observed first paint. Phase instrumentation shows the larger internal result: tool setup falls from roughly 14 ms to 4 ms, eliminating about 10 ms / 71% of that phase. Terminal capability negotiation overlaps and masks most of it in the end-to-end PTY measurement.

## Validation

- `make build`
- `go test ./internal/tools ./internal/tui/chat`
- focused `cmd` tests for tool manager, workspace, MCP, mentions, approval mode, and chat program paths
- `go vet ./...`
- isolated-HOME `go test ./...`

The full suite has one unrelated existing failure in `internal/serveui`: current generated `app.js` and `app.css` exceed their gzip budgets. The exact failure reproduces on `upstream/main`.

Reviewed by a Fable developer pass; no blocking findings. Review suggestions for a discriminating permissions regression test, portable symlink handling, and comment accuracy are included.
