### PR TITLE
fix: Shared-shell replay shifts 1 MiB on every output chunk

### DIFF
--- a/cmd/serve_shell.go
+++ b/cmd/serve_shell.go
@@ -128,15 +128,16 @@ type serveShell struct {
 	cwd       string
 	process   serveShellProcess
 
-	mu         sync.Mutex
-	writeMu    sync.Mutex
-	output     []byte
-	baseOffset int64
-	nextOffset int64
-	exited     bool
-	exitCode   int
-	lastUsed   time.Time
-	changed    chan struct{}
+	mu          sync.Mutex
+	writeMu     sync.Mutex
+	output      []byte
+	outputStart int
+	baseOffset  int64
+	nextOffset  int64
+	exited      bool
+	exitCode    int
+	lastUsed    time.Time
+	changed     chan struct{}
 
 	generationCtx      context.Context
 	generationCancel   context.CancelFunc
@@ -226,13 +227,21 @@ func (s *serveShell) appendOutput(data []byte) {
 	s.lastUsed = time.Now()
 	if len(data) >= serveShellReplayBytes {
 		s.output = append(s.output[:0], data[len(data)-serveShellReplayBytes:]...)
+		s.outputStart = 0
 		s.baseOffset = s.nextOffset - int64(len(s.output))
 	} else {
 		s.output = append(s.output, data...)
-		if overflow := len(s.output) - serveShellReplayBytes; overflow > 0 {
-			copy(s.output, s.output[overflow:])
-			s.output = s.output[:len(s.output)-overflow]
+		if overflow := len(s.output) - s.outputStart - serveShellReplayBytes; overflow > 0 {
+			s.outputStart += overflow
 			s.baseOffset += int64(overflow)
+		}
+		// Reclaim dropped prefixes in replay-window-sized batches so steady PTY
+		// reads do not copy the retained window on every output chunk.
+		if s.outputStart >= serveShellReplayBytes {
+			activeLen := len(s.output) - s.outputStart
+			copy(s.output, s.output[s.outputStart:])
+			s.output = s.output[:activeLen]
+			s.outputStart = 0
 		}
 	}
 	markers := s.protocol.Feed(startOffset, data)
@@ -329,10 +338,10 @@ func (s *serveShell) snapshot(offset int64) serveShellSnapshot {
 	if available > serveShellChunkBytes {
 		available = serveShellChunkBytes
 	}
-	start := int(offset - s.baseOffset)
+	start := s.outputStart + int(offset-s.baseOffset)
 	end := start + int(available)
 	var data []byte
-	if start >= 0 && end <= len(s.output) && start < end {
+	if start >= s.outputStart && end <= len(s.output) && start < end {
 		data = append([]byte(nil), s.output[start:end]...)
 	}
 	return serveShellSnapshot{

--- a/cmd/serve_shell_collaboration.go
+++ b/cmd/serve_shell_collaboration.go
@@ -51,7 +51,9 @@ func (s *serveShell) maskReplayRangeLocked(start, end int64) {
 	if start >= end {
 		return
 	}
-	for i := int(start - s.baseOffset); i < int(end-s.baseOffset); i++ {
+	startIndex := s.outputStart + int(start-s.baseOffset)
+	endIndex := s.outputStart + int(end-s.baseOffset)
+	for i := startIndex; i < endIndex; i++ {
 		s.output[i] = 0
 	}
 }
@@ -65,7 +67,9 @@ func (s *serveShell) replaceReplayRangeLocked(start, end int64, replacement []by
 		return
 	}
 	replacementEnd := min64(int64(len(replacement)), replacementStart+copyEnd-copyStart)
-	copy(s.output[copyStart-s.baseOffset:copyEnd-s.baseOffset], replacement[replacementStart:replacementEnd])
+	startIndex := s.outputStart + int(copyStart-s.baseOffset)
+	endIndex := s.outputStart + int(copyEnd-s.baseOffset)
+	copy(s.output[startIndex:endIndex], replacement[replacementStart:replacementEnd])
 }
 
 // redactProtocolDisplayLocked hides transport syntax through an authoritative

--- a/cmd/serve_shell_test.go
+++ b/cmd/serve_shell_test.go
@@ -298,6 +298,73 @@ func TestServeShellReplayResetAndExit(t *testing.T) {
 	}
 }
 
+func TestServeShellReplayCompactsDroppedPrefixesInBatches(t *testing.T) {
+	const totalBytes = 3*serveShellReplayBytes + 3*serveShellChunkBytes + 123
+	all := make([]byte, totalBytes)
+	for i := range all {
+		all[i] = byte((i*31 + 17) % 251)
+	}
+
+	shell := newServeShell("sh_compaction", "session", t.TempDir())
+	for start := 0; start < len(all); start += serveShellChunkBytes {
+		end := min(start+serveShellChunkBytes, len(all))
+		shell.appendOutput(all[start:end])
+	}
+
+	wantBase := int64(len(all) - serveShellReplayBytes)
+	wantOutputStart := len(all) - 3*serveShellReplayBytes
+	shell.mu.Lock()
+	if shell.baseOffset != wantBase || shell.nextOffset != int64(len(all)) {
+		t.Fatalf("offsets = base %d next %d, want base %d next %d", shell.baseOffset, shell.nextOffset, wantBase, len(all))
+	}
+	if shell.outputStart != wantOutputStart || len(shell.output)-shell.outputStart != serveShellReplayBytes {
+		t.Fatalf("storage = start %d active %d, want start %d active %d", shell.outputStart, len(shell.output)-shell.outputStart, wantOutputStart, serveShellReplayBytes)
+	}
+
+	redactionStart := shell.baseOffset + 1234
+	redactionEnd := redactionStart + 32
+	replacement := []byte("shared")
+	shell.replaceReplayRangeLocked(redactionStart, redactionEnd, replacement)
+	shell.mu.Unlock()
+
+	want := append([]byte(nil), all[len(all)-serveShellReplayBytes:]...)
+	redactionIndex := int(redactionStart - wantBase)
+	clear(want[redactionIndex : redactionIndex+int(redactionEnd-redactionStart)])
+	copy(want[redactionIndex:], replacement)
+
+	reset := shell.snapshot(0)
+	if !reset.reset || reset.baseOffset != wantBase || reset.dataOffset != wantBase {
+		t.Fatalf("reset snapshot = reset %t base %d data %d, want base/data %d", reset.reset, reset.baseOffset, reset.dataOffset, wantBase)
+	}
+
+	var replay []byte
+	for offset := wantBase; offset < int64(len(all)); {
+		snapshot := shell.snapshot(offset)
+		if snapshot.reset || snapshot.dataOffset != offset || len(snapshot.data) == 0 || len(snapshot.data) > serveShellChunkBytes {
+			t.Fatalf("snapshot at %d = reset %t data offset %d len %d", offset, snapshot.reset, snapshot.dataOffset, len(snapshot.data))
+		}
+		replay = append(replay, snapshot.data...)
+		offset += int64(len(snapshot.data))
+	}
+	if !bytes.Equal(replay, want) {
+		t.Fatalf("chunked replay differs: got %d bytes, want %d", len(replay), len(want))
+	}
+}
+
+func BenchmarkServeShellReplaySmallChunks(b *testing.B) {
+	const bytesPerIteration = 256 << 20
+	chunk := bytes.Repeat([]byte("x"), serveShellChunkBytes)
+	shell := newServeShell("sh_benchmark", "session", b.TempDir())
+	shell.appendOutput(bytes.Repeat([]byte("p"), serveShellReplayBytes))
+	b.SetBytes(bytesPerIteration)
+	b.ResetTimer()
+	for range b.N {
+		for written := 0; written < bytesPerIteration; written += len(chunk) {
+			shell.appendOutput(chunk)
+		}
+	}
+}
+
 func TestResolveShellCWDUsesPersistedProjectBindings(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	ctx := context.Background()


### PR DESCRIPTION
## What changed

- Keep a logical start index for the shared-shell replay buffer instead of shifting the retained 1 MiB window after every small PTY output chunk.
- Reclaim dropped storage only after a full replay window has accumulated, while preserving `baseOffset` and `nextOffset` semantics.
- Account for the logical prefix in chunked snapshots and collaboration protocol redaction/replacement.
- Add a regression test that crosses multiple batched compactions with 32 KiB chunks and verifies exact retained bytes, offsets, reset behavior, redaction, and chunked replay.
- Add a 256 MiB sustained-small-chunk benchmark.

## Why this is high-value

The Unix PTY producer reads up to 32 KiB at a time. Once the replay buffer reached 1 MiB, each ordinary output callback previously copied the entire retained window while holding the shell mutex. That meant about 32 MiB copied for each 1 MiB of continued output, delaying snapshots, browser input, lifecycle operations, and collaboration state during verbose builds, tests, searches, and log streams.

The logical prefix makes eviction constant-time per chunk and performs one roughly 1 MiB compaction per additional 1 MiB of output instead of one per 32 KiB chunk: 32x fewer replay-window shifts in the steady producer case. The end-to-end append benchmark improved from a median 520.8 ms (515 MB/s) to 425.3 ms (631 MB/s) for 256 MiB on an i9-14900K, while replay storage remains bounded to roughly two windows between compactions.

## Validation

- `go test ./cmd -run '^TestServeShellReplay(ResetAndExit|CompactsDroppedPrefixesInBatches)$' -count=1`
- `go test -race ./cmd -run '^TestServeShellReplay(ResetAndExit|CompactsDroppedPrefixesInBatches)$' -count=1`
- `go test ./cmd -run '^$' -bench '^BenchmarkServeShellReplaySmallChunks$' -benchtime=1x -benchmem -count=3`
  - Before median: `520768260 ns/op`, `515.46 MB/s`
  - After median: `425333161 ns/op`, `631.12 MB/s`
- `go build ./...`
- `go vet ./...`
- `go test ./...` ran successfully for the changed `cmd` package and all other root-module packages except an unrelated existing generated-frontend budget failure in `internal/serveui`: `app.js` gzip 138137 > 135000 and `app.css` gzip 33383 > 33000. This branch changes no frontend source or bundle-budget code.
