### PR TITLE
fix: One timed-out push endpoint can indefinitely starve completion notifications

### DIFF
--- a/cmd/serve_completion_push.go
+++ b/cmd/serve_completion_push.go
@@ -115,6 +115,10 @@ func (s *serveServer) startCompletionPushDispatcher() {
 func (s *serveServer) dispatchCompletionPushes(outbox session.CompletionPushOutboxStore) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
+	s.dispatchCompletionPushesWithSender(ctx, outbox, 20*time.Second, sendWebPushDetailed)
+}
+
+func (s *serveServer) dispatchCompletionPushesWithSender(ctx context.Context, outbox session.CompletionPushOutboxStore, attemptTimeout time.Duration, send func(context.Context, *session.PushSubscription, []byte, *webpush.Options) (int, time.Duration, error)) {
 	items, err := outbox.ListDueCompletionPushes(ctx, time.Now().UTC(), 25)
 	if err != nil || len(items) == 0 {
 		return
@@ -128,6 +132,9 @@ func (s *serveServer) dispatchCompletionPushes(outbox session.CompletionPushOutb
 		Subscriber: normalizeWebPushSubject(s.cfgRef.Serve.WebPush.Subject), TTL: 300,
 	}
 	for _, item := range items {
+		if ctx.Err() != nil {
+			break
+		}
 		sub, getErr := pushStore.GetPushSubscription(ctx, item.SubscriptionID)
 		if getErr != nil {
 			s.retryCompletionPush(ctx, outbox, item, getErr)
@@ -137,24 +144,34 @@ func (s *serveServer) dispatchCompletionPushes(outbox session.CompletionPushOutb
 			_ = outbox.MarkCompletionPushDead(ctx, item.ID, "subscription is stale or missing")
 			continue
 		}
-		status, retryAfter, sendErr := sendWebPushDetailed(ctx, sub, item.Payload, opts)
-		if sendErr == nil {
-			_ = pushStore.MarkPushSubscriptionUsed(ctx, sub.ID)
-			_ = outbox.MarkCompletionPushDelivered(ctx, item.ID)
-			continue
-		}
-		if status == http.StatusGone || status == http.StatusNotFound {
-			_ = pushStore.MarkPushSubscriptionStale(ctx, sub.ID, fmt.Sprintf("http_%d", status), "push endpoint rejected the subscription")
-			_ = outbox.MarkCompletionPushDead(ctx, item.ID, "push endpoint rejected the subscription")
-			continue
-		}
-		if item.AttemptCount >= 7 {
-			_ = outbox.MarkCompletionPushDead(ctx, item.ID, "delivery retry limit reached")
-			continue
-		}
-		s.retryCompletionPushAfter(ctx, outbox, item, sendErr, retryAfter)
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		status, retryAfter, sendErr := send(attemptCtx, sub, item.Payload, opts)
+		cancel()
+		s.recordCompletionPushResult(outbox, pushStore, item, sub, status, retryAfter, sendErr)
 	}
 	_ = outbox.PruneCompletionPushOutbox(ctx, time.Now().UTC().Add(-7*24*time.Hour))
+}
+
+func (s *serveServer) recordCompletionPushResult(outbox session.CompletionPushOutboxStore, pushStore session.PushSubscriptionLifecycleStore, item session.CompletionPushOutboxItem, sub *session.PushSubscription, status int, retryAfter time.Duration, sendErr error) {
+	// A send may exhaust the entire dispatch budget. Persist its outcome with
+	// a fresh, bounded context so it cannot remain at the head of every batch.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if sendErr == nil {
+		_ = pushStore.MarkPushSubscriptionUsed(ctx, sub.ID)
+		_ = outbox.MarkCompletionPushDelivered(ctx, item.ID)
+		return
+	}
+	if status == http.StatusGone || status == http.StatusNotFound {
+		_ = pushStore.MarkPushSubscriptionStale(ctx, sub.ID, fmt.Sprintf("http_%d", status), "push endpoint rejected the subscription")
+		_ = outbox.MarkCompletionPushDead(ctx, item.ID, "push endpoint rejected the subscription")
+		return
+	}
+	if item.AttemptCount >= 7 {
+		_ = outbox.MarkCompletionPushDead(ctx, item.ID, "delivery retry limit reached")
+		return
+	}
+	s.retryCompletionPushAfter(ctx, outbox, item, sendErr, retryAfter)
 }
 
 func (s *serveServer) retryCompletionPush(ctx context.Context, outbox session.CompletionPushOutboxStore, item session.CompletionPushOutboxItem, err error) {
@@ -162,7 +179,7 @@ func (s *serveServer) retryCompletionPush(ctx context.Context, outbox session.Co
 }
 
 func (s *serveServer) retryCompletionPushAfter(ctx context.Context, outbox session.CompletionPushOutboxStore, item session.CompletionPushOutboxItem, err error, requestedDelay time.Duration) {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 		return
 	}
 	delay := requestedDelay

--- a/cmd/serve_completion_push_test.go
+++ b/cmd/serve_completion_push_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	webpush "github.com/SherClockHolmes/webpush-go"
+	"github.com/samsaffron/term-llm/internal/config"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestCompletionPushTimeoutDoesNotStarveOutbox(t *testing.T) {
+	for _, exhaustBatch := range []bool{false, true} {
+		t.Run(fmt.Sprintf("exhaustBatch=%t", exhaustBatch), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "sessions.db")
+			store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			cfg := &config.Config{}
+			cfg.Serve.WebPush.VAPIDPublicKey = "test-key"
+			s := &serveServer{store: store, cfgRef: cfg}
+			for _, name := range []string{"slow", "healthy"} {
+				sub, err := store.UpsertPushSubscription(context.Background(), &session.PushSubscription{
+					Endpoint: "https://push.example/" + name, KeyP256DH: "key", KeyAuth: "auth",
+					VAPIDKeyID: webPushKeyID(cfg.Serve.WebPush.VAPIDPublicKey),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := store.EnqueueCompletionPush(context.Background(), session.CompletionPushOutboxItem{
+					EventID: name, ResponseID: name, SubscriptionID: sub.ID, Payload: []byte(name),
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertRow := func(name, wantStatus string, wantAttempts int) string {
+				t.Helper()
+				var status, next string
+				var attempts int
+				if err := db.QueryRow(`SELECT status, attempt_count, next_attempt_at FROM completion_push_outbox WHERE event_id = ?`, name).Scan(&status, &attempts, &next); err != nil {
+					t.Fatal(err)
+				}
+				if status != wantStatus || attempts != wantAttempts {
+					t.Fatalf("%s: status=%s attempts=%d; want %s/%d", name, status, attempts, wantStatus, wantAttempts)
+				}
+				return next
+			}
+			var calls []string
+			send := func(ctx context.Context, _ *session.PushSubscription, payload []byte, _ *webpush.Options) (int, time.Duration, error) {
+				calls = append(calls, string(payload))
+				if string(payload) == "slow" {
+					<-ctx.Done()
+					return 0, 0, fmt.Errorf("send: %w", ctx.Err())
+				}
+				if err := ctx.Err(); err != nil {
+					t.Fatalf("healthy send received expired context: %v", err)
+				}
+				return http.StatusCreated, 0, nil
+			}
+			ctx := context.Background()
+			attemptTimeout := time.Millisecond
+			if exhaustBatch {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 100*time.Millisecond)
+				defer cancel()
+				attemptTimeout = time.Second
+			}
+			before := assertRow("slow", "pending", 0)
+			s.dispatchCompletionPushesWithSender(ctx, store, attemptTimeout, send)
+			next := assertRow("slow", "pending", 1)
+			if next <= before {
+				t.Fatalf("retry did not advance next_attempt_at: %q -> %q", before, next)
+			}
+			if len(calls) == 0 || calls[0] != "slow" {
+				t.Fatalf("oldest row was not attempted first: %v", calls)
+			}
+			if exhaustBatch {
+				assertRow("healthy", "pending", 0)
+				if len(calls) != 1 {
+					t.Fatalf("continued exhausted batch: %v", calls)
+				}
+				s.dispatchCompletionPushesWithSender(context.Background(), store, time.Millisecond, send)
+			}
+			assertRow("healthy", "delivered", 1)
+
+			// Advance eligibility directly instead of waiting through exponential backoff.
+			// Preserve the existing cutoff: seven retries, then the eighth failure is dead.
+			for attempt := 2; attempt <= 8; attempt++ {
+				if _, err := db.Exec(`UPDATE completion_push_outbox SET next_attempt_at = '2000-01-01 00:00:00' WHERE event_id = 'slow'`); err != nil {
+					t.Fatal(err)
+				}
+				s.dispatchCompletionPushesWithSender(context.Background(), store, time.Millisecond, send)
+				status := "pending"
+				if attempt == 8 {
+					status = "dead"
+				}
+				assertRow("slow", status, attempt)
+			}
+			assertRow("healthy", "delivered", 1)
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Retain the 20-second dispatch budget and bound each send by an attempt context capped by that budget.
- Persist send outcomes with a separate, fresh five-second context, so exhausting the send/batch deadline does not prevent recording a retry, delivery, or terminal failure.
- Treat send deadline failures as retryable; advance `attempt_count` and `next_attempt_at`, preserving exponential backoff, Retry-After handling, and the existing cutoff (seven retries, then the eighth failed attempt marks the row dead).
- Stop starting further items once the dispatch context expires.
- Add SQLite-backed dispatcher regression tests with an injected sender and short deadlines. They cover an individual timeout with a healthy delivery in the same batch, a timeout that exhausts the batch followed by healthy delivery in the next dispatch, persisted retry scheduling, and eventual dead status.

## Why this is high-value

A slow push endpoint could previously consume the entire batch deadline, while the deadline-error guard discarded its retry update. Every later subscription lookup then used the expired context. Because the outbox orders pending rows by `next_attempt_at, id`, the unchanged oldest row could repeat this indefinitely and suppress unrelated mobile/web completion alerts.

Independently checked the send path and webpush-go v1.4.0's default HTTP client, outbox ordering, retry cutoff, pruning, and existing tests. Pending rows are not pruned, and timeout failures never advanced the retry count. Existing coverage only tested outbox deduplication and successful delivery. None of the supplied recent PRs or current open PRs materially covers this dispatcher bug.

This clears the daily-usage value bar: a realistic push-service outage can hide completion alerts for otherwise healthy endpoints and force manual checking of background responses. The change is localized to completion dispatch; no schema, dependency, or frontend changes.

## Validation

- `gofmt -w cmd/serve_completion_push.go cmd/serve_completion_push_test.go`
- `make build` — passed, using the existing Node v24.15.0 installation to generate required embedded assets.
- `go build ./...` — passed.
- `go test ./cmd -run TestCompletionPushTimeoutDoesNotStarveOutbox -count=5` — passed.
- `go test -race ./cmd -run TestCompletionPushTimeoutDoesNotStarveOutbox -count=10` — passed.
- Regression sensitivity check: temporarily restoring the original deadline-error guard makes both test variants fail because the slow row remains pending with zero attempts. Restored the fix afterward.
- `go vet ./...` — passed.
- `go test ./...` — run. The normal environment exposes two user-skill/config-sensitive cmd tests; rerunning the entire suite with an isolated HOME/XDG environment passes cmd and all other packages except the unrelated `internal/serveui` bundle-size budget test.
- `go test ./internal/serveui -run '^TestProductionBundleSizeBudgets$' -count=1` independently reproduces the remaining failure: app.js raw/gzip 495327/143744 exceeds 488000/140000; app.css raw 174184 exceeds 174000. `git diff --exit-code HEAD -- frontend internal/serveui` confirms those source files are unchanged. No budget or generated-asset workarounds were applied.
- `git diff --check` and staged diff checks — passed.

The regression uses a context-aware injected sender rather than a live push service. Persistence remains best-effort if SQLite itself is unavailable; this fix prevents a network timeout from poisoning the context used to record its outcome. The final attempted item's persistence can extend a dispatch by up to five seconds beyond the existing network budget.
