### PR TITLE
WIP: Coordinate process-wide SIGUSR2 restart lifecycle

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -17,6 +17,8 @@ import (
 	"github.com/samsaffron/term-llm/internal/exitcode"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
+	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/samsaffron/term-llm/internal/restart"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/samsaffron/term-llm/internal/skills"
@@ -229,6 +231,10 @@ func legacyTerminalProgressEnabled(cfg *config.Config) bool {
 }
 
 func runChat(cmd *cobra.Command, args []string) error {
+	// Resolve the installed path before an updater can unlink the old executable.
+	if exe, err := os.Executable(); err == nil {
+		chatReloadExecutable = exe
+	}
 	interactive := chatOwnsTerminalHost()
 	if len(chatAutoSend) == 0 && !interactive {
 		return fmt.Errorf("chat requires an interactive terminal; use --auto-send for non-interactive execution")
@@ -451,6 +457,17 @@ func buildChatSessionRuntime(ctx context.Context, cmd *cobra.Command, launch cha
 	}()
 	failureCleanup = append(failureCleanup, storeCleanup)
 
+	var processReloadState *chat.ProcessReloadState
+	if handoff, state, reloadErr := consumeChatReload(store); reloadErr != nil {
+		return nil, fmt.Errorf("consume process reload: %w", reloadErr)
+	} else if handoff != nil {
+		resumeRequested = true
+		resumeID = handoff.SessionID
+		initialText = ""
+		handoverAutoSend = ""
+		chatAutoSend = nil // original --auto-send argv must not submit its task again
+		processReloadState = state
+	}
 	var sess *session.Session
 	if resumeRequested {
 		if store == nil {
@@ -819,6 +836,9 @@ func buildChatSessionRuntime(ctx context.Context, cmd *cobra.Command, launch cha
 			relaunchHandoff.branchAutoSend = ""
 		}
 	}
+	if processReloadState != nil {
+		model.SetProcessReloadState(*processReloadState)
+	}
 	model.SetSideQuestionProviderFactory(func(providerKey, modelName string) (llm.Provider, error) {
 		if strings.TrimSpace(providerKey) == "" {
 			providerKey = provider.Name()
@@ -1156,6 +1176,9 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	programModel := newChatProgramModel(rt.model, lifecycleReporter)
 	p := tea.NewProgram(programModel, opts...)
 	rt.model.SetProgram(p)
+	unbindRestart := restart.Default.Bind(func() { go p.Send(chat.ProcessReloadMsg{}) })
+	defer unbindRestart()
+	process.State("chat", "ready", "")
 
 	// In-process session switching: /fork, /thread, /tree branches, and
 	// /resume selections swap the visible model inside this running program
@@ -1268,11 +1291,19 @@ func runChatOnce(ctx context.Context, cmd *cobra.Command, initialText, cliAgent 
 	// successor immediately republishes them without an idle gap. If Exec fails,
 	// this function returns and runChat's bounded deferred close releases them.
 	if finalModel.WantsReload() {
+		if !cur.model.WaitStreamDone() || mainRuns.ActiveCount() != 0 {
+			process.State("chat", "failed", "runtime work did not settle")
+			return "", "", fmt.Errorf("reload refused: runtime work did not settle")
+		}
+		id, service, saveErr := saveChatReload(cur.store, finalModel.ReloadSessionID(), finalModel.ProcessReloadState())
+		if saveErr != nil {
+			return "", "", saveErr
+		}
 		cur.cleanupResources()
-		sessionID := finalModel.ReloadSessionID()
-		if execErr := execReload(sessionID); execErr != nil {
-			// exec failed (shouldn't happen on Unix) — fall through and exit normally
-			fmt.Fprintf(cmd.ErrOrStderr(), "reload: %v\n", execErr)
+		process.State("chat", "replacing", "")
+		if execErr := execReload(id, service); execErr != nil {
+			process.State("chat", "failed", execErr.Error())
+			return "", "", fmt.Errorf("reload: %w", execErr)
 		}
 		return "", "", nil
 	}

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/spf13/cobra"
+)
+
+func newProcessCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "process", Short: "Inspect and restart local term-llm processes"}
+	cmd.AddCommand(newProcessListCommand(process.List, os.Getpid()))
+	cmd.AddCommand(newProcessRestartCommand(false, process.List, process.Restart, os.Getpid()))
+	cmd.AddCommand(newProcessRestartCommand(true, process.List, process.Restart, os.Getpid()))
+	return cmd
+}
+
+func newProcessListCommand(list func() ([]process.Record, error), self int) *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use: "list", Short: "List validated local instances and clean stale records",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			records, err := list()
+			if err != nil {
+				return err
+			}
+			visible := make([]process.Record, 0, len(records))
+			for _, record := range records {
+				if record.PID != self {
+					visible = append(visible, record)
+				}
+			}
+			sort.Slice(visible, func(i, j int) bool { return visible[i].PID < visible[j].PID })
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(visible)
+			}
+			out := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(out, "PID\tMODE\tINSTANCE\tBUILD\tSTATE")
+			for _, r := range visible {
+				fmt.Fprintf(out, "%d\t%s\t%s\t%s\t%s\n", r.PID, r.Mode, r.Instance, r.Build, r.Phase)
+			}
+			return out.Flush()
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Print full process records as JSON")
+	return cmd
+}
+
+func init() { rootCmd.AddCommand(newProcessCommand()) }
+
+type processRestartFunc func(context.Context, process.Record, bool) (process.Record, error)
+
+func newProcessRestartCommand(all bool, list func() ([]process.Record, error), restart processRestartFunc, self int) *cobra.Command {
+	var timeout time.Duration
+	var noWait bool
+	command := &cobra.Command{Use: "restart PID", Short: "Restart one registered instance and wait for the installed build", Args: cobra.ExactArgs(1)}
+	if all {
+		command.Use = "restart-all"
+		command.Short = "Restart a snapshot of your registered instances and wait for each"
+		command.Args = cobra.NoArgs
+	}
+	command.Flags().DurationVar(&timeout, "timeout", 2*time.Minute, "Maximum time to wait for replacement readiness")
+	command.Flags().BoolVar(&noWait, "no-wait", false, "Return after signalling; does not confirm restart success")
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		if timeout <= 0 {
+			return errors.New("--timeout must be positive")
+		}
+		var pid int
+		if !all {
+			var err error
+			pid, err = strconv.Atoi(args[0])
+			if err != nil || pid <= 0 {
+				return errors.New("PID must be a positive integer")
+			}
+			if pid == self {
+				return errors.New("refusing to restart self")
+			}
+		}
+		records, err := list()
+		if err != nil {
+			return err
+		}
+		selected := make([]process.Record, 0, len(records))
+		for _, r := range records {
+			if r.PID != self && (all || r.PID == pid) {
+				selected = append(selected, r)
+			}
+		}
+		if len(selected) == 0 {
+			if !all {
+				return fmt.Errorf("PID %d has no validated process record", pid)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "No registered processes to restart.")
+			return nil
+		}
+		sort.Slice(selected, func(i, j int) bool { return selected[i].PID < selected[j].PID })
+		ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+		defer cancel()
+		type result struct {
+			record process.Record
+			err    error
+		}
+		results := make([]result, len(selected))
+		// Snapshot once and request concurrently: waiting for the first process must
+		// not postpone signalling the others. Output remains serialized and ordered.
+		var wg sync.WaitGroup
+		for i, r := range selected {
+			wg.Add(1)
+			go func(i int, r process.Record) {
+				defer wg.Done()
+				results[i].record, results[i].err = restart(ctx, r, !noWait)
+			}(i, r)
+		}
+		wg.Wait()
+		var failures []error
+		for i, result := range results {
+			r := selected[i]
+			if result.err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "%d\tfailed\t%v\n", r.PID, result.err)
+				failures = append(failures, fmt.Errorf("PID %d: %w", r.PID, result.err))
+			} else if noWait {
+				fmt.Fprintf(cmd.OutOrStdout(), "%d\tsignalled (not verified)\n", r.PID)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "%d\tready\t%s -> %s\t%s\n", r.PID, r.Instance, result.record.Instance, result.record.Build)
+			}
+		}
+		return errors.Join(failures...)
+	}
+	return command
+}

--- a/cmd/process_test.go
+++ b/cmd/process_test.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/process"
+)
+
+func TestProcessListJSON(t *testing.T) {
+	command := newProcessListCommand(func() ([]process.Record, error) {
+		return []process.Record{{PID: 30, Instance: "third"}, {PID: 20}, {PID: 10, Instance: "first"}}, nil
+	}, 20)
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetArgs([]string{"--json"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var records []process.Record
+	if err := json.Unmarshal(output.Bytes(), &records); err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 || records[0].PID != 10 || records[1].PID != 30 {
+		t.Fatalf("expected sorted records excluding self, got %+v", records)
+	}
+}
+
+func TestProcessListEmptyJSON(t *testing.T) {
+	command := newProcessListCommand(func() ([]process.Record, error) { return nil, nil }, 20)
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetArgs([]string{"--json"})
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if output.String() != "[]\n" {
+		t.Fatalf("got %q", output.String())
+	}
+}
+
+func TestProcessListFailure(t *testing.T) {
+	expected := errors.New("registry unavailable")
+	command := newProcessListCommand(func() ([]process.Record, error) { return nil, expected }, 20)
+	command.SilenceErrors = true
+	command.SilenceUsage = true
+	command.SetArgs(nil)
+	if err := command.Execute(); !errors.Is(err, expected) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestProcessRestartAllSnapshot(t *testing.T) {
+	var listCalls atomic.Int32
+	entered := make(chan int, 2)
+	release := make(chan struct{})
+	list := func() ([]process.Record, error) {
+		listCalls.Add(1)
+		return []process.Record{{PID: 30, Instance: "old30"}, {PID: 20}, {PID: 10, Instance: "old10"}}, nil
+	}
+	restart := func(ctx context.Context, r process.Record, wait bool) (process.Record, error) {
+		if !wait {
+			return r, errors.New("expected wait")
+		}
+		entered <- r.PID
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return r, ctx.Err()
+		}
+		r.Instance = "new"
+		return r, nil
+	}
+	command := newProcessRestartCommand(true, list, restart, 20)
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetArgs(nil)
+	done := make(chan error, 1)
+	go func() { done <- command.Execute() }()
+	seen := map[int]bool{}
+	for range 2 {
+		select {
+		case pid := <-entered:
+			seen[pid] = true
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatal("restart-all waited before signalling all targets")
+		}
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if !seen[10] || !seen[30] || listCalls.Load() != 1 {
+		t.Fatalf("snapshot: %+v calls=%d", seen, listCalls.Load())
+	}
+	if !strings.HasPrefix(output.String(), "10\tready") {
+		t.Fatalf("unordered output: %s", output.String())
+	}
+}
+
+func TestProcessRestartFailureAndNoWait(t *testing.T) {
+	for _, noWait := range []bool{false, true} {
+		command := newProcessRestartCommand(false, func() ([]process.Record, error) { return []process.Record{{PID: 123}}, nil },
+			func(_ context.Context, r process.Record, wait bool) (process.Record, error) {
+				if wait == noWait {
+					t.Errorf("wrong wait value %v", wait)
+				}
+				if wait {
+					return r, errors.New("deferred")
+				}
+				return r, nil
+			}, 20)
+		var output bytes.Buffer
+		command.SetOut(&output)
+		command.SilenceErrors, command.SilenceUsage = true, true
+		args := []string{"123"}
+		if noWait {
+			args = append(args, "--no-wait")
+		}
+		command.SetArgs(args)
+		err := command.Execute()
+		if noWait {
+			if err != nil || !strings.Contains(output.String(), "not verified") {
+				t.Fatalf("no-wait: %v %s", err, output.String())
+			}
+		} else if err == nil {
+			t.Fatal("failure returned success")
+		}
+	}
+}

--- a/cmd/progressive.go
+++ b/cmd/progressive.go
@@ -33,14 +33,21 @@ type askProgressiveOptions struct {
 }
 
 type progressiveRunOptions struct {
-	StopWhen               progressiveStopWhen
-	ContinueWith           string
-	SessionID              string
-	ForceNamedFinalization bool
-	OnEvent                func(llm.Event) error
-	OnSyntheticUserMessage func(context.Context, llm.Message) error
-	OnResponseCompleted    llm.ResponseCompletedCallback
-	OnTurnCompleted        llm.TurnCompletedCallback
+	ResumePassHadWork        bool
+	ResumePassHadCommit      bool
+	OnPassEnd                func(progressivePassResult)
+	ResumeFinalizationReason string
+	OnFinalizationStart      func(string, llm.Request) error
+	FirstPassMaxTurns        *int
+	OnPassStart              func(context.Context, llm.Request) (context.Context, func(), error)
+	StopWhen                 progressiveStopWhen
+	ContinueWith             string
+	SessionID                string
+	ForceNamedFinalization   bool
+	OnEvent                  func(llm.Event) error
+	OnSyntheticUserMessage   func(context.Context, llm.Message) error
+	OnResponseCompleted      llm.ResponseCompletedCallback
+	OnTurnCompleted          llm.TurnCompletedCallback
 }
 
 type progressiveRunResult struct {
@@ -243,13 +250,52 @@ func runProgressiveSession(ctx context.Context, engine *llm.Engine, req llm.Requ
 	mainCtx, cancelMainCtx, reserve, hasTimeoutBudget := progressiveWorkContext(ctx)
 	defer cancelMainCtx()
 
+	if opts.ResumeFinalizationReason != "" {
+		reason := opts.ResumeFinalizationReason
+		for i := len(history) - 1; i >= 0; i-- {
+			if history[i].Role == llm.RoleAssistant && llm.MessageText(history[i]) != "" {
+				lastText = llm.MessageText(history[i])
+				break
+			}
+		}
+		if tracker.latest != nil && tracker.latest.Final {
+			return buildProgressiveRunResult(opts.SessionID, reason, true, tracker.latest, lastText), nil
+		}
+		if opts.FirstPassMaxTurns != nil {
+			if *opts.FirstPassMaxTurns <= 0 {
+				return buildProgressiveRunResult(opts.SessionID, reason, false, tracker.latest, lastText), nil
+			}
+			req.MaxTurns = *opts.FirstPassMaxTurns
+		}
+		finalized, text := attemptProgressiveFinalization(ctx, engine, finalizeTool, req, history, opts, tracker, reserve, reason)
+		if text != "" {
+			lastText = text
+		}
+		return buildProgressiveRunResult(opts.SessionID, reason, finalized, tracker.latest, lastText), nil
+	}
+	firstPass := true
 	for {
 		passReq := req
+		if firstPass && opts.FirstPassMaxTurns != nil {
+			passReq.MaxTurns = *opts.FirstPassMaxTurns
+		}
+		wasFirst := firstPass
+		firstPass = false
 		passReq.Messages = append([]llm.Message(nil), history...)
 		passReq.Tools = append([]llm.ToolSpec(nil), req.Tools...)
 		passReq.Tools = append(passReq.Tools, updateTool.Spec())
 
-		passResult, err := runProgressivePass(mainCtx, engine, passReq, opts, tracker)
+		var passResult progressivePassResult
+		var err error
+		if !(wasFirst && opts.FirstPassMaxTurns != nil && *opts.FirstPassMaxTurns <= 0) {
+			passResult, err = runProgressivePass(mainCtx, engine, passReq, opts, tracker)
+		}
+		if wasFirst {
+			passResult.hadNonProgressTool = passResult.hadNonProgressTool || opts.ResumePassHadWork
+			if opts.ResumePassHadCommit && passResult.newCommitCount == 0 {
+				passResult.newCommitCount = 1
+			}
+		}
 		if passResult.lastText != "" {
 			lastText = passResult.lastText
 		}
@@ -329,7 +375,18 @@ func newProgressTrackerFromMessages(messages []llm.Message) *progressTracker {
 	return tracker
 }
 
-func runProgressivePass(ctx context.Context, engine *llm.Engine, req llm.Request, opts progressiveRunOptions, tracker *progressTracker) (progressivePassResult, error) {
+func runProgressivePass(ctx context.Context, engine *llm.Engine, req llm.Request, opts progressiveRunOptions, tracker *progressTracker) (result progressivePassResult, resultErr error) {
+	if opts.OnPassEnd != nil {
+		defer func() { opts.OnPassEnd(result) }()
+	}
+	if opts.OnPassStart != nil {
+		owned, release, err := opts.OnPassStart(ctx, req)
+		if err != nil {
+			return progressivePassResult{}, err
+		}
+		ctx = owned
+		defer release()
+	}
 	var produced []llm.Message
 	var text strings.Builder
 	var hadNonProgressTool bool
@@ -426,19 +483,26 @@ func attemptProgressiveFinalization(parentCtx context.Context, engine *llm.Engin
 	}
 	defer finalizeCancel()
 
-	finalPrompt := buildProgressiveFinalizePrompt(tracker.latest)
-	finalizeMsg := llm.UserText(finalPrompt)
-	if opts.OnSyntheticUserMessage != nil {
-		msgCtx, cancel := progressiveSyntheticUserMessageContext(finalizeCtx)
-		err := opts.OnSyntheticUserMessage(msgCtx, finalizeMsg)
-		cancel()
-		if err != nil {
+	if opts.OnFinalizationStart != nil {
+		if err := opts.OnFinalizationStart(exitReason, baseReq); err != nil {
 			return false, ""
 		}
 	}
-
 	finalReq := baseReq
-	finalReq.Messages = append(append([]llm.Message(nil), history...), finalizeMsg)
+	finalReq.Messages = append([]llm.Message(nil), history...)
+	if opts.ResumeFinalizationReason == "" {
+		finalPrompt := buildProgressiveFinalizePrompt(tracker.latest)
+		finalizeMsg := llm.UserText(finalPrompt)
+		if opts.OnSyntheticUserMessage != nil {
+			msgCtx, cancel := progressiveSyntheticUserMessageContext(finalizeCtx)
+			err := opts.OnSyntheticUserMessage(msgCtx, finalizeMsg)
+			cancel()
+			if err != nil {
+				return false, ""
+			}
+		}
+		finalReq.Messages = append(finalReq.Messages, finalizeMsg)
+	}
 	finalReq.Search = false
 	finalReq.ForceExternalSearch = false
 	finalReq.ParallelToolCalls = false

--- a/cmd/progressive_test.go
+++ b/cmd/progressive_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -415,5 +416,127 @@ func TestNewProgressTrackerFromMessagesSeedsCommittedProgress(t *testing.T) {
 	}
 	if len(tracker.pending) != 0 {
 		t.Fatalf("pending progress calls = %d, want 0", len(tracker.pending))
+	}
+}
+
+func TestProgressiveRestartFirstPassKeepsSubsequentFullBudget(t *testing.T) {
+	provider := llm.NewMockProvider("mock")
+	provider.AddToolCall("progress", "update_progress", map[string]any{"state": map[string]any{"step": "saved"}, "message": "saved"})
+	provider.AddTextResponse("first pass complete")
+	provider.AddTextResponse("no more work")
+	provider.AddToolCall("final", "finalize_progress", map[string]any{"state": map[string]any{"step": "final"}, "message": "done"})
+	engine := llm.NewEngine(provider, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	first := 3
+	var limits []int
+	_, err := runProgressiveSession(ctx, engine, llm.Request{Messages: []llm.Message{llm.UserText("work")}, MaxTurns: 8, ToolChoice: llm.ToolChoice{Mode: llm.ToolChoiceAuto}}, progressiveRunOptions{StopWhen: progressiveStopWhenTimeout, FirstPassMaxTurns: &first, OnPassStart: func(ctx context.Context, req llm.Request) (context.Context, func(), error) {
+		limits = append(limits, req.TurnLimit())
+		return ctx, func() {}, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(limits) != 3 || limits[0] != 3 || limits[1] != 8 || limits[2] != 8 {
+		t.Fatalf("pass budgets=%v, want resumed=3 then full=8,8", limits)
+	}
+}
+
+func TestProgressiveResumeFinalizationPreservesPhaseAndPrompt(t *testing.T) {
+	for _, variant := range []string{"resume", "exhausted", "already-final"} {
+		t.Run(variant, func(t *testing.T) {
+			name := "update_progress"
+			remaining := 2
+			if variant == "already-final" {
+				name = "finalize_progress"
+			}
+			if variant == "exhausted" {
+				remaining = 0
+			}
+			history := []llm.Message{
+				llm.UserText("original task"),
+				{Role: llm.RoleAssistant, Parts: []llm.Part{{Type: llm.PartToolCall, ToolCall: &llm.ToolCall{ID: "saved", Name: name, Arguments: json.RawMessage(`{"state":{"step":"saved"},"message":"saved"}`)}}}},
+				{Role: llm.RoleTool, Parts: []llm.Part{{Type: llm.PartToolResult, ToolResult: &llm.ToolResult{ID: "saved", Name: name, Content: "ok"}}}},
+				{Role: llm.RoleAssistant, Parts: []llm.Part{{Type: llm.PartText, Text: "partial final prose"}}},
+				llm.UserText("already persisted finalization prompt"),
+			}
+			provider := llm.NewMockProvider("mock").AddToolCall("final", "finalize_progress", map[string]any{"state": map[string]any{"step": "finished"}, "message": "finished"})
+			engine := llm.NewEngine(provider, nil)
+			synthetic := 0
+			result, err := runProgressiveSession(context.Background(), engine, llm.Request{Messages: history, MaxTurns: 8, Tools: []llm.ToolSpec{{Name: "shell"}}}, progressiveRunOptions{ResumeFinalizationReason: exitReasonNatural, FirstPassMaxTurns: &remaining, OnSyntheticUserMessage: func(context.Context, llm.Message) error { synthetic++; return nil }})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if synthetic != 0 {
+				t.Fatal("replayed synthetic finalization prompt")
+			}
+			requests := provider.RecordedRequests()
+			if variant != "resume" {
+				if len(requests) != 0 {
+					t.Fatal("exhausted/already committed finalization invoked provider")
+				}
+				if variant == "already-final" && !result.Finalized {
+					t.Fatal("lost committed finalization")
+				}
+				if result.Progress["step"] != "saved" {
+					t.Fatal("lost saved progress")
+				}
+				return
+			}
+			if !result.Finalized || result.Progress["step"] != "finished" {
+				t.Fatalf("did not finish prior finalization: %+v", result)
+			}
+			if len(requests) != 1 || requests[0].MaxTurns != 2 {
+				t.Fatalf("wrong resumed finalization budget: %+v", requests)
+			}
+			if len(requests[0].Tools) != 1 || requests[0].Tools[0].Name != "finalize_progress" {
+				t.Fatal("resumed finalization admitted ordinary work tools")
+			}
+			users := 0
+			for _, message := range requests[0].Messages {
+				if message.Role == llm.RoleUser {
+					users++
+				}
+			}
+			if users != 2 {
+				t.Fatalf("changed original user history: %d user messages", users)
+			}
+		})
+	}
+}
+
+func TestProgressiveExhaustedResumeAdvancesWithoutCallingSpentPass(t *testing.T) {
+	for _, hadWork := range []bool{false, true} {
+		t.Run(fmt.Sprint(hadWork), func(t *testing.T) {
+			provider := llm.NewMockProvider("mock").AddTextResponse("done").AddTextResponse("final prose")
+			engine := llm.NewEngine(provider, nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			remaining := 0
+			var limits []int
+			synthetic := 0
+			_, err := runProgressiveSession(ctx, engine, llm.Request{Messages: []llm.Message{llm.UserText("original")}, MaxTurns: 7}, progressiveRunOptions{StopWhen: progressiveStopWhenTimeout, FirstPassMaxTurns: &remaining, ResumePassHadWork: hadWork, OnPassStart: func(ctx context.Context, r llm.Request) (context.Context, func(), error) {
+				limits = append(limits, r.TurnLimit())
+				return ctx, func() {}, nil
+			}, OnSyntheticUserMessage: func(context.Context, llm.Message) error { synthetic++; return nil }})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := 1
+			if hadWork {
+				expected = 2
+			}
+			if len(limits) != expected || len(provider.RecordedRequests()) != expected {
+				t.Fatalf("spent pass executed or continuation lost: limits=%v requests=%d", limits, len(provider.RecordedRequests()))
+			}
+			for _, limit := range limits {
+				if limit != 7 {
+					t.Fatalf("future pass lost full limit: %v", limits)
+				}
+			}
+			if synthetic != expected {
+				t.Fatalf("wrong pass transition prompts: %d", synthetic)
+			}
+		})
 	}
 }

--- a/cmd/reload_exec.go
+++ b/cmd/reload_exec.go
@@ -4,54 +4,19 @@ package cmd
 
 import (
 	"os"
-	"strings"
 	"syscall"
-
-	"github.com/samsaffron/term-llm/internal/tools"
 )
 
-// execReload replaces the current process with a fresh instance of the same
-// binary, resuming sessionID if non-empty.  It strips any pre-existing
-// --resume / -r flags from os.Args and appends the new one so the flags don't
-// stack across repeated reloads.
-//
-// On success this function never returns.  On failure it returns an error.
-func execReload(sessionID string) error {
-	exe, err := os.Executable()
-	if err != nil {
-		return err
-	}
-
-	// Rebuild argv, stripping any existing --resume / -r flags.
-	newArgs := []string{os.Args[0]}
-	skipNext := false
-	for _, arg := range os.Args[1:] {
-		if skipNext {
-			skipNext = false
-			continue
+// execReload shares the explicit environment handoff with serving. Session IDs
+// and drafts stay in SQLite; argv is unchanged across repeated replacements.
+func execReload(id, service string) error {
+	exe := chatReloadExecutable
+	if exe == "" {
+		var err error
+		exe, err = os.Executable()
+		if err != nil {
+			return err
 		}
-		if arg == "--resume" || arg == "-r" {
-			skipNext = true
-			continue
-		}
-		if strings.HasPrefix(arg, "--resume=") || strings.HasPrefix(arg, "-r=") {
-			continue
-		}
-		newArgs = append(newArgs, arg)
 	}
-
-	if sessionID != "" {
-		// Use --resume=ID (not --resume ID) because the flag has NoOptDefVal set,
-		// which means cobra treats the next positional arg as a separate argument
-		// rather than the flag value when the two-arg form is used.
-		newArgs = append(newArgs, "--resume="+sessionID)
-	}
-
-	// Re-exec'ing the SAME binary: hand back any env-provided hub delegation
-	// and registration tokens that startup scrubbed from the environment, or the
-	// next generation would silently lose hub access. This env goes only to
-	// ourselves, never to tool subprocesses.
-	reloadEnv := append(os.Environ(), tools.HubDelegationEnviron()...)
-	reloadEnv = append(reloadEnv, hubRegistrationEnviron()...)
-	return syscall.Exec(exe, newArgs, reloadEnv)
+	return syscall.Exec(exe, append([]string(nil), os.Args...), webExecEnviron(id, service))
 }

--- a/cmd/reload_exec_windows.go
+++ b/cmd/reload_exec_windows.go
@@ -5,6 +5,6 @@ package cmd
 import "fmt"
 
 // execReload is not supported on Windows; it returns an error.
-func execReload(sessionID string) error {
+func execReload(id, service string) error {
 	return fmt.Errorf("reload is not supported on Windows")
 }

--- a/cmd/reload_handoff.go
+++ b/cmd/reload_handoff.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tui/chat"
+)
+
+var chatReloadExecutable string
+
+func commandRestartService() string {
+	cwd, _ := os.Getwd()
+	digest := sha256.Sum256([]byte(strings.Join(os.Args, "\x00") + "\x00" + cwd))
+	return "command:" + hex.EncodeToString(digest[:])
+}
+
+func saveChatReload(store session.Store, sid string, state chat.ProcessReloadState) (string, string, error) {
+	handoffs, ok := session.AsCommandHandoffStore(store)
+	if !ok {
+		return "", "", fmt.Errorf("reload requires durable session storage")
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return "", "", err
+	}
+	id, service := uuid.NewString(), commandRestartService()
+	err = handoffs.SaveCommandHandoff(context.Background(), session.CommandHandoff{ID: id, Service: service, SourceInstance: process.Instance(), SessionID: sid, Payload: raw})
+	return id, service, err
+}
+
+func consumeChatReload(store session.Store) (*session.CommandHandoff, *chat.ProcessReloadState, error) {
+	if execRestartHint == "" {
+		return nil, nil, nil
+	}
+	handoffs, ok := session.AsCommandHandoffStore(store)
+	if !ok {
+		return nil, nil, fmt.Errorf("reload handoff requires durable session storage")
+	}
+	h, err := handoffs.ConsumeCommandHandoff(context.Background(), execRestartHint, commandRestartService(), process.Instance())
+	if err != nil {
+		return nil, nil, err
+	}
+	var state chat.ProcessReloadState
+	if err = json.Unmarshal(h.Payload, &state); err != nil {
+		return nil, nil, err
+	}
+	execRestartHint = ""
+	return &h, &state, nil
+}
+
+// Auto-generated MCP credentials belong only to the replacement executable, not
+// to tool children. Match the existing Hub credential hand-back convention.
+var mcpReloadToken = func() string {
+	token := os.Getenv("TERM_LLM_MCP_RELOAD_TOKEN")
+	_ = os.Unsetenv("TERM_LLM_MCP_RELOAD_TOKEN")
+	return token
+}()

--- a/cmd/restart_http.go
+++ b/cmd/restart_http.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/samsaffron/term-llm/internal/restart"
+)
+
+// processExecOwner is the transport/control-plane adapter: remote model work is
+// owned by its node, not by the Hub's forwarding socket. Only admitted local
+// mutation handlers must settle; passive connections reconnect after exec.
+type processExecOwner struct {
+	next             uint64
+	ctx              context.Context
+	mode, executable string
+	grace            time.Duration
+	gate             restart.Gate
+	requested        atomic.Bool
+	mu               sync.Mutex
+	cancelling       bool
+	cancels          map[uint64]context.CancelFunc
+	exec             func(string, []string, []string) error
+}
+
+func (o *processExecOwner) enter(parent context.Context) (context.Context, func(), error) {
+	return o.track(parent, true)
+}
+func (o *processExecOwner) child(parent context.Context) (context.Context, func(), error) {
+	return o.track(parent, false)
+}
+func (o *processExecOwner) track(parent context.Context, root bool) (context.Context, func(), error) {
+	var release func()
+	if root {
+		var ok bool
+		release, ok = o.gate.Enter()
+		if !ok {
+			return nil, nil, errors.New("process restarting")
+		}
+	} else {
+		release = o.gate.TrackChild()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	o.mu.Lock()
+	o.next++
+	id := o.next
+	o.cancels[id] = cancel
+	if o.cancelling {
+		cancel()
+	}
+	o.mu.Unlock()
+	var once sync.Once
+	return ctx, func() { once.Do(func() { cancel(); o.mu.Lock(); delete(o.cancels, id); o.mu.Unlock(); release() }) }, nil
+}
+
+func (o *processExecOwner) handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet || r.Method == http.MethodHead || r.Method == http.MethodOptions {
+			next.ServeHTTP(w, r)
+			return
+		}
+		ctx, release, err := o.enter(r.Context())
+		if err != nil {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "process restarting; retry", http.StatusServiceUnavailable)
+			return
+		}
+		defer release()
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (o *processExecOwner) request() {
+	if !o.requested.CompareAndSwap(false, true) {
+		return
+	}
+	reopen := o.gate.Pause()
+	process.State(o.mode, "draining", "")
+	go func() {
+		defer o.requested.Store(false)
+		defer func() { o.mu.Lock(); o.cancelling = false; o.mu.Unlock(); reopen() }()
+		timer := time.NewTimer(o.grace)
+		defer timer.Stop()
+		tick := time.NewTicker(10 * time.Millisecond)
+		defer tick.Stop()
+		cancelling := false
+		for {
+			if o.ctx.Err() != nil {
+				return
+			}
+			if o.gate.Drained() {
+				process.State(o.mode, "replacing", "")
+				err := o.exec(o.executable, append([]string(nil), os.Args...), webExecEnviron("", ""))
+				if err != nil {
+					process.State(o.mode, "failed", err.Error())
+				}
+				return
+			}
+			select {
+			case <-o.ctx.Done():
+				return
+			case <-tick.C:
+			case <-timer.C:
+				if cancelling {
+					process.State(o.mode, "failed", "cancelled mutation handlers did not settle")
+					return
+				}
+				cancelling = true
+				process.State(o.mode, "cancelling", "restart grace elapsed")
+				o.mu.Lock()
+				o.cancelling = true
+				for _, cancel := range o.cancels {
+					cancel()
+				}
+				o.mu.Unlock()
+				timer.Reset(o.grace)
+			}
+		}
+	}()
+}
+
+func serveHTTPWithRestart(ctx context.Context, mode string, srv *http.Server) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	owner := &processExecOwner{ctx: ctx, mode: mode, executable: executable, grace: 10 * time.Second, cancels: make(map[uint64]context.CancelFunc), exec: execWebProcess}
+	srv.Handler = owner.handler(srv.Handler)
+	listener, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return err
+	}
+	unbind := restart.Default.Bind(owner.request)
+	defer unbind()
+	finished := make(chan error, 1)
+	go func() { finished <- srv.Serve(listener) }()
+	process.State(mode, "ready", "")
+	select {
+	case err := <-finished:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+		stop, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(stop); err != nil {
+			_ = srv.Close()
+		}
+		if err := <-finished; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("HTTP shutdown: %w", err)
+		}
+		return nil
+	}
+}

--- a/cmd/restart_http_test.go
+++ b/cmd/restart_http_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHTTPExecOwnerCancelsAndJoinsMutation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	owner := &processExecOwner{ctx: ctx, mode: "test", grace: 20 * time.Millisecond, cancels: make(map[uint64]context.CancelFunc)}
+	entered, returned, executed := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	var calls atomic.Int32
+	owner.exec = func(string, []string, []string) error {
+		if calls.Add(1) != 1 {
+			t.Error("duplicate replacement")
+		}
+		select {
+		case <-returned:
+		default:
+			t.Error("replaced before handler settled")
+		}
+		close(executed)
+		return errors.New("fixture exec failure")
+	}
+	handler := owner.handler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { close(entered); <-r.Context().Done(); close(returned) }))
+	go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mutate", nil))
+	<-entered
+	owner.request()
+	owner.request()
+	reject := httptest.NewRecorder()
+	handler.ServeHTTP(reject, httptest.NewRequest(http.MethodPost, "/another", nil))
+	if reject.Code != http.StatusServiceUnavailable {
+		t.Fatal("mutation admitted while draining")
+	}
+	select {
+	case <-executed:
+	case <-time.After(time.Second):
+		t.Fatal("owner did not cancel/join/replace")
+	}
+}
+
+func TestHTTPExecOwnerShutdownDoesNotReplace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	owner := &processExecOwner{ctx: ctx, grace: time.Millisecond, cancels: make(map[uint64]context.CancelFunc), exec: func(string, []string, []string) error { t.Error("replaced after shutdown"); return nil }}
+	owner.request()
+	deadline := time.Now().Add(time.Second)
+	for owner.requested.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if owner.requested.Load() {
+		t.Fatal("restart owner did not stop")
+	}
+}
+
+func TestHTTPExecOwnerJoinsDetachedToolAfterResponseReturns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	owner := &processExecOwner{ctx: ctx, grace: 40 * time.Millisecond, cancels: make(map[uint64]context.CancelFunc)}
+	executed := make(chan struct{}, 1)
+	owner.exec = func(string, []string, []string) error { executed <- struct{}{}; return errors.New("fixture") }
+	var toolCtx context.Context
+	var toolDone func()
+	handler := owner.handler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var err error
+		toolCtx, toolDone, err = owner.child(context.WithoutCancel(r.Context()))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp", nil))
+	owner.request()
+	select {
+	case <-toolCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("detached tool not cancelled")
+	}
+	select {
+	case <-executed:
+		t.Fatal("exec before actual tool return")
+	default:
+	}
+	// A descendant started during cancellation must inherit cancellation too.
+	lateCtx, lateDone, err := owner.child(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lateCtx.Err() == nil {
+		t.Fatal("late descendant escaped cancellation")
+	}
+	toolDone()
+	select {
+	case <-executed:
+		t.Fatal("exec before descendant return")
+	default:
+	}
+	lateDone()
+	select {
+	case <-executed:
+	case <-time.After(time.Second):
+		t.Fatal("exec did not follow settlement")
+	}
+}
+
+func TestHTTPExecOwnerUncooperativeToolPreventsReplacement(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	owner := &processExecOwner{ctx: ctx, grace: 10 * time.Millisecond, cancels: make(map[uint64]context.CancelFunc), exec: func(string, []string, []string) error { t.Error("unsettled work was replaced"); return nil }}
+	work, done, err := owner.enter(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer done()
+	owner.request()
+	deadline := time.Now().Add(time.Second)
+	for owner.requested.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if owner.requested.Load() {
+		t.Fatal("request never settled")
+	}
+	if work.Err() == nil {
+		t.Fatal("work was not cancelled")
+	}
+	if owner.gate.Drained() {
+		t.Fatal("cancellation mistaken for actual return")
+	}
+	// A failed attempt remains usable; the original operation is still accounted.
+	_, release, err := owner.enter(ctx)
+	if err != nil {
+		t.Fatal("failed exec did not reopen admission", err)
+	}
+	release()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/exitcode"
 	pprofserver "github.com/samsaffron/term-llm/internal/pprof"
+	"github.com/samsaffron/term-llm/internal/restart"
 	"github.com/samsaffron/term-llm/internal/terminaltext"
 	"github.com/samsaffron/term-llm/internal/ui"
 	"github.com/samsaffron/term-llm/internal/update"
@@ -200,7 +201,11 @@ func stopProfiling() error {
 }
 
 func Execute() {
-	if err := executeWithArgs(os.Args[1:]); err != nil {
+	stopRestart := restart.Default.Listen()
+	err := executeWithArgs(os.Args[1:])
+	// Execute exits directly on errors, so finish before os.Exit, not in a defer.
+	stopRestart()
+	if err != nil {
 		writeRootError(rootCmd.ErrOrStderr(), err)
 		if exitErr, ok := err.(exitcode.ExitError); ok {
 			os.Exit(exitErr.Code)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/samsaffron/term-llm/internal/exitcode"
 	pprofserver "github.com/samsaffron/term-llm/internal/pprof"
+	"github.com/samsaffron/term-llm/internal/process"
 	"github.com/samsaffron/term-llm/internal/restart"
 	"github.com/samsaffron/term-llm/internal/terminaltext"
 	"github.com/samsaffron/term-llm/internal/ui"
@@ -66,6 +67,7 @@ create media, and automate recurring work—from your terminal or browser.`,
 	SilenceErrors:     true,
 	SilenceUsage:      true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		process.State(cmd.CommandPath(), "deferred", "mode has no resumable owner")
 		if shellCompletionExecution(cmd) {
 			return nil
 		}
@@ -202,9 +204,11 @@ func stopProfiling() error {
 
 func Execute() {
 	stopRestart := restart.Default.Listen()
+	publisher := process.Start(versionString())
 	err := executeWithArgs(os.Args[1:])
 	// Execute exits directly on errors, so finish before os.Exit, not in a defer.
 	stopRestart()
+	publisher.Stop()
 	if err != nil {
 		writeRootError(rootCmd.ErrOrStderr(), err)
 		if exitErr, ok := err.(exitcode.ExitError); ok {

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/agents"
@@ -105,11 +107,23 @@ func (r *cmdRunner) Run(ctx context.Context, req runpkg.Request, sink runpkg.Eve
 		return runpkg.Result{}, err
 	}
 	defer env.Close()
+	if source, ok := ctx.Value(jobsExecutionContextKey{}).(*jobsLLMExecution); ok {
+		source.bind(env)
+		defer source.capture()
+	}
 	if env.req.OnEngineReady != nil {
 		env.req.OnEngineReady(env.engine)
 	}
 	if env.req.OnEngineDone != nil {
 		defer env.req.OnEngineDone(env.engine)
+	}
+
+	// The response loop can return a synthetic cancellation while Execute is
+	// still cleaning up. Do not publish engine completion, close its resources,
+	// or let a job owner release its restart gate until the real call returns.
+	// Borrowed engines are settled by their caller's existing lifetime owner.
+	if !env.runtime.borrowedEngine {
+		defer func() { _ = env.engine.WaitToolSettlement(context.Background()) }()
 	}
 
 	collector := &runnerEventCollector{sink: sink}
@@ -153,6 +167,13 @@ func resolvedRunnerApprovalMode(defaults cmdRunnerOptions, req runpkg.Request) t
 func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg.EventSink) (*cmdRunEnvironment, error) {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if req.Resume {
+		if strings.TrimSpace(req.SessionID) == "" || req.DeferSession || req.ReplaceHistory {
+			return nil, fmt.Errorf("resume requires an existing session ID and preserved history")
+		}
+		req.Persist = true
+		req.Stateful = true
 	}
 	if req.Platform == "" {
 		req.Platform = runpkg.PlatformConsole
@@ -322,30 +343,31 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 		runtimeStore = nil
 	}
 	runtime = &serveRuntime{
-		provider:            provider,
-		providerKey:         cfg.DefaultProvider,
-		engine:              engine,
-		toolMgr:             toolMgr,
-		toolDiscovery:       cfg.ToolDiscovery,
-		store:               runtimeStore,
-		goalStore:           store,
-		baseSystemPrompt:    baseSystemPrompt,
-		systemPrompt:        settings.SystemPrompt,
-		search:              settings.Search,
-		forceExternalSearch: forceExternalSearch,
-		maxTurns:            settings.MaxTurns,
-		debug:               r.defaults.Debug || req.Debug,
-		debugRaw:            r.defaults.DebugRaw || req.DebugRaw,
-		autoCompact:         cfg.AutoCompact,
-		borrowedEngine:      borrowedEngine,
-		skipProviderCleanup: !providerOwned,
-		defaultModel:        modelName,
-		approvalDefault:     approvalMode,
-		yoloMode:            yoloMode,
-		toolsSetting:        settings.Tools,
-		mcpSetting:          settings.MCP,
-		agentName:           agentName,
-		platform:            templatePlatform(req.Platform),
+		provider:                 provider,
+		providerKey:              cfg.DefaultProvider,
+		engine:                   engine,
+		toolMgr:                  toolMgr,
+		toolDiscovery:            cfg.ToolDiscovery,
+		store:                    runtimeStore,
+		goalStore:                store,
+		baseSystemPrompt:         baseSystemPrompt,
+		systemPrompt:             settings.SystemPrompt,
+		search:                   settings.Search,
+		forceExternalSearch:      forceExternalSearch,
+		maxTurns:                 settings.MaxTurns,
+		debug:                    r.defaults.Debug || req.Debug,
+		debugRaw:                 r.defaults.DebugRaw || req.DebugRaw,
+		autoCompact:              cfg.AutoCompact,
+		borrowedEngine:           borrowedEngine,
+		persistenceOwnedByCaller: req.DisableRuntimePersistence,
+		skipProviderCleanup:      !providerOwned,
+		defaultModel:             modelName,
+		approvalDefault:          approvalMode,
+		yoloMode:                 yoloMode,
+		toolsSetting:             settings.Tools,
+		mcpSetting:               settings.MCP,
+		agentName:                agentName,
+		platform:                 templatePlatform(req.Platform),
 	}
 	if agent != nil {
 		runtime.platformMessages = agent.PlatformMessages
@@ -359,6 +381,9 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 	runtime.compactionCB = req.OnCompaction
 	runtime.syntheticUserCB = req.OnSyntheticUserMessage
 
+	if req.Resume && store == nil {
+		return nil, fmt.Errorf("resume requires session storage")
+	}
 	var sess *session.Session
 	if store != nil && !req.DeferSession {
 		sess, err = r.ensureRunSession(ctx, store, req, provider, cfg.DefaultProvider, modelName, agentName, settings)
@@ -414,6 +439,7 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 	}
 
 	llmReq := llm.Request{
+		ModelBoundary:            req.ModelBoundary,
 		Model:                    modelName,
 		SessionID:                req.SessionID,
 		WorkingDir:               settings.BaseDir,
@@ -597,6 +623,11 @@ func (r *cmdRunner) ensureRunSession(ctx context.Context, store session.Store, r
 	}
 	if existing, err := store.Get(ctx, req.SessionID); err == nil && existing != nil {
 		return existing, nil
+	} else if req.Resume {
+		if err != nil {
+			return nil, fmt.Errorf("load resume session %q: %w", req.SessionID, err)
+		}
+		return nil, fmt.Errorf("resume session %q does not exist", req.SessionID)
 	}
 	name := strings.TrimSpace(req.SessionName)
 	summary := name
@@ -658,8 +689,39 @@ func (r *cmdRunner) runProgressive(ctx context.Context, runtime *serveRuntime, e
 	if runtime.systemPrompt != "" && !containsSystemMessage(messages) {
 		messages = append([]llm.Message{llm.SystemText(runtime.systemPrompt)}, messages...)
 	}
-	llmReq.Messages = messages
+	// Only the new input suffix is appended to persistence below. Restoring
+	// provider history must not duplicate the original user turn in the store.
+	if req.Resume {
+		active, err := session.LoadActiveMessages(ctx, store, sess)
+		if err != nil {
+			return runpkg.Result{}, fmt.Errorf("restore progressive resume history: %w", err)
+		}
+		history := make([]llm.Message, 0, len(active)+len(messages))
+		for _, row := range active {
+			history = append(history, row.ToLLMMessage())
+		}
+		messages = progressiveResumeInput(history, messages)
+		llmReq.Messages = append(history, messages...)
+	} else {
+		llmReq.Messages = messages
+	}
 
+	var persistenceMu sync.Mutex
+	var persistenceErr error
+	recordPersistence := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		persistenceMu.Lock()
+		if persistenceErr == nil {
+			persistenceErr = err
+		}
+		persistenceMu.Unlock()
+		if source, ok := ctx.Value(jobsExecutionContextKey{}).(*jobsLLMExecution); ok {
+			source.failCheckpoint(err)
+		}
+		return err
+	}
 	persistResponseCompleted := req.OnResponseCompleted
 	persistTurnCompleted := req.OnTurnCompleted
 	persistSyntheticUserMessage := req.OnSyntheticUserMessage
@@ -670,12 +732,17 @@ func (r *cmdRunner) runProgressive(ctx context.Context, runtime *serveRuntime, e
 	}
 	if persistStore != nil && sess != nil {
 		for _, msg := range messages {
-			_ = persistStore.AddMessage(ctx, sess.ID, session.NewMessage(sess.ID, msg, -1))
+			if err := persistStore.AddMessage(ctx, sess.ID, session.NewMessage(sess.ID, msg, -1)); err != nil {
+				return runpkg.Result{}, recordPersistence(err)
+			}
 			if msg.Role == llm.RoleUser {
-				_ = persistStore.IncrementUserTurns(ctx, sess.ID)
+				if err := persistStore.IncrementUserTurns(ctx, sess.ID); err != nil {
+					return runpkg.Result{}, recordPersistence(err)
+				}
 			}
 		}
-		persistResponseCompleted = func(cbCtx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) error {
+		persistResponseCompleted = func(cbCtx context.Context, turnIndex int, assistantMsg llm.Message, metrics llm.TurnMetrics) (callbackErr error) {
+			defer func() { recordPersistence(callbackErr) }()
 			sessionMsg := session.NewMessage(sess.ID, assistantMsg, -1)
 			sessionMsg.DurationMs = time.Since(turnStartTime).Milliseconds()
 			if err := persistStore.AddMessage(cbCtx, sess.ID, sessionMsg); err != nil {
@@ -686,7 +753,8 @@ func (r *cmdRunner) runProgressive(ctx context.Context, runtime *serveRuntime, e
 			}
 			return nil
 		}
-		persistTurnCompleted = func(cbCtx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) error {
+		persistTurnCompleted = func(cbCtx context.Context, turnIndex int, turnMessages []llm.Message, metrics llm.TurnMetrics) (callbackErr error) {
+			defer func() { recordPersistence(callbackErr) }()
 			for _, msg := range turnMessages {
 				sessionMsg := session.NewMessage(sess.ID, msg, -1)
 				if msg.Role == llm.RoleAssistant {
@@ -697,6 +765,7 @@ func (r *cmdRunner) runProgressive(ctx context.Context, runtime *serveRuntime, e
 				}
 			}
 			if err := persistStore.UpdateMetrics(cbCtx, sess.ID, 1, metrics.ToolCalls, metrics.InputTokens, metrics.OutputTokens, metrics.CachedInputTokens, metrics.CacheWriteTokens); err != nil {
+				recordPersistence(err)
 				log.Printf("[runner] session UpdateMetrics failed for %s: %v", sess.ID, err)
 			}
 			if total, count := engine.ContextEstimateBaseline(); total > 0 {
@@ -709,7 +778,8 @@ func (r *cmdRunner) runProgressive(ctx context.Context, runtime *serveRuntime, e
 			}
 			return nil
 		}
-		persistSyntheticUserMessage = func(cbCtx context.Context, msg llm.Message) error {
+		persistSyntheticUserMessage = func(cbCtx context.Context, msg llm.Message) (callbackErr error) {
+			defer func() { recordPersistence(callbackErr) }()
 			turnStartTime = time.Now()
 			if err := persistStore.AddMessage(cbCtx, sess.ID, session.NewMessage(sess.ID, msg, -1)); err != nil {
 				return err
@@ -721,18 +791,49 @@ func (r *cmdRunner) runProgressive(ctx context.Context, runtime *serveRuntime, e
 		}
 	}
 
+	var resumePassHadWork, resumePassHadCommit bool
+	var passEnd func(progressivePassResult)
+	var finalizationReason string
+	var finalizationStart func(string, llm.Request) error
+	var firstPassMaxTurns *int
+	var passStart func(context.Context, llm.Request) (context.Context, func(), error)
+	if checkpoint, ok := ctx.Value(jobsRestartContextKey{}).(*jobsRestartCheckpoint); ok && checkpoint.PassTurnLimit > 0 {
+		finalizationReason = checkpoint.FinalizationReason
+		resumePassHadWork, resumePassHadCommit = checkpoint.PassHadWork, checkpoint.PassHadCommit
+		remaining := checkpoint.RemainingTurns
+		firstPassMaxTurns = &remaining
+		llmReq.MaxTurns = checkpoint.PassTurnLimit
+	}
+	if source, ok := ctx.Value(jobsExecutionContextKey{}).(*jobsLLMExecution); ok {
+		passStart = source.beginProgressivePass
+		passEnd = source.endProgressivePass
+		finalizationStart = source.beginFinalization
+	}
 	progressiveResult, err := runProgressiveSession(ctx, engine, llmReq, progressiveRunOptions{
-		StopWhen:               progressiveStopWhen(strings.TrimSpace(req.Progressive.StopWhen)),
-		ContinueWith:           req.Progressive.ContinueWith,
-		SessionID:              req.SessionID,
-		ForceNamedFinalization: provider != nil && provider.Capabilities().SupportsToolChoice,
-		OnSyntheticUserMessage: persistSyntheticUserMessage,
-		OnResponseCompleted:    persistResponseCompleted,
-		OnTurnCompleted:        persistTurnCompleted,
+		ResumePassHadWork:        resumePassHadWork,
+		ResumePassHadCommit:      resumePassHadCommit,
+		OnPassEnd:                passEnd,
+		ResumeFinalizationReason: finalizationReason,
+		OnFinalizationStart:      finalizationStart,
+		FirstPassMaxTurns:        firstPassMaxTurns,
+		OnPassStart:              passStart,
+		StopWhen:                 progressiveStopWhen(strings.TrimSpace(req.Progressive.StopWhen)),
+		ContinueWith:             req.Progressive.ContinueWith,
+		SessionID:                req.SessionID,
+		ForceNamedFinalization:   provider != nil && provider.Capabilities().SupportsToolChoice,
+		OnSyntheticUserMessage:   persistSyntheticUserMessage,
+		OnResponseCompleted:      persistResponseCompleted,
+		OnTurnCompleted:          persistTurnCompleted,
 		OnEvent: func(ev llm.Event) error {
 			return collector.Event(ev)
 		},
 	})
+	persistenceMu.Lock()
+	storedErr := persistenceErr
+	persistenceMu.Unlock()
+	if storedErr != nil {
+		err = errors.Join(err, fmt.Errorf("persist progressive transcript: %w", storedErr))
+	}
 	if persistStore != nil && sess != nil {
 		status := session.StatusComplete
 		switch progressiveResult.ExitReason {
@@ -906,4 +1007,25 @@ func (c *runnerEventCollector) Result(sessionID string) runpkg.Result {
 		InputTokens:  c.input,
 		OutputTokens: c.output,
 	}
+}
+
+// Drop only an identical plain-text system message already in the active
+// transcript. Changed policy, summaries, multimodal data and user input survive.
+func progressiveResumeInput(history, input []llm.Message) []llm.Message {
+	result := make([]llm.Message, 0, len(input))
+	for _, msg := range input {
+		duplicate := false
+		if msg.Role == llm.RoleSystem && len(msg.Parts) == 1 && msg.Parts[0].Type == llm.PartText {
+			for _, prior := range history {
+				if prior.Role == llm.RoleSystem && len(prior.Parts) == 1 && prior.Parts[0].Type == llm.PartText && prior.Parts[0].Text == msg.Parts[0].Text {
+					duplicate = true
+					break
+				}
+			}
+		}
+		if !duplicate {
+			result = append(result, msg)
+		}
+	}
+	return result
 }

--- a/cmd/runner_test.go
+++ b/cmd/runner_test.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
@@ -294,5 +297,221 @@ func TestCmdRunnerPrepareUsesBorrowedEngineProvider(t *testing.T) {
 	}
 	if !env.runtime.borrowedEngine {
 		t.Fatal("borrowed engine should preserve provider conversation state")
+	}
+}
+
+func TestCmdRunnerResumeRetainsHistoryAndRejectsMissingSource(t *testing.T) {
+	for _, exists := range []bool{true, false} {
+		t.Run(fmt.Sprint(exists), func(t *testing.T) {
+			store := newServeRuntimeTestStore()
+			const sid = "resume-source"
+			if exists {
+				if err := store.Create(context.Background(), &session.Session{ID: sid, Provider: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+					t.Fatal(err)
+				}
+				if err := store.AddMessage(context.Background(), sid, &session.Message{SessionID: sid, Role: llm.RoleUser, Parts: []llm.Part{{Type: llm.PartText, Text: "original unfinished task"}}, TextContent: "original unfinished task", Sequence: -1}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			provider := llm.NewMockProvider("mock").AddTextResponse("continued")
+			cfg := &config.Config{DefaultProvider: "mock", Providers: map[string]config.ProviderConfig{"mock": {Model: "mock-model"}}}
+			runner := newCmdRunner(cfg, cmdRunnerOptions{Store: store})
+			noTools := false
+			_, err := runner.Run(context.Background(), runpkg.Request{Platform: runpkg.PlatformJob, SessionID: sid, Resume: true, Persist: true, Messages: []llm.Message{{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "internal continuation"}}}}, ProviderInstance: provider, Cwd: t.TempDir(), IncludeConfiguredTools: &noTools}, nil)
+			requests := provider.RecordedRequests()
+			if !exists {
+				if err == nil || len(requests) != 0 {
+					t.Fatalf("missing resume source ran: err=%v calls=%d", err, len(requests))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(requests) != 1 {
+				t.Fatalf("provider calls=%d", len(requests))
+			}
+			found := false
+			for _, msg := range requests[0].Messages {
+				if strings.Contains(llm.MessageText(msg), "original unfinished task") {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatal("Resume dropped the original transcript")
+			}
+		})
+	}
+}
+
+type runnerUncooperativeTool struct{ started, release chan struct{} }
+
+func (t *runnerUncooperativeTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{Name: "hold_cleanup", Description: "test actual execution lifetime", Schema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}}
+}
+func (t *runnerUncooperativeTool) Preview(json.RawMessage) string { return "" }
+func (t *runnerUncooperativeTool) Execute(context.Context, json.RawMessage) (llm.ToolOutput, error) {
+	close(t.started)
+	<-t.release
+	return llm.ToolOutput{}, nil
+}
+
+func TestCmdRunnerCompletionWaitsForActualToolExit(t *testing.T) {
+	tool := &runnerUncooperativeTool{started: make(chan struct{}), release: make(chan struct{})}
+	released := false
+	defer func() {
+		if !released {
+			close(tool.release)
+		}
+	}()
+	provider := llm.NewMockProvider("mock").AddToolCall("held", "hold_cleanup", map[string]any{}).AddTextResponse("done")
+	cfg := &config.Config{DefaultProvider: "mock", Providers: map[string]config.ProviderConfig{"mock": {Model: "mock-model"}}}
+	runner := newCmdRunner(cfg, cmdRunnerOptions{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	returned := make(chan error, 1)
+	engineDone := make(chan struct{})
+	noTools := false
+	go func() {
+		_, err := runner.Run(ctx, runpkg.Request{Platform: runpkg.PlatformJob, Prompt: "work", ProviderInstance: provider, Cwd: t.TempDir(), DeferSession: true, ExtraTools: []llm.ToolSpec{tool.Spec()}, IncludeConfiguredTools: &noTools, OnEngineReady: func(e *llm.Engine) { e.RegisterTool(tool) }, OnEngineDone: func(*llm.Engine) { close(engineDone) }}, nil)
+		returned <- err
+	}()
+	select {
+	case <-tool.started:
+	case err := <-returned:
+		t.Fatalf("runner returned before tool started: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("tool not started")
+	}
+	cancel()
+	select {
+	case <-engineDone:
+		t.Fatal("engine completion preceded actual tool exit")
+	case err := <-returned:
+		t.Fatalf("job returned with Execute still running: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(tool.release)
+	released = true
+	select {
+	case <-returned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runner did not finish after tool exit")
+	}
+	select {
+	case <-engineDone:
+	default:
+		t.Fatal("completion hook missing")
+	}
+}
+
+func TestCmdRunnerProgressiveResumeRetainsHistoryAndRejectsMissingSource(t *testing.T) {
+	for _, exists := range []bool{true, false} {
+		t.Run(fmt.Sprint(exists), func(t *testing.T) {
+			store := newServeRuntimeTestStore()
+			const sid = "resume-source"
+			if exists {
+				if err := store.Create(context.Background(), &session.Session{ID: sid, Provider: "mock", Model: "mock-model", Status: session.StatusActive}); err != nil {
+					t.Fatal(err)
+				}
+				if err := store.AddMessage(context.Background(), sid, &session.Message{SessionID: sid, Role: llm.RoleUser, Parts: []llm.Part{{Type: llm.PartText, Text: "original unfinished task"}}, TextContent: "original unfinished task", Sequence: -1}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			provider := llm.NewMockProvider("mock").AddTextResponse("continued")
+			cfg := &config.Config{DefaultProvider: "mock", Providers: map[string]config.ProviderConfig{"mock": {Model: "mock-model"}}}
+			runner := newCmdRunner(cfg, cmdRunnerOptions{Store: store})
+			noTools := false
+			_, err := runner.Run(context.Background(), runpkg.Request{Platform: runpkg.PlatformJob, SessionID: sid, Resume: true, Progressive: &runpkg.ProgressiveOptions{StopWhen: "done"}, Persist: true, Messages: []llm.Message{{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "internal continuation"}}}}, ProviderInstance: provider, Cwd: t.TempDir(), IncludeConfiguredTools: &noTools}, nil)
+			requests := provider.RecordedRequests()
+			if !exists {
+				if err == nil || len(requests) != 0 {
+					t.Fatalf("missing resume source ran: err=%v calls=%d", err, len(requests))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(requests) < 1 {
+				t.Fatalf("provider calls=%d", len(requests))
+			}
+			found := false
+			for _, msg := range requests[0].Messages {
+				if strings.Contains(llm.MessageText(msg), "original unfinished task") {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatal("Resume dropped the original transcript")
+			}
+		})
+	}
+}
+
+type progressiveFailingMessageStore struct {
+	session.Store
+	role    llm.Role
+	failure error
+}
+
+func (s *progressiveFailingMessageStore) AddMessage(ctx context.Context, id string, message *session.Message) error {
+	if message.Role == s.role {
+		return s.failure
+	}
+	return s.Store.AddMessage(ctx, id, message)
+}
+
+func TestCmdRunnerProgressivePersistenceFailureIsNotSuccess(t *testing.T) {
+	for _, role := range []llm.Role{llm.RoleUser, llm.RoleAssistant} {
+		t.Run(string(role), func(t *testing.T) {
+			failure := errors.New("fixture transcript write failure")
+			store := &progressiveFailingMessageStore{Store: newServeRuntimeTestStore(), role: role, failure: failure}
+			provider := llm.NewMockProvider("mock").AddTextResponse("answer").AddTextResponse("final answer")
+			cfg := &config.Config{DefaultProvider: "mock", Providers: map[string]config.ProviderConfig{"mock": {Model: "mock-model"}}}
+			runner := newCmdRunner(cfg, cmdRunnerOptions{Store: store})
+			noTools := false
+			_, err := runner.Run(context.Background(), runpkg.Request{Platform: runpkg.PlatformJob, SessionID: "failure-source", Persist: true, Progressive: &runpkg.ProgressiveOptions{StopWhen: "done"}, Prompt: "original task", ProviderInstance: provider, Cwd: t.TempDir(), IncludeConfiguredTools: &noTools}, nil)
+			if !errors.Is(err, failure) {
+				t.Fatalf("persistence failure swallowed: %v", err)
+			}
+			if role == llm.RoleUser && len(provider.RecordedRequests()) != 0 {
+				t.Fatal("provider invoked without durable original input")
+			}
+		})
+	}
+}
+
+func TestProgressiveResumeInputKeepsChangedPolicyAndUserInput(t *testing.T) {
+	history := []llm.Message{llm.SystemText("policy"), llm.SystemText("conversation summary"), llm.UserText("task")}
+	input := []llm.Message{llm.SystemText("policy"), llm.SystemText("updated policy"), llm.UserText("task")}
+	got := progressiveResumeInput(history, input)
+	if len(got) != 2 || llm.MessageText(got[0]) != "updated policy" || got[1].Role != llm.RoleUser {
+		t.Fatalf("incorrect resume deduplication: %+v", got)
+	}
+	if len(history) != 3 || len(input) != 3 {
+		t.Fatal("mutated source transcript/input")
+	}
+}
+
+func TestCmdRunnerPreservesRequestModelBoundary(t *testing.T) {
+	cfg := &config.Config{DefaultProvider: "mock", Providers: map[string]config.ProviderConfig{"mock": {Model: "mock-model"}}}
+	provider := llm.NewMockProvider("mock")
+	provider.AddTextResponse("must not execute")
+	engine := newEngine(provider, cfg)
+	runner := newCmdRunner(cfg, cmdRunnerOptions{}).(*cmdRunner)
+	boundaryErr := errors.New("parked boundary")
+	calls := 0
+	_, err := runner.Run(context.Background(), runpkg.Request{Platform: runpkg.PlatformTelegram, Cwd: t.TempDir(), Messages: []llm.Message{llm.UserText("work")}, Engine: engine, ProviderInstance: provider, DeferSession: true, DisableRuntimePersistence: true, ModelBoundary: func(context.Context) error { calls++; return boundaryErr }}, eventSinkFunc(nil))
+	if calls != 1 || err == nil {
+		t.Fatalf("boundary calls=%d err=%v", calls, err)
+	}
+	if len(provider.RecordedRequests()) != 0 {
+		t.Fatal("boundary error still issued provider request")
+	}
+	calls = 0
+	_, err = runner.Run(context.Background(), runpkg.Request{Platform: runpkg.PlatformWeb, Cwd: t.TempDir(), Messages: []llm.Message{llm.UserText("work")}, Engine: engine, ProviderInstance: provider, DeferSession: true, ModelBoundary: func(context.Context) error { calls++; return nil }}, eventSinkFunc(nil))
+	if err == nil || calls != 0 || len(provider.RecordedRequests()) != 0 {
+		t.Fatal("runtime-owned boundary accepted unpersisted input")
 	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -601,6 +602,9 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 			return nil, err
 		}
 		runtime := env.runtime
+		if s != nil && s.webExec != nil && (runtime.provider.Capabilities().InlineToolLoop || runtime.mcpManagerSnapshot() != nil) {
+			s.webExec.reject("a runtime initialized native provider or MCP ownership")
+		}
 		runtime.toolMap = toolMap
 		runtime.platform = "web"
 		runtime.sideProviderFactory = func(providerKey, model string) (llm.Provider, error) {
@@ -748,6 +752,9 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 	}
 
 	hasHTTP := hasWeb || hasAPI || hasJobs
+	if !hasHTTP {
+		defer installWebExecSignal(ctx, &webExecCoordinator{ctx: ctx, unsupported: "SIGUSR2 requires standalone serve web"})()
+	}
 
 	registeredHubURL := ""
 	registeredHubNodeID := ""
@@ -814,6 +821,19 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 				return getErr == nil && sess != nil
 			}),
 		}
+
+		unsupportedExec := ""
+		if !hasWeb || hasAPI || hasJobs || hasTelegram {
+			unsupportedExec = "only standalone serve web supports SIGUSR2"
+		}
+		if widgetsMgr != nil {
+			unsupportedExec = "widget ownership is unsupported; start with --disable-widgets"
+		}
+		if serveWebRTC || strings.TrimSpace(serveHubURL) != "" {
+			unsupportedExec = "Hub and WebRTC transports are not yet supported"
+		}
+		s.webExec = newWebExecCoordinator(ctx, s, unsupportedExec)
+		defer installWebExecSignal(ctx, s.webExec)()
 		if hasJobs {
 			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers, resolvedApproval, s.notifyJobsV2RunDone)
 			if err != nil {
@@ -1331,6 +1351,7 @@ func normalizeBasePath(raw string) (string, error) {
 }
 
 type serveServer struct {
+	webExec                  *webExecCoordinator
 	cfg                      serveServerConfig
 	sessionMgr               *serveSessionManager
 	jobsV2                   *jobsV2Manager
@@ -1474,9 +1495,22 @@ func (s *serveServer) Start() error {
 		s.prewarmUIAssetCache()
 	}
 
+	// Bind before consuming any handoff. Listener ownership, the stable service
+	// identity and durable fences together prevent an env hint from stealing a
+	// still-live service's work. No listener is inherited across exec.
+	listener, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	if s.webExec != nil {
+		if err := s.webExec.resume(); err != nil {
+			_ = listener.Close()
+			return fmt.Errorf("recover web self-exec: %w", err)
+		}
+	}
 	errCh := make(chan error, 1)
 	go func() {
-		err := s.server.ListenAndServe()
+		err := s.server.Serve(listener)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
@@ -1493,6 +1527,11 @@ func (s *serveServer) Start() error {
 		s.startEventWatcher()
 		s.startResponseLifecycle()
 		s.startCompletionPushDispatcher()
+		if s.webExec != nil {
+			s.webExec.mu.Lock()
+			s.webExec.ready = true
+			s.webExec.mu.Unlock()
+		}
 		return nil
 	}
 }
@@ -1500,6 +1539,14 @@ func (s *serveServer) Start() error {
 var registerServeBrowserFixtureRoutes func(*http.ServeMux, *serveServer)
 
 func (s *serveServer) httpHandler() http.Handler {
+	handler := s.rawHTTPHandler()
+	if s.webExec != nil {
+		return s.webExec.handler(handler)
+	}
+	return handler
+}
+
+func (s *serveServer) rawHTTPHandler() http.Handler {
 	// Inner mux: all routes registered at their natural paths.
 	// basePath is stripped by http.StripPrefix on the outer mux when mounted,
 	// so handlers see /v1/..., /images/..., / etc. without the prefix.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -891,7 +891,11 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 
 		if serveHubConnect == "reverse" {
 			localBase := localHubConnectBase(serveHost, servePort)
-			go runHubReverseConnector(ctx, reverseHubURL, reverseHubNodeID, token, localBase, serveBasePath, newHubReverseLocalClient())
+			connector := startHubReverseConnector(ctx, reverseHubURL, reverseHubNodeID, token, localBase, serveBasePath, newHubReverseLocalClient())
+			defer func() {
+				// Join ownership; a deadline must not authorize abandoning requests.
+				_ = connector.Stop(context.Background())
+			}()
 			fmt.Fprintf(cmd.ErrOrStderr(), "hub reverse: connecting %s to %s\n", reverseHubNodeID, reverseHubURL)
 		}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1534,6 +1534,7 @@ func (s *serveServer) Start() error {
 		if s.webExec != nil {
 			s.webExec.mu.Lock()
 			s.webExec.ready = true
+			s.webExec.publishReady()
 			s.webExec.mu.Unlock()
 		}
 		return nil

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/filetrack"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mentions"
+	"github.com/samsaffron/term-llm/internal/process"
 	projectpkg "github.com/samsaffron/term-llm/internal/project"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/serve"
@@ -823,23 +824,19 @@ func runServeLegacy(parentCtx context.Context, cmd *cobra.Command, args []string
 		}
 
 		unsupportedExec := ""
-		if !hasWeb || hasAPI || hasJobs || hasTelegram {
-			unsupportedExec = "only standalone serve web supports SIGUSR2"
-		}
-		if widgetsMgr != nil {
-			unsupportedExec = "widget ownership is unsupported; start with --disable-widgets"
-		}
-		if serveWebRTC || strings.TrimSpace(serveHubURL) != "" {
-			unsupportedExec = "Hub and WebRTC transports are not yet supported"
+		if hasTelegram {
+			unsupportedExec = "Telegram lifecycle not yet attached"
 		}
 		s.webExec = newWebExecCoordinator(ctx, s, unsupportedExec)
+		s.webExec.mode = "serve " + strings.Join(platformNames, ",")
 		defer installWebExecSignal(ctx, s.webExec)()
 		if hasJobs {
-			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers, resolvedApproval, s.notifyJobsV2RunDone)
+			jobsV2, err = newServeJobsV2Manager(cfg, serveJobsWorkers, resolvedApproval, s.notifyJobsV2RunDone, jobsRestartSetup{Store: store, RestartID: execRestartHint, Service: s.webExec.service, Instance: process.Instance()})
 			if err != nil {
 				return fmt.Errorf("initialize jobs v2 manager: %w", err)
 			}
 			s.jobsV2 = jobsV2
+			s.webExec.gates = append(s.webExec.gates, &jobsV2.restartGate)
 		}
 		sessionMgr.onEvict = func(rt *serveRuntime) {
 			for _, rid := range rt.getResponseIDs() {

--- a/cmd/serve_exec.go
+++ b/cmd/serve_exec.go
@@ -1,0 +1,510 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+// Capture before command execution or any child launch. These lookup hints are
+// never left in the environment inherited by tools.
+var execRestartHint, execServiceHint = captureExecHints()
+
+func captureExecHints() (string, string) {
+	id, service := os.Getenv("TERM_LLM_RESTART_ID"), os.Getenv("TERM_LLM_RESTART_SERVICE_ID")
+	_ = os.Unsetenv("TERM_LLM_RESTART_ID")
+	_ = os.Unsetenv("TERM_LLM_RESTART_SERVICE_ID")
+	return id, service
+}
+
+type webExecRun struct {
+	boundaries int
+	run        *responseRun
+	request    llm.Request
+	ctx        context.Context
+	parked     bool
+}
+
+type webExecCoordinator struct {
+	// Coalesce before mu: exec/checkpoint holds mu, so a duplicate must not
+	// wait for failed exec and accidentally start a new drain afterwards.
+	requested                        atomic.Bool
+	ready                            bool
+	safeTool                         func(llm.Tool) bool // test seam; nil uses concrete built-in types
+	quarantined                      bool
+	mu                               sync.Mutex
+	server                           *serveServer
+	ctx                              context.Context
+	store                            session.ExecHandoffStore
+	service, executable, unsupported string
+	runs                             map[string]*webExecRun
+	handlers                         int
+	draining                         bool
+	release                          chan struct{}
+	timeout                          time.Duration
+	exec                             func(string, []string, []string) error
+}
+
+func newWebExecCoordinator(ctx context.Context, s *serveServer, unsupported string) *webExecCoordinator {
+	executable, err := os.Executable()
+	if err != nil {
+		unsupported = "cannot resolve serving executable"
+	}
+	// Resolve once, before an updater can replace/unlink the installed binary.
+	if resolved, e := filepath.EvalSymlinks(executable); e == nil {
+		executable = resolved
+	}
+	if s.cfgRef != nil && s.cfgRef.Serve.AutoTitle {
+		unsupported = "automatic title providers are independently owned; disable serve.auto_title"
+	}
+	store, ok := session.AsExecHandoffStore(s.store)
+	if !ok || !session.SupportsAtomicResponseRunTranscriptFencing(s.store) {
+		unsupported = "durable fenced SQLite sessions required"
+	}
+	service := execServiceHint
+	if _, err := uuid.Parse(service); err != nil {
+		service = uuid.NewString()
+	}
+	// Bind the service UUID to this invocation, not a recycled PID or an env ID
+	// from another listener/working directory. The database further scopes it.
+	s.responseOwnerOnce.Do(func() { s.responseOwnerInstanceID = "owner_" + uuid.NewString() })
+	sum := sha256.Sum256([]byte(strings.Join(os.Args, "\x00") + "\x00" + s.startupDir))
+	service += ":" + hex.EncodeToString(sum[:])
+	return &webExecCoordinator{server: s, ctx: ctx, store: store, service: service, executable: executable, unsupported: unsupported, runs: make(map[string]*webExecRun), timeout: 20 * time.Second, exec: execWebProcess}
+}
+
+func (c *webExecCoordinator) reject(reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.unsupported = reason
+	if c.draining {
+		c.abortLocked()
+	}
+}
+func (c *webExecCoordinator) abortLocked() {
+	if c.quarantined {
+		return
+	}
+	if c.draining {
+		close(c.release)
+		c.draining = false
+	}
+}
+
+// Unsupported owned activities taint this boot conservatively. We do not try
+// to kill children or infer that a returned shell/custom tool has no descendants.
+func (c *webExecCoordinator) observeTool(rt *serveRuntime, ev llm.Event) {
+	if ev.Type == llm.EventToolActivity {
+		c.reject("provider-managed native activity is unsupported")
+		return
+	}
+	if ev.Type != llm.EventToolExecStart {
+		return
+	}
+	tool, ok := rt.engine.Tools().Get(ev.ToolName)
+	safe := webExecSafeTool
+	if c.safeTool != nil {
+		safe = c.safeTool
+	}
+	if !ok || !safe(tool) {
+		c.reject("an unsupported tool or independently owned activity ran in this boot")
+	}
+}
+
+// Names are not authority: custom/skill tools can replace a built-in name.
+func webExecSafeTool(tool llm.Tool) bool {
+	switch tool.(type) {
+	case *tools.ReadFileTool, *tools.WriteFileTool, *tools.EditFileTool, *tools.GlobTool, *tools.GrepTool, *tools.UpdatePlanTool:
+		return true
+	default:
+		return false
+	}
+}
+
+type webExecTicketKey struct{}
+type webExecTicket struct {
+	once        sync.Once
+	coordinator *webExecCoordinator
+}
+
+func (t *webExecTicket) release() {
+	t.once.Do(func() { t.coordinator.mu.Lock(); t.coordinator.handlers--; t.coordinator.mu.Unlock() })
+}
+func releaseWebExecTicket(ctx context.Context) {
+	if t, ok := ctx.Value(webExecTicketKey{}).(*webExecTicket); ok {
+		t.release()
+	}
+}
+
+// All mutation handlers are accounted for before dispatch. Only a response
+// stream transfers its ticket to a tracked engine; detached mutation APIs make
+// this boot ineligible. Read-only SSE streams need not finish for exec.
+func (c *webExecCoordinator) handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, c.server.cfg.basePath)
+		if strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/admin/") || strings.HasPrefix(path, "/widgets/") {
+			// Reuse the real auth policy before any admission/taint effects.
+			admitted := false
+			authRequest := r.Clone(r.Context())
+			authRequest.URL.Path = path
+			c.server.auth(func(http.ResponseWriter, *http.Request) { admitted = true })(w, authRequest)
+			if !admitted {
+				return
+			}
+		}
+		unsafe := strings.Contains(path, "/shell") || (strings.Contains(path, "/widgets") && c.server.widgetsMgr != nil) || strings.HasPrefix(path, "/api/sessions/")
+		mutation := r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions
+		cancel := strings.HasSuffix(path, "/cancel")
+		if mutation && path != "/v1/responses" && path != "/v1/sessions" && !strings.HasSuffix(path, "/attention/seen") && !cancel {
+			unsafe = true
+		}
+		c.mu.Lock()
+		if cancel {
+			c.abortLocked()
+		}
+		if c.draining && mutation && !cancel {
+			c.mu.Unlock()
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "web reload draining; retry", http.StatusServiceUnavailable)
+			return
+		}
+		if unsafe {
+			c.unsupported = "unsupported owned HTTP activity in this boot"
+			c.abortLocked()
+		}
+		readStream := r.Method == http.MethodGet && (path == "/v1/events" || (strings.HasPrefix(path, "/v1/responses/") && strings.HasSuffix(path, "/events")))
+		if readStream {
+			c.mu.Unlock()
+			next.ServeHTTP(w, r)
+			return
+		}
+		c.handlers++
+		c.mu.Unlock()
+		ticket := &webExecTicket{coordinator: c}
+		defer ticket.release()
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), webExecTicketKey{}, ticket)))
+	})
+}
+
+// Called with c.mu held by response admission; registration happens before
+// the goroutine can execute a provider or spawn a tool.
+func (c *webExecCoordinator) register(run *responseRun, ctx context.Context, rt *serveRuntime, req *llm.Request, stateful bool, options startResponseRunOptions) {
+	if !stateful || req.MaxTurns <= 0 || options.rush != nil || options.modelSwap != nil || options.runtimeSetup != nil || rt.provider.Capabilities().InlineToolLoop || rt.mcpManagerSnapshot() != nil {
+		c.unsupported = fmt.Sprintf("unsupported response ownership (stateful=%t UI=%t rush=%t swap=%t setup=%t inline=%t MCP=%t)", stateful, options.uiSession, options.rush != nil, options.modelSwap != nil, options.runtimeSetup != nil, rt.provider.Capabilities().InlineToolLoop, rt.mcpManagerSnapshot() != nil)
+		c.abortLocked()
+		return
+	}
+	copyReq := *req
+	copyReq.Messages = nil
+	copyReq.Tools = make([]llm.ToolSpec, len(req.Tools))
+	for i, spec := range req.Tools {
+		copyReq.Tools[i] = llm.ToolSpec{Name: spec.Name}
+	}
+	copyReq.ApprovalTranscriptPrefix = nil
+	copyReq.ModelBoundary = nil
+	entry := &webExecRun{run: run, request: copyReq, ctx: ctx}
+	run.webExec = c
+	c.runs[run.id] = entry
+	req.ModelBoundary = func(ctx context.Context) error {
+		c.mu.Lock()
+		entry.boundaries++
+		if !c.draining {
+			c.mu.Unlock()
+			return ctx.Err()
+		}
+		// A boundary must already be durable, not wait for asynchronous writes
+		// while holding global admission. The batch transaction validates leases.
+		run.persistence.mu.Lock()
+		durable := run.persistence.inflight == 0 && !run.persistence.failed && (len(run.persistence.outputKeys) == 0 || run.persistence.maxRev > 0)
+		run.persistence.mu.Unlock()
+		if !durable || !run.atomicTranscriptFencing || run.validateLifecycle == nil {
+			c.abortLocked()
+			c.mu.Unlock()
+			return nil
+		}
+		entry.parked = true
+		release := c.release
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+		case <-release:
+		}
+		c.mu.Lock()
+		entry.parked = false
+		c.mu.Unlock()
+		return ctx.Err()
+	}
+}
+func (c *webExecCoordinator) settled(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry := c.runs[id]; entry != nil {
+		// Cancelled Execute implementations may still own side effects.
+		entry.run.mu.Lock()
+		complete := entry.run.status == "completed"
+		entry.run.mu.Unlock()
+		if !complete {
+			c.unsupported = "a cancelled or failed invocation may still own work"
+			c.abortLocked()
+		}
+	}
+	delete(c.runs, id)
+}
+
+func (c *webExecCoordinator) request() {
+	if !c.requested.CompareAndSwap(false, true) {
+		return
+	}
+	started := false
+	defer func() {
+		if !started {
+			c.requested.Store(false)
+		}
+	}()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.draining {
+		return
+	}
+	if c.unsupported != "" {
+		log.Printf("[reload] SIGUSR2 rejected: %s", c.unsupported)
+		return
+	}
+	if c.ctx.Err() != nil {
+		return
+	}
+	if !c.ready {
+		log.Printf("[reload] SIGUSR2 rejected: web startup is not ready")
+		return
+	}
+	c.draining = true
+	c.release = make(chan struct{})
+	started = true
+	go c.drain(c.release)
+}
+func (c *webExecCoordinator) drain(generation chan struct{}) {
+	defer c.requested.Store(false)
+	timer := time.NewTimer(c.timeout)
+	defer timer.Stop()
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-generation:
+			return
+		case <-c.ctx.Done():
+			c.mu.Lock()
+			if c.release == generation {
+				c.abortLocked()
+			}
+			c.mu.Unlock()
+			return
+		case <-timer.C:
+			c.mu.Lock()
+			if c.release == generation {
+				c.abortLocked()
+				log.Printf("[reload] drain timed out; work left running")
+			}
+			c.mu.Unlock()
+			return
+		case <-tick.C:
+		}
+		c.mu.Lock()
+		if !c.draining || c.release != generation {
+			c.mu.Unlock()
+			return
+		}
+		ready := c.handlers == 0
+		for _, r := range c.runs {
+			if !r.parked {
+				ready = false
+			}
+		}
+		if !ready {
+			c.mu.Unlock()
+			continue
+		}
+		err := c.replaceLocked()
+		c.abortLocked()
+		c.mu.Unlock()
+		if err != nil {
+			log.Printf("[reload] self-exec aborted; original process retained: %v", err)
+		}
+		return
+	}
+}
+
+func (c *webExecCoordinator) replaceLocked() error {
+	if c.ctx.Err() != nil {
+		return c.ctx.Err()
+	}
+	if info, err := os.Stat(c.executable); err != nil || info.IsDir() || info.Mode()&0111 == 0 {
+		return errors.New("installed executable is unavailable or not executable")
+	}
+	c.server.modelsMu.Lock()
+	for _, provider := range c.server.modelsProviders {
+		if provider.Capabilities().InlineToolLoop {
+			c.server.modelsMu.Unlock()
+			return errors.New("model listing initialized a native provider")
+		}
+	}
+	c.server.modelsMu.Unlock()
+	if c.server.sessionMgr != nil {
+		c.server.sessionMgr.mu.Lock()
+		for _, rt := range c.server.sessionMgr.sessions {
+			if rt.provider.Capabilities().InlineToolLoop || rt.mcpManagerSnapshot() != nil {
+				c.server.sessionMgr.mu.Unlock()
+				return errors.New("a runtime owns an unsupported provider or MCP manager")
+			}
+		}
+		c.server.sessionMgr.mu.Unlock()
+	}
+	c.server.autoTitleMu.Lock()
+	titles := len(c.server.autoTitleFlights)
+	c.server.autoTitleMu.Unlock()
+	if titles != 0 {
+		return errors.New("title generation still owns provider work")
+	}
+	ctx, cancel := context.WithTimeout(c.ctx, 5*time.Second)
+	defer cancel()
+	id := uuid.NewString()
+	var entries []session.ExecHandoff
+	for _, r := range c.runs {
+		if webExecRunCancelled(r) {
+			return context.Canceled
+		}
+		rev, err := c.server.transcriptRev(ctx, r.run.sessionID)
+		if err != nil {
+			return err
+		}
+		saved := r.request
+		saved.MaxTurns -= r.boundaries - 1
+		if saved.MaxTurns <= 0 {
+			return errors.New("no model turn budget remains")
+		}
+		request, err := json.Marshal(saved)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, session.ExecHandoff{ID: id, ServiceID: c.service, SourceOwnerID: c.server.responseOwnerID(), SessionID: r.run.sessionID, SourceResponseID: r.run.id, SourceFence: r.run.fencingToken, CheckpointRev: rev, Request: request})
+	}
+	if err := c.store.PrepareExecHandoff(ctx, entries); err != nil {
+		return fmt.Errorf("durable checkpoint: %w", err)
+	}
+	// Admission and Stop are serialized through mu. TERM and invocation deadlines
+	// remain authoritative even while persistence was in progress.
+	err := c.ctx.Err()
+	for _, r := range c.runs {
+		if webExecRunCancelled(r) {
+			err = context.Canceled
+		}
+	}
+	if err == nil {
+		env := webExecEnviron(id, strings.SplitN(c.service, ":", 2)[0])
+		err = c.exec(c.executable, append([]string(nil), os.Args...), env)
+	}
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cleanupCancel()
+	if cleanupErr := c.store.DiscardExecHandoff(cleanupCtx, id, c.server.responseOwnerID()); cleanupErr != nil {
+		// Never leave an executable intent behind and silently resume work. The
+		// transcript fence prevents stale adoption, but require operator attention.
+		c.unsupported = "failed to discard restart intent"
+		c.quarantined = true
+		return fmt.Errorf("discard self-exec intent: %w", cleanupErr)
+	}
+	return err
+}
+
+func (c *webExecCoordinator) resume() error {
+	if execRestartHint == "" {
+		return nil
+	}
+	if c.unsupported != "" {
+		return errors.New("self-exec recovery unavailable for this configuration")
+	}
+	entries, err := c.store.ReadExecHandoff(c.ctx, execRestartHint, c.service)
+	if err != nil {
+		return err
+	}
+	for _, h := range entries {
+		if err := c.resumeSession(h); err != nil {
+			// Never terminate other newly admitted engines or replay a rejected intent.
+			log.Printf("[reload] a continuation was not admitted; inspect the session before continuing")
+		}
+	}
+	return nil
+}
+
+func webExecEnviron(id, service string) []string {
+	var env []string
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, "TERM_LLM_RESTART_ID=") && !strings.HasPrefix(entry, "TERM_LLM_RESTART_SERVICE_ID=") {
+			env = append(env, entry)
+		}
+	}
+	env = append(env, tools.HubDelegationEnviron()...)
+	env = append(env, hubRegistrationEnviron()...)
+	return append(env, "TERM_LLM_RESTART_ID="+id, "TERM_LLM_RESTART_SERVICE_ID="+service)
+}
+
+func (c *webExecCoordinator) resumeSession(h session.ExecHandoff) error {
+	sess, err := c.server.store.Get(c.ctx, h.SessionID)
+	if err != nil {
+		return err
+	}
+	provider := sess.ProviderKey
+	if provider == "" {
+		provider = sess.Provider
+	}
+	rt, _, err := c.server.runtimeForProviderModelRequest(c.ctx, h.SessionID, provider, sess.Model)
+	if err != nil {
+		return err
+	}
+	if rt.provider.Capabilities().InlineToolLoop || rt.mcpManagerSnapshot() != nil {
+		return errors.New("replacement provider does not support safe continuation")
+	}
+	var req llm.Request
+	if err = json.Unmarshal(h.Request, &req); err != nil {
+		return err
+	}
+	// Re-resolve selected tools from the replacement registry, retaining
+	// the original request's tool selection without trusting old schemas.
+	for i, spec := range req.Tools {
+		tool, ok := rt.engine.Tools().Get(spec.Name)
+		if !ok {
+			return fmt.Errorf("replacement tool %q is unavailable", spec.Name)
+		}
+		req.Tools[i] = tool.Spec()
+	}
+	message := llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "[Internal web hot-reload recovery]\nContinue the unfinished user task from this durable model boundary. This is not a new user message. All preceding tool results are persisted; do not replay those actions. No pending or unknown action is authorized for replay. Tools remain available for the remaining task. Do not initiate another restart."}}}
+	_, err = c.server.startResponseRun(rt, true, false, []llm.Message{message}, req, h.SessionID, startResponseRunOptions{uiSession: true, previousResponseID: h.SourceResponseID, execRestartID: h.ID, execServiceID: h.ServiceID})
+	if err != nil {
+		return fmt.Errorf("admit self-exec continuation: %w", err)
+	}
+	return nil
+}
+
+func webExecRunCancelled(entry *webExecRun) bool {
+	if entry.ctx.Err() != nil {
+		return true
+	}
+	entry.run.mu.Lock()
+	defer entry.run.mu.Unlock()
+	return entry.run.cancelRequested || entry.run.status != "in_progress"
+}

--- a/cmd/serve_exec.go
+++ b/cmd/serve_exec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/samsaffron/term-llm/internal/restart"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
@@ -35,11 +36,14 @@ func captureExecHints() (string, string) {
 }
 
 type webExecRun struct {
-	boundaries int
-	run        *responseRun
-	request    llm.Request
-	ctx        context.Context
-	parked     bool
+	boundaries  int
+	run         *responseRun
+	engine      *llm.Engine
+	request     llm.Request
+	ctx         context.Context
+	parked      bool
+	interrupted bool
+	settled     bool
 }
 
 type webExecCoordinator struct {
@@ -47,14 +51,19 @@ type webExecCoordinator struct {
 	// wait for failed exec and accidentally start a new drain afterwards.
 	requested                        atomic.Bool
 	ready                            bool
-	safeTool                         func(llm.Tool) bool // test seam; nil uses concrete built-in types
+	mode                             string
+	gates                            []*restart.Gate
+	reopen                           []func()
 	quarantined                      bool
+	interruptionID                   string
+	frozen                           map[*llm.Engine]llm.SteeringTransition
 	mu                               sync.Mutex
 	server                           *serveServer
 	ctx                              context.Context
 	store                            session.ExecHandoffStore
 	service, executable, unsupported string
 	runs                             map[string]*webExecRun
+	retired                          map[*llm.Engine]struct{} // cancelled callers can outlive their response
 	handlers                         int
 	draining                         bool
 	release                          chan struct{}
@@ -63,7 +72,7 @@ type webExecCoordinator struct {
 }
 
 func newWebExecCoordinator(ctx context.Context, s *serveServer, unsupported string) *webExecCoordinator {
-	process.State("serve web", "starting", "")
+	process.State("serve", "starting", "")
 	executable, err := os.Executable()
 	if err != nil {
 		unsupported = "cannot resolve serving executable"
@@ -71,9 +80,6 @@ func newWebExecCoordinator(ctx context.Context, s *serveServer, unsupported stri
 	// Resolve once, before an updater can replace/unlink the installed binary.
 	if resolved, e := filepath.EvalSymlinks(executable); e == nil {
 		executable = resolved
-	}
-	if s.cfgRef != nil && s.cfgRef.Serve.AutoTitle {
-		unsupported = "automatic title providers are independently owned; disable serve.auto_title"
 	}
 	store, ok := session.AsExecHandoffStore(s.store)
 	if !ok || !session.SupportsAtomicResponseRunTranscriptFencing(s.store) {
@@ -88,14 +94,14 @@ func newWebExecCoordinator(ctx context.Context, s *serveServer, unsupported stri
 	s.responseOwnerOnce.Do(func() { s.responseOwnerInstanceID = "owner_" + uuid.NewString() })
 	sum := sha256.Sum256([]byte(strings.Join(os.Args, "\x00") + "\x00" + s.startupDir))
 	service += ":" + hex.EncodeToString(sum[:])
-	return &webExecCoordinator{server: s, ctx: ctx, store: store, service: service, executable: executable, unsupported: unsupported, runs: make(map[string]*webExecRun), timeout: 20 * time.Second, exec: execWebProcess}
+	return &webExecCoordinator{mode: "serve web", server: s, ctx: ctx, store: store, service: service, executable: executable, unsupported: unsupported, runs: make(map[string]*webExecRun), timeout: 10 * time.Second, exec: execWebProcess}
 }
 
 func (c *webExecCoordinator) reject(reason string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.unsupported = reason
-	process.State("serve web", "unsupported", reason)
+	process.State(c.processMode(), "unsupported", reason)
 	if c.draining {
 		c.abortLocked()
 	}
@@ -104,40 +110,67 @@ func (c *webExecCoordinator) abortLocked() {
 	if c.quarantined {
 		return
 	}
+	if c.server != nil && c.server.jobsV2 != nil {
+		if err := c.server.jobsV2.rollbackLLMRestart(); err != nil {
+			process.State(c.processMode(), "failed", err.Error())
+		}
+	}
+	if c.interruptionID != "" && c.store != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := c.store.DiscardExecHandoff(ctx, c.interruptionID, c.server.responseOwnerID())
+		cancel()
+		if err != nil {
+			c.quarantined = true
+			process.State(c.processMode(), "failed", "cannot discard restart intent")
+			return
+		}
+		c.interruptionID = ""
+	}
+	for engine := range c.frozen {
+		if engine.ActiveToolExecutions() != 0 {
+			c.quarantined = true
+			process.State(c.processMode(), "failed", "cancelled execution has not exited; replacement refused")
+			return
+		}
+	}
+	for engine, owner := range c.frozen {
+		engine.ReleaseSteeringFreeze(owner, false)
+	}
+	clear(c.frozen)
 	if c.draining {
+		for id, run := range c.runs {
+			if run.interrupted && !run.settled && run.ctx.Err() == nil {
+				// Preparation may fail before cancellation was ever issued.
+				// Rollback must not leave a live run labelled interrupted.
+				run.interrupted = false
+			}
+			if run.interrupted && run.settled {
+				delete(c.runs, id)
+			}
+		}
 		close(c.release)
 		c.draining = false
-		process.State("serve web", "failed", "restart aborted; original process retained")
+		if c.server != nil && c.server.jobsV2 != nil {
+			c.server.jobsV2.reopenAfterRestart()
+		}
+		for _, reopen := range c.reopen {
+			reopen()
+		}
+		c.reopen = nil
+		if c.server != nil && c.server.jobsV2 != nil {
+			c.server.jobsV2.notifyWorkers(c.server.jobsV2.workers)
+			c.server.jobsV2.notifyScheduler()
+		}
+		process.State(c.processMode(), "failed", "restart aborted; original process retained")
 	}
 }
 
-// Unsupported owned activities taint this boot conservatively. We do not try
-// to kill children or infer that a returned shell/custom tool has no descendants.
-func (c *webExecCoordinator) observeTool(rt *serveRuntime, ev llm.Event) {
+// Native providers retain their own execution loops. Ordinary tools need no
+// type/name allowlist: replacement freezes engine admission and joins actual
+// Execute lifetimes, including tools whose cancelled caller already returned.
+func (c *webExecCoordinator) observeTool(_ *serveRuntime, ev llm.Event) {
 	if ev.Type == llm.EventToolActivity {
 		c.reject("provider-managed native activity is unsupported")
-		return
-	}
-	if ev.Type != llm.EventToolExecStart {
-		return
-	}
-	tool, ok := rt.engine.Tools().Get(ev.ToolName)
-	safe := webExecSafeTool
-	if c.safeTool != nil {
-		safe = c.safeTool
-	}
-	if !ok || !safe(tool) {
-		c.reject("an unsupported tool or independently owned activity ran in this boot")
-	}
-}
-
-// Names are not authority: custom/skill tools can replace a built-in name.
-func webExecSafeTool(tool llm.Tool) bool {
-	switch tool.(type) {
-	case *tools.ReadFileTool, *tools.WriteFileTool, *tools.EditFileTool, *tools.GlobTool, *tools.GrepTool, *tools.UpdatePlanTool:
-		return true
-	default:
-		return false
 	}
 }
 
@@ -162,7 +195,7 @@ func releaseWebExecTicket(ctx context.Context) {
 func (c *webExecCoordinator) handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, c.server.cfg.basePath)
-		if strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/admin/") || strings.HasPrefix(path, "/widgets/") {
+		if strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/v2/") || strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/admin/") || strings.HasPrefix(path, "/widgets/") {
 			// Reuse the real auth policy before any admission/taint effects.
 			admitted := false
 			authRequest := r.Clone(r.Context())
@@ -172,14 +205,17 @@ func (c *webExecCoordinator) handler(next http.Handler) http.Handler {
 				return
 			}
 		}
-		unsafe := strings.Contains(path, "/shell") || (strings.Contains(path, "/widgets") && c.server.widgetsMgr != nil) || strings.HasPrefix(path, "/api/sessions/")
+		unsafe := strings.Contains(path, "/shell") || strings.HasPrefix(path, "/api/sessions/")
 		mutation := r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions
 		cancel := strings.HasSuffix(path, "/cancel")
-		if mutation && path != "/v1/responses" && path != "/v1/sessions" && !strings.HasSuffix(path, "/attention/seen") && !cancel {
+		jobsMutation := c.server.jobsV2 != nil && (path == "/v2/jobs" || strings.HasPrefix(path, "/v2/jobs/") || path == "/v2/runs" || strings.HasPrefix(path, "/v2/runs/"))
+		if mutation && !jobsMutation && !(c.server.widgetsMgr != nil && strings.HasPrefix(path, "/widgets/")) && path != "/v1/responses" && path != "/v1/sessions" && !strings.HasSuffix(path, "/attention/seen") && !cancel {
 			unsafe = true
 		}
 		c.mu.Lock()
-		if cancel {
+		// Job cancellation has its own durable status CAS, including handoff
+		// revocation. Stopping one job must not abort replacement of the process.
+		if cancel && !jobsMutation {
 			c.abortLocked()
 		}
 		if c.draining && mutation && !cancel {
@@ -192,7 +228,7 @@ func (c *webExecCoordinator) handler(next http.Handler) http.Handler {
 			c.unsupported = "unsupported owned HTTP activity in this boot"
 			c.abortLocked()
 		}
-		readStream := r.Method == http.MethodGet && (path == "/v1/events" || (strings.HasPrefix(path, "/v1/responses/") && strings.HasSuffix(path, "/events")))
+		readStream := r.Method == http.MethodGet && (path == "/v1/events" || path == "/v1/events/poll" || (strings.HasPrefix(path, "/v1/responses/") && strings.HasSuffix(path, "/events")))
 		if readStream {
 			c.mu.Unlock()
 			next.ServeHTTP(w, r)
@@ -222,7 +258,13 @@ func (c *webExecCoordinator) register(run *responseRun, ctx context.Context, rt 
 	}
 	copyReq.ApprovalTranscriptPrefix = nil
 	copyReq.ModelBoundary = nil
-	entry := &webExecRun{run: run, request: copyReq, ctx: ctx}
+	// Drop completed retired engines; never retain a whole boot's idle runtimes.
+	for engine := range c.retired {
+		if engine.ActiveToolExecutions() == 0 {
+			delete(c.retired, engine)
+		}
+	}
+	entry := &webExecRun{run: run, engine: rt.engine, request: copyReq, ctx: ctx}
 	run.webExec = c
 	c.runs[run.id] = entry
 	req.ModelBoundary = func(ctx context.Context) error {
@@ -258,15 +300,15 @@ func (c *webExecCoordinator) register(run *responseRun, ctx context.Context, rt 
 func (c *webExecCoordinator) settled(id string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if entry := c.runs[id]; entry != nil {
-		// Cancelled Execute implementations may still own side effects.
-		entry.run.mu.Lock()
-		complete := entry.run.status == "completed"
-		entry.run.mu.Unlock()
-		if !complete {
-			c.unsupported = "a cancelled or failed invocation may still own work"
-			c.abortLocked()
+	if entry := c.runs[id]; entry != nil && entry.interrupted && c.draining {
+		entry.settled = true
+		return
+	}
+	if entry := c.runs[id]; entry != nil && entry.engine != nil && entry.engine.ActiveToolExecutions() != 0 {
+		if c.retired == nil {
+			c.retired = make(map[*llm.Engine]struct{})
 		}
+		c.retired[entry.engine] = struct{}{}
 	}
 	delete(c.runs, id)
 }
@@ -287,7 +329,7 @@ func (c *webExecCoordinator) request() {
 		return
 	}
 	if c.unsupported != "" {
-		process.State("serve web", "unsupported", c.unsupported)
+		process.State(c.processMode(), "unsupported", c.unsupported)
 		log.Printf("[reload] SIGUSR2 rejected: %s", c.unsupported)
 		return
 	}
@@ -295,12 +337,15 @@ func (c *webExecCoordinator) request() {
 		return
 	}
 	if !c.ready {
-		process.State("serve web", "deferred", "web startup is not ready")
+		process.State(c.processMode(), "deferred", "web startup is not ready")
 		log.Printf("[reload] SIGUSR2 rejected: web startup is not ready")
 		return
 	}
 	c.draining = true
-	process.State("serve web", "draining", "")
+	for _, gate := range c.gates {
+		c.reopen = append(c.reopen, gate.Pause())
+	}
+	process.State(c.processMode(), "draining", "")
 	c.release = make(chan struct{})
 	started = true
 	go c.drain(c.release)
@@ -324,12 +369,25 @@ func (c *webExecCoordinator) drain(generation chan struct{}) {
 			return
 		case <-timer.C:
 			c.mu.Lock()
-			if c.release == generation {
-				c.abortLocked()
-				log.Printf("[reload] drain timed out; work left running")
+			if c.release != generation || !c.draining {
+				c.mu.Unlock()
+				return
 			}
+			if c.interruptionID != "" {
+				c.abortLocked()
+				log.Printf("[reload] cancellation did not settle; replacement refused")
+				c.mu.Unlock()
+				return
+			}
+			if err := c.interruptLocked(); err != nil {
+				c.abortLocked()
+				log.Printf("[reload] cannot prepare interruption: %v", err)
+				c.mu.Unlock()
+				return
+			}
+			timer.Reset(c.timeout)
 			c.mu.Unlock()
-			return
+			continue
 		case <-tick.C:
 		}
 		c.mu.Lock()
@@ -338,8 +396,20 @@ func (c *webExecCoordinator) drain(generation chan struct{}) {
 			return
 		}
 		ready := c.handlers == 0
+		for _, gate := range c.gates {
+			if !gate.Drained() {
+				ready = false
+			}
+		}
+		if c.server != nil {
+			c.server.autoTitleMu.Lock()
+			if len(c.server.autoTitleFlights) != 0 {
+				ready = false
+			}
+			c.server.autoTitleMu.Unlock()
+		}
 		for _, r := range c.runs {
-			if !r.parked {
+			if !r.parked && !(r.interrupted && r.settled && r.engine.ActiveToolExecutions() == 0) {
 				ready = false
 			}
 		}
@@ -360,6 +430,11 @@ func (c *webExecCoordinator) drain(generation chan struct{}) {
 func (c *webExecCoordinator) replaceLocked() error {
 	if c.ctx.Err() != nil {
 		return c.ctx.Err()
+	}
+	if c.server.jobsV2 != nil {
+		if err := c.server.jobsV2.llmRestartFailure(); err != nil {
+			return err
+		}
 	}
 	if info, err := os.Stat(c.executable); err != nil || info.IsDir() || info.Mode()&0111 == 0 {
 		return errors.New("installed executable is unavailable or not executable")
@@ -390,35 +465,49 @@ func (c *webExecCoordinator) replaceLocked() error {
 	}
 	ctx, cancel := context.WithTimeout(c.ctx, 5*time.Second)
 	defer cancel()
-	id := uuid.NewString()
-	var entries []session.ExecHandoff
-	for _, r := range c.runs {
-		if webExecRunCancelled(r) {
-			return context.Canceled
+	if c.server.widgetsMgr != nil {
+		if err := c.server.widgetsMgr.StopAllAndWait(ctx); err != nil {
+			return fmt.Errorf("join widgets: %w", err)
 		}
-		rev, err := c.server.transcriptRev(ctx, r.run.sessionID)
-		if err != nil {
-			return err
-		}
-		saved := r.request
-		saved.MaxTurns -= r.boundaries - 1
-		if saved.MaxTurns <= 0 {
-			return errors.New("no model turn budget remains")
-		}
-		request, err := json.Marshal(saved)
-		if err != nil {
-			return err
-		}
-		entries = append(entries, session.ExecHandoff{ID: id, ServiceID: c.service, SourceOwnerID: c.server.responseOwnerID(), SessionID: r.run.sessionID, SourceResponseID: r.run.id, SourceFence: r.run.fencingToken, CheckpointRev: rev, Request: request})
 	}
-	if err := c.store.PrepareExecHandoff(ctx, entries); err != nil {
-		return fmt.Errorf("durable checkpoint: %w", err)
+	id := c.interruptionID
+	if id == "" {
+		id = uuid.NewString()
+	}
+	if err := c.freezeEnginesLocked(id); err != nil {
+		return err
+	}
+	for engine, owner := range c.frozen {
+		if err := engine.WaitSteeringSettlement(ctx, owner); err != nil {
+			return fmt.Errorf("join tool execution: %w", err)
+		}
+	}
+	entries, err := c.handoffEntriesLocked(ctx, id, true)
+	if err != nil {
+		return err
+	}
+	if c.interruptionID == "" {
+		if err := c.store.PrepareExecHandoff(ctx, entries); err != nil {
+			return fmt.Errorf("durable checkpoint: %w", err)
+		}
+	} else {
+		interrupted := make([]session.ExecHandoff, 0, len(entries))
+		for _, h := range entries {
+			var state session.ExecRequestState
+			_ = json.Unmarshal(h.Request, &state)
+			if state.Interrupted {
+				interrupted = append(interrupted, h)
+			}
+		}
+		if err := c.store.SealExecInterruption(ctx, interrupted); err != nil {
+			return fmt.Errorf("seal interrupted checkpoint: %w", err)
+		}
 	}
 	// Admission and Stop are serialized through mu. TERM and invocation deadlines
 	// remain authoritative even while persistence was in progress.
-	err := c.ctx.Err()
+	err = c.ctx.Err()
 	for _, r := range c.runs {
-		if webExecRunCancelled(r) {
+		if !r.interrupted && webExecRunCancelled(r) {
 			err = context.Canceled
 		}
 	}
@@ -486,10 +575,11 @@ func (c *webExecCoordinator) resumeSession(h session.ExecHandoff) error {
 	if rt.provider.Capabilities().InlineToolLoop || rt.mcpManagerSnapshot() != nil {
 		return errors.New("replacement provider does not support safe continuation")
 	}
-	var req llm.Request
-	if err = json.Unmarshal(h.Request, &req); err != nil {
+	var saved execSavedRequest
+	if err = json.Unmarshal(h.Request, &saved); err != nil {
 		return err
 	}
+	req := saved.Request
 	// Re-resolve selected tools from the replacement registry, retaining
 	// the original request's tool selection without trusting old schemas.
 	for i, spec := range req.Tools {
@@ -500,6 +590,9 @@ func (c *webExecCoordinator) resumeSession(h session.ExecHandoff) error {
 		req.Tools[i] = tool.Spec()
 	}
 	message := llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "[Internal web hot-reload recovery]\nContinue the unfinished user task from this durable model boundary. This is not a new user message. All preceding tool results are persisted; do not replay those actions. No pending or unknown action is authorized for replay. Tools remain available for the remaining task. Do not initiate another restart."}}}
+	if saved.Interrupted {
+		message = llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: "[Internal hot-reload recovery after cancellation]\n" + llm.SteeringInterruptionNotice + "\nThe restart grace period expired. Continue the unfinished task; verify interrupted side effects before repeating them. This is not user Stop and not a new user message. Do not restart again."}}}
+	}
 	_, err = c.server.startResponseRun(rt, true, false, []llm.Message{message}, req, h.SessionID, startResponseRunOptions{uiSession: true, previousResponseID: h.SourceResponseID, execRestartID: h.ID, execServiceID: h.ServiceID})
 	if err != nil {
 		return fmt.Errorf("admit self-exec continuation: %w", err)
@@ -519,8 +612,127 @@ func webExecRunCancelled(entry *webExecRun) bool {
 // publishReady is called only after HTTP startup and response lifecycle setup.
 func (c *webExecCoordinator) publishReady() {
 	if c.unsupported != "" {
-		process.State("serve web", "unsupported", c.unsupported)
+		process.State(c.processMode(), "unsupported", c.unsupported)
 	} else {
-		process.State("serve web", "ready", "")
+		process.State(c.processMode(), "ready", "")
 	}
+}
+
+func (c *webExecCoordinator) processMode() string {
+	if c.mode != "" {
+		return c.mode
+	}
+	return "serve"
+}
+
+type execSavedRequest struct {
+	llm.Request
+	session.ExecRequestState
+}
+
+func (c *webExecCoordinator) freezeEnginesLocked(id string) error {
+	if c.frozen == nil {
+		c.frozen = make(map[*llm.Engine]llm.SteeringTransition)
+	}
+	engines := make(map[*llm.Engine]struct{}, len(c.runs)+len(c.retired))
+	for _, r := range c.runs {
+		if r.engine != nil {
+			engines[r.engine] = struct{}{}
+		}
+	}
+	for engine := range c.retired {
+		engines[engine] = struct{}{}
+	}
+	for engine := range engines {
+		if _, exists := c.frozen[engine]; exists {
+			continue
+		}
+		owner := llm.SteeringTransition{OperationID: id, Fence: 1}
+		if err := engine.FreezeExecution(owner); err != nil {
+			return fmt.Errorf("freeze execution: %w", err)
+		}
+		c.frozen[engine] = owner
+	}
+	return nil
+}
+
+func (c *webExecCoordinator) handoffEntriesLocked(ctx context.Context, id string, settled bool) ([]session.ExecHandoff, error) {
+	var entries []session.ExecHandoff
+	for _, r := range c.runs {
+		if r.run == nil {
+			return nil, errors.New("missing response ownership")
+		}
+		if !r.interrupted && webExecRunCancelled(r) {
+			return nil, context.Canceled
+		}
+		if r.interrupted && settled {
+			r.run.mu.Lock()
+			failed := r.run.durableHandoffErr != ""
+			r.run.mu.Unlock()
+			if !r.settled || failed {
+				return nil, errors.New("interrupted response persistence has not settled")
+			}
+		}
+		rev, err := c.server.transcriptRev(ctx, r.run.sessionID)
+		if err != nil {
+			return nil, err
+		}
+		saved := execSavedRequest{Request: r.request, ExecRequestState: session.ExecRequestState{Interrupted: r.interrupted, Settled: r.interrupted && settled}}
+		saved.MaxTurns -= max(0, r.boundaries-1)
+		if saved.MaxTurns <= 0 {
+			return nil, errors.New("no model turn budget remains")
+		}
+		request, err := json.Marshal(saved)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.ExecHandoff{ID: id, ServiceID: c.service, SourceOwnerID: c.server.responseOwnerID(), SessionID: r.run.sessionID, SourceResponseID: r.run.id, SourceFence: r.run.fencingToken, CheckpointRev: rev, Request: request})
+	}
+	return entries, nil
+}
+
+// Grace expiry follows steering: freeze dispatch, durably authorize the internal
+// interruption, cancel the source, then join actual execution before adoption.
+func (c *webExecCoordinator) interruptLocked() error {
+	if c.store == nil || c.server == nil {
+		return errors.New("no durable restart owner")
+	}
+	id := uuid.NewString()
+	if err := c.freezeEnginesLocked(id); err != nil {
+		return err
+	}
+	for _, r := range c.runs {
+		if !r.parked {
+			if r.run == nil || r.engine == nil || webExecRunCancelled(r) {
+				return errors.New("source already stopped")
+			}
+			r.interrupted = true
+		}
+	}
+	ctx, cancel := context.WithTimeout(c.ctx, 5*time.Second)
+	defer cancel()
+	entries, err := c.handoffEntriesLocked(ctx, id, false)
+	if err != nil {
+		return err
+	}
+	if err := c.store.PrepareExecHandoff(ctx, entries); err != nil {
+		return err
+	}
+	c.interruptionID = id
+	if c.server.jobsV2 != nil {
+		setup := jobsRestartSetup{Store: c.server.store, RestartID: id, Service: c.service, Instance: process.Instance()}
+		if err := c.server.jobsV2.beginLLMRestart(ctx, setup); err != nil {
+			return err
+		}
+		if err := c.server.jobsV2.interruptProgramsForRestart(); err != nil {
+			return fmt.Errorf("cancel program jobs for restart: %w", err)
+		}
+	}
+	process.State(c.processMode(), "cancelling", "grace period elapsed; waiting for actual execution settlement")
+	for _, r := range c.runs {
+		if r.interrupted {
+			r.run.cancelRun()
+		}
+	}
+	return nil
 }

--- a/cmd/serve_exec.go
+++ b/cmd/serve_exec.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/process"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
@@ -62,6 +63,7 @@ type webExecCoordinator struct {
 }
 
 func newWebExecCoordinator(ctx context.Context, s *serveServer, unsupported string) *webExecCoordinator {
+	process.State("serve web", "starting", "")
 	executable, err := os.Executable()
 	if err != nil {
 		unsupported = "cannot resolve serving executable"
@@ -93,6 +95,7 @@ func (c *webExecCoordinator) reject(reason string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.unsupported = reason
+	process.State("serve web", "unsupported", reason)
 	if c.draining {
 		c.abortLocked()
 	}
@@ -104,6 +107,7 @@ func (c *webExecCoordinator) abortLocked() {
 	if c.draining {
 		close(c.release)
 		c.draining = false
+		process.State("serve web", "failed", "restart aborted; original process retained")
 	}
 }
 
@@ -283,6 +287,7 @@ func (c *webExecCoordinator) request() {
 		return
 	}
 	if c.unsupported != "" {
+		process.State("serve web", "unsupported", c.unsupported)
 		log.Printf("[reload] SIGUSR2 rejected: %s", c.unsupported)
 		return
 	}
@@ -290,10 +295,12 @@ func (c *webExecCoordinator) request() {
 		return
 	}
 	if !c.ready {
+		process.State("serve web", "deferred", "web startup is not ready")
 		log.Printf("[reload] SIGUSR2 rejected: web startup is not ready")
 		return
 	}
 	c.draining = true
+	process.State("serve web", "draining", "")
 	c.release = make(chan struct{})
 	started = true
 	go c.drain(c.release)
@@ -507,4 +514,13 @@ func webExecRunCancelled(entry *webExecRun) bool {
 	entry.run.mu.Lock()
 	defer entry.run.mu.Unlock()
 	return entry.run.cancelRequested || entry.run.status != "in_progress"
+}
+
+// publishReady is called only after HTTP startup and response lifecycle setup.
+func (c *webExecCoordinator) publishReady() {
+	if c.unsupported != "" {
+		process.State("serve web", "unsupported", c.unsupported)
+	} else {
+		process.State("serve web", "ready", "")
+	}
 }

--- a/cmd/serve_exec_other.go
+++ b/cmd/serve_exec_other.go
@@ -1,0 +1,13 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris
+
+package cmd
+
+import (
+	"context"
+	"errors"
+)
+
+func execWebProcess(string, []string, []string) error {
+	return errors.New("self-exec is unsupported on this platform")
+}
+func installWebExecSignal(context.Context, *webExecCoordinator) func() { return func() {} }

--- a/cmd/serve_exec_posix.go
+++ b/cmd/serve_exec_posix.go
@@ -1,0 +1,29 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package cmd
+
+import (
+	"context"
+	"os"
+	ossignal "os/signal"
+	"syscall"
+)
+
+func execWebProcess(path string, args, env []string) error { return syscall.Exec(path, args, env) }
+
+func installWebExecSignal(ctx context.Context, c *webExecCoordinator) func() {
+	ctx, cancel := context.WithCancel(ctx)
+	ch := make(chan os.Signal, 1)
+	ossignal.Notify(ch, syscall.SIGUSR2)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ch:
+				c.request()
+			}
+		}
+	}()
+	return func() { ossignal.Stop(ch); cancel() }
+}

--- a/cmd/serve_exec_posix.go
+++ b/cmd/serve_exec_posix.go
@@ -4,26 +4,17 @@ package cmd
 
 import (
 	"context"
-	"os"
-	ossignal "os/signal"
 	"syscall"
+
+	"github.com/samsaffron/term-llm/internal/restart"
 )
 
 func execWebProcess(path string, args, env []string) error { return syscall.Exec(path, args, env) }
 
 func installWebExecSignal(ctx context.Context, c *webExecCoordinator) func() {
-	ctx, cancel := context.WithCancel(ctx)
-	ch := make(chan os.Signal, 1)
-	ossignal.Notify(ch, syscall.SIGUSR2)
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ch:
-				c.request()
-			}
+	return restart.Default.Bind(func() {
+		if ctx.Err() == nil {
+			c.request()
 		}
-	}()
-	return func() { ossignal.Stop(ch); cancel() }
+	})
 }

--- a/cmd/serve_exec_test.go
+++ b/cmd/serve_exec_test.go
@@ -1,0 +1,314 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type webExecTestTool struct {
+	entered, release chan struct{}
+	calls            atomic.Int64
+}
+
+func (t *webExecTestTool) Spec() llm.ToolSpec {
+	return llm.ToolSpec{Name: "write_file", Schema: map[string]any{"type": "object"}}
+}
+func (t *webExecTestTool) Preview(json.RawMessage) string { return "" }
+func (t *webExecTestTool) Execute(ctx context.Context, _ json.RawMessage) (llm.ToolOutput, error) {
+	if t.calls.Add(1) == 1 {
+		close(t.entered)
+		select {
+		case <-t.release:
+		case <-ctx.Done():
+			return llm.ToolOutput{}, ctx.Err()
+		}
+	}
+	return llm.ToolOutput{Content: "persisted effect"}, nil
+}
+
+func TestWebExecFailedExecReleasesToolCapableRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	sid := session.NewID()
+	if err := store.Create(ctx, &session.Session{ID: sid, Provider: "mock", Model: "mock", Origin: session.OriginWeb, CreatedAt: time.Now(), UpdatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	tool := &webExecTestTool{entered: make(chan struct{}), release: make(chan struct{})}
+	provider := llm.NewMockProvider("mock").AddToolCall("before", "write_file", map[string]any{}).AddToolCall("after", "write_file", map[string]any{}).AddTextResponse("finished")
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	rt := &serveRuntime{provider: provider, providerKey: "mock", engine: llm.NewEngine(provider, registry), defaultModel: "mock", store: store}
+	rt.Touch()
+	s := &serveServer{store: store, shutdownCh: make(chan struct{}), responseRuns: newServeResponseRunManager()}
+	defer s.responseRuns.Close()
+	defer func() {
+		if s.responseLifecycleCancel != nil {
+			s.responseLifecycleCancel()
+			s.responseLifecycleWG.Wait()
+		}
+	}()
+	c := newWebExecCoordinator(ctx, s, "")
+	s.webExec = c
+	c.ready = true
+	c.safeTool = func(tool llm.Tool) bool { _, ok := tool.(*webExecTestTool); return ok }
+	attempted := make(chan struct{})
+	var attemptedID string
+	var execCalls atomic.Int64
+	c.exec = func(path string, args, env []string) error {
+		if execCalls.Add(1) > 1 {
+			t.Error("duplicate signal queued another exec attempt")
+			return errors.New("unexpected duplicate exec")
+		}
+		duplicateDone := make(chan struct{})
+		go func() {
+			c.request()
+			close(duplicateDone)
+		}()
+		select {
+		case <-duplicateDone:
+		case <-time.After(time.Second):
+			t.Error("duplicate signal blocked behind exec mutex")
+		}
+		if tool.calls.Load() != 1 {
+			t.Errorf("tool executions at exec=%d", tool.calls.Load())
+		}
+		messages, err := store.GetMessages(ctx, sid, 0, 0)
+		if err != nil {
+			t.Error(err)
+		}
+		results := 0
+		users := 0
+		for _, message := range messages {
+			if message.Role == llm.RoleUser {
+				users++
+			}
+			for _, part := range message.Parts {
+				if part.ToolResult != nil {
+					results++
+				}
+			}
+		}
+		if results != 1 || users != 1 {
+			t.Errorf("durable results/users=%d/%d", results, users)
+		}
+		if os.Getenv("TERM_LLM_RESTART_ID") != "" {
+			t.Error("restart hint leaked into process environment")
+		}
+		for _, entry := range env {
+			if strings.HasPrefix(entry, "TERM_LLM_RESTART_ID=") {
+				attemptedID = strings.TrimPrefix(entry, "TERM_LLM_RESTART_ID=")
+			}
+		}
+		close(attempted)
+		return errors.New("fixture exec failure")
+	}
+	run, err := s.startResponseRun(rt, true, false, []llm.Message{llm.UserText("work")}, llm.Request{SessionID: sid, Tools: []llm.ToolSpec{tool.Spec()}, MaxTurns: 5}, sid, startResponseRunOptions{uiSession: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-tool.entered:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("tool not entered: %#v", run.snapshot())
+	}
+	c.request()
+	c.request() // duplicate is the same drain generation
+	close(tool.release)
+	select {
+	case <-attempted:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("exec not attempted: %#v, rejected=%s", run.snapshot(), c.unsupported)
+	}
+	select {
+	case <-run.settled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("original invocation did not recover")
+	}
+	if run.snapshot()["status"] != "completed" || tool.calls.Load() != 2 {
+		t.Fatalf("recovery status=%v calls=%d", run.snapshot(), tool.calls.Load())
+	}
+	entries, err := store.ReadExecHandoff(ctx, attemptedID, c.service)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("failed exec left intents: %v, %v", entries, err)
+	}
+	// The provider sees no fake user turn after failed exec.
+	for _, request := range provider.RecordedRequests() {
+		users := 0
+		for _, m := range request.Messages {
+			if m.Role == llm.RoleUser {
+				users++
+			}
+		}
+		if users != 1 {
+			t.Fatalf("fake user injected: %d", users)
+		}
+	}
+}
+
+func TestWebExecDrainTimeoutDoesNotCancelTool(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := &webExecCoordinator{ready: true, ctx: ctx, runs: map[string]*webExecRun{"busy": {ctx: ctx}}, timeout: time.Millisecond}
+	c.request()
+	c.mu.Lock()
+	released := c.release
+	c.mu.Unlock()
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("drain did not abort")
+	}
+	if ctx.Err() != nil {
+		t.Fatal("drain cancelled the tool owner")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.draining {
+		t.Fatal("admission not reopened")
+	}
+}
+
+func TestWebExecEnvironmentScrub(t *testing.T) {
+	t.Setenv("TERM_LLM_RESTART_ID", "old")
+	t.Setenv("TERM_LLM_RESTART_SERVICE_ID", "service")
+	id, service := captureExecHints()
+	if id != "old" || service != "service" || os.Getenv("TERM_LLM_RESTART_ID") != "" || os.Getenv("TERM_LLM_RESTART_SERVICE_ID") != "" {
+		t.Fatal("hints not captured and scrubbed")
+	}
+	env := strings.Join(webExecEnviron("new", "next"), "\n")
+	if strings.Count(env, "TERM_LLM_RESTART_ID=") != 1 || !strings.Contains(env, "TERM_LLM_RESTART_ID=new") {
+		t.Fatal("replacement environment is not unique")
+	}
+}
+
+func TestWebExecAdmissionAndCancellation(t *testing.T) {
+	for _, scenario := range []string{"mutation", "stop", "quarantined stop", "denied", "unsafe", "read"} {
+		t.Run(scenario, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			s := &serveServer{cfg: serveServerConfig{basePath: "/ui"}}
+			c := &webExecCoordinator{ctx: ctx, server: s, draining: true, release: make(chan struct{})}
+			called := false
+			next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+			method, path := "POST", "/ui/v1/responses"
+			switch scenario {
+			case "stop", "quarantined stop":
+				path = "/ui/v1/responses/source/cancel"
+				c.quarantined = scenario == "quarantined stop"
+			case "denied":
+				s.cfg.requireAuth = true
+				s.cfg.token = "fixture"
+				path = "/ui/v1/sessions/shell"
+			case "unsafe":
+				c.draining = false
+				path = "/ui/v1/sessions/id/shell"
+			case "read":
+				method = "GET"
+				path = "/ui/v1/events"
+			}
+			recorder := httptest.NewRecorder()
+			c.handler(next).ServeHTTP(recorder, httptest.NewRequest(method, path, nil))
+			switch scenario {
+			case "mutation":
+				if called || recorder.Code != 503 {
+					t.Fatalf("mutation admitted: %d", recorder.Code)
+				}
+			case "stop":
+				if !called || c.draining {
+					t.Fatal("stop did not preempt drain")
+				}
+			case "quarantined stop":
+				if !called || !c.draining {
+					t.Fatal("quarantined stop must remain available without reopening admission")
+				}
+			case "denied":
+				if called || recorder.Code != 401 || c.unsupported != "" {
+					t.Fatal("denied request affected restart")
+				}
+			case "unsafe":
+				if !called || c.unsupported == "" {
+					t.Fatal("unsafe owner was not tracked")
+				}
+			case "read":
+				if !called || !c.draining {
+					t.Fatal("read stream was not preserved")
+				}
+			}
+		})
+	}
+}
+
+func TestWebExecParentCancellationAndQuarantine(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &webExecCoordinator{ready: true, ctx: ctx, runs: map[string]*webExecRun{"busy": {}}, timeout: time.Hour}
+	c.request()
+	c.mu.Lock()
+	release := c.release
+	c.mu.Unlock()
+	cancel()
+	select {
+	case <-release:
+	case <-time.After(time.Second):
+		t.Fatal("TERM context did not release drain")
+	}
+	c.mu.Lock()
+	c.draining = true
+	c.quarantined = true
+	c.release = make(chan struct{})
+	c.abortLocked()
+	select {
+	case <-c.release:
+		t.Fatal("quarantined work was resumed")
+	default:
+	}
+	c.mu.Unlock()
+}
+
+func TestWebExecStartupReadiness(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := &webExecCoordinator{ctx: ctx, runs: map[string]*webExecRun{"busy": {}}, timeout: time.Hour}
+	c.request()
+	if c.draining || c.requested.Load() {
+		t.Fatal("startup signal started or retained a drain")
+	}
+	c.mu.Lock()
+	c.ready = true
+	c.mu.Unlock()
+	c.request()
+	c.mu.Lock()
+	draining, release := c.draining, c.release
+	c.mu.Unlock()
+	if !draining {
+		t.Fatal("ready server rejected drain")
+	}
+	cancel()
+	select {
+	case <-release:
+	case <-time.After(time.Second):
+		t.Fatal("drain did not stop")
+	}
+}
+
+func TestWebExecDoesNotTrustToolNames(t *testing.T) {
+	if webExecSafeTool(&webExecTestTool{}) {
+		t.Fatal("custom tool claiming write_file was trusted")
+	}
+}

--- a/cmd/serve_exec_test.go
+++ b/cmd/serve_exec_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -67,7 +68,6 @@ func TestWebExecFailedExecReleasesToolCapableRun(t *testing.T) {
 	c := newWebExecCoordinator(ctx, s, "")
 	s.webExec = c
 	c.ready = true
-	c.safeTool = func(tool llm.Tool) bool { _, ok := tool.(*webExecTestTool); return ok }
 	attempted := make(chan struct{})
 	var attemptedID string
 	var execCalls atomic.Int64
@@ -307,8 +307,110 @@ func TestWebExecStartupReadiness(t *testing.T) {
 	}
 }
 
-func TestWebExecDoesNotTrustToolNames(t *testing.T) {
-	if webExecSafeTool(&webExecTestTool{}) {
-		t.Fatal("custom tool claiming write_file was trusted")
+func TestWebExecGraceCancelsAndSealsBeforeReplacement(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	sid := session.NewID()
+	if err := store.Create(ctx, &session.Session{ID: sid, Provider: "mock", Model: "mock", Origin: session.OriginWeb, CreatedAt: time.Now(), UpdatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	tool := &webExecTestTool{entered: make(chan struct{}), release: make(chan struct{})}
+	provider := llm.NewMockProvider("mock").AddToolCall("slow", "write_file", map[string]any{}).AddTextResponse("must not run before replacement")
+	registry := llm.NewToolRegistry()
+	registry.Register(tool)
+	rt := &serveRuntime{provider: provider, providerKey: "mock", engine: llm.NewEngine(provider, registry), defaultModel: "mock", store: store}
+	rt.Touch()
+	s := &serveServer{store: store, shutdownCh: make(chan struct{}), responseRuns: newServeResponseRunManager()}
+	defer s.responseRuns.Close()
+	defer func() {
+		if s.responseLifecycleCancel != nil {
+			s.responseLifecycleCancel()
+			s.responseLifecycleWG.Wait()
+		}
+	}()
+	c := newWebExecCoordinator(ctx, s, "")
+	s.webExec = c
+	c.ready = true
+	c.timeout = 30 * time.Millisecond
+	attempted := make(chan error, 1)
+	c.exec = func(_ string, _ []string, _ []string) error {
+		entries, e := store.ReadExecHandoff(ctx, c.interruptionID, c.service)
+		if e == nil && len(entries) != 1 {
+			e = fmt.Errorf("expected one intent, got %d", len(entries))
+		}
+		if e == nil {
+			var state session.ExecRequestState
+			e = json.Unmarshal(entries[0].Request, &state)
+			if e == nil && (!state.Interrupted || !state.Settled) {
+				e = errors.New("interruption not sealed")
+			}
+			if e == nil && rt.engine.ActiveToolExecutions() != 0 {
+				e = errors.New("exec before actual tool returned")
+			}
+		}
+		attempted <- e
+		return errors.New("fixture replacement unavailable")
+	}
+	run, err := s.startResponseRun(rt, true, false, []llm.Message{llm.UserText("work")}, llm.Request{SessionID: sid, Tools: []llm.ToolSpec{tool.Spec()}, MaxTurns: 10}, sid, startResponseRunOptions{uiSession: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-tool.entered:
+	case <-time.After(time.Second):
+		t.Fatal("tool did not start")
+	}
+	c.request()
+	select {
+	case err := <-attempted:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("grace did not cancel/join/replace")
+	}
+	select {
+	case <-run.settled:
+	case <-time.After(time.Second):
+		t.Fatal("source did not settle")
+	}
+	if tool.calls.Load() != 1 {
+		t.Fatalf("operation replayed %d times", tool.calls.Load())
+	}
+}
+
+func TestWebExecEventPollDoesNotHoldDrainOpen(t *testing.T) {
+	c := &webExecCoordinator{server: &serveServer{}}
+	called := false
+	handler := c.handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.handlers != 0 {
+			t.Fatal("passive event polling counted as owned mutation work")
+		}
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/events/poll", nil))
+	if !called {
+		t.Fatal("poll not served")
+	}
+}
+
+func TestWebExecJobStopDoesNotAbortProcessRestart(t *testing.T) {
+	c := &webExecCoordinator{ctx: context.Background(), server: &serveServer{jobsV2: &jobsV2Manager{}}, draining: true, release: make(chan struct{})}
+	called := false
+	handler := c.handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true; w.WriteHeader(http.StatusOK) }))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v2/runs/job-run/cancel", nil))
+	if !called || response.Code != http.StatusOK {
+		t.Fatal("job Stop blocked by process drain")
+	}
+	if !c.draining {
+		t.Fatal("stopping one job aborted whole-process restart")
 	}
 }

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -936,6 +936,9 @@ func (s *serveServer) handleResolvedResponses(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	if s.webExec != nil {
+		s.webExec.reject("non-streaming response engines are unsupported")
+	}
 	result, _, err := s.runResponseWithModelSwapFallback(ctx, runtime, stateful, replaceHistory, inputMessages, llmReq, sessionID, modelSwapExec)
 	if err != nil {
 		if errors.Is(err, errServeSessionBusy) {

--- a/cmd/serve_hub_cmd.go
+++ b/cmd/serve_hub_cmd.go
@@ -153,6 +153,8 @@ func lockHubPasskeyState(authFile string) (func() error, error) {
 }
 
 func runServeHub(cmd *cobra.Command, args []string) error {
+	defer installWebExecSignal(cmd.Context(), &webExecCoordinator{ctx: cmd.Context(), unsupported: "SIGUSR2 requires standalone serve web"})()
+
 	authMode, err := resolveHubAuthMode(serveHubAuthMode)
 	if err != nil {
 		return err

--- a/cmd/serve_hub_cmd.go
+++ b/cmd/serve_hub_cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/filelock"
 	"github.com/samsaffron/term-llm/internal/hub"
 	"github.com/samsaffron/term-llm/internal/passkeyauth"
+	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/samsaffron/term-llm/internal/tools"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -153,7 +154,8 @@ func lockHubPasskeyState(authFile string) (func() error, error) {
 }
 
 func runServeHub(cmd *cobra.Command, args []string) error {
-	defer installWebExecSignal(cmd.Context(), &webExecCoordinator{ctx: cmd.Context(), unsupported: "SIGUSR2 requires standalone serve web"})()
+	ctx, stop := signal.NotifyContextWithParent(cmd.Context())
+	defer stop()
 
 	authMode, err := resolveHubAuthMode(serveHubAuthMode)
 	if err != nil {
@@ -344,7 +346,7 @@ func runServeHub(cmd *cobra.Command, args []string) error {
 	if s.registrationToken != "" {
 		fmt.Fprintln(out, "  registration: enabled")
 	}
-	return srv.ListenAndServe()
+	return serveHTTPWithRestart(ctx, "serve hub", srv)
 }
 
 var hubOutputIsTerminal = func(w any) bool { f, ok := w.(interface{ Fd() uintptr }); return ok && term.IsTerminal(int(f.Fd())) }

--- a/cmd/serve_hub_reverse_connector.go
+++ b/cmd/serve_hub_reverse_connector.go
@@ -55,6 +55,35 @@ func netJoinHostPortForURL(host string, port int) string {
 
 var hubReverseReconnectDelay = 2 * time.Second
 
+// hubReverseConnector owns the reconnect loop and every request it forwards.
+// Stop is joinable and idempotent. It does not prove that a remote/local server
+// has rolled back a mutation; that requires the server's admission barrier.
+type hubReverseConnector struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func startHubReverseConnector(ctx context.Context, hubURL, nodeID, token, localBase, allowedBasePath string, client *http.Client) *hubReverseConnector {
+	ctx, cancel := context.WithCancel(ctx)
+	c := &hubReverseConnector{cancel: cancel, done: make(chan struct{})}
+	go func() {
+		defer close(c.done)
+		runHubReverseConnector(ctx, hubURL, nodeID, token, localBase, allowedBasePath, client)
+	}()
+	return c
+}
+
+func (c *hubReverseConnector) Stop(ctx context.Context) error {
+	c.cancel()
+	select {
+	case <-c.done:
+		return nil
+	case <-ctx.Done():
+		// A deadline is a failed join, never authority to exec or kill work.
+		return ctx.Err()
+	}
+}
+
 func runHubReverseConnector(ctx context.Context, hubURL, nodeID, token, localBase, allowedBasePath string, client *http.Client) {
 	if client == nil {
 		client = newHubReverseLocalClient()
@@ -94,14 +123,25 @@ func hubReverseConnectOnce(ctx context.Context, hubURL, nodeID, token, localBase
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	ctx, cancelConnection := context.WithCancel(ctx)
+	var children sync.WaitGroup
+	// Wake blocked reads/writes on cancellation, not just on heartbeat expiry.
+	children.Go(func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	})
+	defer func() {
+		cancelConnection()
+		_ = conn.Close()
+		children.Wait()
+	}()
 	var writeMu sync.Mutex
 	donePing := make(chan struct{})
 	defer close(donePing)
 	if err := hubReverseSetHeartbeat(conn, nil); err != nil {
 		return err
 	}
-	go hubReversePingLoop(conn, &writeMu, donePing)
+	children.Go(func() { hubReversePingLoop(conn, &writeMu, donePing) })
 	log.Printf("hub reverse connect: node %q connected to %s", nodeID, hubURL)
 	activeMu := sync.Mutex{}
 	active := map[string]context.CancelFunc{}
@@ -131,7 +171,9 @@ func hubReverseConnectOnce(ctx context.Context, hubURL, nodeID, token, localBase
 		activeMu.Lock()
 		active[req.ID] = cancel
 		activeMu.Unlock()
+		children.Add(1)
 		go func(req hubReverseRequest, reqCtx context.Context, cancel context.CancelFunc) {
+			defer children.Done()
 			defer func() {
 				activeMu.Lock()
 				delete(active, req.ID)

--- a/cmd/serve_hub_reverse_connector_test.go
+++ b/cmd/serve_hub_reverse_connector_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type reverseJoinTransport struct {
+	entered   chan struct{}
+	cancelled chan struct{}
+	release   chan struct{}
+}
+
+func (tr *reverseJoinTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	close(tr.entered)
+	<-r.Context().Done()
+	close(tr.cancelled)
+	// Model a child transport which observes cancellation but has not yet joined.
+	<-tr.release
+	return nil, r.Context().Err()
+}
+
+func TestHubReverseConnectorStopJoinsRequests(t *testing.T) {
+	tr := &reverseJoinTransport{make(chan struct{}), make(chan struct{}), make(chan struct{})}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(tr.release) }) }
+	defer release()
+	connected := make(chan struct{})
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		close(connected)
+		if err := conn.WriteJSON(hubReverseRequest{Type: hubReverseFrameRequest, ID: "one", Method: "GET", Path: "/chat/healthz"}); err != nil {
+			return
+		}
+		// The client must actively wake its ReadJSON, not wait for a heartbeat.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer hub.Close()
+	c := startHubReverseConnector(context.Background(), hub.URL, "sandbox", "", "http://local.invalid", "/chat", &http.Client{Transport: tr})
+	defer func() {
+		release()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := c.Stop(cleanupCtx); err != nil {
+			t.Errorf("cleanup: %v", err)
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wait := func(ch <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			t.Fatal("connector lifecycle did not progress")
+		}
+	}
+	wait(connected)
+	wait(tr.entered)
+	cancelledCtx, cancelStop := context.WithCancel(context.Background())
+	cancelStop()
+	if err := c.Stop(cancelledCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unjoined stop = %v", err)
+	}
+	wait(tr.cancelled)
+	select {
+	case <-c.done:
+		t.Fatal("stop completed while a request was still owned")
+	default:
+	}
+	release()
+	if err := c.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/serve_hub_reverse_test.go
+++ b/cmd/serve_hub_reverse_test.go
@@ -78,7 +78,7 @@ func TestHubReverseNodeProxy(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 	waitForReverseNode(t, s, "artist")
 
 	req := httptest.NewRequest(http.MethodGet, "/node/artist/healthz", nil)
@@ -139,7 +139,7 @@ func TestHubReverseNodeSessionsSummary(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 	waitForReverseNode(t, s, "artist")
 
 	rec := httptest.NewRecorder()
@@ -184,7 +184,7 @@ func TestHubReverseNodeProxyStreamsChunkedResponse(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 	waitForReverseNode(t, s, "artist")
 
 	req := httptest.NewRequest(http.MethodGet, "/node/artist/stream", nil)
@@ -228,7 +228,7 @@ func TestHubReverseNodeProxyStreamsShellSSEIncrementally(t *testing.T) {
 
 	connectorCtx, stopConnector := context.WithCancel(context.Background())
 	defer stopConnector()
-	go runHubReverseConnector(connectorCtx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(connectorCtx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 	waitForReverseNode(t, s, "artist")
 
 	requestCtx, cancelRequest := context.WithTimeout(context.Background(), 5*time.Second)
@@ -293,7 +293,7 @@ func TestHubReverseNodeProxyRejectsOversizedRequestBody(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 	waitForReverseNode(t, s, "artist")
 
 	payload := strings.Repeat("a", hubReverseMaxRequestBodyBytes+1)
@@ -336,7 +336,7 @@ func TestHubReverseResponseCancellation(t *testing.T) {
 
 	connectorCtx, stopConnector := context.WithCancel(context.Background())
 	defer stopConnector()
-	go runHubReverseConnector(connectorCtx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(connectorCtx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 	waitForReverseNode(t, s, "artist")
 
 	reqCtx, cancelReq := context.WithCancel(context.Background())
@@ -893,7 +893,7 @@ func TestHubReverseConnectorReconnectsAfterDroppedWebsocket(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 
 	first := waitForReverseNodeConnection(t, s, "artist")
 	assertReverseProxyContains(t, s, "/node/artist/healthz", `"agent":"artist"`)
@@ -935,7 +935,7 @@ func TestHubReverseConnectorFailsInFlightRequestAndRecoversAfterDrop(t *testing.
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 
 	first := waitForReverseNodeConnection(t, s, "artist")
 	inFlight := make(chan reverseDoResult, 1)
@@ -980,7 +980,7 @@ func TestHubReverseDelegationNodeJSON(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client())
+	defer startHubReverseConnector(ctx, hubTS.URL, "artist", "node-token", backend.URL, "/chat", backend.Client()).Stop(context.Background())
 	waitForReverseNode(t, s, "artist")
 
 	var out struct {

--- a/cmd/serve_jobs_restart.go
+++ b/cmd/serve_jobs_restart.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+// jobsRestartCheckpoint is mode-owned execution state, not a new job or retry.
+// Transcript/steering data belongs to the existing revision-checked session
+// CommandHandoff; the jobs journal binds its one-shot ID to the original run.
+type jobsRestartCheckpoint struct {
+	PassHadWork        bool                 `json:"pass_had_work,omitempty"`
+	PassHadCommit      bool                 `json:"pass_had_commit,omitempty"`
+	FinalizationReason string               `json:"finalization_reason,omitempty"`
+	PassTurnLimit      int                  `json:"pass_turn_limit,omitempty"`
+	Pending            []llm.QueuedSteering `json:"pending,omitempty"`
+	RemainingTurns     int                  `json:"remaining_turns"`
+	RestartID          string               `json:"restart_id"`
+	RunID              string               `json:"run_id"`
+	Service            string               `json:"service"`
+	SourceInstance     string               `json:"source_instance"`
+	SessionID          string               `json:"session_id"`
+	HandoffID          string               `json:"handoff_id,omitempty"`
+	Job                jobsV2Job            `json:"job"`
+	Deadline           time.Time            `json:"deadline"`
+}
+
+var errJobsRestartConflict = errors.New("job restart checkpoint conflicts with current run")
+
+func initJobsRestartJournal(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS job_restart_checkpoints (
+ run_id TEXT PRIMARY KEY REFERENCES job_runs_v2(id) ON DELETE CASCADE,
+ restart_id TEXT NOT NULL,
+ phase TEXT NOT NULL CHECK(phase IN ('prepared','sealed','ready','claimed')),
+ payload TEXT NOT NULL
+ )`)
+	return err
+}
+
+// prepareLLMRestart records intent before internal cancellation. User CancelRun
+// changes the authoritative run status and therefore wins every later CAS.
+func (m *jobsV2Manager) prepareLLMRestart(ctx context.Context, c jobsRestartCheckpoint) error {
+	if c.RunID == "" || c.RestartID == "" || c.Service == "" || c.SourceInstance == "" || c.SessionID == "" || c.HandoffID != "" || c.Deadline.IsZero() || c.Job.RunnerType != jobsV2RunnerLLM {
+		return errJobsRestartConflict
+	}
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	result, err := m.db.ExecContext(ctx, `INSERT INTO job_restart_checkpoints(run_id,restart_id,phase,payload)
+ SELECT id,?,'prepared',? FROM job_runs_v2 WHERE id=? AND job_id=? AND session_id=? AND status=? AND worker_id=?`, c.RestartID, string(raw), c.RunID, c.Job.ID, c.SessionID, jobsV2RunRunning, m.workerID)
+	if err != nil {
+		return fmt.Errorf("prepare job restart: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return errJobsRestartConflict
+	}
+	return nil
+}
+
+// sealLLMRestart is called only after the owned runner has returned, including
+// actual tool settlement and persistence cleanup, and saved a CommandHandoff.
+func (m *jobsV2Manager) sealLLMRestart(ctx context.Context, runID, restartID, handoffID string, result jobsV2RunResult) error {
+	if handoffID == "" {
+		return errJobsRestartConflict
+	}
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	c, err := readJobsRestart(ctx, tx, runID, restartID, "prepared")
+	if err != nil {
+		return err
+	}
+	c.HandoffID = handoffID
+	if result.restartPass != nil {
+		c.PassHadWork = result.restartPass.hadNonProgressTool
+		c.PassHadCommit = result.restartPass.newCommitCount > 0
+	}
+	usedTurns := result.TurnCount
+	if result.restartBudgetTurns != nil {
+		usedTurns = *result.restartBudgetTurns
+	}
+	c.RemainingTurns = max(0, c.RemainingTurns-usedTurns)
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	updated, err := tx.ExecContext(ctx, `UPDATE job_restart_checkpoints SET phase='sealed',payload=? WHERE run_id=? AND restart_id=? AND phase='prepared' AND EXISTS(SELECT 1 FROM job_runs_v2 WHERE id=? AND status=? AND session_id=?)`, string(raw), runID, restartID, runID, jobsV2RunRunning, c.SessionID)
+	if err != nil {
+		return err
+	}
+	n, err := updated.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return errJobsRestartConflict
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE job_runs_v2 SET stdout=?,stderr=?,thinking=?,response=?,turn_count=turn_count+?,input_tokens=input_tokens+?,output_tokens=output_tokens+?,updated_at=CURRENT_TIMESTAMP WHERE id=?`, result.Stdout, result.Stderr, result.Thinking, result.Response, result.TurnCount, result.InputTokens, result.OutputTokens, runID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// activateLLMRestart requires a successfully consumed, revision-checked session
+// handoff. A crash between consuming that grant and this transaction may lose
+// recovery, but cannot execute it twice. Never infer authorization from a job's
+// cancelled status, a session ID, or a leftover journal row alone.
+func (m *jobsV2Manager) activateLLMRestart(ctx context.Context, runID, restartID string, grant session.CommandHandoff) error {
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	c, err := readJobsRestart(ctx, tx, runID, restartID, "sealed")
+	if err != nil {
+		return err
+	}
+	if grant.ID == "" || grant.ID != c.HandoffID || grant.Service != c.Service || grant.SourceInstance != c.SourceInstance || grant.SessionID != c.SessionID {
+		return errJobsRestartConflict
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE job_runs_v2 SET status=?,worker_id=NULL,updated_at=CURRENT_TIMESTAMP WHERE id=? AND status=? AND session_id=?`, jobsV2RunQueued, runID, jobsV2RunRunning, c.SessionID)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return errJobsRestartConflict
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE job_restart_checkpoints SET phase='ready' WHERE run_id=? AND restart_id=? AND phase='sealed'`, runID, restartID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// takeLLMRestart participates in the worker's existing claim transaction, so
+// checkpoint consumption cannot be separated from claiming the original run.
+func takeLLMRestart(ctx context.Context, tx *sql.Tx, runID string) (*jobsRestartCheckpoint, error) {
+	var raw string
+	err := tx.QueryRowContext(ctx, `SELECT payload FROM job_restart_checkpoints WHERE run_id=? AND phase='ready'`, runID).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var c jobsRestartCheckpoint
+	if err = json.Unmarshal([]byte(raw), &c); err != nil {
+		return nil, err
+	}
+	if c.RunID != runID || c.HandoffID == "" {
+		return nil, errJobsRestartConflict
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE job_restart_checkpoints SET phase='claimed' WHERE run_id=? AND phase='ready' AND EXISTS(SELECT 1 FROM job_runs_v2 WHERE id=? AND status=? AND session_id=?)`, runID, runID, jobsV2RunClaimed, c.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	if n != 1 {
+		return nil, errJobsRestartConflict
+	}
+	return &c, nil
+}
+
+func readJobsRestart(ctx context.Context, tx *sql.Tx, runID, restartID, phase string) (jobsRestartCheckpoint, error) {
+	var c jobsRestartCheckpoint
+	var raw string
+	err := tx.QueryRowContext(ctx, `SELECT payload FROM job_restart_checkpoints WHERE run_id=? AND restart_id=? AND phase=?`, runID, restartID, phase).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return c, errJobsRestartConflict
+	}
+	if err != nil {
+		return c, err
+	}
+	err = json.Unmarshal([]byte(raw), &c)
+	return c, err
+}
+
+type jobsRestartContextKey struct{}
+
+// startJobRun atomically retires the claimed checkpoint at actual admission.
+// Until this point a shutdown can return both the run and its checkpoint to the
+// queue. After this point an unexpected crash follows normal worker-loss rules.
+func (m *jobsV2Manager) startJobRun(run jobsV2Run, started time.Time) (sql.Result, error) {
+	tx, err := m.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	result, err := tx.Exec(`UPDATE job_runs_v2 SET status=?,started_at=COALESCE(started_at,?),session_id=NULLIF(?,''),updated_at=CURRENT_TIMESTAMP WHERE id=? AND status=?`, jobsV2RunRunning, started, run.SessionID, run.ID, jobsV2RunClaimed)
+	if err != nil {
+		return nil, err
+	}
+	if run.restart != nil {
+		n, err := result.RowsAffected()
+		if err != nil {
+			return nil, err
+		}
+		if n == 1 {
+			deleted, err := tx.Exec(`DELETE FROM job_restart_checkpoints WHERE run_id=? AND restart_id=? AND phase='claimed'`, run.ID, run.restart.RestartID)
+			if err != nil {
+				return nil, err
+			}
+			n, err = deleted.RowsAffected()
+			if err != nil {
+				return nil, err
+			}
+			if n != 1 {
+				return nil, errJobsRestartConflict
+			}
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// recoverUnstartedLLMClaims handles a crash after checkpoint claim but before
+// actual execution admission. startJobRun atomically deletes the claimed marker,
+// so its presence proves the continuation has not executed and may be requeued.
+func (m *jobsV2Manager) recoverUnstartedLLMClaims(ctx context.Context) error {
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err = tx.ExecContext(ctx, `UPDATE job_runs_v2 SET status=?,worker_id=NULL,updated_at=CURRENT_TIMESTAMP WHERE status=? AND EXISTS(SELECT 1 FROM job_restart_checkpoints c WHERE c.run_id=job_runs_v2.id AND c.phase='claimed')`, jobsV2RunQueued, jobsV2RunClaimed); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE job_restart_checkpoints SET phase='ready' WHERE phase='claimed' AND EXISTS(SELECT 1 FROM job_runs_v2 r WHERE r.id=job_restart_checkpoints.run_id AND r.status=?)`, jobsV2RunQueued); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/cmd/serve_jobs_restart_driver.go
+++ b/cmd/serve_jobs_restart_driver.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type jobsRestartDriver struct {
+	mu               sync.Mutex
+	setup            jobsRestartSetup
+	active, rollback bool
+	failure          error
+}
+
+func (m *jobsV2Manager) beginLLMRestart(ctx context.Context, setup jobsRestartSetup) error {
+	d := &m.restartDriver
+	d.mu.Lock()
+	if d.setup.RestartID != "" && d.setup.RestartID != setup.RestartID {
+		var pending int
+		err := m.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM job_restart_checkpoints c JOIN job_runs_v2 r ON r.id=c.run_id WHERE c.restart_id=? AND c.phase IN ('prepared','sealed') AND r.status='running'`, d.setup.RestartID).Scan(&pending)
+		if err != nil || pending > 0 {
+			d.mu.Unlock()
+			return errors.New("previous LLM restart cleanup remains unresolved")
+		}
+	}
+	d.setup = setup
+	d.active = true
+	d.rollback = false
+	d.failure = nil
+	d.mu.Unlock()
+	err := m.interruptLLMJobs(ctx, setup.RestartID, setup.Service)
+	if err != nil {
+		d.mu.Lock()
+		d.failure = err
+		d.mu.Unlock()
+	}
+	return err
+}
+
+func (m *jobsV2Manager) prepareLateLLMSource(x *jobsLLMExecution) {
+	d := &m.restartDriver
+	d.mu.Lock()
+	setup, active := d.setup, d.active
+	d.mu.Unlock()
+	if !active {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := x.prepare(ctx, setup.RestartID, setup.Service); err != nil {
+		x.mu.Lock()
+		runID := x.checkpoint.RunID
+		x.mu.Unlock()
+		m.noteLLMRestartFailure(runID, err)
+	}
+}
+
+func (m *jobsV2Manager) noteLLMRestartFailure(runID string, err error) {
+	if err == nil {
+		return
+	}
+	run, getErr := m.GetRun(runID)
+	if getErr == nil && (run.Status == jobsV2RunCancelled || run.Status == jobsV2RunCancelRequested) {
+		return
+	}
+	d := &m.restartDriver
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.failure = fmt.Errorf("LLM job %s checkpoint: %w", runID, err)
+}
+
+func (m *jobsV2Manager) llmRestartFailure() error {
+	d := &m.restartDriver
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.failure
+}
+
+func (m *jobsV2Manager) rollbackLLMRestart() error {
+	d := &m.restartDriver
+	d.mu.Lock()
+	d.active = false
+	d.rollback = true
+	d.mu.Unlock()
+	return m.recoverRolledBackLLMJobs()
+}
+
+// Called after worker source/cancel-map cleanup, before its gate is released.
+// This also recovers sources which only settle after the coordinator aborts.
+func (m *jobsV2Manager) recoverRolledBackLLMJobs() error {
+	d := &m.restartDriver
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.rollback || d.setup.RestartID == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := m.recoverLLMRestarts(ctx, d.setup, true); err != nil {
+		d.failure = err
+		return err
+	}
+	m.notifyWorkers(m.workers)
+	return nil
+}

--- a/cmd/serve_jobs_restart_driver_test.go
+++ b/cmd/serve_jobs_restart_driver_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestJobsRestartDriverLateBindAndLateRollbackSettlement(t *testing.T) {
+	m, c, _ := jobsRestartFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	own, err := session.NewSQLiteStore(session.Config{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer own.Close()
+	shared, err := session.NewSQLiteStore(session.Config{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shared.Close()
+	if err := own.Create(ctx, &session.Session{ID: c.SessionID, Provider: "mock", Model: "mock", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	x := &jobsLLMExecution{manager: m, ctx: ctx, cancel: cancel, checkpoint: c}
+	m.llmExecutions.Store(c.RunID, x)
+	defer m.llmExecutions.Delete(c.RunID)
+	setup := jobsRestartSetup{Store: shared, RestartID: c.RestartID, Service: c.Service, Instance: c.SourceInstance}
+	// Grace can expire while this already-admitted runner is still preparing.
+	if err := m.beginLLMRestart(context.Background(), setup); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.Err() != nil {
+		t.Fatal("cancelled before runtime could checkpoint")
+	}
+	x.bind(&cmdRunEnvironment{engine: llm.NewEngine(llm.NewMockProvider("mock"), llm.NewToolRegistry()), store: own, llmReq: llm.Request{MaxTurns: 7}})
+	if ctx.Err() != nil {
+		t.Fatal("engine binding was mistaken for durable input")
+	}
+	x.markReady()
+	if ctx.Err() == nil {
+		t.Fatal("late binding escaped restart interruption")
+	}
+	if err := m.interruptLLMJobs(context.Background(), setup.RestartID, setup.Service); err != nil {
+		t.Fatal("same generation was not idempotent", err)
+	}
+	// A timed-out drain rolls back while this source is still cleaning up.
+	if err := m.rollbackLLMRestart(); err != nil {
+		t.Fatal(err)
+	}
+	run, err := m.GetRun(c.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != jobsV2RunRunning {
+		t.Fatal("unsettled source requeued")
+	}
+	x.capture()
+	if err := own.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if parked, err := x.seal(&jobsV2RunResult{TurnCount: 2}); !parked || err != nil {
+		t.Fatalf("seal failed: %v", err)
+	}
+	if err := m.recoverRolledBackLLMJobs(); err != nil {
+		t.Fatal(err)
+	}
+	run, ok, err := m.claimNextRun()
+	if err != nil || !ok || run.restart == nil {
+		t.Fatalf("late settled source stranded: %v", err)
+	}
+	if run.restart.RemainingTurns != 5 {
+		t.Fatalf("late source budget reset: %d", run.restart.RemainingTurns)
+	}
+	select {
+	case <-m.workerWake:
+	default:
+		t.Fatal("rollback adoption did not wake worker")
+	}
+}

--- a/cmd/serve_jobs_restart_recover.go
+++ b/cmd/serve_jobs_restart_recover.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type jobsRestartSetup struct {
+	Store                        session.Store
+	RestartID, Service, Instance string
+}
+
+// recoverLLMRestarts runs before worker-loss recovery and before any workers
+// start. A sealed jobs row alone is not authorization: the session grant must
+// pass its atomic revision, service, instance, expiry and one-shot checks.
+func (m *jobsV2Manager) recoverLLMRestarts(ctx context.Context, setup jobsRestartSetup, reclaim bool) error {
+	if setup.RestartID == "" {
+		return nil
+	}
+	rows, err := m.db.QueryContext(ctx, `SELECT phase,payload FROM job_restart_checkpoints WHERE restart_id=? AND phase IN ('prepared','sealed')`, setup.RestartID)
+	if err != nil {
+		return err
+	}
+	type entry struct {
+		phase string
+		c     jobsRestartCheckpoint
+	}
+	var entries []entry
+	for rows.Next() {
+		var e entry
+		var raw string
+		if err = rows.Scan(&e.phase, &raw); err != nil {
+			rows.Close()
+			return err
+		}
+		if err = json.Unmarshal([]byte(raw), &e.c); err != nil {
+			rows.Close()
+			return err
+		}
+		entries = append(entries, e)
+	}
+	err = rows.Err()
+	rows.Close()
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	handoffs, ok := session.AsCommandHandoffStore(setup.Store)
+	if !ok {
+		return fmt.Errorf("LLM restart adoption requires durable session storage")
+	}
+	// Validate the batch's identities/phases before consuming any grants.
+	for _, e := range entries {
+		if reclaim && e.phase == "prepared" {
+			continue
+		}
+		run, err := m.GetRun(e.c.RunID)
+		if err != nil {
+			return err
+		}
+		if run.Status != jobsV2RunRunning {
+			continue
+		}
+		if e.phase != "sealed" || e.c.Service != setup.Service || e.c.RestartID != setup.RestartID || e.c.SessionID != run.SessionID {
+			return errJobsRestartConflict
+		}
+		if setup.Instance == "" || (e.c.SourceInstance == setup.Instance) != reclaim {
+			return errJobsRestartConflict
+		}
+	}
+	for _, e := range entries {
+		if reclaim && e.phase == "prepared" {
+			continue
+		}
+		run, err := m.GetRun(e.c.RunID)
+		if err != nil {
+			return err
+		}
+		if reclaim && run.Status == jobsV2RunCancelRequested {
+			result := jobsV2RunResult{SessionID: run.SessionID, Stdout: run.Stdout, Stderr: run.Stderr, Thinking: run.Thinking, Response: run.Response, TurnCount: run.TurnCount, InputTokens: run.InputTokens, OutputTokens: run.OutputTokens}
+			if err := m.finishRun(run.ID, jobsV2RunCancelled, result, context.Canceled, run.Attempt); err != nil {
+				return err
+			}
+			continue
+		}
+		if run.Status != jobsV2RunRunning {
+			continue
+		} // User Stop is authoritative.
+		var grant session.CommandHandoff
+		if reclaim {
+			grant, err = handoffs.ReclaimCommandHandoff(ctx, e.c.HandoffID, setup.Service, setup.Instance)
+		} else {
+			grant, err = handoffs.ConsumeCommandHandoff(ctx, e.c.HandoffID, setup.Service, setup.Instance)
+		}
+		if err != nil {
+			return fmt.Errorf("adopt LLM job %s: %w", e.c.RunID, err)
+		}
+		if err = m.activateLLMRestart(ctx, e.c.RunID, e.c.RestartID, grant); err != nil {
+			// Stop can win after consuming the grant but before the jobs transaction.
+			current, getErr := m.GetRun(e.c.RunID)
+			if getErr == nil && (current.Status == jobsV2RunCancelled || current.Status == jobsV2RunCancelRequested) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/serve_jobs_restart_recover_test.go
+++ b/cmd/serve_jobs_restart_recover_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestJobsRestartAdoptionPrecedesStartupRecovery(t *testing.T) {
+	for _, variant := range []string{"replacement", "reclaim", "advanced-source", "user-stop"} {
+		t.Run(variant, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "jobs.db")
+			m, c, grant := jobsRestartFixture(t, dbPath)
+			store, err := session.NewSQLiteStore(session.Config{Path: filepath.Join(dir, "sessions.db")})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			if err := store.Create(ctx, &session.Session{ID: c.SessionID, Provider: "mock", Model: "mock", Status: session.StatusActive}); err != nil {
+				t.Fatal(err)
+			}
+			grant.Payload = json.RawMessage(`[]`)
+			if err := m.prepareLLMRestart(ctx, c); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.SaveCommandHandoff(ctx, grant); err != nil {
+				t.Fatal(err)
+			}
+			if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{TurnCount: 2, Response: "checkpoint output"}); err != nil {
+				t.Fatal(err)
+			}
+			setup := jobsRestartSetup{Store: store, RestartID: c.RestartID, Service: c.Service, Instance: "replacement"}
+			if variant == "reclaim" {
+				setup.Instance = c.SourceInstance
+				if err := m.recoverLLMRestarts(ctx, setup, true); err != nil {
+					t.Fatal(err)
+				}
+				run, ok, err := m.claimNextRun()
+				if err != nil || !ok || run.restart == nil {
+					t.Fatalf("old instance could not recover: %v", err)
+				}
+				return
+			}
+			if variant == "advanced-source" {
+				if err := store.AddMessage(ctx, c.SessionID, &session.Message{SessionID: c.SessionID, Role: llm.RoleUser, TextContent: "changed source", Parts: []llm.Part{{Type: llm.PartText, Text: "changed source"}}, Sequence: -1}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if variant == "user-stop" {
+				if _, err := m.CancelRun(c.RunID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := m.Close(); err != nil {
+				t.Fatal(err)
+			}
+			replacement, err := newJobsV2ManagerWithNotifier(dbPath, 0, nil, nil, func(next *jobsV2Manager) error { return next.recoverLLMRestarts(ctx, setup, false) })
+			if variant == "advanced-source" {
+				if err == nil {
+					replacement.Close()
+					t.Fatal("advanced transcript adopted")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer replacement.Close()
+			run, err := replacement.GetRun(c.RunID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if variant == "user-stop" {
+				if run.Status != jobsV2RunCancelled {
+					t.Fatalf("Stop resurrected: %s", run.Status)
+				}
+				return
+			}
+			if run.Status != jobsV2RunQueued || run.Response != "checkpoint output" {
+				t.Fatalf("worker-loss recovery ran before adoption: %+v", run)
+			}
+			claimed, ok, err := replacement.claimNextRun()
+			if err != nil || !ok || claimed.restart == nil || claimed.restart.RemainingTurns != 6 {
+				t.Fatalf("replacement claim lost checkpoint: ok=%v err=%v", ok, err)
+			}
+		})
+	}
+}
+
+func TestJobsRestartCompletionNotificationOccursOnlyOnce(t *testing.T) {
+	ctx := context.Background()
+	m, c, grant := jobsRestartFixture(t)
+	store, err := session.NewSQLiteStore(session.Config{Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Create(ctx, &session.Session{ID: c.SessionID, Provider: "mock", Model: "mock", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	notifications := make(chan jobsV2Run, 4)
+	m.notifyDone = func(_ context.Context, run jobsV2Run, _ jobsV2Job, _ jobsV2RunStatus, _ jobsV2RunResult, _ string, _ bool, _ string) error {
+		notifications <- run
+		return nil
+	}
+	grant.Payload = json.RawMessage(`[]`)
+	if err := m.prepareLLMRestart(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveCommandHandoff(ctx, grant); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{TurnCount: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.recoverLLMRestarts(ctx, jobsRestartSetup{Store: store, RestartID: c.RestartID, Service: c.Service, Instance: "new"}, false); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-notifications:
+		t.Fatal("internal interruption notified completion")
+	default:
+	}
+	run, ok, err := m.claimNextRun()
+	if err != nil || !ok {
+		t.Fatal(err)
+	}
+	m.runners[jobsV2RunnerLLM] = jobsV2RunnerFunc(func(context.Context, jobsV2Job, progressWriter) (jobsV2RunResult, error) {
+		return jobsV2RunResult{SessionID: c.SessionID, TurnCount: 1, Response: "done"}, nil
+	})
+	m.executeRun(run)
+	select {
+	case finished := <-notifications:
+		if finished.ID != c.RunID || finished.Status != jobsV2RunSucceeded || finished.TurnCount != 3 {
+			t.Fatalf("wrong completion: %+v", finished)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no final notification")
+	}
+	// Retrying finalization after a successful commit must not notify again.
+	if err := m.finishRun(c.RunID, jobsV2RunSucceeded, jobsV2RunResult{}, nil, run.Attempt); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-notifications:
+		t.Fatal("duplicate completion notification")
+	default:
+	}
+}

--- a/cmd/serve_jobs_restart_source.go
+++ b/cmd/serve_jobs_restart_source.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+type jobsExecutionContextKey struct{}
+
+// jobsLLMExecution is the source-side lifetime owner. The worker retains its
+// existing restart gate until runner cleanup and journal sealing both finish.
+type jobsLLMExecution struct {
+	native             bool
+	ready              bool
+	progressive        bool
+	passStartTurns     int64
+	passCancel         context.CancelFunc
+	passGeneration     uint64
+	mu                 sync.Mutex
+	manager            *jobsV2Manager
+	ctx                context.Context
+	cancel             context.CancelFunc
+	checkpoint         jobsRestartCheckpoint
+	engine             *llm.Engine
+	handoffs           session.CommandHandoffStore
+	owner              llm.SteeringTransition
+	prepared, finished bool
+	savedID            string
+	saveErr            error
+	initialTurns       int64
+}
+
+func (x *jobsLLMExecution) bind(env *cmdRunEnvironment) {
+	x.mu.Lock()
+	x.engine = env.engine
+	x.native = env.provider != nil && env.provider.Capabilities().InlineToolLoop
+	x.initialTurns = env.engine.ModelTurns()
+	x.handoffs, _ = session.AsCommandHandoffStore(env.store)
+	x.checkpoint.RemainingTurns = env.llmReq.TurnLimit()
+	x.progressive = env.req.Progressive != nil
+	if x.progressive {
+		x.checkpoint.PassTurnLimit = env.llmReq.TurnLimit()
+		if prior, ok := x.ctx.Value(jobsRestartContextKey{}).(*jobsRestartCheckpoint); ok && prior.PassTurnLimit > 0 {
+			x.checkpoint.PassTurnLimit = prior.PassTurnLimit
+			x.checkpoint.RemainingTurns = prior.RemainingTurns
+			x.checkpoint.PassHadWork = prior.PassHadWork
+			x.checkpoint.PassHadCommit = prior.PassHadCommit
+		}
+	}
+	if x.handoffs != nil && !x.native {
+		prior := env.llmReq.ModelBoundary
+		env.llmReq.ModelBoundary = func(ctx context.Context) error {
+			if prior != nil {
+				if err := prior(ctx); err != nil {
+					return err
+				}
+			}
+			x.markReady()
+			return ctx.Err()
+		}
+	} else {
+		x.ready = true
+	}
+	x.mu.Unlock()
+	if x.handoffs == nil || x.native {
+		x.manager.prepareLateLLMSource(x)
+	}
+}
+
+// The existing model boundary runs after initial input persistence, not merely
+// after engine construction. Freezing earlier could lose an uncommitted prompt.
+func (x *jobsLLMExecution) markReady() {
+	x.mu.Lock()
+	x.ready = true
+	x.mu.Unlock()
+	x.manager.prepareLateLLMSource(x)
+}
+
+func (x *jobsLLMExecution) prepare(ctx context.Context, restartID, service string) error {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.finished {
+		return nil
+	}
+	if x.prepared {
+		if x.checkpoint.RestartID == restartID && x.checkpoint.Service == service {
+			return nil
+		}
+		return errors.New("job already owns restart interruption")
+	}
+	if x.engine == nil || !x.ready {
+		return nil
+	} // bind will prepare this already-admitted source.
+	if x.native {
+		return errors.New("native job execution ownership is not yet checkpointable")
+	}
+	if x.handoffs == nil {
+		return errors.New("job runtime has no durable restart checkpoint")
+	}
+	if x.ctx.Err() != nil {
+		// An already timed-out/stopped job has no continuation to authorize,
+		// but its detached finalization may still need to be cancelled.
+		if x.passCancel != nil {
+			x.passCancel()
+		}
+		return nil
+	}
+	owner := llm.SteeringTransition{OperationID: restartID + ":" + x.checkpoint.RunID, Fence: 1}
+	pending, err := x.engine.FreezeExecutionSnapshot(owner)
+	if err != nil {
+		return err
+	}
+	c := x.checkpoint
+	c.RestartID = restartID
+	c.Service = service
+	if c.SourceInstance == "" {
+		c.SourceInstance = process.Instance()
+	}
+	c.Pending = pending
+	if err = x.manager.prepareLLMRestart(ctx, c); err != nil {
+		x.engine.ReleaseSteeringFreeze(owner, false)
+		return err
+	}
+	x.checkpoint = c
+	x.owner = owner
+	x.prepared = true
+	// Only a persisted internal intent authorizes this cancellation. CancelRun
+	// remains separate and its durable status revokes later sealing/adoption.
+	x.cancel()
+	if x.passCancel != nil {
+		x.passCancel()
+	}
+	return nil
+}
+
+// capture executes after the producer and actual tools have settled but while
+// the session store is still open. Journal sealing waits for Run to return too,
+// so provider/MCP cleanup still prevents replacement.
+func (x *jobsLLMExecution) capture() {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	x.finished = true
+	if !x.prepared {
+		return
+	}
+	defer x.engine.ReleaseSteeringFreeze(x.owner, false)
+	if x.saveErr != nil {
+		return
+	}
+	if x.engine.ActiveToolExecutions() != 0 {
+		x.saveErr = errors.New("job execution has not settled")
+		return
+	}
+	raw, err := json.Marshal(x.checkpoint.Pending)
+	if err != nil {
+		x.saveErr = err
+		return
+	}
+	id := uuid.NewString()
+	x.saveErr = x.handoffs.SaveCommandHandoff(context.Background(), session.CommandHandoff{ID: id, Service: x.checkpoint.Service, SourceInstance: x.checkpoint.SourceInstance, SessionID: x.checkpoint.SessionID, Payload: raw})
+	if x.saveErr == nil {
+		x.savedID = id
+	}
+}
+
+func (x *jobsLLMExecution) seal(result *jobsV2RunResult) (bool, error) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.engine != nil {
+		result.TurnCount = max(result.TurnCount, int(x.engine.ModelTurns()-x.initialTurns))
+	}
+	if x.progressive && x.engine != nil {
+		used := int(x.engine.ModelTurns() - x.passStartTurns)
+		result.restartBudgetTurns = &used
+		snapshot := progressivePassResult{hadNonProgressTool: x.checkpoint.PassHadWork}
+		if x.checkpoint.PassHadCommit {
+			snapshot.newCommitCount = 1
+		}
+		result.restartPass = &snapshot
+	}
+	if !x.prepared {
+		return false, nil
+	}
+	if x.saveErr != nil {
+		return false, x.saveErr
+	}
+	if !x.finished || x.savedID == "" {
+		return false, errors.New("job source checkpoint was not captured")
+	}
+	if err := x.manager.sealLLMRestart(context.Background(), x.checkpoint.RunID, x.checkpoint.RestartID, x.savedID, *result); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *jobsV2Manager) interruptLLMJobs(ctx context.Context, restartID, service string) error {
+	var result error
+	m.llmExecutions.Range(func(_, value any) bool {
+		if err := value.(*jobsLLMExecution).prepare(ctx, restartID, service); err != nil {
+			result = fmt.Errorf("prepare LLM job interruption: %w", err)
+			return false
+		}
+		return true
+	})
+	return result
+}
+
+// Each progressive pass has its own model-turn allowance. Its owned context
+// also makes detached finalization cancellable by the process/job owner.
+func (x *jobsLLMExecution) beginProgressivePass(parent context.Context, req llm.Request) (context.Context, func(), error) {
+	x.mu.Lock()
+	if x.prepared {
+		x.mu.Unlock()
+		return nil, nil, context.Canceled
+	}
+	ctx, cancel := context.WithCancel(parent)
+	// Preserve normal deadline grace, but never let explicit user Stop keep
+	// running a detached finalization pass.
+	stopParent := context.AfterFunc(x.ctx, func() {
+		if errors.Is(x.ctx.Err(), context.Canceled) {
+			cancel()
+		}
+	})
+	if errors.Is(x.ctx.Err(), context.Canceled) {
+		cancel()
+	}
+	x.passGeneration++
+	if x.passGeneration > 1 {
+		x.checkpoint.PassHadWork = false
+		x.checkpoint.PassHadCommit = false
+	}
+	generation := x.passGeneration
+	x.passCancel = cancel
+	x.passStartTurns = x.engine.ModelTurns()
+	x.checkpoint.RemainingTurns = req.TurnLimit()
+	x.mu.Unlock()
+	return ctx, func() {
+		stopParent()
+		cancel()
+		x.mu.Lock()
+		if x.passGeneration == generation {
+			x.passCancel = nil
+		}
+		x.mu.Unlock()
+	}, nil
+}
+
+func (x *jobsLLMExecution) beginFinalization(reason string, req llm.Request) error {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.prepared {
+		return context.Canceled
+	}
+	x.checkpoint.FinalizationReason = reason
+	x.checkpoint.RemainingTurns = req.TurnLimit()
+	x.passStartTurns = x.engine.ModelTurns()
+	return nil
+}
+
+func (x *jobsLLMExecution) endProgressivePass(result progressivePassResult) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	x.checkpoint.PassHadWork = x.checkpoint.PassHadWork || result.hadNonProgressTool
+	x.checkpoint.PassHadCommit = x.checkpoint.PassHadCommit || result.newCommitCount > 0
+}
+
+func (x *jobsLLMExecution) failCheckpoint(err error) {
+	if err == nil {
+		return
+	}
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if x.saveErr == nil {
+		x.saveErr = fmt.Errorf("incomplete source persistence: %w", err)
+	}
+}

--- a/cmd/serve_jobs_restart_source_test.go
+++ b/cmd/serve_jobs_restart_source_test.go
@@ -1,0 +1,188 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	runpkg "github.com/samsaffron/term-llm/internal/run"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestJobsRestartSourceCapturesThenSealsAfterCleanup(t *testing.T) {
+	for _, stop := range []bool{false, true} {
+		t.Run(map[bool]string{false: "recovery", true: "user-stop"}[stop], func(t *testing.T) {
+			m, c, _ := jobsRestartFixture(t)
+			path := filepath.Join(t.TempDir(), "sessions.db")
+			store, err := session.NewSQLiteStore(session.Config{Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := store.Create(ctx, &session.Session{ID: c.SessionID, Provider: "mock", Model: "mock", Status: session.StatusActive}); err != nil {
+				t.Fatal(err)
+			}
+			engine := llm.NewEngine(llm.NewMockProvider("mock"), llm.NewToolRegistry())
+			x := &jobsLLMExecution{manager: m, ctx: ctx, cancel: cancel, checkpoint: c}
+			x.bind(&cmdRunEnvironment{engine: engine, store: store, llmReq: llm.Request{MaxTurns: 5}})
+			x.markReady()
+			if err := x.prepare(context.Background(), c.RestartID, c.Service); err != nil {
+				t.Fatal(err)
+			}
+			if ctx.Err() == nil || !engine.SteeringTransitioning() {
+				t.Fatal("internal intent did not freeze then cancel")
+			}
+			// A cancellation acknowledgement alone is not a sealed checkpoint.
+			if parked, err := x.seal(&jobsV2RunResult{}); parked || err == nil {
+				t.Fatal("source sealed before capture/cleanup")
+			}
+			x.capture()
+			if x.saveErr != nil || x.savedID == "" {
+				t.Fatalf("capture failed: %v", x.saveErr)
+			}
+			if engine.SteeringTransitioning() {
+				t.Fatal("finished source retained execution fence")
+			}
+			if stop {
+				if _, err := m.CancelRun(c.RunID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// The source store can close during runtime cleanup before worker sealing.
+			if err := store.Close(); err != nil {
+				t.Fatal(err)
+			}
+			parked, err := x.seal(&jobsV2RunResult{SessionID: c.SessionID, TurnCount: 2, InputTokens: 10, Response: "partial progress"})
+			if stop {
+				if parked || !errors.Is(err, errJobsRestartConflict) {
+					t.Fatalf("user Stop sealed: parked=%v err=%v", parked, err)
+				}
+				return
+			}
+			if err != nil || !parked {
+				t.Fatalf("source did not park: %v", err)
+			}
+			reopened, err := session.NewSQLiteStore(session.Config{Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer reopened.Close()
+			grant, err := reopened.ConsumeCommandHandoff(context.Background(), x.savedID, c.Service, "replacement-instance")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := m.activateLLMRestart(context.Background(), c.RunID, c.RestartID, grant); err != nil {
+				t.Fatal(err)
+			}
+			claimed, ok, err := m.claimNextRun()
+			if err != nil || !ok || claimed.restart == nil {
+				t.Fatalf("claim missing: ok=%v err=%v", ok, err)
+			}
+			if claimed.restart.RemainingTurns != 3 || claimed.TurnCount != 2 || claimed.InputTokens != 10 || claimed.Response != "partial progress" {
+				t.Fatalf("source accounting lost: %+v", claimed)
+			}
+		})
+	}
+}
+
+func TestJobsProgressiveCheckpointUsesActivePassNotTotalTurns(t *testing.T) {
+	m, c, _ := jobsRestartFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store, err := session.NewSQLiteStore(session.Config{Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Create(ctx, &session.Session{ID: c.SessionID, Provider: "mock", Model: "mock", Status: session.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	provider := llm.NewMockProvider("mock")
+	for i := 0; i < 5; i++ {
+		provider.AddTextResponse("work")
+	}
+	engine := llm.NewEngine(provider, llm.NewToolRegistry())
+	x := &jobsLLMExecution{manager: m, ctx: ctx, cancel: cancel, checkpoint: c}
+	x.bind(&cmdRunEnvironment{engine: engine, store: store, llmReq: llm.Request{MaxTurns: 5}, req: runpkg.Request{Progressive: &runpkg.ProgressiveOptions{}}})
+	x.markReady()
+	req := llm.Request{Messages: []llm.Message{llm.UserText("work")}, MaxTurns: 5}
+	first, end, err := x.beginProgressivePass(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := runProgressivePass(first, engine, req, progressiveRunOptions{}, newProgressTracker()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	end()
+	// Natural-finalization contexts may be detached from the job context. The
+	// source owner must nevertheless cancel its admitted active pass.
+	second, end, err := x.beginProgressivePass(context.WithoutCancel(ctx), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer end()
+	if _, err := runProgressivePass(second, engine, req, progressiveRunOptions{}, newProgressTracker()); err != nil {
+		t.Fatal(err)
+	}
+	if err := x.prepare(context.Background(), c.RestartID, c.Service); err != nil {
+		t.Fatal(err)
+	}
+	if second.Err() == nil {
+		t.Fatal("detached pass escaped restart cancellation")
+	}
+	x.capture()
+	result := jobsV2RunResult{}
+	if parked, err := x.seal(&result); !parked || err != nil {
+		t.Fatal(err)
+	}
+	tx, err := m.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	checkpoint, err := readJobsRestart(context.Background(), tx, c.RunID, c.RestartID, "sealed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkpoint.RemainingTurns != 4 || checkpoint.PassTurnLimit != 5 || result.TurnCount != 5 {
+		t.Fatalf("wrong budgets: remaining=%d per-pass=%d total=%d", checkpoint.RemainingTurns, checkpoint.PassTurnLimit, result.TurnCount)
+	}
+}
+
+func TestJobsProgressiveDetachedPassHonorsUserStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	x := &jobsLLMExecution{ctx: ctx, engine: llm.NewEngine(llm.NewMockProvider("mock"), nil)}
+	pass, release, err := x.beginProgressivePass(context.WithoutCancel(ctx), llm.Request{MaxTurns: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	cancel()
+	select {
+	case <-pass.Done():
+	case <-time.After(time.Second):
+		t.Fatal("user Stop left detached finalization running")
+	}
+}
+
+func TestJobsRestartSourceRejectsIncompletePersistence(t *testing.T) {
+	failure := errors.New("transcript write failed")
+	x := &jobsLLMExecution{prepared: true, engine: llm.NewEngine(llm.NewMockProvider("mock"), nil)}
+	x.failCheckpoint(failure)
+	// No handoff store is installed: attempting to mint a grant would panic.
+	x.capture()
+	if x.savedID != "" || !errors.Is(x.saveErr, failure) {
+		t.Fatal("incomplete transcript became a valid handoff")
+	}
+	if parked, err := x.seal(&jobsV2RunResult{}); parked || !errors.Is(err, failure) {
+		t.Fatalf("incomplete source parked: %v", err)
+	}
+}

--- a/cmd/serve_jobs_restart_test.go
+++ b/cmd/serve_jobs_restart_test.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func jobsRestartFixture(t *testing.T, paths ...string) (*jobsV2Manager, jobsRestartCheckpoint, session.CommandHandoff) {
+	t.Helper()
+	path := ":memory:"
+	if len(paths) > 0 {
+		path = paths[0]
+	}
+	m, err := newJobsV2Manager(path, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { m.Close() })
+	if err := initJobsRestartJournal(context.Background(), m.db); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := json.Marshal(jobsV2LLMConfig{AgentName: "fixture", Instructions: "original", Cwd: t.TempDir(), SessionID: "source-session"})
+	job, err := m.CreateJob(jobsV2Job{Name: "checkpoint", Enabled: true, RunnerType: jobsV2RunnerLLM, RunnerConfig: cfg, TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := m.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = m.db.Exec(`UPDATE job_runs_v2 SET status=?,worker_id=?,session_id=? WHERE id=?`, jobsV2RunRunning, m.workerID, "source-session", run.ID); err != nil {
+		t.Fatal(err)
+	}
+	c := jobsRestartCheckpoint{RemainingTurns: 8, RunID: run.ID, RestartID: "restart", Service: "service", SourceInstance: "old-instance", SessionID: "source-session", Job: job, Deadline: time.Now().Add(time.Minute)}
+	grant := session.CommandHandoff{ID: "handoff", Service: c.Service, SourceInstance: c.SourceInstance, SessionID: c.SessionID}
+	return m, c, grant
+}
+
+func TestJobsRestartJournalAtomicClaim(t *testing.T) {
+	m, c, grant := jobsRestartFixture(t)
+	ctx := context.Background()
+	if err := m.prepareLLMRestart(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); !errors.Is(err, errJobsRestartConflict) {
+		t.Fatalf("unsealed intent adopted: %v", err)
+	}
+	if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{}); err != nil {
+		t.Fatal(err)
+	}
+	wrong := grant
+	wrong.SourceInstance = "other"
+	if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, wrong); !errors.Is(err, errJobsRestartConflict) {
+		t.Fatalf("wrong grant adopted: %v", err)
+	}
+	if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); !errors.Is(err, errJobsRestartConflict) {
+		t.Fatalf("duplicate activation: %v", err)
+	}
+	// Roll back a claim: the checkpoint must remain available, and no new run
+	// or attempt is created by recovery.
+	for _, commit := range []bool{false, true} {
+		tx, err := m.db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = tx.Exec(`UPDATE job_runs_v2 SET status=? WHERE id=? AND status=?`, jobsV2RunClaimed, c.RunID, jobsV2RunQueued); err != nil {
+			tx.Rollback()
+			t.Fatal(err)
+		}
+		got, err := takeLLMRestart(ctx, tx, c.RunID)
+		if err != nil {
+			tx.Rollback()
+			t.Fatal(err)
+		}
+		if got == nil || got.SessionID != c.SessionID || got.Job.ID != c.Job.ID || !got.Deadline.Equal(c.Deadline) {
+			tx.Rollback()
+			t.Fatalf("checkpoint lost: %+v", got)
+		}
+		if commit {
+			err = tx.Commit()
+		} else {
+			err = tx.Rollback()
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	tx, err := m.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	if got, err := takeLLMRestart(ctx, tx, c.RunID); err != nil || got != nil {
+		t.Fatalf("checkpoint consumed twice: %+v %v", got, err)
+	}
+}
+
+func TestJobsRestartJournalUserStopWinsEveryBoundary(t *testing.T) {
+	for _, stage := range []string{"before-prepare", "before-seal", "before-activate", "before-claim"} {
+		t.Run(stage, func(t *testing.T) {
+			m, c, grant := jobsRestartFixture(t)
+			ctx := context.Background()
+			stop := func() {
+				t.Helper()
+				if _, err := m.CancelRun(c.RunID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if stage == "before-prepare" {
+				stop()
+				if err := m.prepareLLMRestart(ctx, c); !errors.Is(err, errJobsRestartConflict) {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err := m.prepareLLMRestart(ctx, c); err != nil {
+				t.Fatal(err)
+			}
+			if stage == "before-seal" {
+				stop()
+				if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{}); !errors.Is(err, errJobsRestartConflict) {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{}); err != nil {
+				t.Fatal(err)
+			}
+			if stage == "before-activate" {
+				stop()
+				if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); !errors.Is(err, errJobsRestartConflict) {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); err != nil {
+				t.Fatal(err)
+			}
+			stop()
+			tx, err := m.db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Rollback()
+			if _, err := takeLLMRestart(ctx, tx, c.RunID); !errors.Is(err, errJobsRestartConflict) {
+				t.Fatalf("cancelled run adopted: %v", err)
+			}
+		})
+	}
+}
+
+func TestJobsRestartWorkerPreservesCheckpointAcrossUnstartedShutdown(t *testing.T) {
+	m, c, grant := jobsRestartFixture(t)
+	ctx := context.Background()
+	if err := m.prepareLLMRestart(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); err != nil {
+		t.Fatal(err)
+	}
+	run, ok, err := m.claimNextRun()
+	if err != nil || !ok || run.restart == nil {
+		t.Fatalf("claim lost checkpoint: ok=%v err=%v", ok, err)
+	}
+	m.requeueClaimedRunAfterShutdown(run.ID)
+	run, ok, err = m.claimNextRun()
+	if err != nil || !ok || run.restart == nil {
+		t.Fatalf("reclaim lost checkpoint: ok=%v err=%v", ok, err)
+	}
+	calls := 0
+	m.runners[jobsV2RunnerLLM] = jobsV2RunnerFunc(func(ctx context.Context, job jobsV2Job, _ progressWriter) (jobsV2RunResult, error) {
+		calls++
+		checkpoint, _ := ctx.Value(jobsRestartContextKey{}).(*jobsRestartCheckpoint)
+		if checkpoint == nil || checkpoint.RunID != c.RunID {
+			t.Fatal("worker lost authorized continuation")
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok || !deadline.Equal(c.Deadline) {
+			t.Fatal("worker reset original deadline")
+		}
+		var cfg jobsV2LLMConfig
+		if err := json.Unmarshal(job.RunnerConfig, &cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.SessionID != c.SessionID || cfg.MaxTurns != c.RemainingTurns || cfg.Instructions != "original" {
+			t.Fatalf("worker changed pinned execution: %+v", cfg)
+		}
+		return jobsV2RunResult{SessionID: cfg.SessionID, TurnCount: 1}, nil
+	})
+	// An edit to a recurring job is not permission to replace this run's task.
+	if _, err := m.db.Exec(`UPDATE jobs_v2 SET runner_config='{"agent_name":"other","instructions":"wrong task"}' WHERE id=?`, c.Job.ID); err != nil {
+		t.Fatal(err)
+	}
+	m.executeRun(run)
+	finished, err := m.GetRun(c.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || finished.Status != jobsV2RunSucceeded || finished.SessionID != c.SessionID || finished.Attempt != run.Attempt {
+		t.Fatalf("bad recovered run: calls=%d run=%+v", calls, finished)
+	}
+	var count int
+	if err := m.db.QueryRow(`SELECT COUNT(*) FROM job_restart_checkpoints WHERE run_id=?`, c.RunID).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("consumed checkpoint left reusable: count=%d err=%v", count, err)
+	}
+}
+
+func TestJobsRestartWorkerExpiredDeadlineDoesNotRun(t *testing.T) {
+	m, c, grant := jobsRestartFixture(t)
+	ctx := context.Background()
+	c.Deadline = time.Now().Add(-time.Second)
+	if err := m.prepareLLMRestart(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); err != nil {
+		t.Fatal(err)
+	}
+	run, ok, err := m.claimNextRun()
+	if err != nil || !ok {
+		t.Fatal(err)
+	}
+	m.runners[jobsV2RunnerLLM] = jobsV2RunnerFunc(func(context.Context, jobsV2Job, progressWriter) (jobsV2RunResult, error) {
+		t.Error("expired job called runner")
+		return jobsV2RunResult{}, nil
+	})
+	m.executeRun(run)
+	finished, err := m.GetRun(c.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finished.Status != jobsV2RunTimedOut {
+		t.Fatalf("expired continuation status=%s", finished.Status)
+	}
+}
+
+func TestJobsRestartWorkerCrashBeforeAdmissionRetainsAuthorization(t *testing.T) {
+	m, c, grant := jobsRestartFixture(t)
+	ctx := context.Background()
+	if err := m.prepareLLMRestart(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.sealLLMRestart(ctx, c.RunID, c.RestartID, grant.ID, jobsV2RunResult{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.activateLLMRestart(ctx, c.RunID, c.RestartID, grant); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := m.claimNextRun(); err != nil || !ok {
+		t.Fatal(err)
+	}
+	if err := m.recoverRuns(); err != nil {
+		t.Fatal(err)
+	}
+	run, ok, err := m.claimNextRun()
+	if err != nil || !ok || run.restart == nil {
+		t.Fatalf("unstarted recovery lost: ok=%v err=%v", ok, err)
+	}
+	if run.ID != c.RunID || run.restart.HandoffID != grant.ID {
+		t.Fatal("recovery changed run or authorization")
+	}
+}

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/providerhttp"
 	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
+	"github.com/samsaffron/term-llm/internal/restart"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -166,6 +167,7 @@ func jobsV2JobToRequest(req jobsV2Job) jobsV2JobRequest {
 }
 
 type jobsV2Run struct {
+	restart      *jobsRestartCheckpoint
 	ID           string          `json:"id"`
 	JobID        string          `json:"job_id"`
 	Attempt      int             `json:"attempt"`
@@ -201,17 +203,19 @@ type jobsV2RunEvent struct {
 }
 
 type jobsV2RunResult struct {
-	ExitCode     int
-	Stdout       string
-	Stderr       string
-	Thinking     string
-	Response     string
-	SessionID    string
-	TurnCount    int    // number of LLM turns taken
-	InputTokens  int    // total input tokens consumed
-	OutputTokens int    // total output tokens generated
-	ExitReason   string // see exit reason constants
-	Truncated    bool   // true when exit_reason is "max_turns_exceeded"
+	restartPass        *progressivePassResult
+	restartBudgetTurns *int
+	ExitCode           int
+	Stdout             string
+	Stderr             string
+	Thinking           string
+	Response           string
+	SessionID          string
+	TurnCount          int    // number of LLM turns taken
+	InputTokens        int    // total input tokens consumed
+	OutputTokens       int    // total output tokens generated
+	ExitReason         string // see exit reason constants
+	Truncated          bool   // true when exit_reason is "max_turns_exceeded"
 }
 
 // progressWriter receives real-time progress updates from a running job.
@@ -495,11 +499,15 @@ func classifyRunError(err error, result jobsV2RunResult) (exitReason string, tru
 }
 
 type jobsV2Manager struct {
-	db         *sql.DB
-	workers    int
-	workerID   string
-	runners    map[jobsV2RunnerType]jobsV2Runner
-	notifyDone jobsV2RunDoneNotifier
+	restartDriver   jobsRestartDriver
+	llmExecutions   sync.Map
+	restartGate     restart.Gate
+	restartPrograms bool // protected by mu; no new program starts after grace
+	db              *sql.DB
+	workers         int
+	workerID        string
+	runners         map[jobsV2RunnerType]jobsV2Runner
+	notifyDone      jobsV2RunDoneNotifier
 	// Idle timers are only fallbacks; job/run mutations wake the loops immediately.
 	schedulerIdleDelay time.Duration
 	workerIdleDelay    time.Duration
@@ -527,7 +535,7 @@ func newJobsV2Manager(dbPath string, workers int, llmExec serveJobsExecutor) (*j
 	return newJobsV2ManagerWithNotifier(dbPath, workers, llmExec, nil)
 }
 
-func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsExecutor, notifyDone jobsV2RunDoneNotifier) (*jobsV2Manager, error) {
+func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsExecutor, notifyDone jobsV2RunDoneNotifier, beforeRecover ...func(*jobsV2Manager) error) (*jobsV2Manager, error) {
 	if workers < 0 {
 		workers = 1
 	}
@@ -590,6 +598,13 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 		notifyCancel:  notifyCancel,
 	}
 
+	for _, setup := range beforeRecover {
+		if err := setup(mgr); err != nil {
+			notifyCancel()
+			db.Close()
+			return nil, err
+		}
+	}
 	if err := mgr.recoverRuns(); err != nil {
 		notifyCancel()
 		_ = db.Close()
@@ -612,6 +627,9 @@ func newJobsV2ManagerWithNotifier(dbPath string, workers int, llmExec serveJobsE
 }
 
 func (m *jobsV2Manager) recoverRuns() error {
+	if err := m.recoverUnstartedLLMClaims(context.Background()); err != nil {
+		return fmt.Errorf("recover unstarted LLM continuation: %w", err)
+	}
 	rows, err := m.db.Query(`SELECT id, job_id, attempt, trigger, scheduled_for, status, worker_id, session_id, started_at, finished_at, exit_code, error, stdout, stderr, thinking, response, exit_reason, truncated, turn_count, input_tokens, output_tokens, created_at, updated_at FROM job_runs_v2 WHERE status IN (?, ?) ORDER BY created_at ASC`, jobsV2RunClaimed, jobsV2RunRunning)
 	if err != nil {
 		return fmt.Errorf("load interrupted runs: %w", err)
@@ -825,12 +843,19 @@ func (m *jobsV2Manager) schedulerLoop() {
 			return
 		}
 
+		release, admitted := m.restartGate.Enter()
+		if !admitted {
+			resetTimer(timer, m.schedulerIdleDelay)
+			continue
+		}
 		now := time.Now().UTC()
 		if err := m.scheduleDueRuns(now); err != nil {
+			release()
 			resetTimer(timer, jobsV2SchedulerErrorDelay)
 			continue
 		}
 		if err := m.maybeRunCleanup(now); err != nil {
+			release()
 			resetTimer(timer, jobsV2SchedulerErrorDelay)
 			continue
 		}
@@ -838,6 +863,7 @@ func (m *jobsV2Manager) schedulerLoop() {
 		if err != nil {
 			delay = jobsV2SchedulerErrorDelay
 		}
+		release()
 		resetTimer(timer, delay)
 	}
 }
@@ -1042,8 +1068,16 @@ func (m *jobsV2Manager) workerLoop() {
 		default:
 		}
 
+		release, admitted := m.restartGate.Enter()
+		if !admitted {
+			if !m.waitForWorkerWake(m.workerIdleDelay) {
+				return
+			}
+			continue
+		}
 		run, ok, err := m.claimNextRun()
 		if err != nil {
+			release()
 			if !m.waitForWorkerWake(jobsV2WorkerErrorDelay) {
 				return
 			}
@@ -1051,12 +1085,14 @@ func (m *jobsV2Manager) workerLoop() {
 		}
 		if ok {
 			m.executeRun(run)
+			release()
 			continue
 		}
 		delay, err := m.nextWorkerDelayWithError(time.Now().UTC())
 		if err != nil {
 			delay = jobsV2WorkerErrorDelay
 		}
+		release()
 		if !m.waitForWorkerWake(delay) {
 			return
 		}
@@ -1272,6 +1308,10 @@ func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
 		return jobsV2Run{}, false, nil
 	}
 
+	run.restart, err = takeLLMRestart(context.Background(), tx, run.ID)
+	if err != nil {
+		return jobsV2Run{}, false, err
+	}
 	if err := tx.Commit(); err != nil {
 		return jobsV2Run{}, false, err
 	}
@@ -1282,7 +1322,13 @@ func (m *jobsV2Manager) claimNextRun() (jobsV2Run, bool, error) {
 }
 
 func (m *jobsV2Manager) requeueClaimedRunAfterShutdown(runID string) {
-	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ? AND worker_id = ?`, jobsV2RunQueued, runID, jobsV2RunClaimed, m.workerID)
+	tx, err := m.db.Begin()
+	if err != nil {
+		log.Printf("jobs v2: begin unstarted requeue: %v", err)
+		return
+	}
+	defer tx.Rollback()
+	res, err := tx.Exec(`UPDATE job_runs_v2 SET status = ?, worker_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ? AND worker_id = ?`, jobsV2RunQueued, runID, jobsV2RunClaimed, m.workerID)
 	if err != nil {
 		log.Printf("jobs v2: failed to requeue unstarted run %q during shutdown: %v", runID, err)
 		return
@@ -1295,12 +1341,26 @@ func (m *jobsV2Manager) requeueClaimedRunAfterShutdown(runID string) {
 	if affected == 0 {
 		return
 	}
+	if _, err = tx.Exec(`UPDATE job_restart_checkpoints SET phase='ready' WHERE run_id=? AND phase='claimed'`, runID); err != nil {
+		log.Printf("jobs v2: restore unstarted checkpoint: %v", err)
+		return
+	}
+	if err = tx.Commit(); err != nil {
+		log.Printf("jobs v2: commit unstarted requeue: %v", err)
+		return
+	}
 	if err := m.addRunEvent(runID, "requeued", "run returned to queue during worker shutdown", map[string]any{"worker_id": m.workerID}); err != nil {
 		log.Printf("jobs v2: failed to record shutdown requeue event for run %q: %v", runID, err)
 	}
 }
 
 func (m *jobsV2Manager) executeRun(run jobsV2Run) {
+	defer func() {
+		if err := m.recoverRolledBackLLMJobs(); err != nil {
+			log.Printf("jobs v2: failed restart recovery: %v", err)
+		}
+	}()
+
 	// Avoid turning a claim into a terminal failure when shutdown had already won
 	// before this worker began admission. Keep the check below as well: shutdown
 	// can still race with loading the job and preparing its context.
@@ -1310,6 +1370,10 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 	}
 
 	job, err := m.GetJob(run.JobID)
+	if run.restart != nil {
+		job = run.restart.Job
+		err = nil
+	}
 	if err != nil {
 		m.finishRunWithRetry(run.ID, jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("load job: %w", err), run.Attempt)
 		return
@@ -1321,13 +1385,46 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 		return
 	}
 
+	// Bind the persisted conversation to this run before any provider/tool work.
+	// A worker lost mid-run must not leave its transcript undiscoverable or
+	// recover by allocating a different session and replaying the original task.
+	if job.RunnerType == jobsV2RunnerLLM {
+		var cfg jobsV2LLMConfig
+		if err := json.Unmarshal(job.RunnerConfig, &cfg); err != nil {
+			m.finishRunWithRetry(run.ID, jobsV2RunFailed, jobsV2RunResult{}, err, run.Attempt)
+			return
+		}
+		if run.restart != nil {
+			cfg.SessionID = run.restart.SessionID
+			cfg.MaxTurns = run.restart.RemainingTurns
+		}
+		if cfg.sessionPersistenceEnabled() {
+			cfg.SessionID = cfg.effectiveSessionID()
+			run.SessionID = cfg.SessionID
+			raw, err := json.Marshal(cfg)
+			if err != nil {
+				m.finishRunWithRetry(run.ID, jobsV2RunFailed, jobsV2RunResult{}, err, run.Attempt)
+				return
+			}
+			// Per-execution copy only: recurring jobs need distinct sessions.
+			job.RunnerConfig = raw
+		}
+	}
+
 	timeout := time.Duration(job.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	deadline := time.Now().Add(timeout)
+	if run.restart != nil {
+		deadline = run.restart.Deadline
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	if run.restart != nil {
+		ctx = context.WithValue(ctx, jobsRestartContextKey{}, run.restart)
+	}
 	m.mu.Lock()
-	if m.closed {
+	if m.closed || (m.restartPrograms && job.RunnerType == jobsV2RunnerProgram) {
 		m.mu.Unlock()
 		cancel()
 		m.requeueClaimedRunAfterShutdown(run.ID)
@@ -1343,7 +1440,7 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 	}()
 
 	started := time.Now().UTC()
-	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = ?, started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunRunning, started, run.ID, jobsV2RunClaimed)
+	res, err := m.startJobRun(run, started)
 	if err != nil {
 		m.finishRunWithRetry(run.ID, jobsV2RunFailed, jobsV2RunResult{}, fmt.Errorf("mark run running: %w", err), run.Attempt)
 		return
@@ -1371,7 +1468,43 @@ func (m *jobsV2Manager) executeRun(run jobsV2Run) {
 			_ = m.addRunEvent(run.ID, eventType, message, data)
 		}
 	}
-	result, runErr := runner.Run(ctx, job, pw)
+	// Registration and the claimed->running database transition are separate.
+	// Recheck after that transition so grace expiry cannot miss a late start.
+	m.mu.Lock()
+	if m.restartPrograms && job.RunnerType == jobsV2RunnerProgram {
+		cancel()
+	}
+	m.mu.Unlock()
+	var source *jobsLLMExecution
+	if job.RunnerType == jobsV2RunnerLLM {
+		source = &jobsLLMExecution{manager: m, ctx: ctx, cancel: cancel, checkpoint: jobsRestartCheckpoint{RunID: run.ID, SessionID: run.SessionID, Job: job, Deadline: deadline}}
+		ctx = context.WithValue(ctx, jobsExecutionContextKey{}, source)
+		m.llmExecutions.Store(run.ID, source)
+		defer m.llmExecutions.CompareAndDelete(run.ID, source)
+	}
+	var result jobsV2RunResult
+	runErr := ctx.Err()
+	if run.restart != nil && run.restart.RemainingTurns <= 0 && run.restart.PassTurnLimit == 0 {
+		result.ExitReason = exitReasonMaxTurns
+		result.Truncated = true
+	} else if runErr == nil {
+		result, runErr = runner.Run(ctx, job, pw)
+	}
+	if source != nil {
+		parked, sealErr := source.seal(&result)
+		if parked {
+			return
+		} // Internal interruption is not job completion.
+		if sealErr != nil {
+			m.noteLLMRestartFailure(run.ID, sealErr)
+			log.Printf("jobs v2: restart checkpoint refused for %s: %v", run.ID, sealErr)
+		}
+	}
+	if run.restart != nil {
+		result.TurnCount += run.TurnCount
+		result.InputTokens += run.InputTokens
+		result.OutputTokens += run.OutputTokens
+	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		m.finishRunWithRetry(run.ID, jobsV2RunTimedOut, result, context.DeadlineExceeded, run.Attempt)
 		return
@@ -1444,7 +1577,7 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		errText = runErr.Error()
 	}
 	cancelledErrText := context.Canceled.Error()
-	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = CASE WHEN status = ? THEN ? ELSE ? END, finished_at = ?, exit_code = ?, error = CASE WHEN status = ? THEN ? ELSE ? END, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = ?, exit_reason = CASE WHEN status = ? THEN ? ELSE ? END, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?, ?)`,
+	res, err := m.db.Exec(`UPDATE job_runs_v2 SET status = CASE WHEN status = ? THEN ? ELSE ? END, finished_at = ?, exit_code = ?, error = CASE WHEN status = ? THEN ? ELSE ? END, stdout = ?, stderr = ?, thinking = ?, response = ?, session_id = COALESCE(NULLIF(?, ''), session_id), exit_reason = CASE WHEN status = ? THEN ? ELSE ? END, truncated = ?, turn_count = ?, input_tokens = ?, output_tokens = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN (?, ?, ?, ?)`,
 		jobsV2RunCancelRequested, jobsV2RunCancelled, status,
 		now, result.ExitCode,
 		jobsV2RunCancelRequested, cancelledErrText, errText,
@@ -1465,6 +1598,9 @@ func (m *jobsV2Manager) finishRun(runID string, status jobsV2RunStatus, result j
 		return err
 	}
 	status = run.Status
+	// Early failures may have no runner result, but the pre-execution session
+	// binding remains authoritative for events and completion notifications.
+	result.SessionID = run.SessionID
 	exitReason = run.ExitReason
 	truncated = run.Truncated
 	errText = run.Error
@@ -1522,8 +1658,10 @@ func (m *jobsV2Manager) enqueueRunDoneNotification(run jobsV2Run, status jobsV2R
 	if m == nil || m.notifyDone == nil || !jobsV2NotifyTerminalStatus(status) {
 		return
 	}
+	release := m.restartGate.TrackChild()
 	m.wg.Add(1)
 	go func() {
+		defer release()
 		defer m.wg.Done()
 		m.notifyRunDone(run, status, result, exitReason, truncated, errText)
 	}()
@@ -2917,8 +3055,15 @@ func (s *serveServer) handleRunV2ByID(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, run)
 }
 
-func newServeJobsV2Manager(cfg *config.Config, workers int, approval resolvedApprovalMode, notifyDone jobsV2RunDoneNotifier) (*jobsV2Manager, error) {
-	return newJobsV2ManagerWithNotifier("", workers, newServeJobsExecutor(cfg, approval), notifyDone)
+func newServeJobsV2Manager(cfg *config.Config, workers int, approval resolvedApprovalMode, notifyDone jobsV2RunDoneNotifier, setups ...jobsRestartSetup) (*jobsV2Manager, error) {
+	return newJobsV2ManagerWithNotifier("", workers, newServeJobsExecutor(cfg, approval), notifyDone, func(m *jobsV2Manager) error {
+		for _, setup := range setups {
+			if err := m.recoverLLMRestarts(context.Background(), setup, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func queryBool(r *http.Request, key string) bool {
@@ -3115,7 +3260,7 @@ func newServeJobsExecutor(baseCfg *config.Config, approval resolvedApprovalMode)
 
 		runner := newCmdRunner(baseCfg, serveJobsRunnerOptions(approval))
 
-		result, err := runner.Run(ctx, runpkg.Request{
+		request := runpkg.Request{
 			Platform:        runpkg.PlatformJob,
 			AgentName:       cfg.AgentName,
 			Prompt:          cfg.Instructions,
@@ -3134,7 +3279,51 @@ func newServeJobsExecutor(baseCfg *config.Config, approval resolvedApprovalMode)
 			SystemMessage:   cfg.SystemMessage,
 			Skills:          cfg.Skills,
 			Progressive:     progressive,
-		}, eventSinkFunc(onEvent))
+		}
+		if checkpoint, ok := ctx.Value(jobsRestartContextKey{}).(*jobsRestartCheckpoint); ok {
+			request.Resume = true
+			request.Prompt = ""
+			request.Messages = []llm.Message{{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: llm.SteeringInterruptionNotice + "\nThe process was replaced after its restart grace. Continue the unfinished task, checking interrupted effects before repeating them. This is internal recovery, not user Stop or new user input. Do not restart again."}}}}
+			for _, pending := range checkpoint.Pending {
+				request.Messages = append(request.Messages, pending.Message)
+			}
+		}
+		result, err := runner.Run(ctx, request, eventSinkFunc(onEvent))
 		return serveJobsExecResult{Progressive: progressiveFromRunResult(result.Progressive)}, err
 	}
 }
+
+// interruptProgramsForRestart uses the ordinary durable cancellation path. An
+// arbitrary program has no safe instruction pointer to resume: never replay it.
+// Runs not yet started remain queued. LLM runs require a separate session handoff.
+func (m *jobsV2Manager) interruptProgramsForRestart() error {
+	m.mu.Lock()
+	m.restartPrograms = true
+	m.mu.Unlock()
+	rows, err := m.db.Query(`SELECT r.id FROM job_runs_v2 r JOIN jobs_v2 j ON j.id=r.job_id WHERE j.runner_type=? AND r.status IN (?,?)`, jobsV2RunnerProgram, jobsV2RunRunning, jobsV2RunCancelRequested)
+	if err != nil {
+		return err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err = rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		ids = append(ids, id)
+	}
+	err = rows.Err()
+	rows.Close()
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if _, err = m.CancelRun(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *jobsV2Manager) reopenAfterRestart() { m.mu.Lock(); m.restartPrograms = false; m.mu.Unlock() }

--- a/cmd/serve_jobs_v2_migrations.go
+++ b/cmd/serve_jobs_v2_migrations.go
@@ -263,6 +263,13 @@ func readJobsV2Version(db jobsV2MarkerReader) (int, error) {
 }
 
 func initJobsV2Schema(ctx context.Context, db *sql.DB) error {
+	if err := initJobsV2BaseSchema(ctx, db); err != nil {
+		return err
+	}
+	return initJobsRestartJournal(ctx, db)
+}
+
+func initJobsV2BaseSchema(ctx context.Context, db *sql.DB) error {
 	version, err := readJobsV2Version(db)
 	if err == nil {
 		if version == jobsV2SchemaVersion {

--- a/cmd/serve_jobs_v2_test.go
+++ b/cmd/serve_jobs_v2_test.go
@@ -2419,3 +2419,200 @@ func TestJobsV2ListJobsIncludesLastRunSummary(t *testing.T) {
 		t.Fatalf("LastRun = %+v, want failed run_new with error", jobs[0].LastRun)
 	}
 }
+
+func TestJobsV2RestartCancelsProgramAndWaitsForActualReturn(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatalf("newJobsV2Manager failed: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	job, err := mgr.CreateJob(jobsV2Job{
+		Name:          "cancel-claimed-race",
+		Enabled:       true,
+		RunnerType:    jobsV2RunnerProgram,
+		RunnerConfig:  json.RawMessage(`{"command":"echo","args":["x"]}`),
+		TriggerType:   jobsV2TriggerManual,
+		TriggerConfig: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatalf("TriggerJob failed: %v", err)
+	}
+	if _, err := mgr.db.Exec(`UPDATE job_runs_v2 SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?`, jobsV2RunClaimed, run.ID, jobsV2RunQueued); err != nil {
+		t.Fatalf("mark run claimed: %v", err)
+	}
+
+	runnerStarted := make(chan struct{})
+	cancelObserved := make(chan struct{})
+	releaseRunner := make(chan struct{})
+	runnerDone := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseRunner:
+		default:
+			close(releaseRunner)
+		}
+	}()
+	mgr.runners[jobsV2RunnerProgram] = jobsV2RunnerFunc(func(ctx context.Context, job jobsV2Job, pw progressWriter) (jobsV2RunResult, error) {
+		close(runnerStarted)
+		<-ctx.Done()
+		close(cancelObserved)
+		<-releaseRunner
+		return jobsV2RunResult{}, ctx.Err()
+	})
+
+	release, ok := mgr.restartGate.Enter()
+	if !ok {
+		t.Fatal("gate unexpectedly paused")
+	}
+	go func() {
+		defer release()
+		mgr.executeRun(run)
+		close(runnerDone)
+	}()
+	select {
+	case <-runnerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not start")
+	}
+
+	reopen := mgr.restartGate.Pause()
+	defer reopen()
+	if err := mgr.interruptProgramsForRestart(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-cancelObserved:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not observe cancellation")
+	}
+
+	if mgr.restartGate.Drained() {
+		t.Fatal("cancelled caller was mistaken for settled runner")
+	}
+	close(releaseRunner)
+	select {
+	case <-runnerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not finish")
+	}
+	finished, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if finished.Status != jobsV2RunCancelled {
+		t.Fatalf("finished status = %s, want %s", finished.Status, jobsV2RunCancelled)
+	}
+}
+
+func TestJobsV2RestartKeepsUnstartedProgramQueuedAndReopens(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+	job, err := mgr.CreateJob(jobsV2Job{Name: "late-restart-claim", Enabled: true, RunnerType: jobsV2RunnerProgram, RunnerConfig: json.RawMessage(`{"command":"true"}`), TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := mgr.TriggerJob(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := func() {
+		t.Helper()
+		if _, err := mgr.db.Exec(`UPDATE job_runs_v2 SET status=?, worker_id=? WHERE id=?`, jobsV2RunClaimed, mgr.workerID, run.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	calls := 0
+	mgr.runners[jobsV2RunnerProgram] = jobsV2RunnerFunc(func(context.Context, jobsV2Job, progressWriter) (jobsV2RunResult, error) {
+		calls++
+		return jobsV2RunResult{}, nil
+	})
+	claim()
+	if err := mgr.interruptProgramsForRestart(); err != nil {
+		t.Fatal(err)
+	}
+	mgr.executeRun(run)
+	queued, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 || queued.Status != jobsV2RunQueued {
+		t.Fatalf("unstarted program executed or lost: calls=%d status=%s", calls, queued.Status)
+	}
+	mgr.reopenAfterRestart()
+	claim()
+	mgr.executeRun(run)
+	completed, err := mgr.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || completed.Status != jobsV2RunSucceeded {
+		t.Fatalf("failed restart left admission blocked: calls=%d status=%s", calls, completed.Status)
+	}
+}
+
+func TestJobsV2SessionBoundBeforeExecutionAndRetainedOnFailure(t *testing.T) {
+	mgr, err := newJobsV2Manager(":memory:", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+	raw, _ := json.Marshal(jobsV2LLMConfig{AgentName: "fixture", Instructions: "do not replay", Cwd: t.TempDir()})
+	job, err := mgr.CreateJob(jobsV2Job{Name: "durable-run-binding", Enabled: true, RunnerType: jobsV2RunnerLLM, RunnerConfig: raw, TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		run, err := mgr.TriggerJob(job.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := mgr.db.Exec(`UPDATE job_runs_v2 SET status=?,worker_id=? WHERE id=?`, jobsV2RunClaimed, mgr.workerID, run.ID); err != nil {
+			t.Fatal(err)
+		}
+		var bound string
+		mgr.runners[jobsV2RunnerLLM] = jobsV2RunnerFunc(func(_ context.Context, execution jobsV2Job, _ progressWriter) (jobsV2RunResult, error) {
+			var cfg jobsV2LLMConfig
+			if err := json.Unmarshal(execution.RunnerConfig, &cfg); err != nil {
+				t.Fatal(err)
+			}
+			live, err := mgr.GetRun(run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.SessionID == "" || cfg.SessionID != live.SessionID || live.Status != jobsV2RunRunning {
+				t.Fatalf("missing atomic pre-execution binding: cfg=%q run=%q status=%s", cfg.SessionID, live.SessionID, live.Status)
+			}
+			bound = cfg.SessionID
+			return jobsV2RunResult{}, errors.New("fixture failure before producing result")
+		})
+		mgr.executeRun(run)
+		finished, err := mgr.GetRun(run.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bound == "" || finished.SessionID != bound || seen[bound] {
+			t.Fatalf("binding lost/reused: %q -> %q", bound, finished.SessionID)
+		}
+		seen[bound] = true
+	}
+	stored, err := mgr.GetJob(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg jobsV2LLMConfig
+	if err := json.Unmarshal(stored.RunnerConfig, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SessionID != "" {
+		t.Fatal("per-run session leaked into recurring job configuration")
+	}
+}

--- a/cmd/serve_mcp.go
+++ b/cmd/serve_mcp.go
@@ -139,6 +139,8 @@ func resolveServeMCPApprovalMode(cmd *cobra.Command, cfg *config.Config) (resolv
 }
 
 func runServeMCP(cmd *cobra.Command, args []string) error {
+	defer installWebExecSignal(cmd.Context(), &webExecCoordinator{ctx: cmd.Context(), unsupported: "SIGUSR2 requires standalone serve web"})()
+
 	if serveMCPTools == "" {
 		return fmt.Errorf("--tools is required\n\nExamples:\n  term-llm serve mcp --tools all\n  term-llm serve mcp --tools read_file,grep,glob,shell")
 	}

--- a/cmd/serve_mcp.go
+++ b/cmd/serve_mcp.go
@@ -13,6 +13,8 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcphttp"
+	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/samsaffron/term-llm/internal/restart"
 	"github.com/samsaffron/term-llm/internal/search"
 	"github.com/samsaffron/term-llm/internal/signal"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -139,7 +141,13 @@ func resolveServeMCPApprovalMode(cmd *cobra.Command, cfg *config.Config) (resolv
 }
 
 func runServeMCP(cmd *cobra.Command, args []string) error {
-	defer installWebExecSignal(cmd.Context(), &webExecCoordinator{ctx: cmd.Context(), unsupported: "SIGUSR2 requires standalone serve web"})()
+	ctx, stop := signal.NotifyContextWithParent(cmd.Context())
+	defer stop()
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	owner := &processExecOwner{ctx: ctx, mode: "serve mcp", executable: executable, grace: 10 * time.Second, cancels: make(map[uint64]context.CancelFunc), exec: execWebProcess}
 
 	if serveMCPTools == "" {
 		return fmt.Errorf("--tools is required\n\nExamples:\n  term-llm serve mcp --tools all\n  term-llm serve mcp --tools read_file,grep,glob,shell")
@@ -270,6 +278,12 @@ func runServeMCP(cmd *cobra.Command, args []string) error {
 
 	// Build executor that routes to the right tool.
 	executor := func(ctx context.Context, name string, args json.RawMessage) (mcphttp.ToolResult, error) {
+		workCtx, release, err := owner.child(ctx)
+		if err != nil {
+			return mcphttp.ToolResult{}, err
+		}
+		defer release()
+		ctx = workCtx
 		// Check web tools first.
 		if name == mcpWebSearchToolName && webSearchTool != nil {
 			out, err := webSearchTool.Execute(ctx, args)
@@ -301,6 +315,9 @@ func runServeMCP(cmd *cobra.Command, args []string) error {
 	// Resolve auth token.
 	token := strings.TrimSpace(serveMCPToken)
 	if token == "" {
+		token = mcpReloadToken
+	}
+	if token == "" {
 		generated, err := generateServeToken()
 		if err != nil {
 			return fmt.Errorf("generate auth token: %w", err)
@@ -311,14 +328,19 @@ func runServeMCP(cmd *cobra.Command, args []string) error {
 	// Start MCP server.
 	server := mcphttp.NewServer(executor)
 	server.SetDebug(serveMCPDebug)
-
-	ctx, stop := signal.NotifyContext()
-	defer stop()
+	server.SetMiddleware(owner.handler)
 
 	url, actualToken, err := server.StartOnAddress(serveMCPHost, serveMCPPort, token, mcpTools)
 	if err != nil {
 		return fmt.Errorf("start MCP server: %w", err)
 	}
+
+	owner.exec = func(path string, args, env []string) error {
+		return execWebProcess(path, args, append(env, "TERM_LLM_MCP_RELOAD_TOKEN="+token))
+	}
+	unbind := restart.Default.Bind(owner.request)
+	defer unbind()
+	process.State("serve mcp", "ready", "")
 
 	// Print server info.
 	toolNames := make([]string, len(mcpTools))

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -122,6 +122,7 @@ type responseRunResolvedInteraction struct {
 }
 
 type responseRun struct {
+	webExec                 *webExecCoordinator
 	settled                 chan struct{}
 	rushStateful            bool
 	rushRequest             llm.Request
@@ -196,6 +197,8 @@ type responseRun struct {
 }
 
 type startResponseRunOptions struct {
+	execRestartID              string
+	execServiceID              string
 	onInitialInput             func()
 	rush                       *session.RushOperation
 	previousResponseID         string
@@ -3111,6 +3114,9 @@ func (s *serveServer) persistResponseRunErrorEvent(ctx context.Context, runtime 
 }
 
 func (s *serveServer) appendResponseRunEvent(runtime *serveRuntime, run *responseRun, state *responseRunStreamState, ev llm.Event) error {
+	if s.webExec != nil {
+		s.webExec.observeTool(runtime, ev)
+	}
 	switch ev.Type {
 	case llm.EventTextDelta:
 		segmentOrdinal := state.assistantSegmentOrdinal
@@ -3604,6 +3610,13 @@ func (s *serveServer) handleResponseByID(w http.ResponseWriter, r *http.Request)
 
 	runID := parts[0]
 	run, ok := mgr.get(runID)
+	if !ok && s.webExec != nil && s.webExec.store != nil && r.Method == http.MethodPost && len(parts) == 2 && parts[1] == "cancel" {
+		// A browser Stop sent with the pre-exec response ID must stop that exact
+		// continuation, never whatever unrelated user turn happens to be newest.
+		if replacement, err := s.webExec.store.ExecContinuation(r.Context(), runID, s.webExec.service); err == nil {
+			run, ok = mgr.get(replacement)
+		}
+	}
 	if !ok {
 		writeOpenAIError(w, http.StatusNotFound, "invalid_request_error", "response not found")
 		return
@@ -3913,6 +3926,14 @@ func (s *serveServer) responseRunContinuationID(ctx context.Context, runtime *se
 }
 
 func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, replaceHistory bool, inputMessages []llm.Message, llmReq llm.Request, sessionID string, options startResponseRunOptions) (*responseRun, error) {
+	if s.webExec != nil {
+		s.webExec.mu.Lock()
+		defer s.webExec.mu.Unlock()
+		if s.webExec.draining {
+			return nil, fmt.Errorf("%w: web reload draining", errServeSessionBusy)
+		}
+	}
+
 	mgr := s.ensureResponseRuns()
 
 	if t := mgr.steeringTransition(sessionID); t != nil && (options.rush == nil || options.rush.RequestID != t.owner.OperationID) {
@@ -4012,6 +4033,7 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		ownerID := s.responseOwnerID()
 		admitCtx, admitCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		lease, admitErr := lifecycle.AdmitResponseRun(admitCtx, session.ResponseRunAdmission{
+			ExecRestartID: options.execRestartID, ExecServiceID: options.execServiceID,
 			ResponseID:      respID,
 			SessionID:       sessionID,
 			RunEpoch:        run.runEpoch,
@@ -4115,8 +4137,14 @@ func (s *serveServer) startResponseRun(runtime *serveRuntime, stateful bool, rep
 		return nil, err
 	}
 
+	if s.webExec != nil {
+		s.webExec.register(run, runCtx, runtime, &llmReq, stateful, options)
+	}
 	if err := mgr.start(func() {
 		defer close(run.settled)
+		if s.webExec != nil {
+			defer s.webExec.settled(run.id)
+		}
 		defer cancel()
 		if options.onDone != nil {
 			defer options.onDone()

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -2290,6 +2290,20 @@ func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHisto
 		if len(msgs) > 0 && msgs[0].Role == llm.RoleAssistant {
 			rt.refreshResponseDeadline()
 		}
+		if run := responseRunFromContext(cbCtx); run != nil && run.webExec != nil {
+			// Synchronous with the engine boundary: a buffered SSE event is
+			// not an acknowledgement that an unsafe tool has been observed.
+			for _, msg := range msgs {
+				for _, part := range msg.Parts {
+					if part.ToolActivity != nil {
+						run.webExec.reject("provider-managed native activity is unsupported")
+					}
+					if part.ToolCall != nil {
+						run.webExec.observeTool(rt, llm.Event{Type: llm.EventToolExecStart, ToolName: part.ToolCall.Name})
+					}
+				}
+			}
+		}
 		for i := range msgs {
 			msgs[i] = tagResponseRunMessage(cbCtx, msgs[i], callbackTurnIndex)
 		}
@@ -2375,6 +2389,17 @@ func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHisto
 		persistProducedSnapshot(deferCtx)
 	}()
 
+	if boundary := req.ModelBoundary; boundary != nil {
+		req.ModelBoundary = func(boundaryCtx context.Context) error {
+			producedMu.Lock()
+			durable := persisted && initialPersisted && !assistantSnapshotDirty && !assistantSnapshotNeedsReconcile && lastAppendedIdx == len(produced)
+			producedMu.Unlock()
+			if !durable {
+				return fmt.Errorf("web restart boundary has unpersisted transcript data")
+			}
+			return boundary(boundaryCtx)
+		}
+	}
 	stream, err := rt.engine.Stream(runCtx, req)
 	if err != nil {
 		runErr = err

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -24,71 +24,72 @@ import (
 )
 
 type serveRuntime struct {
-	mu                     sync.Mutex
-	goalMu                 sync.Mutex
-	interruptMu            sync.Mutex
-	steeringMutationMu     sync.Mutex
-	responseMu             sync.Mutex // guards lastResponseID and responseIDs
-	askUserMu              sync.Mutex
-	approvalMu             sync.Mutex
-	approvalModeMu         sync.Mutex
-	mcpManagerMu           sync.RWMutex
-	uiStateMu              sync.Mutex
-	compactionIdentityMu   sync.Mutex
-	provider               llm.Provider
-	providerKey            string
-	engine                 *llm.Engine
-	toolMgr                *tools.ToolManager
-	mcpManager             *mcp.Manager
-	toolDiscovery          config.ToolDiscoveryConfig
-	store                  session.Store
-	goalStore              session.Store
-	syntheticUserCB        func(context.Context, llm.Message) error
-	baseSystemPrompt       string // agent-resolved prompt before workspace skill metadata
-	systemPrompt           string
-	history                []llm.Message
-	historyPersisted       bool // history matches the persisted active transcript and can safely append next turn
-	search                 bool
-	toolsSetting           string
-	mcpSetting             string
-	agentName              string
-	sessionMeta            *session.Session
-	forceExternalSearch    bool
-	maxTurns               int
-	toolMap                map[string]string
-	debug                  bool
-	debugRaw               bool
-	autoCompact            bool
-	borrowedEngine         bool
-	skipProviderCleanup    bool
-	defaultModel           string
-	approvalDefault        tools.ApprovalMode
-	yoloMode               bool
-	compacting             atomic.Bool
-	lastUsedUnixNano       atomic.Int64
-	activeInterrupt        *runtimeInterruptState
-	steeringCalls          map[string]*runtimeSteeringCall
-	lastResponseID         string
-	responseIDs            []string
-	cumulativeUsage        llm.Usage
-	pendingAskUsers        map[string]*servePendingAskUser
-	askUserFunc            func(context.Context, []tools.AskUserQuestion) ([]tools.AskUserAnswer, error)
-	assistantSnapshotCB    llm.AssistantSnapshotCallback
-	responseCompletedCB    llm.ResponseCompletedCallback
-	turnCompletedCB        llm.TurnCompletedCallback
-	compactionCB           llm.CompactionCallback
-	pendingCompactions     []runtimeCompactionIdentity
-	pendingApprovals       map[string]*servePendingApproval
-	approvalEventFunc      func(event string, data map[string]any) error
-	approvalCtx            context.Context
-	pauseResponseTimeout   func() func()
-	refreshResponseTimeout func()
-	lastUIRunError         string
-	platform               string
-	platformMessages       agents.PlatformMessagesConfig
-	lastInjectedPlatform   string
-	sideQuestion           sideQuestionRuntime
-	sideProviderFactory    func(providerKey, model string) (llm.Provider, error)
+	mu                       sync.Mutex
+	goalMu                   sync.Mutex
+	interruptMu              sync.Mutex
+	steeringMutationMu       sync.Mutex
+	responseMu               sync.Mutex // guards lastResponseID and responseIDs
+	askUserMu                sync.Mutex
+	approvalMu               sync.Mutex
+	approvalModeMu           sync.Mutex
+	mcpManagerMu             sync.RWMutex
+	uiStateMu                sync.Mutex
+	compactionIdentityMu     sync.Mutex
+	provider                 llm.Provider
+	providerKey              string
+	engine                   *llm.Engine
+	toolMgr                  *tools.ToolManager
+	mcpManager               *mcp.Manager
+	toolDiscovery            config.ToolDiscoveryConfig
+	store                    session.Store
+	goalStore                session.Store
+	syntheticUserCB          func(context.Context, llm.Message) error
+	baseSystemPrompt         string // agent-resolved prompt before workspace skill metadata
+	systemPrompt             string
+	history                  []llm.Message
+	historyPersisted         bool // history matches the persisted active transcript and can safely append next turn
+	search                   bool
+	toolsSetting             string
+	mcpSetting               string
+	agentName                string
+	sessionMeta              *session.Session
+	forceExternalSearch      bool
+	maxTurns                 int
+	toolMap                  map[string]string
+	debug                    bool
+	debugRaw                 bool
+	autoCompact              bool
+	borrowedEngine           bool
+	persistenceOwnedByCaller bool // platform runner owns its transcript callbacks and restart fence
+	skipProviderCleanup      bool
+	defaultModel             string
+	approvalDefault          tools.ApprovalMode
+	yoloMode                 bool
+	compacting               atomic.Bool
+	lastUsedUnixNano         atomic.Int64
+	activeInterrupt          *runtimeInterruptState
+	steeringCalls            map[string]*runtimeSteeringCall
+	lastResponseID           string
+	responseIDs              []string
+	cumulativeUsage          llm.Usage
+	pendingAskUsers          map[string]*servePendingAskUser
+	askUserFunc              func(context.Context, []tools.AskUserQuestion) ([]tools.AskUserAnswer, error)
+	assistantSnapshotCB      llm.AssistantSnapshotCallback
+	responseCompletedCB      llm.ResponseCompletedCallback
+	turnCompletedCB          llm.TurnCompletedCallback
+	compactionCB             llm.CompactionCallback
+	pendingCompactions       []runtimeCompactionIdentity
+	pendingApprovals         map[string]*servePendingApproval
+	approvalEventFunc        func(event string, data map[string]any) error
+	approvalCtx              context.Context
+	pauseResponseTimeout     func() func()
+	refreshResponseTimeout   func()
+	lastUIRunError           string
+	platform                 string
+	platformMessages         agents.PlatformMessagesConfig
+	lastInjectedPlatform     string
+	sideQuestion             sideQuestionRuntime
+	sideProviderFactory      func(providerKey, model string) (llm.Provider, error)
 }
 
 type runtimeCompactionIdentity struct {
@@ -2394,7 +2395,7 @@ func (rt *serveRuntime) runOnce(ctx context.Context, stateful bool, replaceHisto
 			producedMu.Lock()
 			durable := persisted && initialPersisted && !assistantSnapshotDirty && !assistantSnapshotNeedsReconcile && lastAppendedIdx == len(produced)
 			producedMu.Unlock()
-			if !durable {
+			if !rt.persistenceOwnedByCaller && !durable {
 				return fmt.Errorf("web restart boundary has unpersisted transcript data")
 			}
 			return boundary(boundaryCtx)

--- a/cmd/serve_ui_stream.go
+++ b/cmd/serve_ui_stream.go
@@ -49,6 +49,7 @@ func (s *serveServer) streamResponseRun(ctx context.Context, w http.ResponseWrit
 		writeOpenAIError(w, status, errType, err.Error())
 		return false
 	}
+	releaseWebExecTicket(ctx)
 	w.Header().Set("x-response-id", run.id)
 	s.streamResponseRunEvents(ctx, w, run, 0)
 	return true

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,0 +1,196 @@
+# Process signals
+
+This matrix describes application handlers, not a promise that every operating
+system exposes every signal. An unhandled signal follows Go/OS defaults and any
+inherited disposition; it is not a supported control command.
+
+## Handler matrix
+
+| Mode | SIGINT / SIGTERM | SIGHUP | SIGUSR1 | SIGUSR2 |
+| --- | --- | --- | --- | --- |
+| Standalone `serve web` | Cancels the serve context and enters shutdown | No reload handler | Stops widget subprocesses when widgets are enabled; their manager remains available | Cooperative self-exec, subject to the restrictions below |
+| Web combined with API, jobs or Telegram | Same shared serve shutdown | No reload handler | Same widget handling when enabled | Logged rejection; no restart |
+| `serve api`, `serve jobs`, `serve telegram` without web | Same shared serve shutdown | No reload handler | No application handler | Logged rejection; no restart |
+| `serve mcp` | Cancels the MCP context and enters shutdown | No reload handler | No application handler | Logged rejection; no restart |
+| `serve hub` | No application shutdown signal handler; Go/OS default disposition | No reload handler | No application handler | Logged rejection; no restart |
+
+USR1/USR2 handling is compiled for AIX, Darwin, DragonFly BSD, FreeBSD, illumos,
+Linux, NetBSD, OpenBSD and Solaris. Other platforms compile no-op installers.
+The same-PID browser integration has been exercised on Linux. Windows does not
+provide these Unix controls. Chat/TUI, ask and exec modes do not acquire the web
+restart handler.
+
+SIGINT/SIGTERM handling is unchanged: the shared serve context registers
+`os.Interrupt` and `syscall.SIGTERM`. HTTP shutdown uses a ten-second context;
+MCP shutdown uses five seconds. Shutdown is **not** a promise that every external
+side effect has completed. Shell SIGHUP/SIGTERM calls target child shell sessions
+or process groups, not server configuration reloads. SIGWINCH/SIGCONT terminal
+handlers do not implement restarts.
+
+## Supported first slice
+
+SIGUSR2 is deliberately narrower than all the activities a web server can own:
+
+- Standalone, direct-HTTP `serve web`, with writable SQLite sessions and atomic
+  response/transcript fencing. No `--no-session`, mixed platforms, Hub routing,
+  WebRTC, widgets, or independently owned automatic title providers.
+- Set `serve.auto_title: false` in the service's configuration and start with
+  `--disable-widgets`. Those defaults are **not** silently changed by the signal.
+- Stateful, streaming Responses runs with an explicit turn budget (the web
+  request handler supplies one). Native inline-loop providers, MCP runtimes,
+  model swaps, steering rushes and skill-run setup are rejected.
+- Completed calls to the concrete built-in `read_file`, `write_file`, `edit_file`,
+  `glob`, `grep` and `update_plan` tools can precede a restart boundary. Merely
+  naming a custom tool `write_file` does not make it safe.
+- Shells, custom/child tools, native provider activities, side questions,
+  independently owned mutation APIs, and cancelled/failed invocations make the
+  current boot ineligible. A shell returning is not proof that it left no
+  descendants. Rejection does not kill it or disable ordinary chat operation.
+
+The unsupported-activity record is intentionally conservative and persists for
+that boot. Returning from a tool or closing its UI is not used to infer external
+quiescence. Enabling more modes/tools requires an ownership and drain protocol,
+not just another name in an allow-list. Opening read-only views or acknowledging
+attention does not invalidate eligibility; unauthorized requests cannot do so.
+
+## Deployment limitation: Hub, WebRTC and widgets
+
+**This slice does not self-reload a deployed web using Hub reverse routing,
+WebRTC and widgets.** Such a process logs a rejection and keeps running. The
+local browser evidence below is not evidence for that deployment.
+
+Inspection found that `runHubReverseConnector` has no owned stop/join handle:
+its socket read is not directly interrupted by context cancellation, and its
+per-request goroutines are cancelled but not joined. WebRTC `peer.Close` only
+cancels its context; it does not acknowledge completion of transport handlers.
+Widget `CloseContext` is a one-way, best-effort shutdown that may return on its
+deadline and escalates subprocess termination; it is not a reversible drain.
+Simply invoking these shutdown methods before exec would not establish safe
+quiescence or restore the old service after exec failure.
+
+Supporting the deployed combination needs joinable transport owners, mutation
+admission across transport teardown, restartable widget ownership (with an
+explicit policy for external effects), and failed-exec rollback. Browser HTTPS
+fallback/reconnection must be exercised through a sandbox Hub and WebRTC relay,
+including ambiguous mutation delivery: automatic transport fallback is not a
+proof of exactly-once request admission. These changes and their combined
+browser proof are intentionally not claimed by this PR.
+
+## Lifecycle
+
+1. **Coalesce and gate.** Signals received by the installed handler before web
+   startup/recovery is ready are rejected, not queued. A signal then starts one
+   drain generation. Duplicate signals
+   during it do not queue another restart. New mutations receive HTTP 503 with
+   `Retry-After`; existing handlers are accounted for. Response streams transfer
+   ownership to their tracked engine. Read-only event streams remain connected
+   until exec. Stop remains available and preempts draining.
+2. **Reach a model boundary.** An engine finishes its current provider/tool turn
+   and persists the results before parking, without cancelling its tools. It can
+   also park before its first provider request once the real input is durable.
+   Initial/turn persistence failures cannot acknowledge a safe boundary. A
+   naturally completed answer is not automatically continued.
+3. **Abort rather than force.** The drain waits up to 20 seconds. Stuck tools,
+   approvals and providers are not killed to meet that deadline. Timeout releases
+   parked invocations and reopens admission. SIGINT/SIGTERM preempts the drain and
+   follows the existing shutdown path instead of restarting.
+4. **Prepare a durable batch.** Once every tracked engine is parked or settled
+   and other handlers are idle, a bounded five-second checkpoint phase verifies
+   the source leases, transcript revisions and absence of pending steering. All
+   selected sessions share a random restart UUID. Preparation itself neither
+   fences nor cancels the source engines.
+5. **Self-exec.** The process executes the executable pathname captured at serve
+   startup, using the original argv. It does not run a build, deploy, supervisor,
+   shell, or second server process. Successful exec retains the PID and replaces
+   memory. The installed pathname must remain present and executable; updating
+   the captured file atomically is supported. Repointing a different symlink is
+   not an executable-selection mechanism. No sockets are inherited.
+6. **Acquire and consume.** The replacement captures and unsets
+   `TERM_LLM_RESTART_ID` and `TERM_LLM_RESTART_SERVICE_ID` before commands or tools
+   run. It binds the same listener **before** consuming any intent. A stable
+   service UUID is bound to the serving argv and startup directory, and each
+   boot has a fresh UUID owner. PID reuse is not ownership. SQLite checks the
+   service, distinct boot, live source lease, transcript revision and latest
+   response fence. Consuming each intent, fencing its source and admitting the
+   replacement response happen in one writer transaction.
+7. **Continue the same chat.** Recovery injects an internal **developer** message,
+   not a fabricated user bubble. The replacement loads the persisted transcript
+   and re-resolves the original selected tools from its own registry, retaining
+   the remaining explicit turn budget. Completed actions are not dispatched
+   again. The model can call tools for the unfinished task. This is a new model
+   invocation, not restoration of a Go stack or replay of unknown pending calls.
+   The browser's existing reconnect/session reconciliation finds the replacement
+   run and preserves local drafts. Stop addressed to a source response follows
+   only its explicit restart-continuation chain, never an unrelated newer turn.
+
+Handoff IDs are lookup hints, not authentication. They are neither HTTP inputs
+nor a general crash-recovery queue. Without the startup hint, no intent is
+implicitly resumed. Consumed, expired, cancelled, advanced or differently owned
+intents cannot be admitted again. Lookup expires after five minutes; the live
+source lease normally imposes a tighter startup window. If a session cannot be
+safely admitted after exec, it remains available for inspection/manual
+continuation; failure does not terminate other already-admitted recoveries.
+
+## Failure behavior
+
+If executable selection, checkpointing or `exec` fails, the current process
+remains alive. A failed exec discards its unconsumed intents and releases the
+original, still tool-capable invocations. If discarding the intent also fails,
+the service enters a safe paused state: mutation admission stays closed and
+parked work is **not** silently released. Reads and Stop remain available; an
+operator must address persistence health or perform an ordinary shutdown.
+
+Scrubbed Hub credentials needed by a replacement are restored only in the
+private environment passed to self-exec, using the existing reload helpers.
+Restart hints and those credentials are never deliberately installed in the
+ambient environment inherited by tool children. Do not export restart hints,
+copy them between services, or use them as a manual resume API.
+
+A successful OS exec cannot roll back a replacement that subsequently fails to
+start (for example, invalid new configuration). Install a compatible binary and
+check health; a failed startup does not authorize replaying an old intent.
+
+## Example
+
+For a **test or explicitly authorized service**, configure:
+
+```yaml
+serve:
+  auto_title: false
+```
+
+Start a supported web instance, for example:
+
+```sh
+term-llm serve web --disable-widgets --tools read_file,write_file,edit_file,grep,glob
+```
+
+After atomically installing an updated executable at the captured pathname,
+send SIGUSR2 to the **verified PID of that service**:
+
+```sh
+kill -USR2 "$verified_web_service_pid"
+```
+
+Do not use a broad `pkill` pattern. A logged rejection or timeout is not a
+successful reload. Check health/version and the continued session; do not resend
+user input to simulate recovery. This feature grants no permission to restart
+production or to deploy a binary.
+
+## Verification
+
+Focused regression checks:
+
+```sh
+go test -race ./internal/llm ./internal/session ./cmd \
+  -run 'Test(ModelBoundary|ExecHandoff|WebExec)' -count=1
+```
+
+The isolated Linux browser fixture uses a local scripted OpenAI-compatible
+endpoint and real built-in file tools: atomic A→B install, SIGUSR2, unchanged
+PID, distinct durable boot owners, one pre-restart tool result, working
+post-restart tools, same-chat recovery, unsent draft preservation and the next
+user turn. It also exercises simultaneous sessions, a quiet reload with no
+replayed continuation, and a real shell child verifying that restart hints were
+scrubbed. Private fixture homes, transcripts, logs and screenshots are not
+repository assets and must not be published.

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,8 +1,14 @@
 # Process signals
 
 This matrix describes application handlers, not a promise that every operating
-system exposes every signal. An unhandled signal follows Go/OS defaults and any
-inherited disposition; it is not a supported control command.
+system exposes every signal. **Universal safe restart is work in progress, not
+implemented by the current PR.** Unix executables now register one process-wide
+SIGUSR2 listener at command entry, before argument parsing or configuration.
+Without an installed mode owner, signals are coalesced into a logged `deferred`
+status and the original invocation continues; normal command completion logs
+`finished`. No arguments, stdin, mutations, or tool calls are replayed. These
+logs are not the planned authoritative generation registry or a readiness API.
+Other unhandled signals retain Go/OS defaults and inherited dispositions.
 
 ## Handler matrix
 
@@ -13,12 +19,19 @@ inherited disposition; it is not a supported control command.
 | `serve api`, `serve jobs`, `serve telegram` without web | Same shared serve shutdown | No reload handler | No application handler | Logged rejection; no restart |
 | `serve mcp` | Cancels the MCP context and enters shutdown | No reload handler | No application handler | Logged rejection; no restart |
 | `serve hub` | No application shutdown signal handler; Go/OS default disposition | No reload handler | No application handler | Logged rejection; no restart |
+| Chat/TUI, ask, exec, loop, edit, image/music/embed, benchmark | Existing per-command cancellation/terminal handling, unchanged | Unchanged | Unchanged | Nonfatal deferred; no resume implementation yet |
+| Stdio `mcp-server`, MCP clients, maintenance/CRUD, completion, external editors and subprocess wrappers | Existing per-command handling, unchanged | Unchanged | Unchanged | Nonfatal deferred; finishes original invocation without replay |
+
+Deferred semantics are a safety floor, **not** completed long-lived-mode restart
+support. Jobs, Telegram, Hub, TUI, proxy/MCP and combined serve still require
+mode-specific checkpoint/admission/ownership integration. Even a successful
+command completion is not evidence that detached descendants have finished.
 
 USR1/USR2 handling is compiled for AIX, Darwin, DragonFly BSD, FreeBSD, illumos,
 Linux, NetBSD, OpenBSD and Solaris. Other platforms compile no-op installers.
 The same-PID browser integration has been exercised on Linux. Windows does not
-provide these Unix controls. Chat/TUI, ask and exec modes do not acquire the web
-restart handler.
+provide these Unix controls. Chat/TUI, ask and exec have the process-wide
+nonfatal listener but do not yet have resumable lifecycle owners.
 
 SIGINT/SIGTERM handling is unchanged: the shared serve context registers
 `os.Interrupt` and `syscall.SIGTERM`. HTTP shutdown uses a ten-second context;
@@ -59,10 +72,16 @@ attention does not invalidate eligibility; unauthorized requests cannot do so.
 WebRTC and widgets.** Such a process logs a rejection and keeps running. The
 local browser evidence below is not evidence for that deployment.
 
-Inspection found that `runHubReverseConnector` has no owned stop/join handle:
-its socket read is not directly interrupted by context cancellation, and its
-per-request goroutines are cancelled but not joined. WebRTC `peer.Close` only
-cancels its context; it does not acknowledge completion of transport handlers.
+The reverse connector now has a joinable `Stop(ctx)` owner. Cancellation closes
+its socket to wake reads/writes; completion joins the reconnect loop, ping loop
+and forwarded requests. A deadline reports a failed join and never authorizes
+exec. Tests include a transport that observes cancellation but cannot yet return;
+Stop must not claim completion. This joins the forwarding client, **not** the
+server-side mutation: an HTTP client returning does not prove its backend handler
+finished. Existing reconnect tests now join their connectors before cleanup.
+
+WebRTC `peer.Close` still only cancels its context; it does not acknowledge
+completion of transport handlers.
 Widget `CloseContext` is a one-way, best-effort shutdown that may return on its
 deadline and escalates subprocess termination; it is not a reversible drain.
 Simply invoking these shutdown methods before exec would not establish safe
@@ -74,7 +93,7 @@ explicit policy for external effects), and failed-exec rollback. Browser HTTPS
 fallback/reconnection must be exercised through a sandbox Hub and WebRTC relay,
 including ambiguous mutation delivery: automatic transport fallback is not a
 proof of exactly-once request admission. These changes and their combined
-browser proof are intentionally not claimed by this PR.
+browser proof remain required before this PR can claim universal restart.
 
 ## Lifecycle
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -213,3 +213,43 @@ user turn. It also exercises simultaneous sessions, a quiet reload with no
 replayed continuation, and a real shell child verifying that restart hints were
 scrubbed. Private fixture homes, transcripts, logs and screenshots are not
 repository assets and must not be published.
+
+## Local process discovery and restart commands (Linux)
+
+```sh
+term-llm process list
+term-llm process list --json
+term-llm process restart 123 --timeout 2m
+term-llm process restart-all --timeout 2m
+```
+
+Discovery is opt-in through running binaries that publish process records. Older
+binaries are not found by scanning arbitrary command lines and are never signalled
+by these commands. Records are owner-private under
+`$XDG_RUNTIME_DIR/term-llm-processes`, falling back to the user's cache directory.
+They contain PID, OS process-start identity, random executable-instance UUID,
+build identity, mode and last reported lifecycle phase, not arguments or tokens.
+
+Publication runs in a goroutine after a 25 ms grace period rather than blocking
+command startup on filesystem I/O. Commands that exit during that period cancel
+publication without opening procfs or the registry. Discovery is therefore eventually
+consistent: a just-started process can be absent briefly. Status is advisory, not a live health probe. Discovery validates
+process ownership, kernel boot/start identity and non-zombie state, and removes
+stale records under the same lock used by publishers. Normal exit asks the single
+publisher to stop and remove its own instance's record; cleanup cannot race a late
+writer into recreating that record after cleanup. Advisory publication does not
+replace synchronous durable resume-intent writes before exec.
+
+`restart` binds a Linux pidfd and revalidates the discovered instance before sending
+SIGUSR2. There is no numeric-PID kill fallback if pidfd is unavailable. By default
+it waits for a different instance UUID, the same OS process lifetime, the installed
+executable's Go build identity, matching mode, and reported `ready` state. Self-exec
+keeps the PID. Exit, unsupported/deferred handling, wrong build or timeout returns
+an error; `--no-wait` reports only that the signal was sent, not restart success.
+
+`restart-all` discovers once, excludes itself, requests restarts concurrently and
+prints ordered per-process results. It does not rescan and restart replacements.
+Any selected process that cannot restart makes the command fail rather than being
+silently counted as success. Modes without a resumable lifecycle owner remain
+unsupported/deferred as described above; these commands do not make those modes
+resumable by themselves.

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,220 +1,98 @@
-# Process signals
+# Signals and planned process replacement
 
-This matrix describes application handlers, not a promise that every operating
-system exposes every signal. **Universal safe restart is work in progress, not
-implemented by the current PR.** Unix executables now register one process-wide
-SIGUSR2 listener at command entry, before argument parsing or configuration.
-Without an installed mode owner, signals are coalesced into a logged `deferred`
-status and the original invocation continues; normal command completion logs
-`finished`. No arguments, stdin, mutations, or tool calls are replayed. These
-logs are not the planned authoritative generation registry or a readiness API.
-Other unhandled signals retain Go/OS defaults and inherited dispositions.
+SIGUSR2 requests a planned self-exec; it is not configuration reload or permission
+to replay a command. Successful exec keeps the OS PID and generates a fresh
+executable-instance UUID. The installed executable is resolved before replacement;
+resume state stays in SQLite, with only a random lookup ID in the replacement
+environment. Startup removes that hint before launching tools. Argv does not grow
+`--resume` flags.
 
-## Handler matrix
+## Current implementation scope
 
-| Mode | SIGINT / SIGTERM | SIGHUP | SIGUSR1 | SIGUSR2 |
-| --- | --- | --- | --- | --- |
-| Standalone `serve web` | Cancels the serve context and enters shutdown | No reload handler | Stops widget subprocesses when widgets are enabled; their manager remains available | Cooperative self-exec, subject to the restrictions below |
-| Web combined with API, jobs or Telegram | Same shared serve shutdown | No reload handler | Same widget handling when enabled | Logged rejection; no restart |
-| `serve api`, `serve jobs`, `serve telegram` without web | Same shared serve shutdown | No reload handler | No application handler | Logged rejection; no restart |
-| `serve mcp` | Cancels the MCP context and enters shutdown | No reload handler | No application handler | Logged rejection; no restart |
-| `serve hub` | No application shutdown signal handler; Go/OS default disposition | No reload handler | No application handler | Logged rejection; no restart |
-| Chat/TUI, ask, exec, loop, edit, image/music/embed, benchmark | Existing per-command cancellation/terminal handling, unchanged | Unchanged | Unchanged | Nonfatal deferred; no resume implementation yet |
-| Stdio `mcp-server`, MCP clients, maintenance/CRUD, completion, external editors and subprocess wrappers | Existing per-command handling, unchanged | Unchanged | Unchanged | Nonfatal deferred; finishes original invocation without replay |
+This PR remains work in progress toward process-wide support. Do not describe
+nonfatal signal handling as successful restart in an unsupported mode.
 
-Deferred semantics are a safety floor, **not** completed long-lived-mode restart
-support. Jobs, Telegram, Hub, TUI, proxy/MCP and combined serve still require
-mode-specific checkpoint/admission/ownership integration. Even a successful
-command completion is not evidence that detached descendants have finished.
+| Mode | Current SIGUSR2 behaviour |
+|---|---|
+| Web / API | Drain admitted work, checkpoint, self-exec, resume eligible responses. Default natural grace is 10 seconds; then cancel through the existing cancellation path and join actual execution before resuming. |
+| Jobs, alone or alongside web/API | Pause scheduler/worker admission and account for running jobs and completion notifications. Programs finishing within grace are not replayed. After grace, running programs use ordinary durable cancellation and their actual exit gates replacement; never-started claims remain queued. Arbitrary programs are not automatically replayed. Persistent ordinary LLM jobs checkpoint and resume the same run/session after forced cancellation; failed exec reclaims the checkpoint in the original process. Progressive/native-provider parity and no-persistence handling still need verification. |
+| Chat/TUI | Uses the existing `/reload` lifecycle through the UI message loop, with a 10-second grace and normal interruption. Restores foreground session, draft and attachments through SQLite, preserving argv. Foreground interrupted tasks receive an internal continuation, not a fabricated user message. Background-session continuation remains incomplete. |
+| Web reverse Hub / WebRTC transports | Requests use the same admission fence as direct HTTP. Passive event streams do not block replacement. Sockets close on exec and clients reconnect; current-source combined-transport browser proof is still required. |
+| Web widgets | Reuses StopAll with verified child exit. The manager remains available for lazy restart if exec fails. No success is claimed when child exit is unacknowledged. |
+| Standalone Hub | Drain local mutation handlers; after 10 seconds cancel and join them before same-PID self-exec. Remote work remains node-owned. Sandbox dashboard and replacement proof passes. |
+| MCP HTTP (`serve mcp`) | Drain full mutation responses and actual tool execution, including detached descendants. After 10 seconds cancel and join before exec. Clients reinitialize after replacement; the generated bearer token is preserved. Active-shell sandbox proof passes. |
+| Telegram, stdio MCP, other long-lived commands | Early listener handles SIGUSR2 nonfatally, but complete lifecycle/recovery adapters are not yet implemented. |
+| Short-lived maintenance/CRUD/one-shot commands | Deferred without replay. Natural completion does not execute the command again. |
 
-USR1/USR2 handling is compiled for AIX, Darwin, DragonFly BSD, FreeBSD, illumos,
-Linux, NetBSD, OpenBSD and Solaris. Other platforms compile no-op installers.
-The same-PID browser integration has been exercised on Linux. Windows does not
-provide these Unix controls. Chat/TUI, ask and exec have the process-wide
-nonfatal listener but do not yet have resumable lifecycle owners.
+Native inline provider loops, MCP-owned resources and some independently owned
+mutation APIs still have explicit restart exclusions. Those are unfinished
+ownership integrations, not a universal restart guarantee.
 
-SIGINT/SIGTERM handling is unchanged: the shared serve context registers
-`os.Interrupt` and `syscall.SIGTERM`. HTTP shutdown uses a ten-second context;
-MCP shutdown uses five seconds. Shutdown is **not** a promise that every external
-side effect has completed. Shell SIGHUP/SIGTERM calls target child shell sessions
-or process groups, not server configuration reloads. SIGWINCH/SIGCONT terminal
-handlers do not implement restarts.
+## Other signals
 
-## Supported first slice
+- SIGINT/SIGTERM retain existing shutdown/cancellation behaviour. Web/API/jobs and
+  Telegram use the shared serve shutdown context. TUI restores terminal ownership;
+  a raw-mode Ctrl+C key remains a UI event distinct from an OS signal.
+- SIGHUP has no new configuration-reload contract. Do not send it expecting reload.
+  Tool-child HUP cleanup is not a serving reload handler.
+- SIGUSR1 retains widget-stop behaviour when widget support installs its handler.
+- Standalone Hub uses graceful SIGINT/SIGTERM HTTP shutdown; shutdown takes
+  precedence over a pending process replacement.
+- The process signal dispatcher is installed before command configuration on Unix.
+  Duplicate requests coalesce at their lifecycle owner. Unsupported modes retain
+  the original invocation rather than dying or blindly repeating side effects.
+- Windows has no Unix SIGUSR2/self-exec support. Linux is the tested discovery and
+  pidfd-targeting platform; other Unix process-discovery support is not implemented.
 
-SIGUSR2 is deliberately narrower than all the activities a web server can own:
+## Grace, cancellation and safety
 
-- Standalone, direct-HTTP `serve web`, with writable SQLite sessions and atomic
-  response/transcript fencing. No `--no-session`, mixed platforms, Hub routing,
-  WebRTC, widgets, or independently owned automatic title providers.
-- Set `serve.auto_title: false` in the service's configuration and start with
-  `--disable-widgets`. Those defaults are **not** silently changed by the signal.
-- Stateful, streaming Responses runs with an explicit turn budget (the web
-  request handler supplies one). Native inline-loop providers, MCP runtimes,
-  model swaps, steering rushes and skill-run setup are rejected.
-- Completed calls to the concrete built-in `read_file`, `write_file`, `edit_file`,
-  `glob`, `grep` and `update_plan` tools can precede a restart boundary. Merely
-  naming a custom tool `write_file` does not make it safe.
-- Shells, custom/child tools, native provider activities, side questions,
-  independently owned mutation APIs, and cancelled/failed invocations make the
-  current boot ineligible. A shell returning is not proof that it left no
-  descendants. Rejection does not kill it or disable ordinary chat operation.
+For response-owning web/API and foreground TUI work:
 
-The unsupported-activity record is intentionally conservative and persists for
-that boot. Returning from a tool or closing its UI is not used to infer external
-quiescence. Enabling more modes/tools requires an ownership and drain protocol,
-not just another name in an allow-list. Opening read-only views or acknowledging
-attention does not invalidate eligibility; unauthorized requests cannot do so.
+1. Stop new admission and allow up to **10 seconds** to reach a durable boundary.
+2. If grace expires, authorize the internal restart interruption before cancelling.
+3. Use normal steering-style cancellation and wait for actual execution to exit.
+   A synthetic cancellation result is not proof that Tool.Execute returned.
+4. Seal the interrupted transcript checkpoint, then exec and admit continuation.
+5. A further bounded settlement wait refuses replacement if cleanup does not finish.
+   No SIGKILL of the main process is used to fabricate a clean checkpoint.
 
-## Deployment limitation: Hub, WebRTC and widgets
+User Stop differs from internal restart cancellation: Stop revokes automatic
+continuation. Cancelled sources can only be resumed through a prepared and sealed
+restart intent; unrelated cancelled, superseded or unsealed sources are rejected.
+On recovery the model is told that interrupted external effects may have happened
+and must be checked before repetition. Tools are available for remaining work.
 
-**This slice does not self-reload a deployed web using Hub reverse routing,
-WebRTC and widgets.** Such a process logs a rejection and keeps running. The
-local browser evidence below is not evidence for that deployment.
+The engine reuses its execution/steering freeze and actual-tool lifetime accounting;
+there is no ordinary-tool name allowlist. Concurrent/child execution must settle,
+even when its caller already received cancellation. Program/native subprocess
+cleanup is a separate ownership responsibility, not something inferred from a name.
 
-The reverse connector now has a joinable `Stop(ctx)` owner. Cancellation closes
-its socket to wake reads/writes; completion joins the reconnect loop, ping loop
-and forwarded requests. A deadline reports a failed join and never authorizes
-exec. Tests include a transport that observes cancellation but cannot yet return;
-Stop must not claim completion. This joins the forwarding client, **not** the
-server-side mutation: an HTTP client returning does not prove its backend handler
-finished. Existing reconnect tests now join their connectors before cleanup.
+A failed exec does not count as successful restart. A parked invocation can be
+released; an already cancelled invocation remains interrupted. Failure to discard
+an intent or verify execution settlement keeps the affected restart quarantined
+rather than reopening unsafe execution.
 
-WebRTC `peer.Close` still only cancels its context; it does not acknowledge
-completion of transport handlers.
-Widget `CloseContext` is a one-way, best-effort shutdown that may return on its
-deadline and escalates subprocess termination; it is not a reversible drain.
-Simply invoking these shutdown methods before exec would not establish safe
-quiescence or restore the old service after exec failure.
+## Explicit handoffs
 
-Supporting the deployed combination needs joinable transport owners, mutation
-admission across transport teardown, restartable widget ownership (with an
-explicit policy for external effects), and failed-exec rollback. Browser HTTPS
-fallback/reconnection must be exercised through a sandbox Hub and WebRTC relay,
-including ambiguous mutation delivery: automatic transport fallback is not a
-proof of exactly-once request admission. These changes and their combined
-browser proof remain required before this PR can claim universal restart.
+Web response handoffs bind restart ID, logical service identity, source boot/fence,
+session and transcript revision. Acceptance and replacement-run admission are one
+SQLite transaction. A grace-expired interruption must first have been prepared
+while the source was running, then sealed only after cancellation/persistence
+settled. Source-ID Stop follows accepted replacement edges.
 
-## Lifecycle
+TUI command handoffs use one-shot private SQLite metadata with source instance,
+service/argv/cwd identity, foreground session revision, and serialized UI state.
+They are consumed by a different instance, not selected through a PID match.
+A missing environment hint never resurrects old unfinished sessions.
 
-1. **Coalesce and gate.** Signals received by the installed handler before web
-   startup/recovery is ready are rejected, not queued. A signal then starts one
-   drain generation. Duplicate signals
-   during it do not queue another restart. New mutations receive HTTP 503 with
-   `Retry-After`; existing handlers are accounted for. Response streams transfer
-   ownership to their tracked engine. Read-only event streams remain connected
-   until exec. Stop remains available and preempts draining.
-2. **Reach a model boundary.** An engine finishes its current provider/tool turn
-   and persists the results before parking, without cancelling its tools. It can
-   also park before its first provider request once the real input is durable.
-   Initial/turn persistence failures cannot acknowledge a safe boundary. A
-   naturally completed answer is not automatically continued.
-3. **Abort rather than force.** The drain waits up to 20 seconds. Stuck tools,
-   approvals and providers are not killed to meet that deadline. Timeout releases
-   parked invocations and reopens admission. SIGINT/SIGTERM preempts the drain and
-   follows the existing shutdown path instead of restarting.
-4. **Prepare a durable batch.** Once every tracked engine is parked or settled
-   and other handlers are idle, a bounded five-second checkpoint phase verifies
-   the source leases, transcript revisions and absence of pending steering. All
-   selected sessions share a random restart UUID. Preparation itself neither
-   fences nor cancels the source engines.
-5. **Self-exec.** The process executes the executable pathname captured at serve
-   startup, using the original argv. It does not run a build, deploy, supervisor,
-   shell, or second server process. Successful exec retains the PID and replaces
-   memory. The installed pathname must remain present and executable; updating
-   the captured file atomically is supported. Repointing a different symlink is
-   not an executable-selection mechanism. No sockets are inherited.
-6. **Acquire and consume.** The replacement captures and unsets
-   `TERM_LLM_RESTART_ID` and `TERM_LLM_RESTART_SERVICE_ID` before commands or tools
-   run. It binds the same listener **before** consuming any intent. A stable
-   service UUID is bound to the serving argv and startup directory, and each
-   boot has a fresh UUID owner. PID reuse is not ownership. SQLite checks the
-   service, distinct boot, live source lease, transcript revision and latest
-   response fence. Consuming each intent, fencing its source and admitting the
-   replacement response happen in one writer transaction.
-7. **Continue the same chat.** Recovery injects an internal **developer** message,
-   not a fabricated user bubble. The replacement loads the persisted transcript
-   and re-resolves the original selected tools from its own registry, retaining
-   the remaining explicit turn budget. Completed actions are not dispatched
-   again. The model can call tools for the unfinished task. This is a new model
-   invocation, not restoration of a Go stack or replay of unknown pending calls.
-   The browser's existing reconnect/session reconciliation finds the replacement
-   run and preserves local drafts. Stop addressed to a source response follows
-   only its explicit restart-continuation chain, never an unrelated newer turn.
+The restart lookup hint is not a credential or authorization. Existing Hub
+credential hand-back and auto-generated MCP HTTP bearer tokens use separate
+exec-only environment entries, removed at startup before tool children launch.
+Handoff claims remain synchronous correctness operations; they are not moved into
+the advisory registry publisher. Admission is at-most-once, not a claim of exactly-once
+external side effects or guaranteed completion after a second crash.
 
-Handoff IDs are lookup hints, not authentication. They are neither HTTP inputs
-nor a general crash-recovery queue. Without the startup hint, no intent is
-implicitly resumed. Consumed, expired, cancelled, advanced or differently owned
-intents cannot be admitted again. Lookup expires after five minutes; the live
-source lease normally imposes a tighter startup window. If a session cannot be
-safely admitted after exec, it remains available for inspection/manual
-continuation; failure does not terminate other already-admitted recoveries.
-
-## Failure behavior
-
-If executable selection, checkpointing or `exec` fails, the current process
-remains alive. A failed exec discards its unconsumed intents and releases the
-original, still tool-capable invocations. If discarding the intent also fails,
-the service enters a safe paused state: mutation admission stays closed and
-parked work is **not** silently released. Reads and Stop remain available; an
-operator must address persistence health or perform an ordinary shutdown.
-
-Scrubbed Hub credentials needed by a replacement are restored only in the
-private environment passed to self-exec, using the existing reload helpers.
-Restart hints and those credentials are never deliberately installed in the
-ambient environment inherited by tool children. Do not export restart hints,
-copy them between services, or use them as a manual resume API.
-
-A successful OS exec cannot roll back a replacement that subsequently fails to
-start (for example, invalid new configuration). Install a compatible binary and
-check health; a failed startup does not authorize replaying an old intent.
-
-## Example
-
-For a **test or explicitly authorized service**, configure:
-
-```yaml
-serve:
-  auto_title: false
-```
-
-Start a supported web instance, for example:
-
-```sh
-term-llm serve web --disable-widgets --tools read_file,write_file,edit_file,grep,glob
-```
-
-After atomically installing an updated executable at the captured pathname,
-send SIGUSR2 to the **verified PID of that service**:
-
-```sh
-kill -USR2 "$verified_web_service_pid"
-```
-
-Do not use a broad `pkill` pattern. A logged rejection or timeout is not a
-successful reload. Check health/version and the continued session; do not resend
-user input to simulate recovery. This feature grants no permission to restart
-production or to deploy a binary.
-
-## Verification
-
-Focused regression checks:
-
-```sh
-go test -race ./internal/llm ./internal/session ./cmd \
-  -run 'Test(ModelBoundary|ExecHandoff|WebExec)' -count=1
-```
-
-The isolated Linux browser fixture uses a local scripted OpenAI-compatible
-endpoint and real built-in file tools: atomic A→B install, SIGUSR2, unchanged
-PID, distinct durable boot owners, one pre-restart tool result, working
-post-restart tools, same-chat recovery, unsent draft preservation and the next
-user turn. It also exercises simultaneous sessions, a quiet reload with no
-replayed continuation, and a real shell child verifying that restart hints were
-scrubbed. Private fixture homes, transcripts, logs and screenshots are not
-repository assets and must not be published.
-
-## Local process discovery and restart commands (Linux)
+## Operator commands (Linux)
 
 ```sh
 term-llm process list
@@ -223,33 +101,24 @@ term-llm process restart 123 --timeout 2m
 term-llm process restart-all --timeout 2m
 ```
 
-Discovery is opt-in through running binaries that publish process records. Older
-binaries are not found by scanning arbitrary command lines and are never signalled
-by these commands. Records are owner-private under
-`$XDG_RUNTIME_DIR/term-llm-processes`, falling back to the user's cache directory.
-They contain PID, OS process-start identity, random executable-instance UUID,
-build identity, mode and last reported lifecycle phase, not arguments or tokens.
+Only binaries publishing validated owner-private records are discovered. Older
+binaries and arbitrary command lines are not scanned and signalled. Records live
+under `$XDG_RUNTIME_DIR/term-llm-processes`, falling back to the user's cache dir.
+They contain PID, kernel boot/process-start identity, instance UUID, build, mode
+and last reported lifecycle phase—not argv or tokens.
 
-Publication runs in a goroutine after a 25 ms grace period rather than blocking
-command startup on filesystem I/O. Commands that exit during that period cancel
-publication without opening procfs or the registry. Discovery is therefore eventually
-consistent: a just-started process can be absent briefly. Status is advisory, not a live health probe. Discovery validates
-process ownership, kernel boot/start identity and non-zombie state, and removes
-stale records under the same lock used by publishers. Normal exit asks the single
-publisher to stop and remove its own instance's record; cleanup cannot race a late
-writer into recreating that record after cleanup. Advisory publication does not
-replace synchronous durable resume-intent writes before exec.
+Publication runs in a goroutine after a **25 ms** grace period. Short commands
+exiting before filesystem work begins do not wait for it. Discovery is eventually
+consistent and status is advisory, not a live health probe. List validates ownership,
+PID reuse and zombie state; stale records are removed under the publisher lock.
+The publisher owns both writing and cleanup so it cannot write after its cleanup.
 
-`restart` binds a Linux pidfd and revalidates the discovered instance before sending
-SIGUSR2. There is no numeric-PID kill fallback if pidfd is unavailable. By default
-it waits for a different instance UUID, the same OS process lifetime, the installed
-executable's Go build identity, matching mode, and reported `ready` state. Self-exec
-keeps the PID. Exit, unsupported/deferred handling, wrong build or timeout returns
-an error; `--no-wait` reports only that the signal was sent, not restart success.
+Restart opens a Linux pidfd and revalidates the snapshot before SIGUSR2. It waits
+for a new instance, the installed Go build identity, matching mode and reported
+ready state. pidfd readiness—not a transient procfs read failure—is authoritative
+for death. There is no unsafe numeric-kill fallback when pidfd is unavailable.
 
-`restart-all` discovers once, excludes itself, requests restarts concurrently and
-prints ordered per-process results. It does not rescan and restart replacements.
-Any selected process that cannot restart makes the command fail rather than being
-silently counted as success. Modes without a resumable lifecycle owner remain
-unsupported/deferred as described above; these commands do not make those modes
-resumable by themselves.
+`restart-all` snapshots once, excludes itself, requests concurrently and reports
+ordered per-process outcomes. Unsupported/deferred outcomes are errors, not silent
+success. `--no-wait` reports only signal delivery. Nothing here installs a binary;
+install it atomically first, then request replacement.

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -2097,7 +2097,7 @@ func (e *Engine) Stream(ctx context.Context, req Request) (Stream, error) {
 	// Providers with a true mid-generation interrupt also need the loop when no
 	// tools are exposed: the next provider turn is where the queued steer is
 	// committed and delivered after the interrupted turn.
-	useLoop := caps.ToolCalls && (len(req.Tools) > 0 || planner != nil || e.providerSupportsImmediateInterruption())
+	useLoop := req.ModelBoundary != nil || (caps.ToolCalls && (len(req.Tools) > 0 || planner != nil || e.providerSupportsImmediateInterruption()))
 
 	if useLoop {
 		e.beginSteeringRun(getMaxTurns(req) > 1)
@@ -2673,8 +2673,13 @@ func restoreToolDiscoveryReplay(messages []Message, replay []Part) []Message {
 }
 
 func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) error {
-	ctx = withResponsesWebSocketContinuationLifetime(ctx)
+	boundary := req.ModelBoundary
+	req.ModelBoundary = nil
 	defer e.markSteeringRunNonConsuming()
+	if boundary != nil && e.provider.Capabilities().InlineToolLoop {
+		return fmt.Errorf("cooperative model boundary unavailable for inline tool-loop provider")
+	}
+	ctx = withResponsesWebSocketContinuationLifetime(ctx)
 	runID := e.beginToolRun()
 	modelSwitchOrdinal := 0
 	e.recordFileTrackingRunStart(ctx, req.SessionID, runID)
@@ -2713,6 +2718,20 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 	turnCallback := e.getTurnCallback()
 	responseCallback := e.getResponseCallback()
 	snapshotCallback := e.getSnapshotCallback()
+
+	// Ordinary invocations retain their existing best-effort persistence policy.
+	// Cooperative callers must never park at a boundary after a failed write.
+	var boundaryPersistenceErr error
+	if boundary != nil && turnCallback != nil {
+		persist := turnCallback
+		turnCallback = func(ctx context.Context, turn int, messages []Message, metrics TurnMetrics) error {
+			err := persist(ctx, turn, messages, metrics)
+			if err != nil && boundaryPersistenceErr == nil {
+				boundaryPersistenceErr = fmt.Errorf("persist cooperative model boundary: %w", err)
+			}
+			return err
+		}
+	}
 
 	e.callbackMu.RLock()
 	compactionConfig := e.compactionConfig
@@ -2982,6 +3001,20 @@ func (e *Engine) runLoop(ctx context.Context, req Request, send eventSender) err
 	}
 turnLoop:
 	for attempt := 0; attempt < maxTurns; attempt++ {
+		if boundary != nil {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if boundaryPersistenceErr != nil {
+				return boundaryPersistenceErr
+			}
+			if err := boundary(ctx); err != nil {
+				return fmt.Errorf("cooperative model boundary: %w", err)
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
 		// The final provider turn has no later agentic boundary. Reject arrivals
 		// throughout that stream instead of accepting steering it cannot consume.
 		e.beginSteeringRun(attempt < maxTurns-1)

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -40,6 +40,9 @@ const (
 	toolHeartbeatInterval              = 10 * time.Second
 )
 
+// TurnLimit reports the effective request budget used by the engine.
+func (r Request) TurnLimit() int { return getMaxTurns(r) }
+
 // getMaxTurns returns the max turns from request, with fallback to default
 func getMaxTurns(req Request) int {
 	if req.MaxTurns > 0 {
@@ -124,6 +127,7 @@ type FileTrackingRunLifecycle interface {
 }
 
 type Engine struct {
+	modelTurns       atomic.Int64
 	provider         Provider
 	tools            *ToolRegistry
 	debugLogger      *DebugLogger
@@ -2388,6 +2392,7 @@ func (e *Engine) runSimpleScratchpad(ctx context.Context, req Request, send even
 		e.applyPendingServiceTier(&req)
 		providerReq := e.prepareProviderRequest(req)
 		e.clearInlineFlush()
+		e.modelTurns.Add(1)
 		stream, err := e.provider.Stream(ctx, providerReq)
 		if err != nil {
 			return err
@@ -3130,6 +3135,7 @@ turnLoop:
 		if err := e.awaitSteeringDispatch(ctx); err != nil {
 			return err
 		}
+		e.modelTurns.Add(1)
 		stream, err := e.provider.Stream(ctx, providerReq)
 		if err != nil {
 			// Reactive compaction: if this is a context overflow error, try compacting and retrying (once)
@@ -5211,3 +5217,7 @@ func (s *cleanupStream) cleanupOnce() (err error) {
 	})
 	return err
 }
+
+// ModelTurns counts provider calls started by this engine, independently of
+// optional usage chunks. Lifecycle owners use differences for restart budgets.
+func (e *Engine) ModelTurns() int64 { return e.modelTurns.Load() }

--- a/internal/llm/model_boundary.go
+++ b/internal/llm/model_boundary.go
@@ -1,0 +1,14 @@
+package llm
+
+import "context"
+
+// ModelBoundaryCallback runs before an engine-managed model turn, after the
+// preceding turn's tools and persistence callbacks have returned. The callback
+// may block to park the invocation, but must honor ctx cancellation. Returning
+// nil continues the same invocation; returning an error ends it without issuing
+// another provider request. It is not called on a naturally completed response.
+//
+// This is a cooperation point, not proof of a durable checkpoint: callers must
+// separately validate their transcript fence and any independently owned work.
+// Native inline tool loops cannot offer this boundary and are rejected.
+type ModelBoundaryCallback func(context.Context) error

--- a/internal/llm/model_boundary_test.go
+++ b/internal/llm/model_boundary_test.go
@@ -1,0 +1,199 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+)
+
+func boundaryStreamError(stream Stream) error {
+	defer stream.Close()
+	for {
+		event, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if event.Type == EventError {
+			return event.Err
+		}
+	}
+}
+
+func TestModelBoundaryAfterToolPersistence(t *testing.T) {
+	provider := NewMockProvider("boundary").
+		AddToolCall("before", "count_tool", map[string]any{}).
+		AddToolCall("after", "count_tool", map[string]any{}).
+		AddTextResponse("finished")
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+	var persisted atomic.Int64
+	engine.SetTurnCompletedCallback(func(_ context.Context, _ int, messages []Message, _ TurnMetrics) error {
+		for _, message := range messages {
+			for _, part := range message.Parts {
+				if part.ToolResult != nil {
+					persisted.Add(1)
+				}
+			}
+		}
+		return nil
+	})
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	boundary := func(ctx context.Context) error {
+		if persisted.Load() != 1 {
+			return nil
+		}
+		close(parked)
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	stream, err := engine.Stream(ctx, Request{ModelBoundary: boundary, Messages: []Message{UserText("work")}, Tools: []ToolSpec{tool.Spec()}, MaxTurns: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- boundaryStreamError(stream) }()
+	select {
+	case <-parked:
+	case err := <-done:
+		t.Fatalf("ended before parking: %v", err)
+	}
+	if got := tool.calls.Load(); got != 1 {
+		t.Errorf("executions while parked = %d, want 1", got)
+	}
+	if got := len(provider.RecordedRequests()); got != 1 {
+		t.Errorf("provider requests while parked = %d, want 1", got)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if got := tool.calls.Load(); got != 2 {
+		t.Fatalf("executions after release = %d, want 2", got)
+	}
+	requests := provider.RecordedRequests()
+	if len(requests) != 3 {
+		t.Fatalf("requests = %d, want 3", len(requests))
+	}
+	for _, request := range requests {
+		users := 0
+		for _, message := range request.Messages {
+			if message.Role == RoleUser {
+				users++
+			}
+		}
+		if users != 1 {
+			t.Errorf("boundary injected user input: %d user messages", users)
+		}
+	}
+}
+
+func TestModelBoundaryFailsClosedOnPersistenceError(t *testing.T) {
+	provider := NewMockProvider("boundary").AddToolCall("before", "count_tool", map[string]any{}).AddTextResponse("must not run")
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+	want := errors.New("checkpoint unavailable")
+	engine.SetTurnCompletedCallback(func(context.Context, int, []Message, TurnMetrics) error { return want })
+	var boundaries atomic.Int64
+	ctx := context.Background()
+	boundary := func(context.Context) error { boundaries.Add(1); return nil }
+	stream, err := engine.Stream(ctx, Request{ModelBoundary: boundary, Messages: []Message{UserText("work")}, Tools: []ToolSpec{tool.Spec()}, MaxTurns: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := boundaryStreamError(stream); !errors.Is(err, want) {
+		t.Fatalf("error = %v, want persistence failure", err)
+	}
+	if got := boundaries.Load(); got != 1 {
+		t.Fatalf("boundary callbacks = %d, want initial boundary only", got)
+	}
+	if got := len(provider.RecordedRequests()); got != 1 {
+		t.Fatalf("provider requests = %d, want 1", got)
+	}
+}
+
+func TestModelBoundaryCancellation(t *testing.T) {
+	provider := NewMockProvider("boundary").AddTextResponse("must not run")
+	tool := &countingTool{}
+	registry := NewToolRegistry()
+	registry.Register(tool)
+	engine := NewEngine(provider, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	boundary := func(ctx context.Context) error {
+		cancel()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	stream, err := engine.Stream(ctx, Request{ModelBoundary: boundary, Messages: []Message{UserText("work")}, Tools: []ToolSpec{tool.Spec()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = boundaryStreamError(stream) // Cancellation may close the event stream directly.
+	if got := len(provider.RecordedRequests()); got != 0 {
+		t.Fatalf("provider requests = %d after cancellation, want 0", got)
+	}
+}
+
+func TestModelBoundaryRejectsInlineTools(t *testing.T) {
+	provider := NewMockProvider("native").WithCapabilities(Capabilities{ToolCalls: true, InlineToolLoop: true}).AddTextResponse("must not run")
+	engine := NewEngine(provider, NewToolRegistry())
+	var boundaries atomic.Int64
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("work")},
+		ModelBoundary: func(context.Context) error {
+			boundaries.Add(1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := boundaryStreamError(stream); err == nil {
+		t.Fatal("inline tool-loop provider admitted a cooperative boundary")
+	}
+	if boundaries.Load() != 0 || len(provider.RecordedRequests()) != 0 {
+		t.Fatal("unsupported provider reached boundary or model")
+	}
+}
+
+func TestModelBoundaryTextOnly(t *testing.T) {
+	provider := NewMockProvider("text").WithCapabilities(Capabilities{}).AddTextResponse("finished")
+	engine := NewEngine(provider, NewToolRegistry())
+	var boundaries atomic.Int64
+	stream, err := engine.Stream(context.Background(), Request{
+		Messages: []Message{UserText("work")},
+		ModelBoundary: func(context.Context) error {
+			boundaries.Add(1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := boundaryStreamError(stream); err != nil {
+		t.Fatal(err)
+	}
+	if boundaries.Load() != 1 {
+		t.Fatal("completed text response must not create a continuation boundary")
+	}
+	requests := provider.RecordedRequests()
+	if len(requests) != 1 || requests[0].ModelBoundary != nil {
+		t.Fatal("internal boundary leaked into provider request")
+	}
+}

--- a/internal/llm/steering.go
+++ b/internal/llm/steering.go
@@ -66,6 +66,37 @@ func (e *Engine) FreezeSteering(owner SteeringTransition) ([]QueuedSteering, err
 	return entries, nil
 }
 
+// FreezeExecution closes model/tool admission for lifecycle operations without
+// requiring queued user steering. It reuses the same ownership fence and actual
+// tool-lifetime accounting as steering: cancelling a caller is not settlement.
+// The caller must park its response loop first, then WaitSteeringSettlement,
+// and release with consume=false if replacement fails.
+func (e *Engine) FreezeExecution(owner SteeringTransition) error {
+	_, err := e.FreezeExecutionSnapshot(owner)
+	return err
+}
+
+// FreezeExecutionSnapshot preserves already submitted steering atomically with
+// closing dispatch, so lifecycle cancellation cannot lose or duplicate it.
+func (e *Engine) FreezeExecutionSnapshot(owner SteeringTransition) ([]QueuedSteering, error) {
+	e.callbackMu.Lock()
+	defer e.callbackMu.Unlock()
+	if owner.OperationID == "" || owner.Fence <= 0 || e.steeringTransition != nil {
+		return nil, ErrSteeringTransition
+	}
+	e.steeringTransition = &owner
+	e.steeringTransitionDone = make(chan struct{})
+	return append([]QueuedSteering(nil), e.pendingSteering...), nil
+}
+
+// ActiveToolExecutions counts actual Execute calls, including calls whose
+// cancelled parent already returned a synthetic result.
+func (e *Engine) ActiveToolExecutions() int {
+	e.callbackMu.RLock()
+	defer e.callbackMu.RUnlock()
+	return e.activeSteeringTools
+}
+
 // ReleaseSteeringFreeze rolls admission back without moving input or changing
 // identity. On successful handoff, consume removes only this owner's snapshot.
 func (e *Engine) ReleaseSteeringFreeze(owner SteeringTransition, consume bool) bool {
@@ -145,6 +176,21 @@ func (e *Engine) WaitSteeringSettlement(ctx context.Context, owner SteeringTrans
 	}
 	done := e.steeringToolsSettled
 	e.callbackMu.RUnlock()
+	return waitToolSettlement(ctx, done)
+}
+
+// WaitToolSettlement joins actual Execute calls after the owning response loop
+// has stopped. It does not close admission: owners must stop that loop first,
+// or use FreezeExecution and WaitSteeringSettlement while parking a live loop.
+// A cancelled context bounds the wait, never counts outstanding work as done.
+func (e *Engine) WaitToolSettlement(ctx context.Context) error {
+	e.callbackMu.RLock()
+	done := e.steeringToolsSettled
+	e.callbackMu.RUnlock()
+	return waitToolSettlement(ctx, done)
+}
+
+func waitToolSettlement(ctx context.Context, done <-chan struct{}) error {
 	if done == nil {
 		return nil
 	}

--- a/internal/llm/steering_test.go
+++ b/internal/llm/steering_test.go
@@ -233,3 +233,118 @@ func TestRushUsesNormalContinuationAcrossProviders(t *testing.T) {
 		})
 	}
 }
+
+func TestExecutionFreezeJoinsCancelledToolWithoutUserSteering(t *testing.T) {
+	tool := newContextIgnoringTool(1)
+	released := false
+	defer func() {
+		if !released {
+			close(tool.release)
+		}
+	}()
+	engine := NewEngine(NewMockProvider("custom"), NewToolRegistry())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	returned := make(chan error, 1)
+	go func() {
+		_, err, _ := engine.executeToolWithCancellation(ctx, tool, json.RawMessage(`{}`))
+		returned <- err
+	}()
+	select {
+	case <-tool.started:
+	case <-time.After(time.Second):
+		t.Fatal("tool never started")
+	}
+	owner := SteeringTransition{OperationID: "process-restart", Fence: 1}
+	if err := engine.FreezeExecution(owner); err != nil {
+		t.Fatal(err)
+	}
+	defer engine.ReleaseSteeringFreeze(owner, false)
+	if err := engine.FreezeExecution(owner); !errors.Is(err, ErrSteeringTransition) {
+		t.Fatalf("second owner accepted: %v", err)
+	}
+	cancel()
+	select {
+	case err := <-returned:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("caller result %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled caller did not return")
+	}
+	if engine.ActiveToolExecutions() != 1 {
+		t.Fatal("synthetic cancellation hid actual execution")
+	}
+	if err := engine.WaitSteeringSettlement(ctx, owner); !errors.Is(err, context.Canceled) {
+		t.Fatalf("joined too early: %v", err)
+	}
+	if !engine.SteeringTransitioning() {
+		t.Fatal("wait failure removed admission fence")
+	}
+	close(tool.release)
+	released = true
+	joined, joinCancel := context.WithTimeout(context.Background(), time.Second)
+	defer joinCancel()
+	if err := engine.WaitSteeringSettlement(joined, owner); err != nil {
+		t.Fatal(err)
+	}
+	if engine.ActiveToolExecutions() != 0 {
+		t.Fatal("tool count not settled")
+	}
+	if !engine.ReleaseSteeringFreeze(owner, false) {
+		t.Fatal("rollback failed")
+	}
+	if err := engine.beginSteeringTool(joined); err != nil {
+		t.Fatalf("rollback didn't reopen tool admission: %v", err)
+	}
+	engine.actualSteeringToolDone()
+}
+
+func TestWaitToolSettlementAfterCancelledResponse(t *testing.T) {
+	tool := newContextIgnoringTool(1)
+	released := false
+	defer func() {
+		if !released {
+			close(tool.release)
+		}
+	}()
+	engine := NewEngine(NewMockProvider("custom"), NewToolRegistry())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	returned := make(chan struct{})
+	go func() {
+		_, _, _ = engine.executeToolWithCancellation(ctx, tool, json.RawMessage(`{}`))
+		close(returned)
+	}()
+	select {
+	case <-tool.started:
+	case <-time.After(time.Second):
+		t.Fatal("tool not started")
+	}
+	cancel()
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("synthetic cancellation not returned")
+	}
+	if err := engine.WaitToolSettlement(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("premature settlement: %v", err)
+	}
+	settled := make(chan error, 1)
+	go func() { settled <- engine.WaitToolSettlement(context.Background()) }()
+	select {
+	case <-settled:
+		t.Fatal("joined before real tool exit")
+	default:
+	}
+	close(tool.release)
+	released = true
+	select {
+	case err := <-settled:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("actual exit did not release settlement")
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -227,6 +227,10 @@ func (o ResponsesOptions) IsZero() bool {
 
 // Request represents a single model turn.
 type Request struct {
+	// ModelBoundary is an internal, request-scoped cooperation point. It is
+	// never serialized to providers and is not inherited through tool contexts.
+	ModelBoundary ModelBoundaryCallback `json:"-"`
+
 	Model      string
 	SessionID  string // Optional session ID for provider-side continuity/caching hints
 	WorkingDir string // Optional working directory for local subprocess providers

--- a/internal/mcphttp/http_server.go
+++ b/internal/mcphttp/http_server.go
@@ -83,11 +83,12 @@ type ToolSpec struct {
 // Server runs an MCP server over HTTP with token-based authentication.
 // It exposes tools to local CLI transports and executes them using the provided executor.
 type Server struct {
-	server    *http.Server
-	listener  net.Listener
-	authToken string
-	executor  ToolExecutor
-	debug     bool
+	middleware func(http.Handler) http.Handler
+	server     *http.Server
+	listener   net.Listener
+	authToken  string
+	executor   ToolExecutor
+	debug      bool
 
 	mu      sync.Mutex
 	running bool
@@ -207,7 +208,11 @@ func (s *Server) startInternal(host string, port int, token string, tools []Tool
 	// Chain: logging -> auth -> mcp handler
 	mux.Handle("/mcp", s.loggingMiddleware(s.authMiddleware(mcpHandler)))
 
-	s.server = &http.Server{Handler: mux}
+	var handler http.Handler = mux
+	if s.middleware != nil {
+		handler = s.middleware(handler)
+	}
+	s.server = &http.Server{Handler: handler}
 	s.running = true
 
 	// Use a channel to capture immediate startup errors
@@ -394,3 +399,7 @@ func ParseMCPToolName(mcpName string) string {
 	}
 	return mcpName
 }
+
+// SetMiddleware wraps the full HTTP lifetime, not just tool execution. Configure
+// it before Start; process owners use it to drain responses before replacement.
+func (s *Server) SetMiddleware(wrap func(http.Handler) http.Handler) { s.middleware = wrap }

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -90,3 +90,16 @@ func (p *Publisher) Stop() {
 }
 
 var ErrUnsupported = errors.New("safe process discovery/restart requires Linux procfs and pidfd support")
+
+// Instance returns the in-memory executable incarnation without registry I/O.
+func Instance() string {
+	currentMu.RLock()
+	p := current
+	currentMu.RUnlock()
+	if p == nil {
+		return ""
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.record.Instance
+}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -1,0 +1,92 @@
+// Package process provides advisory process discovery, never restart authority.
+package process
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Record struct {
+	PID        int    `json:"pid"`
+	Start      string `json:"os_start"`
+	Instance   string `json:"instance"`
+	Build      string `json:"build"`
+	BuildID    string `json:"build_id"`
+	Executable string `json:"executable"`
+	Mode       string `json:"mode"`
+	Phase      string `json:"phase"`
+	Detail     string `json:"detail,omitempty"`
+}
+
+// Publisher has no filesystem work on the command startup path. One worker owns
+// publication AND final removal: a timed-out Stop cannot race a late writer into
+// resurrecting a record after cleanup. An abruptly exited worker leaves only an
+// advisory stale record, which List validates against the OS.
+type Publisher struct {
+	mu         sync.Mutex
+	record     Record
+	wake       chan struct{}
+	cancel     context.CancelFunc
+	done       chan struct{}
+	publishing bool // guarded by mu; false means Stop need not join filesystem work
+}
+
+var currentMu sync.RWMutex
+var current *Publisher
+
+func Start(build string) *Publisher {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Publisher{record: Record{PID: os.Getpid(), Instance: uuid.NewString(), Build: build, Mode: "command", Phase: "starting"}, wake: make(chan struct{}, 1), cancel: cancel, done: make(chan struct{})}
+	currentMu.Lock()
+	current = p
+	currentMu.Unlock()
+	go p.run(ctx)
+	return p
+}
+
+// State only changes memory and coalesces a notification; it never waits for I/O.
+func State(mode, phase, detail string) {
+	currentMu.RLock()
+	p := current
+	currentMu.RUnlock()
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	if mode != "" {
+		p.record.Mode = mode
+	}
+	p.record.Phase, p.record.Detail = phase, detail
+	p.mu.Unlock()
+	select {
+	case p.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (p *Publisher) Stop() {
+	p.mu.Lock()
+	p.cancel()
+	publishing := p.publishing
+	p.mu.Unlock()
+	if publishing {
+		timer := time.NewTimer(50 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-p.done:
+		case <-timer.C:
+		}
+	}
+	currentMu.Lock()
+	if current == p {
+		current = nil
+	}
+	currentMu.Unlock()
+}
+
+var ErrUnsupported = errors.New("safe process discovery/restart requires Linux procfs and pidfd support")

--- a/internal/process/process_linux.go
+++ b/internal/process/process_linux.go
@@ -1,0 +1,364 @@
+//go:build linux
+
+package process
+
+import (
+	"context"
+	"crypto/sha256"
+	"debug/elf"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+var errDead = errors.New("dead process")
+
+func identity(pid int) (string, error) {
+	info, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	if err != nil {
+		return "", err
+	}
+	if info.Sys().(*syscall.Stat_t).Uid != uint32(os.Getuid()) {
+		return "", errors.New("process has different owner")
+	}
+	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return "", err
+	}
+	end := strings.LastIndexByte(string(b), ')')
+	if end < 0 {
+		return "", errors.New("invalid proc stat")
+	}
+	f := strings.Fields(string(b[end+1:]))
+	if len(f) < 20 || f[0] == "Z" || f[0] == "X" {
+		return "", errDead
+	}
+	boot, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(boot)) + ":" + f[19], nil
+}
+
+// ELF's Go build ID identifies the actual executable, independent of linker
+// version labels. Reading a small note avoids hashing the entire binary at boot.
+func BuildID(path string) (string, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	s := f.Section(".note.go.buildid")
+	if s == nil || s.Size > 4096 {
+		return "", errors.New("missing Go build ID")
+	}
+	b, err := s.Data()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func registry() (*os.Root, error) {
+	base := os.Getenv("XDG_RUNTIME_DIR")
+	if base == "" {
+		var err error
+		base, err = os.UserCacheDir()
+		if err != nil {
+			return nil, err
+		}
+	}
+	path := filepath.Join(base, "term-llm-processes")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return nil, err
+	}
+	// Reject even a symlink to a private directory. Validate the opened directory
+	// too, so replacement between lookup and open cannot weaken ownership checks.
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("registry is a symlink")
+	}
+	root, err := os.OpenRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err = root.Stat(".")
+	if err != nil {
+		root.Close()
+		return nil, err
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || st.Uid != uint32(os.Getuid()) || info.Mode().Perm() != 0700 {
+		root.Close()
+		return nil, errors.New("registry must be owner-private (0700)")
+	}
+	return root, nil
+}
+
+func filename(r Record) string { return strconv.Itoa(r.PID) + ".json" }
+func read(root *os.Root, name string) (Record, error) {
+	var r Record
+	info, err := root.Lstat(name)
+	if err != nil {
+		return r, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+		return r, errors.New("record is not a private regular file")
+	}
+	f, err := root.OpenFile(name, os.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return r, err
+	}
+	defer f.Close()
+	info, err = f.Stat()
+	if err != nil {
+		return r, err
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || st.Uid != uint32(os.Getuid()) || info.Mode().Perm() != 0600 || info.Size() > 16384 {
+		return r, errors.New("invalid record owner/size/mode")
+	}
+	err = json.NewDecoder(io.LimitReader(f, 16385)).Decode(&r)
+	if err == nil && (r.PID <= 0 || filename(r) != name || r.Instance == "" || r.Start == "" || r.BuildID == "" || !filepath.IsAbs(r.Executable)) {
+		err = errors.New("invalid record identity")
+	}
+	return r, err
+}
+
+func write(root *os.Root, r Record) error {
+	lock, err := root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err = unix.Flock(int(lock.Fd()), unix.LOCK_EX); err != nil {
+		return err
+	}
+	defer unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+	b, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	tmp := "." + r.Instance + ".tmp"
+	f, err := root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	defer root.Remove(tmp)
+	_, err = f.Write(b)
+	closeErr := f.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return root.Rename(tmp, filename(r)) // advisory: deliberately no fsync
+}
+
+func (p *Publisher) run(ctx context.Context) {
+	defer close(p.done)
+	// Short commands should exit without even opening procfs/the registry. This
+	// is advisory discovery only; signal handling and durable handoffs don't wait.
+	timer := time.NewTimer(25 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return
+	case <-timer.C:
+	}
+	p.mu.Lock()
+	if ctx.Err() != nil {
+		p.mu.Unlock()
+		return
+	}
+	p.publishing = true
+	p.mu.Unlock()
+	start, err := identity(os.Getpid())
+	if err != nil {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	id, err := BuildID("/proc/self/exe")
+	if err != nil {
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	root, err := registry()
+	if err != nil {
+		return
+	}
+	defer root.Close()
+	p.mu.Lock()
+	p.record.Start, p.record.Executable, p.record.BuildID = start, exe, id
+	p.mu.Unlock()
+	defer func() {
+		lock, e := root.Open(".")
+		if e != nil {
+			return
+		}
+		defer lock.Close()
+		if unix.Flock(int(lock.Fd()), unix.LOCK_EX) != nil {
+			return
+		}
+		defer unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+		r, e := read(root, strconv.Itoa(os.Getpid())+".json")
+		if e == nil && r.Instance == p.record.Instance {
+			_ = root.Remove(filename(r))
+		}
+	}()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		p.mu.Lock()
+		r := p.record
+		p.mu.Unlock()
+		_ = write(root, r)
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.wake:
+		}
+	}
+}
+
+// List never trusts a PID alone. Cleanup is restricted to records whose OS
+// identity is dead/mismatched. Publishers and cleaners hold the same directory
+// lock, so cleanup cannot delete a newly published replacement record.
+func List() ([]Record, error) {
+	root, err := registry()
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	dir, err := root.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+	if err = unix.Flock(int(dir.Fd()), unix.LOCK_EX); err != nil {
+		return nil, err
+	}
+	defer unix.Flock(int(dir.Fd()), unix.LOCK_UN)
+	entries, err := dir.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]Record, 0)
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		r, err := read(root, e.Name())
+		if err != nil {
+			continue
+		}
+		start, err := identity(r.PID)
+		if err != nil && !errors.Is(err, os.ErrNotExist) && !errors.Is(err, errDead) {
+			continue
+		}
+		if err != nil || start != r.Start {
+			// Lock also coordinates replacement, not only other cleaners.
+			_ = root.Remove(e.Name())
+			continue
+		}
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+// Restart opens a pidfd before revalidating the snapshot. No numeric kill
+// fallback: kernels/sandboxes without pidfd fail closed rather than risk PID reuse.
+func Restart(ctx context.Context, r Record, wait bool) (Record, error) {
+	if r.PID == os.Getpid() {
+		return r, errors.New("refusing to restart self")
+	}
+	if r.Phase != "ready" {
+		return r, fmt.Errorf("%s: %s", r.Phase, r.Detail)
+	}
+	fd, err := unix.PidfdOpen(r.PID, 0)
+	if err != nil {
+		return r, fmt.Errorf("pidfd: %w", err)
+	}
+	defer unix.Close(fd)
+	start, err := identity(r.PID)
+	if err != nil || start != r.Start {
+		return r, errors.New("process identity changed")
+	}
+	root, err := registry()
+	if err != nil {
+		return r, err
+	}
+	defer root.Close()
+	live, err := read(root, filename(r))
+	if err != nil || live.Instance != r.Instance || live.Start != r.Start || live.Phase != "ready" {
+		return r, errors.New("process instance or readiness changed")
+	}
+	expected, err := BuildID(r.Executable)
+	if err != nil {
+		return r, fmt.Errorf("installed build: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return r, err
+	}
+	if err = unix.PidfdSendSignal(fd, unix.SIGUSR2, nil, 0); err != nil {
+		return r, err
+	}
+	if !wait {
+		return r, nil
+	}
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return r, ctx.Err()
+		case <-tick.C:
+		}
+		start, err = identity(r.PID)
+		if err != nil || start != r.Start {
+			return r, errors.New("process exited or identity changed")
+		}
+		next, e := read(root, filename(r))
+		if e != nil {
+			continue
+		}
+		if next.Start != r.Start {
+			return r, errors.New("registry identity changed")
+		}
+		if next.Instance != r.Instance {
+			if next.BuildID != expected {
+				return next, errors.New("restarted into unexpected build")
+			}
+			if next.Phase == "ready" {
+				if next.Mode != r.Mode {
+					return next, errors.New("restarted into unexpected mode")
+				}
+				return next, nil
+			}
+		}
+		if next.Phase == "failed" || next.Phase == "unsupported" || (next.Instance == r.Instance && next.Phase == "deferred") {
+			return next, fmt.Errorf("%s: %s", next.Phase, next.Detail)
+		}
+	}
+}

--- a/internal/process/process_linux.go
+++ b/internal/process/process_linux.go
@@ -335,9 +335,24 @@ func Restart(ctx context.Context, r Record, wait bool) (Record, error) {
 			return r, ctx.Err()
 		case <-tick.C:
 		}
+		// pidfd readiness is authoritative for process exit. A transient procfs
+		// read failure during replacement is not proof that the target died.
+		poll := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+		if _, err := unix.Poll(poll, 0); err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return r, err
+		}
+		if poll[0].Revents != 0 {
+			return r, errors.New("process exited before restart completed")
+		}
 		start, err = identity(r.PID)
-		if err != nil || start != r.Start {
-			return r, errors.New("process exited or identity changed")
+		if err != nil {
+			continue
+		}
+		if start != r.Start {
+			return r, errors.New("process identity changed")
 		}
 		next, e := read(root, filename(r))
 		if e != nil {

--- a/internal/process/process_linux_test.go
+++ b/internal/process/process_linux_test.go
@@ -1,0 +1,234 @@
+//go:build linux
+
+package process
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func testRecord(t *testing.T, pid int) Record {
+	t.Helper()
+	start, err := identity(pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Record{PID: pid, Start: start, Instance: "test-instance", BuildID: "test-build", Executable: "/test/term-llm", Phase: "ready"}
+}
+
+func TestListCleansDeadAndReusedIdentity(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	root, err := registry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	self := testRecord(t, os.Getpid())
+	if err := write(root, self); err != nil {
+		t.Fatal(err)
+	}
+	records, err := List()
+	if err != nil || len(records) != 1 {
+		t.Fatalf("live record: %+v, %v", records, err)
+	}
+	self.Start = "previous-owner"
+	if err := write(root, self); err != nil {
+		t.Fatal(err)
+	}
+	records, err = List()
+	if err != nil || len(records) != 0 {
+		t.Fatalf("stale identity: %+v, %v", records, err)
+	}
+	if _, err := root.Stat(filename(self)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale file retained: %v", err)
+	}
+
+	child := exec.Command("sleep", "60")
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer child.Process.Kill()
+	dead := testRecord(t, child.Process.Pid)
+	if err := write(root, dead); err != nil {
+		t.Fatal(err)
+	}
+	if err := child.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	_ = child.Wait()
+	records, err = List()
+	if err != nil || len(records) != 0 {
+		t.Fatalf("dead record: %+v, %v", records, err)
+	}
+	if _, err := root.Stat(filename(dead)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dead file retained: %v", err)
+	}
+}
+
+func TestRegistryRejectsUnsafeDirectory(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", base)
+	path := filepath.Join(base, "term-llm-processes")
+	if err := os.Mkdir(path, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if root, err := registry(); err == nil {
+		root.Close()
+		t.Fatal("accepted nonprivate registry")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), path); err != nil {
+		t.Fatal(err)
+	}
+	if root, err := registry(); err == nil {
+		root.Close()
+		t.Fatal("accepted symlink registry")
+	}
+}
+
+func TestPublisherStopDoesNotResurrect(t *testing.T) {
+	runtimeDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	for i := 0; i < 20; i++ {
+		p := Start("test")
+		State("test", "ready", "")
+		p.Stop()
+		select {
+		case <-p.done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("publisher did not stop")
+		}
+		if i == 0 {
+			if _, err := os.Stat(filepath.Join(runtimeDir, "term-llm-processes")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("short-lived publisher touched registry: %v", err)
+			}
+		}
+		records, err := List()
+		if err != nil || len(records) != 0 {
+			t.Fatalf("record resurrected after Stop: %+v, %v", records, err)
+		}
+	}
+}
+
+func TestPublisherLifecycle(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	p := Start("test")
+	defer p.Stop()
+	State("test", "ready", "")
+	deadline := time.After(3 * time.Second)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		records, err := List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(records) == 1 && records[0].Phase == "ready" {
+			if records[0].Instance == "" || records[0].BuildID == "" {
+				t.Fatalf("incomplete: %+v", records[0])
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("publisher never became discoverable")
+		case <-tick.C:
+		}
+	}
+	p.Stop()
+	<-p.done
+	records, err := List()
+	if err != nil || len(records) != 0 {
+		t.Fatalf("normal cleanup: %+v %v", records, err)
+	}
+}
+
+func TestRestartRefusesSelfAndUnsupported(t *testing.T) {
+	_, err := Restart(context.Background(), Record{PID: os.Getpid(), Phase: "ready"}, true)
+	if err == nil {
+		t.Fatal("accepted self restart")
+	}
+	_, err = Restart(context.Background(), Record{PID: 123, Phase: "deferred"}, true)
+	if err == nil {
+		t.Fatal("accepted deferred restart")
+	}
+}
+
+// This subprocess registers exactly like the executable, then self-execs on
+// SIGUSR2. The parent only signals the child it created, never a live service.
+func TestProcessRestartHelper(t *testing.T) {
+	if os.Getenv("TERM_LLM_TEST_PROCESS_HELPER") != "1" {
+		return
+	}
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGUSR2)
+	p := Start("sandbox")
+	defer p.Stop()
+	State("sandbox", "ready", "")
+	<-signals
+	State("sandbox", "replacing", "")
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRestartRealSelfExec(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	child := exec.Command(os.Args[0], "-test.run=^TestProcessRestartHelper$")
+	child.Env = append(os.Environ(), "TERM_LLM_TEST_PROCESS_HELPER=1")
+	child.Stderr = os.Stderr
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = child.Process.Kill(); _ = child.Wait() }()
+	deadline := time.After(5 * time.Second)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	var before Record
+	for before.PID == 0 {
+		records, err := List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, r := range records {
+			if r.PID == child.Process.Pid && r.Phase == "ready" {
+				before = r
+			}
+		}
+		if before.PID != 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("child never published ready")
+		case <-tick.C:
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	after, err := Restart(ctx, before, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.PID != before.PID || after.Start != before.Start || after.Instance == before.Instance || after.BuildID != before.BuildID {
+		t.Fatalf("bad handoff: before=%+v after=%+v", before, after)
+	}
+	// The old instance record must not authorize a second signal.
+	if _, err := Restart(ctx, before, true); err == nil {
+		t.Fatal("accepted stale instance")
+	}
+	t.Logf("same PID %d, new instance %s -> %s, ready", before.PID, before.Instance, after.Instance)
+}

--- a/internal/process/process_other.go
+++ b/internal/process/process_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package process
+
+import "context"
+
+func (p *Publisher) run(ctx context.Context)                { close(p.done) }
+func List() ([]Record, error)                               { return nil, ErrUnsupported }
+func Restart(context.Context, Record, bool) (Record, error) { return Record{}, ErrUnsupported }

--- a/internal/restart/dispatch.go
+++ b/internal/restart/dispatch.go
@@ -1,0 +1,76 @@
+// Package restart owns process-wide restart signal dispatch. A signal never
+// implies permission to replay a command: until a mode installs an owner, it is
+// deferred and the original invocation is allowed to finish.
+package restart
+
+import (
+	"log"
+	"sync"
+)
+
+// Dispatcher keeps the signal disposition installed while mode owners come and
+// go. Hooks must return promptly and coalesce their asynchronous drain requests.
+// Unbinding joins dispatch of the hook, so a torn-down owner cannot be called.
+type Dispatcher struct {
+	mu       sync.Mutex
+	owner    *binding
+	deferred bool
+	report   func(string)
+}
+
+type binding struct{ request func() }
+
+func New(report func(string)) *Dispatcher { return &Dispatcher{report: report} }
+
+// Default is shared by the executable entry point and per-mode owners.
+var Default = New(func(phase string) {
+	log.Printf("[reload] SIGUSR2 %s: invocation retained; no replay", phase)
+})
+
+func (d *Dispatcher) Request() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.owner != nil {
+		d.owner.request()
+		return
+	}
+	if !d.deferred {
+		d.deferred = true
+		if d.report != nil {
+			d.report("deferred")
+		}
+	}
+}
+
+// Bind installs the one process owner. A combined mode must coordinate all its
+// components behind this hook; independent subscribers are not permitted.
+// Signals received before binding are not replayed into a not-yet-ready mode.
+func (d *Dispatcher) Bind(request func()) func() {
+	if request == nil {
+		panic("restart: nil owner")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.owner != nil {
+		panic("restart: process already has an owner")
+	}
+	b := &binding{request: request}
+	d.owner = b
+	return func() {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		if d.owner == b {
+			d.owner = nil
+		}
+	}
+}
+
+// Finish makes a deferred short-lived command's completion observable without
+// starting a second invocation. It must run before os.Exit.
+func (d *Dispatcher) Finish() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.deferred && d.report != nil {
+		d.report("finished")
+	}
+}

--- a/internal/restart/dispatch.go
+++ b/internal/restart/dispatch.go
@@ -6,6 +6,8 @@ package restart
 import (
 	"log"
 	"sync"
+
+	"github.com/samsaffron/term-llm/internal/process"
 )
 
 // Dispatcher keeps the signal disposition installed while mode owners come and
@@ -36,6 +38,7 @@ func (d *Dispatcher) Request() {
 	}
 	if !d.deferred {
 		d.deferred = true
+		process.State("", "deferred", "signal retained original invocation; no replay")
 		if d.report != nil {
 			d.report("deferred")
 		}

--- a/internal/restart/dispatch_test.go
+++ b/internal/restart/dispatch_test.go
@@ -1,0 +1,60 @@
+package restart
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestDeferredInvocationIsNeverReplayed(t *testing.T) {
+	var phases []string
+	d := New(func(phase string) { phases = append(phases, phase) })
+	d.Request()
+	d.Request()
+	calls := 0
+	unbind := d.Bind(func() { calls++ })
+	if calls != 0 {
+		t.Fatal("early signal replayed into new owner")
+	}
+	d.Request()
+	unbind()
+	unbind()
+	d.Request()
+	d.Finish()
+	if calls != 1 {
+		t.Fatalf("owner calls = %d", calls)
+	}
+	if !reflect.DeepEqual(phases, []string{"deferred", "finished"}) {
+		t.Fatalf("phases = %v", phases)
+	}
+}
+
+func TestOwnerUnbindJoinsDispatch(t *testing.T) {
+	d := New(nil)
+	entered, release := make(chan struct{}), make(chan struct{})
+	unbind := d.Bind(func() { close(entered); <-release })
+	var wg sync.WaitGroup
+	wg.Go(d.Request)
+	<-entered
+	unbound := make(chan struct{})
+	wg.Go(func() { unbind(); close(unbound) })
+	select {
+	case <-unbound:
+		t.Fatal("unbind did not join owner")
+	default:
+	}
+	close(release)
+	wg.Wait()
+	d.Request() // must not call the now-destroyed owner again
+}
+
+func TestMultipleOwnersRequireCoordination(t *testing.T) {
+	d := New(nil)
+	defer d.Bind(func() {})()
+	defer func() {
+		if recover() == nil {
+			t.Error("accepted competing process owner")
+		}
+	}()
+	d.Bind(func() {})
+}

--- a/internal/restart/gate.go
+++ b/internal/restart/gate.go
@@ -1,0 +1,54 @@
+package restart
+
+import "sync"
+
+// Gate accounts for actual owned work, independently of cancellation or mode.
+// Closing admission lets already admitted work (and its descendants) finish.
+// It neither cancels work nor invents a resumable checkpoint.
+// The zero value is usable.
+type Gate struct {
+	mu     sync.Mutex
+	pauses int
+	active int
+}
+
+// Enter admits a new root operation unless draining. The returned release is
+// idempotent and must outlive all synchronous effects of the operation.
+func (g *Gate) Enter() (release func(), ok bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.pauses != 0 {
+		return nil, false
+	}
+	return g.trackLocked(), true
+}
+
+// TrackChild accounts for a descendant before its admitted parent releases.
+// Descendants remain permitted during drain; rejecting them would lose work.
+func (g *Gate) TrackChild() func() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.trackLocked()
+}
+
+func (g *Gate) trackLocked() func() {
+	g.active++
+	var once sync.Once
+	return func() { once.Do(func() { g.mu.Lock(); g.active--; g.mu.Unlock() }) }
+}
+
+// Pause closes new admission without affecting existing operations. Its rollback
+// must be called if replacement fails. One lifecycle owner controls each gate.
+func (g *Gate) Pause() func() {
+	g.mu.Lock()
+	g.pauses++
+	g.mu.Unlock()
+	var once sync.Once
+	return func() { once.Do(func() { g.mu.Lock(); g.pauses--; g.mu.Unlock() }) }
+}
+
+func (g *Gate) Drained() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.pauses != 0 && g.active == 0
+}

--- a/internal/restart/gate_test.go
+++ b/internal/restart/gate_test.go
@@ -1,0 +1,48 @@
+package restart
+
+import "testing"
+
+func TestGateIncludesDescendantsAndRollback(t *testing.T) {
+	var gate Gate
+	release, ok := gate.Enter()
+	if !ok {
+		t.Fatal("initial work rejected")
+	}
+	reopen := gate.Pause()
+	if _, ok := gate.Enter(); ok {
+		t.Fatal("new work admitted during drain")
+	}
+	child := gate.TrackChild()
+	release()
+	release()
+	if gate.Drained() {
+		t.Fatal("ignored child ownership")
+	}
+	child()
+	child()
+	if !gate.Drained() {
+		t.Fatal("completed gate not drained")
+	}
+	reopen()
+	reopen()
+	release, ok = gate.Enter()
+	if !ok {
+		t.Fatal("failed replacement did not reopen admission")
+	}
+	release()
+}
+
+func TestGateNestedPauseDoesNotReopenAnotherOwner(t *testing.T) {
+	var gate Gate
+	first, second := gate.Pause(), gate.Pause()
+	first()
+	if _, ok := gate.Enter(); ok {
+		t.Fatal("one rollback reopened another owner")
+	}
+	second()
+	release, ok := gate.Enter()
+	if !ok {
+		t.Fatal("all owners released but admission stayed closed")
+	}
+	release()
+}

--- a/internal/restart/signal_other.go
+++ b/internal/restart/signal_other.go
@@ -1,0 +1,5 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris
+
+package restart
+
+func (d *Dispatcher) Listen() func() { return d.Finish }

--- a/internal/restart/signal_unix.go
+++ b/internal/restart/signal_unix.go
@@ -1,0 +1,32 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package restart
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// Listen registers only SIGUSR2. Stop joins dispatch without changing INT, TERM,
+// HUP, USR1 or terminal signal handling. Call at executable entry, before command
+// parsing, configuration loading or tool launch.
+func (d *Dispatcher) Listen() func() {
+	ch := make(chan os.Signal, 1)
+	done, joined := make(chan struct{}), make(chan struct{})
+	signal.Notify(ch, syscall.SIGUSR2)
+	go func() {
+		defer close(joined)
+		for {
+			select {
+			case <-done:
+				return
+			case <-ch:
+				d.Request()
+			}
+		}
+	}()
+	var once sync.Once
+	return func() { once.Do(func() { signal.Stop(ch); close(done); <-joined; d.Finish() }) }
+}

--- a/internal/restart/signal_unix_test.go
+++ b/internal/restart/signal_unix_test.go
@@ -1,0 +1,86 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package restart
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSignalProcess(t *testing.T) {
+	if os.Getenv("TERM_LLM_TEST_RESTART_HELPER") == "1" {
+		d := New(func(phase string) { fmt.Println(phase) })
+		stop := d.Listen()
+		fmt.Println("listening")
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			switch scanner.Text() {
+			case "bind":
+				unbind := d.Bind(func() { fmt.Println("owner") })
+				defer unbind()
+				fmt.Println("bound")
+			case "finish":
+				stop()
+				return
+			}
+		}
+		stop()
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSignalProcess$")
+	cmd.Env = append(os.Environ(), "TERM_LLM_TEST_RESTART_HELPER=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		stdin.Close()
+		if cmd.ProcessState == nil {
+			cmd.Process.Kill()
+			cmd.Wait()
+		}
+	}()
+	scanner := bufio.NewScanner(stdout)
+	expect := func(want string) {
+		t.Helper()
+		if !scanner.Scan() || scanner.Text() != want {
+			t.Fatalf("want %q, got %q (%v)", want, scanner.Text(), scanner.Err())
+		}
+	}
+	signal := func() {
+		t.Helper()
+		if err := cmd.Process.Signal(syscall.SIGUSR2); err != nil {
+			t.Fatal(err)
+		}
+	}
+	expect("listening")
+	signal()
+	expect("deferred")
+	fmt.Fprintln(stdin, "bind")
+	expect("bound")
+	signal()
+	expect("owner")
+	signal()
+	expect("owner")
+	fmt.Fprintln(stdin, "finish")
+	expect("finished")
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/run/types.go
+++ b/internal/run/types.go
@@ -109,8 +109,11 @@ type Request struct {
 	OnTurnCompleted        llm.TurnCompletedCallback
 	OnCompaction           llm.CompactionCallback
 	OnSyntheticUserMessage func(context.Context, llm.Message) error
-	OnEngineReady          func(*llm.Engine)
-	OnEngineDone           func(*llm.Engine)
+	// ModelBoundary is a request-scoped engine cooperation point, not a
+	// persistence acknowledgement. Native inline loops cannot provide it.
+	ModelBoundary llm.ModelBoundaryCallback
+	OnEngineReady func(*llm.Engine)
+	OnEngineDone  func(*llm.Engine)
 
 	Progressive *ProgressiveOptions
 

--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -25,6 +25,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/image"
 	"github.com/samsaffron/term-llm/internal/llm"
 	memorystore "github.com/samsaffron/term-llm/internal/memory"
+	"github.com/samsaffron/term-llm/internal/restart"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
 	"github.com/samsaffron/term-llm/internal/tools"
@@ -370,7 +371,8 @@ func recordTelegramUpload(cfg *config.Config, agent, sessionID, mimeType, captio
 }
 
 type TelegramPlatform struct {
-	cfg config.TelegramServeConfig
+	receiver telegramReceiver
+	cfg      config.TelegramServeConfig
 }
 
 // NewTelegramPlatform creates a new TelegramPlatform with the given config.
@@ -506,35 +508,68 @@ func (p *TelegramPlatform) Run(ctx context.Context, cfg *config.Config, settings
 		messageSlots:     make(chan struct{}, telegramMaxConcurrentHandlers),
 	}
 
-	u := tgbotapi.NewUpdate(0)
-	u.Timeout = telegramUpdateLongPollSeconds
-	updates := bot.GetUpdatesChan(u)
+	defer mgr.closeAllSessions()
+	return p.receiver.run(ctx, bot, func(pollCtx context.Context, update tgbotapi.Update) bool {
+		return mgr.acceptUpdate(ctx, pollCtx, bot, update)
+	})
+}
 
-	for {
-		select {
-		case <-ctx.Done():
-			mgr.closeAllSessions()
-			bot.StopReceivingUpdates()
-			return nil
-		case update, ok := <-updates:
-			if !ok {
-				return nil
-			}
-			if update.Message == nil {
-				continue
-			}
-			if !mgr.acquireMessageSlot(ctx) {
-				mgr.closeAllSessions()
-				bot.StopReceivingUpdates()
-				return nil
-			}
-			admission := mgr.admitMessage(update.Message)
-			go func(msg *tgbotapi.Message, admission *telegramMessageAdmission) {
-				defer mgr.releaseMessageSlot()
-				mgr.handleMessageWithAdmission(ctx, bot, msg, admission)
-			}(update.Message, admission)
-		}
+// acceptUpdate is shared by polling and recovered input. Admission cancellation
+// must not cancel already accepted handlers, which belong to the platform ctx.
+func (m *telegramSessionMgr) acceptUpdate(ctx, admissionCtx context.Context, bot telegramBot, update tgbotapi.Update) bool {
+	if update.Message == nil {
+		return true
 	}
+	if !m.acquireMessageSlotFor(admissionCtx, ctx) {
+		return false
+	}
+	if admissionCtx.Err() != nil || ctx.Err() != nil {
+		m.releaseMessageSlot()
+		return false
+	}
+	release, admitted := m.restartGate.Enter()
+	if !admitted {
+		m.releaseMessageSlot()
+		return false
+	}
+	finishUpdate, duplicate, err := m.inbox.begin(update)
+	if err != nil || duplicate {
+		release()
+		m.releaseMessageSlot()
+		if err != nil {
+			log.Printf("[telegram] cannot retain accepted update %d: %v", update.UpdateID, err)
+		}
+		return duplicate
+	}
+	admission := m.admitMessage(update.Message)
+	go func(msg *tgbotapi.Message, admission *telegramMessageAdmission) {
+		defer m.releaseMessageSlot()
+		defer release()
+		defer finishUpdate()
+		handlerCtx := context.WithValue(ctx, telegramInboxContextKey{}, telegramInboxReceipt{inbox: &m.inbox, id: update.UpdateID})
+		m.handleMessageWithAdmission(handlerCtx, bot, msg, admission)
+	}(update.Message, admission)
+	return true
+}
+
+// admitRecoveredInputs advances only after ownership has transferred to the
+// normal handler path. A failed admission retains that update and its suffix;
+// retrying must not replay the already admitted prefix. The lifecycle owner
+// keeps this queue and manager alive, and calls this before resuming polling.
+func (m *telegramSessionMgr) admitRecoveredInputs(ctx, admissionCtx context.Context, bot telegramBot, pending *[]tgbotapi.Update) error {
+	for len(*pending) > 0 {
+		if !m.acceptUpdate(ctx, admissionCtx, bot, (*pending)[0]) {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := admissionCtx.Err(); err != nil {
+				return err
+			}
+			return fmt.Errorf("Telegram recovered input admission is paused")
+		}
+		*pending = (*pending)[1:]
+	}
+	return nil
 }
 
 func buildAllowedSet(ids []int64) map[int64]struct{} {
@@ -554,6 +589,10 @@ func buildAllowedUsernameSet(names []string) map[string]struct{} {
 }
 
 func (m *telegramSessionMgr) acquireMessageSlot(ctx context.Context) bool {
+	return m.acquireMessageSlotFor(ctx, ctx)
+}
+
+func (m *telegramSessionMgr) acquireMessageSlotFor(ctx, lifetime context.Context) bool {
 	slots := m.messageSlots
 	if slots == nil {
 		slots = make(chan struct{}, telegramMaxConcurrentHandlers)
@@ -562,6 +601,8 @@ func (m *telegramSessionMgr) acquireMessageSlot(ctx context.Context) bool {
 	select {
 	case slots <- struct{}{}:
 		return true
+	case <-lifetime.Done():
+		return false
 	case <-ctx.Done():
 		return false
 	}
@@ -628,6 +669,7 @@ func (a *telegramMessageAdmission) release() {
 
 // telegramSession holds per-chat conversation state.
 type telegramSession struct {
+	restoredExecution     *telegramExecutionState // unpublished continuation work from authenticated handoff
 	mu                    sync.Mutex
 	activityMu            sync.Mutex // protects lastActivity without blocking behind an active stream
 	runtime               *SessionRuntime
@@ -635,20 +677,22 @@ type telegramSession struct {
 	systemPromptPersisted bool
 	runtimeStale          atomic.Bool // a detached runner may still own runtime; reset before reuse
 	cleanupOnce           sync.Once
-	carryoverContext      string // one-time context carried from the previous replaced session
+	cleanupDone           chan struct{} // protected by cancelMu; closes after actual Cleanup returns
+	carryoverContext      string        // one-time context carried from the previous replaced session
 	carryoverContextLabel string
 	carryoverMessageCount int // number of restored prior-session messages at the start of history; not persisted to this session
 	meta                  *session.Session
 	lastActivity          time.Time
 
-	cancelMu      sync.Mutex         // protects active stream state and task/tool tracking
-	streamCancel  context.CancelFunc // cancels the active stream's context
-	streamEngine  *llm.Engine        // active runner engine for mid-stream steering
-	streamToken   chan struct{}      // identifies callbacks owned by the active stream
-	runnerDone    <-chan struct{}    // closes when a detached runner no longer owns runtime
-	replyDone     chan struct{}      // closed when streamReply exits
-	currentTask   string             // text from the user message that started the active stream
-	toolsRanNames []string           // tool names executed during the active stream
+	cancelMu       sync.Mutex             // protects active stream state and task/tool tracking
+	streamCancel   context.CancelFunc     // user cancellation; revokes restart continuation
+	restartControl *telegramStreamControl // guarded by cancelMu; retained for handoff revocation
+	streamEngine   *llm.Engine            // active runner engine for mid-stream steering
+	streamToken    chan struct{}          // identifies callbacks owned by the active stream
+	runnerDone     <-chan struct{}        // closes when a detached runner no longer owns runtime
+	replyDone      chan struct{}          // closed when streamReply exits
+	currentTask    string                 // text from the user message that started the active stream
+	toolsRanNames  []string               // tool names executed during the active stream
 
 	streamProseLen atomic.Int64
 	streamToolCnt  atomic.Int32
@@ -657,6 +701,8 @@ type telegramSession struct {
 
 // telegramSessionMgr manages per-chat sessions.
 type telegramSessionMgr struct {
+	inbox                telegramInbox
+	restartGate          restart.Gate
 	mu                   sync.Mutex
 	sessions             map[int64]*telegramSession
 	cfg                  *config.Config
@@ -1053,7 +1099,14 @@ func closeTelegramSession(sess *telegramSession) {
 }
 
 func (m *telegramSessionMgr) closeTelegramSession(sess *telegramSession) {
-	closeTelegramSessionWithTimeout(sess, m.sessionShutdownTimeout())
+	release := m.restartGate.TrackChild()
+	done := closeTelegramSessionWithTimeout(sess, m.sessionShutdownTimeout())
+	select {
+	case <-done:
+		release()
+	default:
+		go func() { <-done; release() }()
+	}
 }
 
 func (m *telegramSessionMgr) interruptGrace() time.Duration {
@@ -1070,20 +1123,30 @@ func (m *telegramSessionMgr) sessionShutdownTimeout() time.Duration {
 	return telegramSessionShutdownFallbackTimeout
 }
 
-func closeTelegramSessionWithTimeout(sess *telegramSession, wait time.Duration) {
+func closeTelegramSessionWithTimeout(sess *telegramSession, wait time.Duration) <-chan struct{} {
 	if sess == nil {
-		return
+		done := make(chan struct{})
+		close(done)
+		return done
 	}
 	if wait <= 0 {
 		wait = telegramSessionShutdownFallbackTimeout
 	}
 
 	sess.cancelMu.Lock()
+	if sess.cleanupDone == nil {
+		sess.cleanupDone = make(chan struct{})
+	}
+	cleanupDone := sess.cleanupDone
 	cancelFn := sess.streamCancel
+	control := sess.restartControl
 	doneCh := sess.replyDone
 	runnerDone := sess.runnerDone
 	sess.cancelMu.Unlock()
 
+	if control != nil {
+		control.stop()
+	}
 	if cancelFn != nil {
 		cancelFn()
 	}
@@ -1097,6 +1160,7 @@ func closeTelegramSessionWithTimeout(sess *telegramSession, wait time.Duration) 
 
 	cleanup := func() {
 		sess.cleanupOnce.Do(func() {
+			defer close(cleanupDone)
 			if sess.runtime != nil && sess.runtime.Cleanup != nil {
 				sess.runtime.Cleanup()
 			}
@@ -1114,9 +1178,10 @@ func closeTelegramSessionWithTimeout(sess *telegramSession, wait time.Duration) 
 				cleanup()
 			}()
 		}
-		return
+		return cleanupDone
 	}
 	cleanup()
+	return cleanupDone
 }
 
 func (m *telegramSessionMgr) runStoreOp(ctx context.Context, sessionID, op string, fn func(context.Context) error) bool {
@@ -1188,7 +1253,8 @@ func newTelegramStoreOpQueue(mgr *telegramSessionMgr, sessionID string) *telegra
 		done:      make(chan struct{}),
 		closedCh:  make(chan struct{}),
 	}
-	go q.run()
+	release := mgr.restartGate.TrackChild()
+	go func() { defer release(); q.run() }()
 	return q
 }
 
@@ -1390,6 +1456,10 @@ func (m *telegramSessionMgr) handleMessageWithAdmission(ctx context.Context, bot
 
 	chatID := msg.Chat.ID
 	if !admission.wait(ctx) {
+		return
+	}
+
+	if !startTelegramInboxReceipt(ctx) {
 		return
 	}
 
@@ -1665,6 +1735,31 @@ func (m *telegramSessionMgr) streamReply(ctx context.Context, bot botSender, ses
 }
 
 func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot botSender, sess *telegramSession, chatID int64, userMsg llm.Message, releaseAdmission func()) error {
+	return m.streamReplyTurn(ctx, bot, sess, chatID, userMsg, releaseAdmission, 0, false, nil)
+}
+
+// streamReplyContinuation is only for a sealed internal restart handoff. It
+// consumes the remaining model-turn allowance without creating a new user turn.
+// Delivery restoration and authorization belong to the restart adapter.
+func (m *telegramSessionMgr) streamReplyContinuation(ctx context.Context, bot botSender, sess *telegramSession, chatID int64, instruction string, remainingTurns int, reply *telegramReplyCursor) error {
+	if remainingTurns <= 0 {
+		return fmt.Errorf("Telegram continuation has no remaining model turns")
+	}
+	if strings.TrimSpace(instruction) == "" {
+		return fmt.Errorf("Telegram continuation instruction is empty")
+	}
+	if reply != nil && (reply.MessageID <= 0 || (reply.NeedNewMessage && reply.Prefix != "")) {
+		return fmt.Errorf("invalid Telegram reply cursor")
+	}
+	message := llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: instruction}}}
+	return m.streamReplyTurn(ctx, bot, sess, chatID, message, nil, remainingTurns, true, reply)
+}
+
+func (m *telegramSessionMgr) streamReplyTurn(ctx context.Context, bot botSender, sess *telegramSession, chatID int64, userMsg llm.Message, releaseAdmission func(), remainingTurns int, continuation bool, reply *telegramReplyCursor) error {
+	maxTurns := m.settings.MaxTurns
+	if continuation {
+		maxTurns = remainingTurns
+	}
 	// We acquire the session lock for the entire streaming call so that
 	// concurrent messages from the same chat are serialised.
 	sess.mu.Lock()
@@ -1676,15 +1771,40 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		return fmt.Errorf("telegram runtime is not initialized")
 	}
 
+	if continuation {
+		if err := m.prepareRestoredSteering(ctx, sess); err != nil {
+			return err
+		}
+	} else {
+		// A newer user turn supersedes an unstarted recovered continuation.
+		sess.restoredExecution = nil
+	}
+
 	// Create a cancellable child context so new messages can interrupt the stream.
-	streamCtx, streamCancel := context.WithCancel(ctx)
+	control := newTelegramStreamControl(ctx)
+	streamCtx, streamCancel := control.ctx, control.close
 	defer streamCancel()
 
+	actualDone := make(chan struct{})
+	releaseExecution := m.restartGate.TrackChild()
+	joinStarted := false
+	defer func() {
+		if !joinStarted {
+			close(actualDone)
+			releaseExecution()
+		}
+	}()
+	executionEngine := sess.runtime.Engine
 	replyDone := make(chan struct{})
 	streamToken := make(chan struct{})
 	sess.cancelMu.Lock()
-	sess.streamCancel = streamCancel
+	if sess.restartControl != nil {
+		sess.restartControl.stop()
+	}
+	sess.restartControl = control
+	sess.streamCancel = control.stop
 	sess.replyDone = replyDone
+	sess.runnerDone = actualDone
 	sess.streamToken = streamToken
 	sess.cancelMu.Unlock()
 	defer func() {
@@ -1765,21 +1885,27 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		}
 		storeUserMsg := &session.Message{
 			SessionID:   sess.meta.ID,
-			Role:        llm.RoleUser,
+			Role:        userMsg.Role,
 			Parts:       userMsg.Parts,
 			TextContent: userText,
 			CreatedAt:   time.Now(),
 			Sequence:    -1,
 		}
-		if !m.runStoreOp(ctx, sess.meta.ID, "AddMessage(user)", func(storeCtx context.Context) error {
+		inputOp := "AddMessage(user)"
+		if continuation {
+			inputOp = "AddMessage(continuation)"
+		}
+		if !m.runStoreOp(ctx, sess.meta.ID, inputOp, func(storeCtx context.Context) error {
 			return m.store.AddMessage(storeCtx, sess.meta.ID, storeUserMsg)
 		}) {
 			turnPersistenceDegraded = true
 		}
-		m.runStoreOp(ctx, sess.meta.ID, "IncrementUserTurns", func(storeCtx context.Context) error {
-			return m.store.IncrementUserTurns(storeCtx, sess.meta.ID)
-		})
-		if sess.meta.Summary == "" {
+		if !continuation {
+			m.runStoreOp(ctx, sess.meta.ID, "IncrementUserTurns", func(storeCtx context.Context) error {
+				return m.store.IncrementUserTurns(storeCtx, sess.meta.ID)
+			})
+		}
+		if !continuation && sess.meta.Summary == "" {
 			sess.meta.Summary = session.TruncateSummary(userText)
 			m.runStoreOp(ctx, sess.meta.ID, "Update(summary)", func(storeCtx context.Context) error {
 				return m.store.Update(storeCtx, sess.meta)
@@ -1793,6 +1919,14 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		})
 	}
 
+	if continuation && (m.store == nil || sess.meta == nil || turnPersistenceDegraded) {
+		return fmt.Errorf("Telegram continuation input was not durably committed")
+	}
+
+	var modelBoundary llm.ModelBoundaryCallback
+	if _, durable := session.AsCommandHandoffStore(m.store); durable && !turnPersistenceDegraded && sess.runtime.Provider != nil && !sess.runtime.Provider.Capabilities().InlineToolLoop {
+		modelBoundary = control.modelBoundary
+	}
 	// The turn is now durably ordered and its cancellation state is visible.
 	// Let the next same-chat message inspect or interrupt it before provider output completes.
 	if releaseAdmission != nil {
@@ -1900,6 +2034,29 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 			}()
 		})
 	}
+	var joinOnce sync.Once
+	startExecutionJoin := func() {
+		joinOnce.Do(func() {
+			joinStarted = true
+			startStreamClose()
+			producer, consumer := runnerDone, streamConsumerDone
+			go func() {
+				defer releaseExecution()
+				defer close(actualDone)
+				if producer != nil {
+					<-producer
+				}
+				if consumer != nil {
+					<-consumer
+				}
+				<-streamCloseDone
+				if executionEngine != nil {
+					_ = executionEngine.WaitToolSettlement(context.Background())
+				}
+			}()
+		})
+	}
+	defer startExecutionJoin()
 	cleanupDetached := false
 	markCleanupDetached := func() {
 		if cleanupDetached {
@@ -1910,29 +2067,20 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		log.Printf("[telegram] stream for chat %d did not stop after cancellation; detaching and resetting runtime before reuse", chatID)
 	}
 	waitForCleanup := func(waitCtx context.Context) bool {
-		for _, done := range []<-chan struct{}{streamCloseDone, streamConsumerDone, runnerDone} {
-			if done == nil {
-				continue
-			}
-			select {
-			case <-done:
-			case <-waitCtx.Done():
-				markCleanupDetached()
-				return false
-			}
+		startExecutionJoin()
+		select {
+		case <-actualDone:
+			return true
+		case <-waitCtx.Done():
+			markCleanupDetached()
+			return false
 		}
-		return true
 	}
 	if m.settings.Runner != nil {
 		pipe := runpkg.NewEventPipe(streamCtx, ui.DefaultStreamBufferSize)
 		stream = pipe
 		done := make(chan struct{})
 		runnerDone = done
-		sess.cancelMu.Lock()
-		if sess.streamToken == streamToken {
-			sess.runnerDone = done
-		}
-		sess.cancelMu.Unlock()
 		search := m.settings.Search
 		forceExternalSearch := m.settings.ForceExternalSearch
 		go func() {
@@ -1949,14 +2097,17 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 				Persist:                   false,
 				Tools:                     m.settings.Tools,
 				MCP:                       m.settings.MCP,
-				MaxTurns:                  m.settings.MaxTurns,
+				MaxTurns:                  maxTurns,
 				Search:                    &search,
 				Debug:                     m.settings.Debug,
 				DebugRaw:                  m.settings.DebugRaw,
 				ForceExternalSearch:       &forceExternalSearch,
 				OnResponseCompleted:       responseCompletedCB,
 				OnTurnCompleted:           turnCompletedCB,
+				ModelBoundary:             modelBoundary,
 				OnEngineReady: func(engine *llm.Engine) {
+					control.bind(engine, maxTurns)
+					executionEngine = engine
 					sess.cancelMu.Lock()
 					if sess.streamToken == streamToken {
 						sess.streamEngine = engine
@@ -1974,10 +2125,12 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 			pipe.CloseWithError(runErr)
 		}()
 	} else {
+		control.bind(sess.runtime.Engine, maxTurns)
 		req := llm.Request{
+			ModelBoundary:       modelBoundary,
 			SessionID:           sessionID,
 			Messages:            messages,
-			MaxTurns:            m.settings.MaxTurns,
+			MaxTurns:            maxTurns,
 			Debug:               m.settings.Debug,
 			DebugRaw:            m.settings.DebugRaw,
 			Search:              m.settings.Search,
@@ -2000,11 +2153,6 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 			}
 			return fmt.Errorf("stream: %w", err)
 		}
-		sess.cancelMu.Lock()
-		if sess.streamToken == streamToken {
-			sess.runnerDone = streamCloseDone
-		}
-		sess.cancelMu.Unlock()
 	}
 	defer func() {
 		streamCancel()
@@ -2018,9 +2166,17 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 	}()
 
 	// Send placeholder message to obtain a message ID for live editing.
-	placeholder, err := bot.Send(tgbotapi.NewMessage(chatID, "⏳"))
-	if err != nil {
-		return fmt.Errorf("send placeholder: %w", err)
+	var placeholder tgbotapi.Message
+	replyPrefix := ""
+	if reply != nil && !reply.NeedNewMessage {
+		placeholder.MessageID = reply.MessageID
+		replyPrefix = reply.Prefix
+	} else {
+		var err error
+		placeholder, err = bot.Send(tgbotapi.NewMessage(chatID, "⏳"))
+		if err != nil {
+			return fmt.Errorf("send placeholder: %w", err)
+		}
 	}
 
 	var (
@@ -2046,6 +2202,13 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		lastEventPing    = make(chan struct{}, 1)
 		watchdogTimedOut atomic.Bool
 	)
+
+	var pendingMedia []llm.MediaArtifact
+	if reply != nil {
+		collectedImages = append([]string(nil), reply.Images...)
+		collectedMedia = append([]llm.MediaArtifact(nil), reply.Media...)
+		pendingMedia = append([]llm.MediaArtifact(nil), reply.PendingMedia...)
+	}
 
 	watchdogTimeout := m.streamEventTimeout
 	if watchdogTimeout <= 0 {
@@ -2079,19 +2242,6 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 
 	// Goroutine: consume stream events.
 	streamConsumerDone = make(chan struct{})
-	if runnerDone == nil {
-		streamCleanupDone := make(chan struct{})
-		go func() {
-			<-streamConsumerDone
-			<-streamCloseDone
-			close(streamCleanupDone)
-		}()
-		sess.cancelMu.Lock()
-		if sess.streamToken == streamToken {
-			sess.runnerDone = streamCleanupDone
-		}
-		sess.cancelMu.Unlock()
-	}
 	go func() {
 		defer close(streamConsumerDone)
 		for {
@@ -2391,7 +2541,7 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		// otherwise duplicate or reorder the repaired snapshot.
 		queueDrained := drainCallbackStoreQueue()
 		queueDegraded := callbackStoreQueue != nil && callbackStoreQueue.isDegraded()
-		if partial == "" && len(producedSnapshot) == 0 && !turnPersistenceDegraded && !queueDegraded {
+		if partial == "" && len(producedSnapshot) == 0 && !turnPersistenceDegraded && !queueDegraded && !control.restarting() {
 			return
 		}
 
@@ -2453,7 +2603,7 @@ loop:
 			break loop
 		case <-ticker.C:
 			textMu.Lock()
-			full, toolDisplay, phase := textBuf.String(), activeToolDisplay(activeTools), activePhase
+			full, toolDisplay, phase := replyPrefix+textBuf.String(), activeToolDisplay(activeTools), activePhase
 			textMu.Unlock()
 
 			prose := ""
@@ -2536,7 +2686,7 @@ loop:
 		drained := stopStreamWithCleanupTimeout()
 
 		textMu.Lock()
-		partial := textBuf.String()
+		partial := replyPrefix + textBuf.String()
 		textMu.Unlock()
 
 		// Edit the Telegram message to show partial text + interrupted marker.
@@ -2544,15 +2694,20 @@ loop:
 		if msgStart < len(partial) {
 			display = partial[msgStart:]
 		}
+		marker := "interrupted"
+		if control.restarting() {
+			marker = "restarting"
+		}
 		if display == "" {
-			display = "(interrupted)"
+			display = "(" + marker + ")"
 		} else {
-			display += "\n\n_(interrupted)_"
+			display += "\n\n_(" + marker + ")_"
 		}
 		if needNewMsg {
 			newMsg, sendErr := bot.Send(tgbotapi.NewMessage(chatID, "⏳"))
 			if sendErr == nil {
 				currentMsgID = newMsg.MessageID
+				needNewMsg = false
 			}
 		}
 		sendEdit(currentMsgID, display, true)
@@ -2561,6 +2716,15 @@ loop:
 		// after every producer has stopped mutating the callback snapshot.
 		if drained {
 			salvagePartialHistory(streamCtx, "AddMessage(assistant_interrupt_fallback)")
+			// A failed new-message send can have been accepted remotely without
+			// returning its ID. Do not publish a replayable cursor in that case.
+			if control.restarting() && !needNewMsg {
+				prefix := ""
+				if msgStart < len(partial) {
+					prefix = partial[msgStart:]
+				}
+				control.reply.Store(&telegramReplyCursor{MessageID: currentMsgID, Prefix: prefix, NeedNewMessage: needNewMsg, Images: append([]string(nil), collectedImages...), Media: append([]llm.MediaArtifact(nil), collectedMedia...), PendingMedia: mergeTelegramPendingMedia(pendingMedia, referencedTelegramMedia(partial, collectedMedia))})
+			}
 		}
 
 		if m.store != nil && sess.meta != nil {
@@ -2606,7 +2770,7 @@ loop:
 		finalOtherTypes[k] = v
 	}
 	imagesToSend := append([]string(nil), collectedImages...)
-	mediaToSend := referencedTelegramMedia(full, collectedMedia)
+	mediaToSend := mergeTelegramPendingMedia(pendingMedia, referencedTelegramMedia(full, collectedMedia))
 	textMu.Unlock()
 
 	finalDeliveryCtx, cancelFinalDelivery := context.WithTimeout(ctx, telegramFinalDeliveryTimeout)
@@ -2614,8 +2778,9 @@ loop:
 	var finalDeliveryErr error
 
 	prose := ""
-	if msgStart < len(full) {
-		prose = full[msgStart:]
+	displayFull := replyPrefix + full
+	if msgStart < len(displayFull) {
+		prose = displayFull[msgStart:]
 		prose = telegramMediaMarkdownPattern.ReplaceAllString(prose, "$1")
 	}
 	switch {
@@ -2828,6 +2993,9 @@ func collectUserText(msg llm.Message) string {
 }
 
 func normalizeUserMessageForHistory(msg llm.Message) llm.Message {
+	if msg.Role == llm.RoleDeveloper {
+		return msg
+	}
 	text := extractMessageTextWithPlaceholders(msg)
 	if text == "" {
 		return llm.UserText("")
@@ -3066,4 +3234,26 @@ func formatElapsed(elapsed time.Duration) string {
 		return fmt.Sprintf("%dm %ds", mins, secs)
 	}
 	return fmt.Sprintf("%ds", secs)
+}
+
+// Both slices contain only not-yet-sent artifacts. Keep earlier references in
+// their original order, without resending an artifact referenced again after
+// continuation. This must never be seeded with already delivered media.
+func mergeTelegramPendingMedia(prior, current []llm.MediaArtifact) []llm.MediaArtifact {
+	result := make([]llm.MediaArtifact, 0, len(prior)+len(current))
+	seen := make(map[string]bool)
+	for _, items := range [][]llm.MediaArtifact{prior, current} {
+		for _, item := range items {
+			key := strings.ToLower(strings.TrimSpace(item.Reference))
+			if key == "" {
+				key = item.PublishedPath()
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			result = append(result, item)
+		}
+	}
+	return result
 }

--- a/internal/serve/telegram_continuation_test.go
+++ b/internal/serve/telegram_continuation_test.go
@@ -1,0 +1,161 @@
+package serve
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	runpkg "github.com/samsaffron/term-llm/internal/run"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/testutil"
+)
+
+func TestTelegramContinuationDoesNotCreateUserTurn(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	h := testutil.NewEngineHarness()
+	h.Provider.AddTextResponse("initial answer")
+	h.Provider.AddTextResponse("continued answer")
+	mgr := &telegramSessionMgr{sessions: make(map[int64]*telegramSession), store: store, settings: Settings{MaxTurns: 9, NewSession: func(context.Context) (*SessionRuntime, error) {
+		return &SessionRuntime{Engine: h.Engine, ProviderName: "mock", ModelName: "mock"}, nil
+	}}}
+	sess, err := mgr.getOrCreate(ctx, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.closeAllSessions()
+	bot := &fakeBotSender{nextID: 1}
+	if err := mgr.streamReply(ctx, bot, sess, 42, llm.UserText("original task")); err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.Get(ctx, sess.meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newMessages := bot.newMessages
+	if err := mgr.streamReplyContinuation(ctx, bot, sess, 42, "Continue unfinished work; do not repeat completed effects.", 1, &telegramReplyCursor{MessageID: 1, Prefix: "initial answer\n"}); err != nil {
+		t.Fatal(err)
+	}
+	if bot.newMessages != newMessages || bot.editIDs[len(bot.editIDs)-1] != 1 || bot.lastText() != "initial answer\ncontinued answer" {
+		t.Fatal("continuation duplicated a message or lost its displayed prefix")
+	}
+	after, err := store.Get(ctx, sess.meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.UserTurns != 1 || after.UserTurns != before.UserTurns || after.Summary != before.Summary {
+		t.Fatalf("continuation changed user accounting: before=%+v after=%+v", before, after)
+	}
+	messages, err := store.GetMessages(ctx, sess.meta.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	users, developers := 0, 0
+	var answers []string
+	for _, msg := range messages {
+		if msg.Role == llm.RoleAssistant {
+			answers = append(answers, msg.TextContent)
+		}
+		if msg.Role == llm.RoleUser {
+			users++
+		}
+		if msg.Role == llm.RoleDeveloper {
+			developers++
+		}
+	}
+	if len(answers) != 2 || answers[0] != "initial answer" || answers[1] != "continued answer" {
+		t.Fatalf("display prefix duplicated into transcript: %q", answers)
+	}
+	if users != 1 || developers != 1 {
+		t.Fatalf("persisted roles: users=%d developers=%d", users, developers)
+	}
+	historyDevelopers := 0
+	for _, msg := range sess.history {
+		if msg.Role == llm.RoleDeveloper {
+			historyDevelopers++
+		}
+	}
+	if historyDevelopers != 1 {
+		t.Fatal("continuation was relabelled as user in live history")
+	}
+	if len(h.Provider.Requests) != 2 || h.Provider.Requests[1].MaxTurns != 1 {
+		t.Fatal("remaining turn allowance was reset")
+	}
+	if err := mgr.streamReplyContinuation(ctx, bot, sess, 42, "exhausted", 0, nil); err == nil {
+		t.Fatal("exhausted allowance started another model turn")
+	}
+	if len(h.Provider.Requests) != 2 {
+		t.Fatal("exhausted continuation contacted provider")
+	}
+	mgr.store = &failingTelegramTurnStore{Store: store, failRole: llm.RoleDeveloper}
+	if err := mgr.streamReplyContinuation(ctx, bot, sess, 42, "must commit before running", 1, nil); err == nil {
+		t.Fatal("failed continuation persistence still started model work")
+	}
+	if len(h.Provider.Requests) != 2 {
+		t.Fatal("uncommitted continuation contacted provider")
+	}
+}
+
+type telegramContinuationRunner struct{ requests chan runpkg.Request }
+
+func (r *telegramContinuationRunner) Run(ctx context.Context, req runpkg.Request, sink runpkg.EventSink) (runpkg.Result, error) {
+	r.requests <- req
+	req.OnEngineReady(req.Engine)
+	defer req.OnEngineDone(req.Engine)
+	message := llm.AssistantText("continued via shared runner")
+	if err := req.OnResponseCompleted(ctx, 0, message, llm.TurnMetrics{}); err != nil {
+		return runpkg.Result{}, err
+	}
+	sink.Event(llm.Event{Type: llm.EventTextDelta, Text: "continued via shared runner"})
+	return runpkg.Result{}, nil
+}
+
+func TestTelegramContinuationSharedRunnerUsesExistingHistory(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	h := testutil.NewEngineHarness()
+	runner := &telegramContinuationRunner{requests: make(chan runpkg.Request, 1)}
+	mgr := &telegramSessionMgr{store: store, sessions: make(map[int64]*telegramSession), settings: Settings{MaxTurns: 50, Runner: runner, NewSession: func(context.Context) (*SessionRuntime, error) {
+		return &SessionRuntime{Engine: h.Engine, ProviderName: "mock", ModelName: "mock"}, nil
+	}}}
+	sess, err := mgr.getOrCreate(ctx, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.closeAllSessions()
+	sess.history = []llm.Message{llm.UserText("original task"), llm.AssistantText("completed partial work")}
+	for _, message := range sess.history {
+		if err := store.AddMessage(ctx, sess.meta.ID, session.NewMessage(sess.meta.ID, message, -1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.IncrementUserTurns(ctx, sess.meta.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.streamReplyContinuation(ctx, &fakeBotSender{}, sess, 42, "Continue only unfinished work.", 2, nil); err != nil {
+		t.Fatal(err)
+	}
+	req := <-runner.requests
+	if req.MaxTurns != 2 || req.SessionID != sess.meta.ID || req.Engine != h.Engine || req.Persist || !req.DisableRuntimePersistence {
+		t.Fatal("shared runner lost original runtime/session/budget ownership")
+	}
+	if len(req.Messages) != 3 || req.Messages[0].Role != llm.RoleUser || req.Messages[2].Role != llm.RoleDeveloper {
+		t.Fatal("shared runner did not receive original history plus developer continuation")
+	}
+	meta, err := store.Get(ctx, sess.meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.UserTurns != 1 {
+		t.Fatal("shared runner continuation counted as another user turn")
+	}
+}

--- a/internal/serve/telegram_conversation_handoff.go
+++ b/internal/serve/telegram_conversation_handoff.go
@@ -1,0 +1,126 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+// telegramConversationState preserves the live conversation, including history
+// carried from earlier sessions that is deliberately absent from this session's
+// transcript. This is not the lossy history used for ordinary /reset carryover.
+// Active execution/delivery state must be sealed separately before replacement.
+type telegramConversationState struct {
+	Execution             *telegramExecutionState `json:"execution,omitempty"`
+	ChatID                int64                   `json:"chat_id"`
+	SessionID             string                  `json:"session_id"`
+	Revision              int64                   `json:"revision"`
+	History               []llm.Message           `json:"history"`
+	SystemPromptPersisted bool                    `json:"system_prompt_persisted"`
+	CarryoverContext      string                  `json:"carryover_context,omitempty"`
+	CarryoverContextLabel string                  `json:"carryover_context_label,omitempty"`
+	CarryoverMessageCount int                     `json:"carryover_message_count"`
+	LastActivity          time.Time               `json:"last_activity"`
+}
+
+func (m *telegramSessionMgr) snapshotConversation(ctx context.Context, chatID int64, sess *telegramSession) (json.RawMessage, error) {
+	if !m.restartGate.Drained() {
+		return nil, fmt.Errorf("Telegram work has not settled")
+	}
+	if sess == nil || !sess.mu.TryLock() {
+		return nil, fmt.Errorf("Telegram conversation is busy")
+	}
+	defer sess.mu.Unlock()
+	if sess.meta == nil || sess.runtimeStale.Load() {
+		return nil, fmt.Errorf("Telegram conversation cannot be checkpointed")
+	}
+	index, ok := m.store.(session.TranscriptIndexer)
+	if !ok {
+		return nil, fmt.Errorf("Telegram store does not support transcript fencing")
+	}
+	sess.cancelMu.Lock()
+	control := sess.restartControl
+	sess.cancelMu.Unlock()
+	execution := sess.restoredExecution
+	if control != nil {
+		var err error
+		execution, err = control.executionState()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if execution != nil && !m.reconcileTelegramTranscript(ctx, sess, sess.history, sess.systemPromptPersisted, "ReplaceMessages(restart_seal)") {
+		return nil, fmt.Errorf("Telegram interrupted transcript could not be sealed")
+	}
+	revision, err := index.TranscriptRev(ctx, sess.meta.ID)
+	if err != nil {
+		return nil, err
+	}
+	sess.activityMu.Lock()
+	lastActivity := sess.lastActivity
+	sess.activityMu.Unlock()
+	return json.Marshal(telegramConversationState{Execution: execution, ChatID: chatID, SessionID: sess.meta.ID, Revision: revision, History: sess.history, SystemPromptPersisted: sess.systemPromptPersisted, CarryoverContext: sess.carryoverContext, CarryoverContextLabel: sess.carryoverContextLabel, CarryoverMessageCount: sess.carryoverMessageCount, LastActivity: lastActivity})
+}
+
+// restoreConversation constructs, but does not publish, an exact session. The
+// caller must first authenticate/consume the durable one-shot process handoff,
+// and keep platform admission closed until all conversations have been restored.
+func (m *telegramSessionMgr) restoreConversation(ctx context.Context, raw json.RawMessage) (*telegramSession, int64, error) {
+	var state telegramConversationState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, 0, err
+	}
+	if state.SessionID == "" || state.CarryoverMessageCount < 0 || state.CarryoverMessageCount > len(state.History) {
+		return nil, 0, fmt.Errorf("invalid Telegram conversation checkpoint")
+	}
+	if state.Execution != nil && (state.Execution.RemainingTurns < 0 || state.Execution.Reply == nil || state.Execution.Reply.MessageID <= 0) {
+		return nil, 0, fmt.Errorf("invalid Telegram execution checkpoint")
+	}
+	index, ok := m.store.(session.TranscriptIndexer)
+	if !ok {
+		return nil, 0, fmt.Errorf("Telegram store does not support transcript fencing")
+	}
+	revision, err := index.TranscriptRev(ctx, state.SessionID)
+	if err != nil {
+		return nil, 0, err
+	}
+	if revision != state.Revision {
+		return nil, 0, session.ErrExecHandoffConflict
+	}
+	meta, err := m.store.Get(ctx, state.SessionID)
+	if err != nil {
+		return nil, 0, err
+	}
+	if meta.Origin != session.OriginTelegram || meta.Name != fmt.Sprintf("telegram:%d", state.ChatID) || meta.Agent != m.settings.Agent {
+		return nil, 0, fmt.Errorf("Telegram checkpoint session identity mismatch")
+	}
+	if m.settings.NewSession == nil {
+		return nil, 0, fmt.Errorf("Telegram runtime factory is not configured")
+	}
+	runtime, err := m.settings.NewSession(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	if runtime == nil {
+		return nil, 0, fmt.Errorf("Telegram runtime factory returned nil")
+	}
+	identity := func(value string) string {
+		if value = strings.TrimSpace(value); value == "" {
+			return "unknown"
+		}
+		return value
+	}
+	if runtime.Engine == nil || identity(runtime.ProviderName) != meta.Provider || identity(runtime.ModelName) != meta.Model {
+		if runtime.Cleanup != nil {
+			runtime.Cleanup()
+		}
+		return nil, 0, fmt.Errorf("Telegram checkpoint runtime does not match saved provider/model")
+	}
+	runtime.Engine.SetContextEstimateBaseline(meta.LastTotalTokens, meta.LastMessageCount)
+	return &telegramSession{restoredExecution: state.Execution, runtime: runtime, meta: meta, history: state.History, systemPromptPersisted: state.SystemPromptPersisted, carryoverContext: state.CarryoverContext, carryoverContextLabel: state.CarryoverContextLabel, carryoverMessageCount: state.CarryoverMessageCount, lastActivity: state.LastActivity}, state.ChatID, nil
+}

--- a/internal/serve/telegram_conversation_handoff_test.go
+++ b/internal/serve/telegram_conversation_handoff_test.go
@@ -1,0 +1,102 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/testutil"
+)
+
+func TestTelegramConversationHandoffPreservesExactSession(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	h := testutil.NewEngineHarness()
+	created, cleaned := 0, 0
+	mgr := &telegramSessionMgr{store: store, settings: Settings{Agent: "test", TelegramCarryoverChars: 0, NewSession: func(context.Context) (*SessionRuntime, error) {
+		created++
+		return &SessionRuntime{Engine: h.Engine, ProviderName: "mock", ModelName: "mock", Cleanup: func() { cleaned++ }}, nil
+	}}}
+	sess, err := mgr.newSession(ctx, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.persistSession(ctx, sess)
+	sess.history = []llm.Message{llm.SystemText("prior policy"), llm.UserImageMessageWithPath("image/png", "aW1hZ2U=", "/private/upload.png", "untruncated original input"), llm.AssistantText("complete answer")}
+	sess.carryoverMessageCount = 2
+	sess.carryoverContext = "pending carryover"
+	sess.carryoverContextLabel = "custom label"
+	sess.systemPromptPersisted = true
+	sess.lastActivity = time.Date(2026, 9, 6, 1, 2, 3, 0, time.UTC)
+	if _, err := mgr.snapshotConversation(ctx, 42, sess); err == nil {
+		t.Fatal("snapshot allowed open admission")
+	}
+	reopen := mgr.restartGate.Pause()
+	defer reopen()
+	releaseChild := mgr.restartGate.TrackChild()
+	if _, err := mgr.snapshotConversation(ctx, 42, sess); err == nil {
+		t.Fatal("snapshot allowed unsettled descendant")
+	}
+	releaseChild()
+	sess.runtimeStale.Store(true)
+	if _, err := mgr.snapshotConversation(ctx, 42, sess); err == nil {
+		t.Fatal("snapshot allowed quarantined runtime")
+	}
+	sess.runtimeStale.Store(false)
+	raw, err := mgr.snapshotConversation(ctx, 42, sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, chatID, err := mgr.restoreConversation(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restored.runtime.Cleanup()
+	if chatID != 42 || restored.meta.ID != sess.meta.ID || !reflect.DeepEqual(restored.history, sess.history) || restored.carryoverMessageCount != 2 || !restored.systemPromptPersisted || restored.carryoverContext != sess.carryoverContext || restored.carryoverContextLabel != sess.carryoverContextLabel || !restored.lastActivity.Equal(sess.lastActivity) {
+		t.Fatal("conversation restored lossily or with new identity")
+	}
+	var state telegramConversationState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatal(err)
+	}
+	state.ChatID = 99
+	wrong, _ := json.Marshal(state)
+	if _, _, err := mgr.restoreConversation(ctx, wrong); err == nil {
+		t.Fatal("wrong chat accepted")
+	}
+	if created != 2 {
+		t.Fatal("invalid handoff created a runtime")
+	}
+	factory := mgr.settings.NewSession
+	mgr.settings.NewSession = func(ctx context.Context) (*SessionRuntime, error) {
+		runtime, err := factory(ctx)
+		runtime.ModelName = "different-model"
+		return runtime, err
+	}
+	if _, _, err := mgr.restoreConversation(ctx, raw); err == nil {
+		t.Fatal("changed model accepted")
+	}
+	mgr.settings.NewSession = factory
+	if cleaned != 1 || created != 3 {
+		t.Fatal("rejected runtime was not cleaned exactly once")
+	}
+	if err := store.AddMessage(ctx, sess.meta.ID, &session.Message{SessionID: sess.meta.ID, Role: llm.RoleUser, Parts: llm.UserText("later change").Parts, CreatedAt: time.Now(), Sequence: -1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := mgr.restoreConversation(ctx, raw); !errors.Is(err, session.ErrExecHandoffConflict) {
+		t.Fatalf("stale transcript accepted: %v", err)
+	}
+	if cleaned != 1 || created != 3 {
+		t.Fatal("stale handoff created or cleaned runtime")
+	}
+}

--- a/internal/serve/telegram_conversations_handoff.go
+++ b/internal/serve/telegram_conversations_handoff.go
@@ -1,0 +1,111 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+// snapshotConversations runs only after the receiver and actual work have
+// stopped. Holding the manager lock keeps chat membership stable as it captures
+// each exact conversation. No session is reset or retired during preparation.
+func (m *telegramSessionMgr) snapshotConversations(ctx context.Context) ([]json.RawMessage, error) {
+	if !m.restartGate.Drained() {
+		return nil, fmt.Errorf("Telegram work has not settled")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ids := make([]int64, 0, len(m.sessions))
+	for id := range m.sessions {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	result := make([]json.RawMessage, 0, len(ids))
+	for _, id := range ids {
+		raw, err := m.snapshotConversation(ctx, id, m.sessions[id])
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, raw)
+	}
+	return result, nil
+}
+
+// restoreConversations publishes all chats together or none. A bad later chat
+// must not leave earlier chats visible, or leak their fresh runtimes. This is a
+// startup-only operation; the caller must keep receiving closed throughout and
+// authenticate the one-shot handoff before calling it.
+func (m *telegramSessionMgr) restoreConversations(ctx context.Context, states []json.RawMessage) error {
+	m.mu.Lock()
+	occupied := len(m.sessions) != 0
+	m.mu.Unlock()
+	if occupied {
+		return fmt.Errorf("Telegram conversations already initialized")
+	}
+	// Check duplicate chat/session identities before invoking any runtime factory.
+	chats := make(map[int64]bool, len(states))
+	sessions := make(map[string]bool, len(states))
+	revisions := make(map[string]int64, len(states))
+	for _, raw := range states {
+		var state telegramConversationState
+		if err := json.Unmarshal(raw, &state); err != nil {
+			return err
+		}
+		if state.SessionID == "" || chats[state.ChatID] || sessions[state.SessionID] {
+			return fmt.Errorf("duplicate or missing Telegram checkpoint identity")
+		}
+		chats[state.ChatID] = true
+		sessions[state.SessionID] = true
+		revisions[state.SessionID] = state.Revision
+	}
+	restored := make(map[int64]*telegramSession, len(states))
+	published := false
+	defer func() {
+		if !published {
+			for _, sess := range restored {
+				closeTelegramSession(sess)
+			}
+		}
+	}()
+	for _, raw := range states {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		sess, chatID, err := m.restoreConversation(ctx, raw)
+		if err != nil {
+			return err
+		}
+		restored[chatID] = sess
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(m.sessions) != 0 {
+		return fmt.Errorf("Telegram conversations initialized during recovery")
+	}
+	// Factories can take time. Recheck earlier transcripts before publishing,
+	// rather than assuming their pre-construction revision is still current.
+	if len(revisions) > 0 {
+		index, ok := m.store.(session.TranscriptIndexer)
+		if !ok {
+			return fmt.Errorf("Telegram store does not support transcript fencing")
+		}
+		for id, expected := range revisions {
+			current, err := index.TranscriptRev(ctx, id)
+			if err != nil {
+				return err
+			}
+			if current != expected {
+				return session.ErrExecHandoffConflict
+			}
+		}
+	}
+	m.sessions = restored
+	published = true
+	return nil
+}

--- a/internal/serve/telegram_conversations_handoff_test.go
+++ b/internal/serve/telegram_conversations_handoff_test.go
@@ -1,0 +1,116 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/testutil"
+)
+
+func TestTelegramConversationsHandoffPublishesAllOrNone(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	created, cleaned := 0, 0
+	settings := Settings{NewSession: func(context.Context) (*SessionRuntime, error) {
+		created++
+		h := testutil.NewEngineHarness()
+		return &SessionRuntime{Engine: h.Engine, ProviderName: "mock", ModelName: "mock", Cleanup: func() { cleaned++ }}, nil
+	}}
+	source := &telegramSessionMgr{store: store, settings: settings, sessions: make(map[int64]*telegramSession)}
+	for _, chat := range []int64{20, 10} {
+		sess, err := source.newSession(ctx, chat)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source.persistSession(ctx, sess)
+		source.sessions[chat] = sess
+	}
+	defer source.closeAllSessions()
+	reopen := source.restartGate.Pause()
+	defer reopen()
+	states, err := source.snapshotConversations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var first telegramConversationState
+	if err := json.Unmarshal(states[0], &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.ChatID != 10 {
+		t.Fatal("nondeterministic snapshot order")
+	}
+	target := &telegramSessionMgr{store: store, settings: settings}
+	if err := target.restoreConversations(ctx, []json.RawMessage{states[0], states[0]}); err == nil {
+		t.Fatal("duplicate chat accepted")
+	}
+	if created != 2 {
+		t.Fatal("duplicate identities allocated runtimes")
+	}
+	var bad telegramConversationState
+	if err := json.Unmarshal(states[1], &bad); err != nil {
+		t.Fatal(err)
+	}
+	bad.Revision++
+	raw, _ := json.Marshal(bad)
+	if err := target.restoreConversations(ctx, []json.RawMessage{states[0], raw}); err == nil {
+		t.Fatal("stale later chat accepted")
+	}
+	if len(target.sessions) != 0 || created != 3 || cleaned != 1 {
+		t.Fatalf("partial recovery leaked: published=%d created=%d cleaned=%d", len(target.sessions), created, cleaned)
+	}
+	if err := target.restoreConversations(ctx, states); err != nil {
+		t.Fatal(err)
+	}
+	defer target.closeAllSessions()
+	for id, old := range source.sessions {
+		if target.sessions[id] == nil || target.sessions[id].meta.ID != old.meta.ID {
+			t.Fatal("original chat identity lost")
+		}
+	}
+	if err := target.restoreConversations(ctx, states); err == nil {
+		t.Fatal("recovery overwrote live chats")
+	}
+	if created != 5 || cleaned != 1 {
+		t.Fatal("duplicate publication changed runtimes")
+	}
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cancelled := &telegramSessionMgr{store: store, settings: settings}
+	cancelled.settings.NewSession = func(ctx context.Context) (*SessionRuntime, error) {
+		runtime, err := settings.NewSession(ctx)
+		cancel()
+		return runtime, err
+	}
+	if err := cancelled.restoreConversations(cancelCtx, states); err == nil {
+		t.Fatal("cancelled bootstrap published chats")
+	}
+	if len(cancelled.sessions) != 0 || created != 6 || cleaned != 2 {
+		t.Fatal("cancelled bootstrap leaked runtime or published a partial map")
+	}
+	raced := &telegramSessionMgr{store: store, settings: settings}
+	factories := 0
+	raced.settings.NewSession = func(ctx context.Context) (*SessionRuntime, error) {
+		runtime, err := settings.NewSession(ctx)
+		factories++
+		if factories == 2 {
+			if err := store.AddMessage(ctx, first.SessionID, session.NewMessage(first.SessionID, llm.UserText("changed during runtime construction"), -1)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return runtime, err
+	}
+	if err := raced.restoreConversations(ctx, states); err == nil {
+		t.Fatal("earlier transcript changed during recovery but was published")
+	}
+	if len(raced.sessions) != 0 || created != 8 || cleaned != 4 {
+		t.Fatal("late revision conflict leaked recovered runtimes")
+	}
+}

--- a/internal/serve/telegram_inbox.go
+++ b/internal/serve/telegram_inbox.go
@@ -1,0 +1,143 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// telegramInbox tracks accepted updates until their handler actually returns.
+// Releasing per-chat admission only permits steering/interrupt messages; it does
+// not finish the original update. A poll offset alone loses these live updates.
+// Snapshots are immutable input records, not permission to replay completed tools
+// or delivered replies. Conversation handoff must supply execution/delivery state.
+type telegramInbox struct {
+	mu      sync.Mutex
+	pending map[int]*telegramInboxEntry
+	paused  bool
+}
+
+type telegramInboxEntry struct {
+	raw                       json.RawMessage
+	started, parked, finished bool
+}
+
+type telegramInboxContextKey struct{}
+type telegramInboxReceipt struct {
+	inbox *telegramInbox
+	id    int
+}
+
+// Start is the side-effect boundary, after per-chat admission ordering. Paused
+// receipts are retained for replacement instead of being silently acknowledged.
+func (r telegramInboxReceipt) start() bool {
+	r.inbox.mu.Lock()
+	defer r.inbox.mu.Unlock()
+	entry := r.inbox.pending[r.id]
+	if entry == nil {
+		return false
+	}
+	if entry.started {
+		return true
+	}
+	if r.inbox.paused {
+		entry.parked = true
+		return false
+	}
+	entry.started = true
+	return true
+}
+func startTelegramInboxReceipt(ctx context.Context) bool {
+	receipt, ok := ctx.Value(telegramInboxContextKey{}).(telegramInboxReceipt)
+	return !ok || receipt.start()
+}
+
+// Only stop unstarted handlers after the natural grace period. The caller must
+// first pause receiving, then join existing handlers before sealing Pending.
+func (i *telegramInbox) pauseUnstarted() { i.mu.Lock(); i.paused = true; i.mu.Unlock() }
+
+// Rollback transfers only fully settled parked inputs back to the intake owner.
+// The owner must admit these in order before resuming polling.
+func (i *telegramInbox) resumeUnstarted() ([]json.RawMessage, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	result, err := i.parkedInputsLocked()
+	if err != nil {
+		return nil, err
+	}
+	for id := range i.pending {
+		delete(i.pending, id)
+	}
+	i.paused = false
+	return result, nil
+}
+
+func (i *telegramInbox) parkedInputs() ([]json.RawMessage, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.parkedInputsLocked()
+}
+func (i *telegramInbox) parkedInputsLocked() ([]json.RawMessage, error) {
+	ids := make([]int, 0, len(i.pending))
+	for id, entry := range i.pending {
+		if !entry.parked || entry.started || !entry.finished {
+			return nil, fmt.Errorf("Telegram admitted input has not settled at an unstarted boundary")
+		}
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	result := make([]json.RawMessage, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, append(json.RawMessage(nil), i.pending[id].raw...))
+	}
+	return result, nil
+}
+
+func (i *telegramInbox) begin(update tgbotapi.Update) (finish func(), duplicate bool, err error) {
+	raw, err := json.Marshal(update)
+	if err != nil {
+		return nil, false, err
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if _, exists := i.pending[update.UpdateID]; exists {
+		return nil, true, nil
+	}
+	if i.pending == nil {
+		i.pending = make(map[int]*telegramInboxEntry)
+	}
+	entry := &telegramInboxEntry{raw: raw}
+	i.pending[update.UpdateID] = entry
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			i.mu.Lock()
+			entry.finished = true
+			if !entry.parked {
+				delete(i.pending, update.UpdateID)
+			}
+			i.mu.Unlock()
+		})
+	}, false, nil
+}
+
+// snapshot orders accepted inputs by Telegram update ID, independently of
+// handler scheduling. Call after receiving is paused to pair with its offset.
+func (i *telegramInbox) snapshot() []json.RawMessage {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	ids := make([]int, 0, len(i.pending))
+	for id := range i.pending {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	result := make([]json.RawMessage, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, append(json.RawMessage(nil), i.pending[id].raw...))
+	}
+	return result
+}

--- a/internal/serve/telegram_inbox_test.go
+++ b/internal/serve/telegram_inbox_test.go
@@ -1,0 +1,153 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/samsaffron/term-llm/internal/testutil"
+	"testing"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+func TestTelegramInboxRetainsInputAfterAdmissionRelease(t *testing.T) {
+	mgr := &telegramSessionMgr{}
+	msg := &tgbotapi.Message{MessageID: 7, Chat: &tgbotapi.Chat{ID: 42}, Text: "original"}
+	finish, duplicate, err := mgr.inbox.begin(tgbotapi.Update{UpdateID: 12, Message: msg})
+	if err != nil || duplicate {
+		t.Fatalf("begin: duplicate=%v err=%v", duplicate, err)
+	}
+	admission := mgr.admitMessage(msg)
+	admission.release() // Active stream now accepts steering; it is not finished.
+	msg.Text = "mutated caller"
+	raw := mgr.inbox.snapshot()
+	if len(raw) != 1 {
+		t.Fatal("admission release lost unfinished input")
+	}
+	var saved tgbotapi.Update
+	if err := json.Unmarshal(raw[0], &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.Message.Text != "original" {
+		t.Fatal("input snapshot aliases caller")
+	}
+	raw[0][0] = '!'
+	if !json.Valid(mgr.inbox.snapshot()[0]) {
+		t.Fatal("snapshot aliases inbox")
+	}
+	if _, duplicate, err := mgr.inbox.begin(tgbotapi.Update{UpdateID: 12}); err != nil || !duplicate {
+		t.Fatal("duplicate active input was admitted")
+	}
+	finish()
+	// Finishing twice must not remove a subsequently admitted receipt.
+	next, duplicate, err := mgr.inbox.begin(tgbotapi.Update{UpdateID: 12})
+	if err != nil || duplicate {
+		t.Fatal("completed receipt retained")
+	}
+	finish()
+	if len(mgr.inbox.snapshot()) != 1 {
+		t.Fatal("stale completion removed new receipt")
+	}
+	next()
+	if len(mgr.inbox.snapshot()) != 0 {
+		t.Fatal("finished update retained")
+	}
+}
+
+func TestTelegramInboxSnapshotUsesUpdateOrder(t *testing.T) {
+	var inbox telegramInbox
+	for _, id := range []int{20, 3, 15} {
+		finish, duplicate, err := inbox.begin(tgbotapi.Update{UpdateID: id})
+		if err != nil || duplicate {
+			t.Fatal(err)
+		}
+		defer finish()
+	}
+	for n, raw := range inbox.snapshot() {
+		var update tgbotapi.Update
+		if err := json.Unmarshal(raw, &update); err != nil {
+			t.Fatal(err)
+		}
+		if update.UpdateID != []int{3, 15, 20}[n] {
+			t.Fatal("snapshot reordered inputs")
+		}
+	}
+}
+
+func TestTelegramParkedHandlerHasNoEffectsAndReplaysOnceOnRollback(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	h.Provider.AddTextResponse("done")
+	factories := 0
+	mgr := &telegramSessionMgr{sessions: make(map[int64]*telegramSession), allowedUserIDs: map[int64]struct{}{1: {}}, idleTimeout: time.Hour, settings: Settings{MaxTurns: 5, NewSession: func(context.Context) (*SessionRuntime, error) {
+		factories++
+		return &SessionRuntime{Engine: h.Engine, Provider: h.Provider, ProviderName: "mock", ModelName: "mock"}, nil
+	}}}
+	defer mgr.closeAllSessions()
+	update := tgbotapi.Update{UpdateID: 8, Message: &tgbotapi.Message{MessageID: 3, Chat: &tgbotapi.Chat{ID: 42}, From: &tgbotapi.User{ID: 1}, Text: "original queued input"}}
+	finish, duplicate, err := mgr.inbox.begin(update)
+	if err != nil || duplicate {
+		t.Fatal("could not admit fixture")
+	}
+	mgr.inbox.pauseUnstarted()
+	ctx := context.WithValue(context.Background(), telegramInboxContextKey{}, telegramInboxReceipt{inbox: &mgr.inbox, id: 8})
+	bot := &fakeBotSender{}
+	mgr.handleMessage(ctx, bot, update.Message)
+	if _, err := mgr.inbox.resumeUnstarted(); err == nil {
+		t.Fatal("rollback released an unfinished receipt")
+	}
+	finish()
+	if factories != 0 || len(bot.allTexts()) != 0 || len(h.Provider.RecordedRequests()) != 0 {
+		t.Fatal("parked handler performed side effects")
+	}
+	pending, err := mgr.inbox.parkedInputs()
+	if err != nil || len(pending) != 1 {
+		t.Fatal("parked input lost after handler return")
+	}
+	replay, err := mgr.inbox.resumeUnstarted()
+	if err != nil || len(replay) != 1 {
+		t.Fatal("rollback failed to transfer pending input")
+	}
+	if len(mgr.inbox.snapshot()) != 0 {
+		t.Fatal("rollback retained duplicate receipt")
+	}
+	var recovered tgbotapi.Update
+	if err := json.Unmarshal(replay[0], &recovered); err != nil {
+		t.Fatal(err)
+	}
+	again, duplicate, err := mgr.inbox.begin(recovered)
+	if err != nil || duplicate {
+		t.Fatal("rollback input could not be readmitted")
+	}
+	mgr.handleMessage(ctx, bot, recovered.Message)
+	again()
+	if factories != 1 || len(h.Provider.RecordedRequests()) != 1 {
+		t.Fatal("rollback input not executed exactly once")
+	}
+	if len(mgr.inbox.snapshot()) != 0 {
+		t.Fatal("completed replay remained pending")
+	}
+}
+
+func TestTelegramStartedReceiptCannotBecomeReplayInput(t *testing.T) {
+	var inbox telegramInbox
+	finish, _, err := inbox.begin(tgbotapi.Update{UpdateID: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := telegramInboxReceipt{inbox: &inbox, id: 1}
+	if !receipt.start() {
+		t.Fatal("receipt not started")
+	}
+	inbox.pauseUnstarted()
+	if !receipt.start() {
+		t.Fatal("pause retroactively parked running work")
+	}
+	if _, err := inbox.parkedInputs(); err == nil {
+		t.Fatal("running work classified as safe replay")
+	}
+	finish()
+	pending, err := inbox.parkedInputs()
+	if err != nil || len(pending) != 0 {
+		t.Fatal("completed work retained for replay")
+	}
+}

--- a/internal/serve/telegram_platform_handoff.go
+++ b/internal/serve/telegram_platform_handoff.go
@@ -1,0 +1,131 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+// telegramPlatformHandoff pairs the acknowledgement boundary with exact chats
+// and admitted inputs that have NOT committed a model turn. Committed inputs
+// belong to conversation execution state, never Pending: replaying them would
+// duplicate a user turn or completed effects. The intake owner must classify
+// and settle handlers before assembling this envelope.
+type telegramPlatformHandoff struct {
+	Version       int               `json:"version"`
+	BotID         int64             `json:"bot_id"`
+	NextOffset    int               `json:"next_offset"`
+	Conversations []json.RawMessage `json:"conversations"`
+	Pending       []json.RawMessage `json:"pending,omitempty"`
+}
+
+func (s *telegramPlatformHandoff) validate(botID int64) error {
+	if s.Version != 1 || botID <= 0 || s.BotID != botID || s.NextOffset < 0 {
+		return fmt.Errorf("invalid Telegram platform checkpoint identity or version")
+	}
+	previous := -1
+	for _, raw := range s.Pending {
+		var update tgbotapi.Update
+		if err := json.Unmarshal(raw, &update); err != nil {
+			return err
+		}
+		if update.UpdateID < 0 || update.UpdateID <= previous || update.UpdateID >= s.NextOffset || update.Message == nil || update.Message.Chat == nil || update.Message.From == nil {
+			return fmt.Errorf("invalid Telegram pending input or acknowledgement boundary")
+		}
+		previous = update.UpdateID
+	}
+	return nil
+}
+
+func telegramHandoffService(service string, botID int64) string {
+	// Bind bot identity in the store's lookup fence, not just in payload validation
+	// after consumption. A changed bot must not consume the correct bot's intent.
+	return fmt.Sprintf("%s:telegram:%d", service, botID)
+}
+
+func (m *telegramSessionMgr) savePlatformHandoff(ctx context.Context, id, service, instance string, botID int64, offset int) error {
+	handoffs, ok := session.AsCommandHandoffStore(m.store)
+	if !ok {
+		return fmt.Errorf("Telegram restart requires durable handoff storage")
+	}
+	pending, err := m.inbox.parkedInputs()
+	if err != nil {
+		return err
+	}
+	state := telegramPlatformHandoff{Version: 1, BotID: botID, NextOffset: offset, Pending: pending}
+	if err := state.validate(botID); err != nil {
+		return err
+	}
+	conversations, err := m.snapshotConversations(ctx)
+	if err != nil {
+		return err
+	}
+	state.Conversations = conversations
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return handoffs.SaveCommandHandoff(ctx, session.CommandHandoff{ID: id, Service: telegramHandoffService(service, botID), SourceInstance: instance, Payload: raw})
+}
+
+// takeTelegramPlatformHandoff authenticates a one-shot replacement/reclaim. It
+// deliberately does not start polling, publish chats or dispatch pending input.
+// The supervisor must retain the returned state across initialization retries.
+func takeTelegramPlatformHandoff(ctx context.Context, store session.Store, id, service, instance string, botID int64, reclaim bool) (*telegramPlatformHandoff, error) {
+	handoffs, ok := session.AsCommandHandoffStore(store)
+	if !ok {
+		return nil, fmt.Errorf("Telegram restart requires durable handoff storage")
+	}
+	var handoff session.CommandHandoff
+	var err error
+	if reclaim {
+		handoff, err = handoffs.ReclaimCommandHandoff(ctx, id, telegramHandoffService(service, botID), instance)
+	} else {
+		handoff, err = handoffs.ConsumeCommandHandoff(ctx, id, telegramHandoffService(service, botID), instance)
+	}
+	if err != nil {
+		return nil, err
+	}
+	var state telegramPlatformHandoff
+	if err := json.Unmarshal(handoff.Payload, &state); err != nil {
+		return nil, err
+	}
+	if err := state.validate(botID); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+// restorePlatformHandoff installs chats and acknowledgement state together,
+// before polling can start. Pending inputs are returned in update order for the
+// intake owner to admit before requesting newer updates; they are not executed
+// here. Failed initialization leaves the receiver offset and chat map unchanged.
+func (m *telegramSessionMgr) restorePlatformHandoff(ctx context.Context, receiver *telegramReceiver, state *telegramPlatformHandoff, botID int64) ([]tgbotapi.Update, error) {
+	if state == nil || receiver == nil {
+		return nil, fmt.Errorf("missing Telegram restart state or receiver")
+	}
+	if err := state.validate(botID); err != nil {
+		return nil, err
+	}
+	pending := make([]tgbotapi.Update, 0, len(state.Pending))
+	for _, raw := range state.Pending {
+		var update tgbotapi.Update
+		if err := json.Unmarshal(raw, &update); err != nil {
+			return nil, err
+		}
+		pending = append(pending, update)
+	}
+	receiver.mu.Lock()
+	defer receiver.mu.Unlock()
+	if receiver.running {
+		return nil, fmt.Errorf("Telegram receiver already running during recovery")
+	}
+	if err := m.restoreConversations(ctx, state.Conversations); err != nil {
+		return nil, err
+	}
+	receiver.state.NextOffset = state.NextOffset
+	return pending, nil
+}

--- a/internal/serve/telegram_platform_handoff_test.go
+++ b/internal/serve/telegram_platform_handoff_test.go
@@ -1,0 +1,106 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestTelegramPlatformHandoffBindsBotAndAcknowledgement(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	mgr := &telegramSessionMgr{store: store, sessions: make(map[int64]*telegramSession)}
+	reopen := mgr.restartGate.Pause()
+	defer reopen()
+	input, err := json.Marshal(tgbotapi.Update{UpdateID: 105, Message: &tgbotapi.Message{MessageID: 8, Chat: &tgbotapi.Chat{ID: 42}, From: &tgbotapi.User{ID: 1}, Text: "not started"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var update tgbotapi.Update
+	if err := json.Unmarshal(input, &update); err != nil {
+		t.Fatal(err)
+	}
+	finish, _, err := mgr.inbox.begin(update)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.inbox.pauseUnstarted()
+	if (telegramInboxReceipt{inbox: &mgr.inbox, id: update.UpdateID}).start() {
+		t.Fatal("paused input started")
+	}
+	finish()
+	for _, reclaim := range []bool{false, true} {
+		id := "replacement"
+		instance := "new"
+		if reclaim {
+			id = "rollback"
+			instance = "original"
+		}
+		if err := mgr.savePlatformHandoff(ctx, id, "service", "original", 7, 108); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := takeTelegramPlatformHandoff(ctx, store, id, "service", instance, 8, reclaim); err == nil {
+			t.Fatal("wrong bot consumed handoff")
+		}
+		wrongInstance := "original"
+		if reclaim {
+			wrongInstance = "new"
+		}
+		if _, err := takeTelegramPlatformHandoff(ctx, store, id, "service", wrongInstance, 7, reclaim); err == nil {
+			t.Fatal("wrong instance consumed handoff")
+		}
+		state, err := takeTelegramPlatformHandoff(ctx, store, id, "service", instance, 7, reclaim)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state.BotID != 7 || state.NextOffset != 108 || len(state.Pending) != 1 || string(state.Pending[0]) != string(input) {
+			t.Fatal("handoff lost acknowledgement or admitted input")
+		}
+		receiver := &telegramReceiver{state: telegramPollState{NextOffset: 12}}
+		target := &telegramSessionMgr{store: store}
+		broken := *state
+		broken.Conversations = []json.RawMessage{json.RawMessage(`{"session_id":"missing","chat_id":42}`)}
+		if _, err := target.restorePlatformHandoff(ctx, receiver, &broken, 7); err == nil {
+			t.Fatal("invalid chat bootstrap succeeded")
+		}
+		if receiver.state.NextOffset != 12 || len(target.sessions) != 0 {
+			t.Fatal("failed bootstrap partly installed state")
+		}
+		inputs, err := target.restorePlatformHandoff(ctx, receiver, state, 7)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if receiver.state.NextOffset != 108 || len(inputs) != 1 || inputs[0].UpdateID != 105 {
+			t.Fatal("bootstrap lost cursor or pending input")
+		}
+		receiver.running = true
+		if _, err := target.restorePlatformHandoff(ctx, receiver, state, 7); err == nil {
+			t.Fatal("live receiver accepted restoration")
+		}
+		if _, err := takeTelegramPlatformHandoff(ctx, store, id, "service", instance, 7, reclaim); err == nil {
+			t.Fatal("handoff consumed twice")
+		}
+	}
+	state := telegramPlatformHandoff{Version: 1, BotID: 7, NextOffset: 108, Pending: []json.RawMessage{input, input}}
+	if err := state.validate(7); err == nil {
+		t.Fatal("duplicate pending update accepted")
+	}
+	state.Pending = state.Pending[:1]
+	state.NextOffset = 105
+	if err := state.validate(7); err == nil {
+		t.Fatal("unacknowledged input accepted for replay")
+	}
+	state.NextOffset = 108
+	state.Version = 2
+	if err := state.validate(7); err == nil {
+		t.Fatal("unknown checkpoint schema accepted")
+	}
+}

--- a/internal/serve/telegram_poll.go
+++ b/internal/serve/telegram_poll.go
@@ -1,0 +1,65 @@
+package serve
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// telegramPollState is the next Telegram acknowledgement boundary. An update
+// advances it only after the platform accepts ownership; no hidden library
+// goroutine may acknowledge a prefetched batch during process drain.
+type telegramPollState struct {
+	NextOffset int `json:"next_offset"`
+}
+
+type telegramPollClient struct {
+	ctx    context.Context
+	client tgbotapi.HTTPClient
+}
+
+func (c telegramPollClient) Do(request *http.Request) (*http.Response, error) {
+	return c.client.Do(request.Clone(c.ctx))
+}
+
+// runTelegramPolling has one synchronous fetch/admission owner. The bot copy
+// shares its HTTP client but binds ONLY polling requests to this context; normal
+// message delivery retains the original bot and its own existing lifetime.
+// accept=false leaves that update unacknowledged for a later poll/resumption.
+func runTelegramPolling(ctx context.Context, bot *tgbotapi.BotAPI, state *telegramPollState, accept func(tgbotapi.Update) bool) error {
+	polling := *bot
+	polling.Client = telegramPollClient{ctx: ctx, client: bot.Client}
+	for ctx.Err() == nil {
+		config := tgbotapi.NewUpdate(state.NextOffset)
+		config.Timeout = telegramUpdateLongPollSeconds
+		updates, err := polling.GetUpdates(config)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			// Transport errors can contain the bot token in their URL. Do not log it.
+			log.Printf("[telegram] update polling failed (%T); retrying", err)
+			timer := time.NewTimer(3 * time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil
+			case <-timer.C:
+			}
+			continue
+		}
+		for _, update := range updates {
+			if update.UpdateID < state.NextOffset {
+				continue
+			}
+			if ctx.Err() != nil || !accept(update) {
+				return nil
+			}
+			state.NextOffset = update.UpdateID + 1
+		}
+	}
+	return nil
+}

--- a/internal/serve/telegram_poll_test.go
+++ b/internal/serve/telegram_poll_test.go
@@ -1,0 +1,141 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+func TestTelegramPollingAcknowledgesOnlyOwnedUpdates(t *testing.T) {
+	offsets := make(chan int, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "getMe") {
+			fmt.Fprint(w, `{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"fixture"}}`)
+			return
+		}
+		r.ParseForm()
+		offset, _ := strconv.Atoi(r.Form.Get("offset"))
+		offsets <- offset
+		if offset == 0 {
+			fmt.Fprint(w, `{"ok":true,"result":[{"update_id":10},{"update_id":11}]}`)
+		} else {
+			fmt.Fprint(w, `{"ok":true,"result":[{"update_id":10},{"update_id":11},{"update_id":12}]}`)
+		}
+	}))
+	defer server.Close()
+	bot, err := tgbotapi.NewBotAPIWithClient("fixture", server.URL+"/bot%s/%s", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := &telegramPollState{}
+	blocked, release, done := make(chan struct{}), make(chan struct{}), make(chan error, 1)
+	go func() {
+		done <- runTelegramPolling(context.Background(), bot, state, func(update tgbotapi.Update) bool {
+			if update.UpdateID == 11 {
+				close(blocked)
+				<-release
+				return false
+			}
+			return true
+		})
+	}()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("admission not reached")
+	}
+	if offset := <-offsets; offset != 0 {
+		t.Fatalf("initial offset=%d", offset)
+	}
+	select {
+	case offset := <-offsets:
+		close(release)
+		t.Fatalf("prefetched/acknowledged blocked update: offset=%d", offset)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("polling did not stop at admission boundary")
+	}
+	if state.NextOffset != 11 {
+		t.Fatalf("unowned update acknowledged: %d", state.NextOffset)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var accepted []int
+	if err := runTelegramPolling(ctx, bot, state, func(update tgbotapi.Update) bool {
+		accepted = append(accepted, update.UpdateID)
+		if update.UpdateID == 12 {
+			cancel()
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if offset := <-offsets; offset != 11 {
+		t.Fatalf("resumed offset=%d", offset)
+	}
+	if len(accepted) != 2 || accepted[0] != 11 || accepted[1] != 12 || state.NextOffset != 13 {
+		t.Fatalf("resumption dropped/replayed updates: accepted=%v next=%d", accepted, state.NextOffset)
+	}
+}
+
+func TestTelegramPollingCancellationJoinsLongPoll(t *testing.T) {
+	entered, left, release := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "getMe") {
+			fmt.Fprint(w, `{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"fixture"}}`)
+			return
+		}
+		r.ParseForm()
+		close(entered)
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+		close(left)
+	}))
+	defer server.Close()
+	defer close(release)
+	bot, err := tgbotapi.NewBotAPIWithClient("fixture", server.URL+"/bot%s/%s", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- runTelegramPolling(ctx, bot, &telegramPollState{}, func(tgbotapi.Update) bool { t.Error("unexpected update"); return true })
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("long poll not started")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("long poll retained after owner cancellation")
+	}
+	select {
+	case <-left:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP long poll not cancelled")
+	}
+}

--- a/internal/serve/telegram_receiver.go
+++ b/internal/serve/telegram_receiver.go
@@ -1,0 +1,126 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+// telegramReceiver separates a restart receive pause from platform shutdown.
+// Only the polling cycle mutates state; pause joins that cycle before reading it.
+type telegramReceiver struct {
+	mu              sync.Mutex
+	state           telegramPollState
+	running, paused bool
+	wake            chan struct{}
+	cancel          context.CancelFunc
+	done            chan struct{}
+}
+
+func (r *telegramReceiver) run(ctx context.Context, bot *tgbotapi.BotAPI, accept func(context.Context, tgbotapi.Update) bool) error {
+	r.mu.Lock()
+	if r.running {
+		r.mu.Unlock()
+		return errors.New("Telegram receiver already running")
+	}
+	r.running = true
+	r.mu.Unlock()
+	defer func() { r.mu.Lock(); r.running = false; r.mu.Unlock() }()
+	for {
+		r.mu.Lock()
+		if ctx.Err() != nil {
+			r.mu.Unlock()
+			return nil
+		}
+		if r.paused {
+			wake := r.wake
+			r.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-wake:
+			}
+			continue
+		}
+		pollCtx, cancel := context.WithCancel(ctx)
+		done := make(chan struct{})
+		r.cancel = cancel
+		r.done = done
+		r.mu.Unlock()
+		err := runTelegramPolling(pollCtx, bot, &r.state, func(update tgbotapi.Update) bool { return accept(pollCtx, update) })
+		interrupted := pollCtx.Err() != nil
+		cancel()
+		r.mu.Lock()
+		r.cancel = nil
+		r.done = nil
+		paused := r.paused
+		close(done)
+		r.mu.Unlock()
+		if err != nil || (!paused && !interrupted) {
+			return err
+		}
+	}
+}
+
+func (r *telegramReceiver) pause(ctx context.Context) (int, error) {
+	r.mu.Lock()
+	if !r.paused {
+		r.paused = true
+		r.wake = make(chan struct{})
+	}
+	if r.cancel != nil {
+		r.cancel()
+	}
+	done := r.done
+	r.mu.Unlock()
+	if done != nil {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-done:
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.paused || r.done != nil {
+		return 0, errors.New("Telegram receiving resumed before pause settled")
+	}
+	return r.state.NextOffset, nil
+}
+
+func (r *telegramReceiver) resume() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.paused {
+		r.paused = false
+		close(r.wake)
+		r.wake = nil
+	}
+}
+
+func (r *telegramReceiver) restore(offset int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.running || offset < 0 {
+		return errors.New("Telegram receive offset can only be restored before startup")
+	}
+	r.state.NextOffset = offset
+	return nil
+}
+
+// PauseReceiving stops and joins polling/admission without cancelling message
+// handlers or closing session runtimes. Those retain their natural grace period.
+func (p *TelegramPlatform) PauseReceiving(ctx context.Context) (int, error) {
+	return p.receiver.pause(ctx)
+}
+
+// ResumeReceiving rolls back a receive pause after a failed process replacement.
+func (p *TelegramPlatform) ResumeReceiving() { p.receiver.resume() }
+
+// RestoreReceivingOffset installs an authenticated handoff's acknowledgement
+// boundary before Run. It is not sufficient to restore in-flight conversations.
+func (p *TelegramPlatform) RestoreReceivingOffset(offset int) error {
+	return p.receiver.restore(offset)
+}

--- a/internal/serve/telegram_receiver_test.go
+++ b/internal/serve/telegram_receiver_test.go
@@ -1,0 +1,206 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+func TestTelegramReceiverPauseKeepsPlatformAliveAndResumesOffset(t *testing.T) {
+	var polls21 atomic.Int32
+	blocked := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "getMe") {
+			fmt.Fprint(w, `{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"fixture"}}`)
+			return
+		}
+		r.ParseForm()
+		offset, _ := strconv.Atoi(r.Form.Get("offset"))
+		switch offset {
+		case 20:
+			fmt.Fprint(w, `{"ok":true,"result":[{"update_id":20}]}`)
+		case 21:
+			if polls21.Add(1) == 1 {
+				close(blocked)
+				<-r.Context().Done()
+				return
+			}
+			fmt.Fprint(w, `{"ok":true,"result":[{"update_id":21}]}`)
+		default:
+			<-r.Context().Done()
+		}
+	}))
+	defer server.Close()
+	bot, err := tgbotapi.NewBotAPIWithClient("fixture", server.URL+"/bot%s/%s", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receiver telegramReceiver
+	if err := receiver.restore(20); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	accepted := make(chan int, 4)
+	done := make(chan error, 1)
+	go func() {
+		done <- receiver.run(ctx, bot, func(_ context.Context, update tgbotapi.Update) bool { accepted <- update.UpdateID; return true })
+	}()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("poll did not reach offset 21")
+	}
+	pauseCtx, pauseCancel := context.WithTimeout(ctx, time.Second)
+	defer pauseCancel()
+	offset, err := receiver.pause(pauseCtx)
+	if err != nil || offset != 21 {
+		t.Fatalf("pause=%d %v", offset, err)
+	}
+	if ctx.Err() != nil {
+		t.Fatal("receive pause cancelled platform handlers")
+	}
+	select {
+	case <-done:
+		t.Fatal("receive pause shut down platform")
+	default:
+	}
+	if err := receiver.restore(99); err == nil {
+		t.Fatal("live receive offset overwritten")
+	}
+	receiver.resume()
+	for _, expected := range []int{20, 21} {
+		select {
+		case id := <-accepted:
+			if id != expected {
+				t.Fatalf("update=%d want=%d", id, expected)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("resumption did not deliver update")
+		}
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("platform shutdown did not finish")
+	}
+}
+
+type receiverIgnoringClient struct {
+	entered, release chan struct{}
+	calls            atomic.Int32
+}
+
+func (c *receiverIgnoringClient) Do(r *http.Request) (*http.Response, error) {
+	body := `{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"fixture"}}`
+	if !strings.HasSuffix(r.URL.Path, "getMe") {
+		if c.calls.Add(1) == 1 {
+			close(c.entered)
+			<-c.release
+		}
+		body = `{"ok":true,"result":[{"update_id":7}]}`
+	}
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+}
+
+func TestTelegramReceiverFailedPauseCanResumeBeforeOldPollReturns(t *testing.T) {
+	client := &receiverIgnoringClient{entered: make(chan struct{}), release: make(chan struct{})}
+	released := false
+	defer func() {
+		if !released {
+			close(client.release)
+		}
+	}()
+	bot, err := tgbotapi.NewBotAPIWithClient("fixture", "http://fixture/bot%s/%s", client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receiver telegramReceiver
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	accepted := make(chan int, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- receiver.run(ctx, bot, func(_ context.Context, update tgbotapi.Update) bool {
+			accepted <- update.UpdateID
+			cancel()
+			return true
+		})
+	}()
+	<-client.entered
+	pauseCtx, stop := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer stop()
+	if _, err := receiver.pause(pauseCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("unsettled poll reported success: %v", err)
+	}
+	receiver.resume() // rollback must not turn the late poll return into shutdown
+	close(client.release)
+	released = true
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("rolled-back receiver did not resume")
+	}
+	select {
+	case id := <-accepted:
+		if id != 7 {
+			t.Fatal(id)
+		}
+	default:
+		t.Fatal("failed pause dropped unowned update")
+	}
+	if client.calls.Load() != 2 {
+		t.Fatalf("poll ownership/retry calls=%d", client.calls.Load())
+	}
+}
+
+func TestTelegramCleanupAcknowledgementWaitsForRuntimeExit(t *testing.T) {
+	runnerDone := make(chan struct{})
+	cleanupEntered := make(chan struct{})
+	release := make(chan struct{})
+	sess := &telegramSession{runnerDone: runnerDone, runtime: &SessionRuntime{Cleanup: func() { close(cleanupEntered); <-release }}}
+	done := closeTelegramSessionWithTimeout(sess, time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("cleanup acknowledged while runner owns runtime")
+	default:
+	}
+	close(runnerDone)
+	select {
+	case <-cleanupEntered:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup not started after runner exit")
+	}
+	select {
+	case <-done:
+		t.Fatal("cleanup acknowledged before Cleanup returned")
+	default:
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup acknowledgement missing")
+	}
+	again := closeTelegramSessionWithTimeout(sess, time.Millisecond)
+	if again != done {
+		t.Fatal("cleanup completion identity changed")
+	}
+}

--- a/internal/serve/telegram_recovered_inputs_test.go
+++ b/internal/serve/telegram_recovered_inputs_test.go
@@ -1,0 +1,118 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/samsaffron/term-llm/internal/testutil"
+)
+
+func TestTelegramRecoveredAdmissionRetainsOnlyUnacceptedSuffix(t *testing.T) {
+	ctx, cancelLife := context.WithCancel(context.Background())
+	defer cancelLife()
+	h := testutil.NewEngineHarness()
+	h.Provider.AddTextResponse("first answer")
+	h.Provider.AddTextResponse("second answer")
+	started := make(chan context.Context, 1)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	mgr := &telegramSessionMgr{sessions: make(map[int64]*telegramSession), messageSlots: make(chan struct{}, 1), allowedUserIDs: map[int64]struct{}{1: {}}, idleTimeout: time.Hour, settings: Settings{MaxTurns: 5, NewSession: func(ctx context.Context) (*SessionRuntime, error) {
+		started <- ctx
+		<-release
+		return &SessionRuntime{Engine: h.Engine, Provider: h.Provider, ProviderName: "mock", ModelName: "mock"}, nil
+	}}}
+	defer func() {
+		if !released {
+			close(release)
+			released = true
+		}
+		cancelLife()
+		mgr.closeAllSessions()
+	}()
+	updates := []tgbotapi.Update{}
+	for id, text := range []string{"first input", "second input"} {
+		updates = append(updates, tgbotapi.Update{UpdateID: id + 10, Message: &tgbotapi.Message{MessageID: id + 1, Chat: &tgbotapi.Chat{ID: 42}, From: &tgbotapi.User{ID: 1}, Text: text}})
+	}
+	bot := &fakeBotSender{}
+	admissionCtx, cancelAdmission := context.WithCancel(ctx)
+	defer cancelAdmission()
+	done := make(chan error, 1)
+	go func() { done <- mgr.admitRecoveredInputs(ctx, admissionCtx, bot, &updates) }()
+	var handlerCtx context.Context
+	select {
+	case handlerCtx = <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first recovered input not accepted")
+	}
+	cancelAdmission()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("admission error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked admission did not cancel")
+	}
+	if len(updates) != 1 || updates[0].UpdateID != 11 {
+		t.Fatal("retry queue retained accepted prefix or lost suffix")
+	}
+	if handlerCtx.Err() != nil {
+		t.Fatal("admission cancellation cancelled already accepted handler")
+	}
+	close(release)
+	released = true
+	waitDrained := func() {
+		t.Helper()
+		deadline := time.Now().Add(time.Second)
+		for !mgr.restartGate.Drained() && time.Now().Before(deadline) {
+			time.Sleep(time.Millisecond)
+		}
+		if !mgr.restartGate.Drained() {
+			t.Fatal("accepted handlers did not settle")
+		}
+	}
+	reopen := mgr.restartGate.Pause()
+	waitDrained()
+	reopen()
+	if err := mgr.admitRecoveredInputs(ctx, ctx, bot, &updates); err != nil {
+		t.Fatal(err)
+	}
+	reopen = mgr.restartGate.Pause()
+	defer reopen()
+	waitDrained()
+	if len(updates) != 0 || len(h.Provider.RecordedRequests()) != 2 {
+		t.Fatal("retry did not execute each input exactly once")
+	}
+	if len(mgr.inbox.snapshot()) != 0 {
+		t.Fatal("completed recovered receipts retained")
+	}
+}
+
+func TestTelegramRecoveredAdmissionStopsWithPlatformLifetime(t *testing.T) {
+	mgr := &telegramSessionMgr{messageSlots: make(chan struct{}, 1)}
+	mgr.messageSlots <- struct{}{}
+	life, cancel := context.WithCancel(context.Background())
+	pending := []tgbotapi.Update{{UpdateID: 1, Message: &tgbotapi.Message{}}}
+	result := make(chan error, 1)
+	go func() { result <- mgr.admitRecoveredInputs(life, context.Background(), &fakeBotSender{}, &pending) }()
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("platform cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("admission outlived cancelled platform")
+	}
+	if len(pending) != 1 || len(mgr.inbox.snapshot()) != 0 {
+		t.Fatal("shutdown transferred or lost unadmitted input")
+	}
+}

--- a/internal/serve/telegram_restore_steering.go
+++ b/internal/serve/telegram_restore_steering.go
@@ -1,0 +1,56 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+// prepareRestoredSteering runs under sess.mu, before building the continuation
+// request. Pending notes must be visible on its FIRST model turn, including when
+// only one turn remains; requeueing them into the engine would defer them until
+// a later tool boundary and can lose them entirely at the turn limit.
+func (m *telegramSessionMgr) prepareRestoredSteering(ctx context.Context, sess *telegramSession) error {
+	state := sess.restoredExecution
+	if state == nil || len(state.Steering) == 0 {
+		return nil
+	}
+	history := append([]llm.Message(nil), sess.history...)
+	seen := make(map[string]llm.Message)
+	for _, msg := range history {
+		if id := strings.TrimSpace(msg.ClientMessageID); id != "" {
+			seen[id] = msg
+		}
+	}
+	pending := make(map[string]bool)
+	for _, entry := range state.Steering {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" || pending[id] {
+			return fmt.Errorf("invalid restored Telegram steering identity")
+		}
+		pending[id] = true
+		msg := entry.Message
+		msg.Role = llm.RoleUser
+		if msg.ClientMessageID != "" && msg.ClientMessageID != id {
+			return fmt.Errorf("conflicting restored Telegram steering identity")
+		}
+		msg.ClientMessageID = id
+		if prior, exists := seen[id]; exists {
+			if prior.Role != msg.Role || !reflect.DeepEqual(prior.Parts, msg.Parts) {
+				return fmt.Errorf("restored Telegram steering conflicts with committed intent")
+			}
+			continue
+		}
+		history = append(history, msg)
+		seen[id] = msg
+	}
+	if !m.reconcileTelegramTranscript(ctx, sess, history, sess.systemPromptPersisted, "ReplaceMessages(restart_steering)") {
+		return fmt.Errorf("restored Telegram steering could not be committed")
+	}
+	sess.history = history
+	state.Steering = nil
+	return nil
+}

--- a/internal/serve/telegram_restore_steering_test.go
+++ b/internal/serve/telegram_restore_steering_test.go
@@ -1,0 +1,87 @@
+package serve
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/testutil"
+)
+
+func TestTelegramRestoredSteeringIsCommittedBeforeLastModelTurn(t *testing.T) {
+	ctx := context.Background()
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	h := testutil.NewEngineHarness()
+	h.Provider.AddTextResponse("done")
+	mgr := &telegramSessionMgr{store: store, sessions: make(map[int64]*telegramSession), settings: Settings{MaxTurns: 9, NewSession: func(context.Context) (*SessionRuntime, error) {
+		return &SessionRuntime{Engine: h.Engine, Provider: h.Provider, ProviderName: "mock", ModelName: "mock"}, nil
+	}}}
+	sess, err := mgr.getOrCreate(ctx, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.closeAllSessions()
+	note := llm.UserText("already committed note")
+	note.ClientMessageID = "one"
+	sess.history = []llm.Message{llm.UserText("original task"), note}
+	if !mgr.reconcileTelegramTranscript(ctx, sess, sess.history, false, "fixture") {
+		t.Fatal("persist fixture")
+	}
+	sess.restoredExecution = &telegramExecutionState{RemainingTurns: 1, Reply: &telegramReplyCursor{MessageID: 1}, Steering: []llm.QueuedSteering{{ID: "one", Message: note}, {ID: "two", Message: llm.UserText("pending instruction")}}}
+	original := sess.restoredExecution.Steering[0]
+	sess.restoredExecution.Steering[0].Message = llm.UserText("conflicting intent")
+	if err := mgr.streamReplyContinuation(ctx, &fakeBotSender{}, sess, 42, "continue", 1, sess.restoredExecution.Reply); err == nil {
+		t.Fatal("conflicting committed identity accepted")
+	}
+	sess.restoredExecution.Steering[0] = original
+	mgr.store = &telegramFailedSealStore{Store: store, TranscriptIndexer: store.(session.TranscriptIndexer)}
+	if err := mgr.streamReplyContinuation(ctx, &fakeBotSender{}, sess, 42, "continue", 1, sess.restoredExecution.Reply); err == nil {
+		t.Fatal("failed steering commit started continuation")
+	}
+	if len(sess.history) != 2 || len(sess.restoredExecution.Steering) != 2 || len(h.Provider.RecordedRequests()) != 0 {
+		t.Fatal("failed commit consumed input or executed model")
+	}
+	mgr.store = store
+	if err := mgr.streamReplyContinuation(ctx, &fakeBotSender{}, sess, 42, "continue", 1, sess.restoredExecution.Reply); err != nil {
+		t.Fatal(err)
+	}
+	requests := h.Provider.RecordedRequests()
+	if len(requests) != 1 || requests[0].MaxTurns != 1 {
+		t.Fatal("last-turn recovery changed budget")
+	}
+	counts := map[string]int{}
+	for _, msg := range requests[0].Messages {
+		if msg.ClientMessageID != "" {
+			counts[msg.ClientMessageID]++
+		}
+	}
+	if counts["one"] != 1 || counts["two"] != 1 {
+		t.Fatalf("first model request lost or duplicated steering: %v", counts)
+	}
+	messages, err := store.GetMessages(ctx, sess.meta.ID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts = map[string]int{}
+	for _, msg := range messages {
+		if msg.ClientMessageID != "" {
+			counts[msg.ClientMessageID]++
+		}
+	}
+	if counts["one"] != 1 || counts["two"] != 1 || len(sess.restoredExecution.Steering) != 0 {
+		t.Fatal("steering persistence/ownership did not settle exactly once")
+	}
+	h.Provider.AddTextResponse("new work")
+	if err := mgr.streamReply(ctx, &fakeBotSender{}, sess, 42, llm.UserText("replacement task")); err != nil {
+		t.Fatal(err)
+	}
+	if sess.restoredExecution != nil {
+		t.Fatal("newer user turn retained recovered continuation")
+	}
+}

--- a/internal/serve/telegram_stream_control.go
+++ b/internal/serve/telegram_stream_control.go
@@ -1,0 +1,140 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"sync"
+	"sync/atomic"
+)
+
+var errTelegramRestart = errors.New("Telegram stream interrupted for process replacement")
+
+// telegramReplyCursor preserves the unfinished text segment, not prior delivered chunks.
+type telegramReplyCursor struct {
+	MessageID      int                 `json:"message_id"`
+	Prefix         string              `json:"prefix,omitempty"`
+	NeedNewMessage bool                `json:"need_new_message,omitempty"`
+	Images         []string            `json:"images,omitempty"`
+	Media          []llm.MediaArtifact `json:"media,omitempty"`
+	PendingMedia   []llm.MediaArtifact `json:"pending_media,omitempty"`
+}
+
+// Cursor media is not-yet-sent work, not a list of already delivered uploads.
+// Uncertain outbound sends still require resolution before handoff sealing.
+func (c *telegramStreamControl) replyCursor() *telegramReplyCursor {
+	if !c.restarting() {
+		return nil
+	}
+	cursor := c.reply.Load()
+	if cursor == nil {
+		return nil
+	}
+	copy := *cursor
+	copy.Images = append([]string(nil), cursor.Images...)
+	copy.Media = append([]llm.MediaArtifact(nil), cursor.Media...)
+	copy.PendingMedia = append([]llm.MediaArtifact(nil), cursor.PendingMedia...)
+	return &copy
+}
+
+// telegramStreamControl distinguishes a lifecycle interruption from user Stop.
+// Context cancellation is first-cause-wins; Stop must still revoke continuation
+// when it arrives after the restart cancellation has already won that race.
+// This is cancellation intent only: the restart owner must freeze execution
+// before interrupting and join actual work before authorizing any handoff.
+type telegramStreamControl struct {
+	mu              sync.Mutex
+	engine          *llm.Engine
+	initialTurns    int64
+	turnLimit       int
+	ready           bool
+	frozen          bool
+	pendingSteering []llm.QueuedSteering
+	ctx             context.Context
+	parent          context.Context
+	cancel          context.CancelCauseFunc
+	stopped         atomic.Bool
+	reply           atomic.Pointer[telegramReplyCursor]
+}
+
+func newTelegramStreamControl(parent context.Context) *telegramStreamControl {
+	ctx, cancel := context.WithCancelCause(parent)
+	return &telegramStreamControl{ctx: ctx, parent: parent, cancel: cancel}
+}
+func (c *telegramStreamControl) stop()                { c.stopped.Store(true); c.cancel(context.Canceled) }
+func (c *telegramStreamControl) interruptForRestart() { c.cancel(errTelegramRestart) }
+func (c *telegramStreamControl) close()               { c.cancel(context.Canceled) }
+func (c *telegramStreamControl) restarting() bool {
+	return c.parent.Err() == nil && context.Cause(c.ctx) == errTelegramRestart && !c.stopped.Load()
+}
+
+func (c *telegramStreamControl) bind(engine *llm.Engine, limit int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.engine = engine
+	c.initialTurns = engine.ModelTurns()
+	c.turnLimit = (llm.Request{MaxTurns: limit}).TurnLimit()
+}
+
+// Installed only after the original input committed to durable storage, and
+// only for a provider that actually supports engine-managed model boundaries.
+func (c *telegramStreamControl) modelBoundary(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.ready = true
+	return nil
+}
+
+func (c *telegramStreamControl) freezeForRestart(owner llm.SteeringTransition) ([]llm.QueuedSteering, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.ready || c.engine == nil || c.stopped.Load() || c.ctx.Err() != nil {
+		return nil, fmt.Errorf("Telegram execution is not ready for restart")
+	}
+	pending, err := c.engine.FreezeExecutionSnapshot(owner)
+	if err != nil {
+		return nil, err
+	}
+	c.frozen = true
+	c.pendingSteering = append([]llm.QueuedSteering(nil), pending...)
+	c.interruptForRestart()
+	return pending, nil
+}
+
+// Read only after actual execution settles, not when cancellation returns.
+func (c *telegramStreamControl) remainingTurns() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.engine == nil {
+		return 0
+	}
+	used := int(c.engine.ModelTurns() - c.initialTurns)
+	return max(0, c.turnLimit-used)
+}
+
+type telegramExecutionState struct {
+	RemainingTurns int                  `json:"remaining_turns"`
+	Steering       []llm.QueuedSteering `json:"steering,omitempty"`
+	Reply          *telegramReplyCursor `json:"reply"`
+}
+
+// Caller must have stopped admission and joined the complete manager gate.
+func (c *telegramStreamControl) executionState() (*telegramExecutionState, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.restarting() {
+		return nil, nil
+	}
+	if !c.frozen || c.engine == nil {
+		return nil, fmt.Errorf("Telegram restart execution was not frozen")
+	}
+	reply := c.replyCursor()
+	if reply == nil {
+		return nil, fmt.Errorf("Telegram restart delivery has not settled")
+	}
+	return &telegramExecutionState{RemainingTurns: max(0, c.turnLimit-int(c.engine.ModelTurns()-c.initialTurns)), Steering: append([]llm.QueuedSteering(nil), c.pendingSteering...), Reply: reply}, nil
+}

--- a/internal/serve/telegram_stream_control_test.go
+++ b/internal/serve/telegram_stream_control_test.go
@@ -1,0 +1,252 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/testutil"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTelegramStreamControlStopRevokesRestart(t *testing.T) {
+	for _, stopFirst := range []bool{false, true} {
+		c := newTelegramStreamControl(context.Background())
+		if stopFirst {
+			c.stop()
+		}
+		c.interruptForRestart()
+		if !stopFirst && !c.restarting() {
+			t.Fatal("restart cause not retained")
+		}
+		c.stop()
+		if c.restarting() {
+			t.Fatal("Stop failed to revoke restart intent")
+		}
+	}
+	c := newTelegramStreamControl(context.Background())
+	c.interruptForRestart()
+	c.close() // Normal stream cleanup must not masquerade as a user Stop.
+	if !c.restarting() {
+		t.Fatal("cleanup revoked internal interruption")
+	}
+	closeTelegramSession(&telegramSession{restartControl: c})
+	if c.restarting() {
+		t.Fatal("reset/retirement retained restart permission")
+	}
+	parent, cancel := context.WithCancel(context.Background())
+	c = newTelegramStreamControl(parent)
+	c.interruptForRestart()
+	cancel()
+	if c.restarting() {
+		t.Fatal("platform shutdown retained restart permission")
+	}
+}
+
+func TestTelegramStreamControlConcurrentStopWins(t *testing.T) {
+	for n := 0; n < 100; n++ {
+		c := newTelegramStreamControl(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); c.interruptForRestart() }()
+		go func() { defer wg.Done(); c.stop() }()
+		wg.Wait()
+		if c.restarting() {
+			t.Fatal("concurrent restart overrode Stop")
+		}
+	}
+}
+
+func TestTelegramStreamUsesRestartCauseWithoutRevokingOnCleanup(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	started := make(chan struct{})
+	h.Registry.Register(&testutil.MockTool{SpecData: llm.ToolSpec{Name: "wait", Schema: map[string]interface{}{"type": "object"}}, ExecuteFn: func(ctx context.Context, _ json.RawMessage) (llm.ToolOutput, error) {
+		close(started)
+		<-ctx.Done()
+		return llm.TextOutput("cancelled"), ctx.Err()
+	}})
+	h.Provider.AddToolCall("wait-1", "wait", map[string]any{})
+	mgr, sess := newTestMgrAndSession(h)
+	store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	mgr.store = store
+	runtime := sess.runtime
+	runtime.Provider = h.Provider
+	mgr.settings.NewSession = func(context.Context) (*SessionRuntime, error) { return runtime, nil }
+	sess, err = mgr.getOrCreate(context.Background(), 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot := &fakeBotSender{nextID: 1}
+	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { done <- mgr.streamReply(ctx, bot, sess, 42, llm.UserText("work")) }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("tool did not start")
+	}
+	sess.cancelMu.Lock()
+	control := sess.restartControl
+	sess.cancelMu.Unlock()
+	if control == nil {
+		t.Fatal("stream control was not installed")
+	}
+	_, status := h.Engine.QueueSteeringWithStatus(llm.QueuedSteering{Message: llm.UserText("pending note"), DisplayText: "pending note"})
+	if status != llm.SteeringQueueQueued {
+		t.Fatalf("queue steering: %v", status)
+	}
+	owner := llm.SteeringTransition{OperationID: "restart-test", Fence: 1}
+	if _, err := control.freezeForRestart(owner); err != nil {
+		t.Fatal(err)
+	}
+	defer h.Engine.ReleaseSteeringFreeze(owner, false)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not settle")
+	}
+	if control.remainingTurns() != 4 {
+		t.Fatalf("remaining turns=%d, want 4", control.remainingTurns())
+	}
+	if !control.restarting() {
+		t.Fatal("stream cleanup revoked restart intent")
+	}
+	if !strings.Contains(bot.lastText(), "restarting") {
+		t.Fatalf("restart presented as user interruption: %q", bot.lastText())
+	}
+	cursor := control.replyCursor()
+	if cursor == nil || cursor.MessageID != 1 {
+		t.Fatal("settled internal interruption lost reply cursor")
+	}
+	cursor.MessageID = 99
+	if control.replyCursor().MessageID != 1 {
+		t.Fatal("cursor aliases stored state")
+	}
+	reopen := mgr.restartGate.Pause()
+	defer reopen()
+	deadline := time.Now().Add(time.Second)
+	for !mgr.restartGate.Drained() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	raw, err := mgr.snapshotConversation(ctx, 42, sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handoffs, ok := session.AsCommandHandoffStore(store)
+	if !ok {
+		t.Fatal("missing durable handoff store")
+	}
+	if err := handoffs.SaveCommandHandoff(ctx, session.CommandHandoff{ID: "telegram-state-test", Service: "telegram-test", SourceInstance: "old", SessionID: sess.meta.ID, Payload: raw}); err != nil {
+		t.Fatal(err)
+	}
+	handoff, err := handoffs.ConsumeCommandHandoff(ctx, "telegram-state-test", "telegram-test", "new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.settings.NewSession = func(context.Context) (*SessionRuntime, error) {
+		next := testutil.NewEngineHarness()
+		return &SessionRuntime{Engine: next.Engine, ProviderName: "mock", ModelName: "test"}, nil
+	}
+	restored, chatID, err := mgr.restoreConversation(ctx, handoff.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeTelegramSession(restored)
+	state := restored.restoredExecution
+	if chatID != 42 || state == nil || state.RemainingTurns != 4 || state.Reply.MessageID != 1 || len(state.Steering) != 1 || state.Steering[0].DisplayText != "pending note" {
+		t.Fatal("SQLite handoff lost interrupted execution state")
+	}
+	if len(restored.history) == 0 || collectUserText(restored.history[0]) != "work" {
+		t.Fatal("checkpoint lost original input")
+	}
+	if _, err := handoffs.ConsumeCommandHandoff(ctx, "telegram-state-test", "telegram-test", "another"); err == nil {
+		t.Fatal("handoff consumed twice")
+	}
+	if err := mgr.savePlatformHandoff(ctx, "platform-roundtrip", "service", "old", 7, 108); err != nil {
+		t.Fatal(err)
+	}
+	platform, err := takeTelegramPlatformHandoff(ctx, store, "platform-roundtrip", "service", "new", 7, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if platform.NextOffset != 108 || len(platform.Conversations) != 1 {
+		t.Fatal("platform envelope lost chat or offset")
+	}
+	var conversation telegramConversationState
+	if err := json.Unmarshal(platform.Conversations[0], &conversation); err != nil {
+		t.Fatal(err)
+	}
+	if conversation.Execution == nil || conversation.Execution.RemainingTurns != 4 || len(conversation.Execution.Steering) != 1 {
+		t.Fatal("platform envelope lost execution state")
+	}
+	mgr.store = &telegramFailedSealStore{Store: store, TranscriptIndexer: store.(session.TranscriptIndexer)}
+	if _, err := mgr.snapshotConversation(ctx, 42, sess); err == nil {
+		t.Fatal("failed transcript sealing still produced checkpoint")
+	}
+	mgr.store = store
+	closeTelegramSession(sess)
+	if control.replyCursor() != nil {
+		t.Fatal("Stop did not revoke reply cursor")
+	}
+	if control.restarting() {
+		t.Fatal("session retirement failed to revoke continuation")
+	}
+}
+
+func TestTelegramCannotFreezeBeforeDurableBoundary(t *testing.T) {
+	h := testutil.NewEngineHarness()
+	c := newTelegramStreamControl(context.Background())
+	defer c.close()
+	c.bind(h.Engine, 5)
+	if _, err := c.freezeForRestart(llm.SteeringTransition{OperationID: "early", Fence: 1}); err == nil {
+		t.Fatal("engine binding falsely implied durable readiness")
+	}
+	if c.ctx.Err() != nil {
+		t.Fatal("failed readiness check cancelled live work")
+	}
+}
+
+func TestTelegramPendingMediaSurvivesCursorCopyWithoutDuplicateReferences(t *testing.T) {
+	a := llm.MediaArtifact{Reference: "IMAGE-A", StoredPath: "/durable/a.png", MediaType: "image/png"}
+	b := llm.MediaArtifact{Reference: "video-b", StoredPath: "/durable/b.mp4", MediaType: "video/mp4"}
+	duplicate := a
+	duplicate.Reference = "image-a"
+	merged := mergeTelegramPendingMedia([]llm.MediaArtifact{a}, []llm.MediaArtifact{duplicate, b})
+	if len(merged) != 2 || merged[0] != a || merged[1] != b {
+		t.Fatal("pending media was duplicated or reordered")
+	}
+	c := newTelegramStreamControl(context.Background())
+	defer c.close()
+	c.interruptForRestart()
+	c.reply.Store(&telegramReplyCursor{MessageID: 1, Images: []string{"legacy.png"}, Media: []llm.MediaArtifact{a, b}, PendingMedia: merged})
+	copy := c.replyCursor()
+	copy.Images[0] = "changed"
+	copy.Media[0].StoredPath = "changed"
+	copy.PendingMedia[0].Reference = "changed"
+	original := c.replyCursor()
+	if original.Images[0] != "legacy.png" || original.Media[0] != a || original.PendingMedia[0] != a {
+		t.Fatal("cursor copy aliases media state")
+	}
+}
+
+type telegramFailedSealStore struct {
+	session.Store
+	session.TranscriptIndexer
+}
+
+func (s *telegramFailedSealStore) ReplaceMessages(context.Context, string, []session.Message) error {
+	return errors.New("injected checkpoint write failure")
+}

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -108,6 +108,8 @@ type fakeBotSender struct {
 	mu             sync.Mutex
 	sent           []string // text of each successful Send call, in order
 	edits          []string // text of each successful EditMessageText call, in order
+	editIDs        []int
+	newMessages    int
 	overLimitEdits []string // rejected edit texts that exceeded maxEditRunes
 	nextID         int      // auto-incrementing MessageID
 	sendErr        error    // if non-nil, returned on the very first Send call
@@ -128,6 +130,7 @@ func (f *fakeBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
 	var text string
 	switch v := c.(type) {
 	case tgbotapi.MessageConfig:
+		f.newMessages++
 		text = v.Text
 	case tgbotapi.EditMessageTextConfig:
 		text = v.Text
@@ -136,6 +139,7 @@ func (f *fakeBotSender) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
 			return tgbotapi.Message{}, fmt.Errorf("telegram: message is too long")
 		}
 		f.edits = append(f.edits, text)
+		f.editIDs = append(f.editIDs, v.MessageID)
 	}
 	f.sent = append(f.sent, text)
 
@@ -2090,6 +2094,14 @@ func TestTelegramSessionMgrResetSessionIfCurrent_CancelsActiveStream(t *testing.
 		t.Fatal("streamReply did not stop after session reset")
 	}
 
+	original.cancelMu.Lock()
+	cleanupDone := original.cleanupDone
+	original.cancelMu.Unlock()
+	select {
+	case <-cleanupDone:
+	case <-time.After(time.Second):
+		t.Fatal("deferred runtime cleanup did not complete")
+	}
 	if cleanupCalls.Load() != 1 {
 		t.Fatalf("cleanup calls = %d, want 1", cleanupCalls.Load())
 	}
@@ -4273,5 +4285,72 @@ func TestHandleMessage_PhotoInterruptCancelsAndPreservesImage(t *testing.T) {
 		if strings.Contains(text, "Noted") {
 			t.Fatalf("photo was acknowledged as an steering instead of a replacement: %v", bot.allTexts())
 		}
+	}
+}
+
+func TestTelegramRestartGateWaitsForActualToolAndRetiredRuntime(t *testing.T) {
+	old := telegramRunnerCleanupTimeout
+	telegramRunnerCleanupTimeout = 20 * time.Millisecond
+	defer func() { telegramRunnerCleanupTimeout = old }()
+	h := testutil.NewEngineHarness()
+	started, release := make(chan struct{}), make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	h.Registry.Register(&testutil.MockTool{SpecData: llm.ToolSpec{Name: "uncooperative", Schema: map[string]interface{}{"type": "object"}}, ExecuteFn: func(context.Context, json.RawMessage) (llm.ToolOutput, error) {
+		close(started)
+		<-release
+		return llm.TextOutput("settled"), nil
+	}})
+	h.Provider.AddToolCall("held", "uncooperative", map[string]any{})
+	var cleaned atomic.Int32
+	sess := &telegramSession{runtime: &SessionRuntime{Engine: h.Engine, ProviderName: "mock", ModelName: "mock", Cleanup: func() { cleaned.Add(1) }}}
+	mgr := &telegramSessionMgr{settings: Settings{MaxTurns: 5}, tickerInterval: time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	returned := make(chan error, 1)
+	go func() { returned <- mgr.streamReply(ctx, &fakeBotSender{}, sess, 42, llm.UserText("work")) }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("tool did not start")
+	}
+	reopen := mgr.restartGate.Pause()
+	defer reopen()
+	cancel()
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("UI cancellation did not return within cleanup bound")
+	}
+	if mgr.restartGate.Drained() {
+		t.Fatal("synthetic cancellation released restart ownership")
+	}
+	if !sess.runtimeStale.Load() {
+		t.Fatal("unsettled runtime remained reusable")
+	}
+	mgr.closeTelegramSession(sess)
+	if cleaned.Load() != 0 {
+		t.Fatal("runtime cleanup raced actual tool execution")
+	}
+	sess.cancelMu.Lock()
+	done := sess.cleanupDone
+	sess.cancelMu.Unlock()
+	close(release)
+	released = true
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("retired runtime cleanup not acknowledged")
+	}
+	deadline := time.Now().Add(time.Second)
+	for !mgr.restartGate.Drained() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !mgr.restartGate.Drained() || cleaned.Load() != 1 {
+		t.Fatalf("ownership not settled: drained=%v cleanup=%d", mgr.restartGate.Drained(), cleaned.Load())
 	}
 }

--- a/internal/session/attention.go
+++ b/internal/session/attention.go
@@ -120,6 +120,11 @@ func (s *SQLiteStore) AdmitResponseRun(ctx context.Context, admission ResponseRu
 	if err != nil {
 		return ResponseRunLease{}, fmt.Errorf("allocate response run fence: %w", err)
 	}
+	if admission.ExecRestartID != "" {
+		if err := consumeExecHandoffTx(ctx, tx, admission); err != nil {
+			return ResponseRunLease{}, err
+		}
+	}
 	leaseExpiresAt := now.Add(leaseDuration)
 	result, err := tx.ExecContext(ctx, `INSERT INTO serve_response_lifecycle(
 		response_id, session_id, run_epoch, state, owner_instance_id, fencing_token,

--- a/internal/session/command_handoff.go
+++ b/internal/session/command_handoff.go
@@ -1,0 +1,120 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// CommandHandoff carries mode-owned UI state across an explicit self-exec. It is
+// private session metadata, never argv or a synthetic user message.
+type CommandHandoff struct {
+	ID             string          `json:"id"`
+	Service        string          `json:"service"`
+	SourceInstance string          `json:"source_instance"`
+	SessionID      string          `json:"session_id,omitempty"`
+	Revision       int64           `json:"revision"`
+	Created        time.Time       `json:"created"`
+	Payload        json.RawMessage `json:"payload"`
+}
+
+type CommandHandoffStore interface {
+	SaveCommandHandoff(context.Context, CommandHandoff) error
+	ConsumeCommandHandoff(context.Context, string, string, string) (CommandHandoff, error)
+	ReclaimCommandHandoff(context.Context, string, string, string) (CommandHandoff, error)
+	DiscardCommandHandoff(context.Context, string) error
+}
+
+func AsCommandHandoffStore(store Store) (CommandHandoffStore, bool) {
+	if wrapped, ok := store.(*LoggingStore); ok {
+		return AsCommandHandoffStore(wrapped.Store)
+	}
+	if s, ok := store.(*SQLiteStore); ok && (s.cfg.ReadOnly || s.cfg.Path == ":memory:") {
+		return nil, false
+	}
+	result, ok := store.(CommandHandoffStore)
+	return result, ok
+}
+
+func (s *SQLiteStore) SaveCommandHandoff(ctx context.Context, h CommandHandoff) error {
+	if h.ID == "" || h.Service == "" || h.SourceInstance == "" || !json.Valid(h.Payload) {
+		return ErrExecHandoffConflict
+	}
+	h.Created = time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err = tx.ExecContext(ctx, `UPDATE metadata SET value=value WHERE key='serve_response_fencing_token'`); err != nil {
+		return err
+	}
+	if h.SessionID != "" {
+		if err = tx.QueryRowContext(ctx, `SELECT transcript_rev FROM sessions WHERE id=?`, h.SessionID).Scan(&h.Revision); err != nil {
+			return err
+		}
+	}
+	raw, err := json.Marshal(h)
+	if err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `INSERT INTO metadata(key,value) VALUES(?,?)`, "process_handoff:"+h.ID, string(raw)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *SQLiteStore) ConsumeCommandHandoff(ctx context.Context, id, service, instance string) (CommandHandoff, error) {
+	return s.takeCommandHandoff(ctx, id, service, instance, false)
+}
+
+// ReclaimCommandHandoff is the explicit failed-replacement path for the original
+// instance. It retains the same service, revision, expiry and one-shot checks;
+// unlike replacement adoption, it requires identity equality, not a fake boot ID.
+func (s *SQLiteStore) ReclaimCommandHandoff(ctx context.Context, id, service, sourceInstance string) (CommandHandoff, error) {
+	return s.takeCommandHandoff(ctx, id, service, sourceInstance, true)
+}
+
+func (s *SQLiteStore) takeCommandHandoff(ctx context.Context, id, service, instance string, reclaim bool) (CommandHandoff, error) {
+	var h CommandHandoff
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return h, err
+	}
+	defer tx.Rollback()
+	if _, err = tx.ExecContext(ctx, `UPDATE metadata SET value=value WHERE key='serve_response_fencing_token'`); err != nil {
+		return h, err
+	}
+	var raw string
+	if err = tx.QueryRowContext(ctx, `SELECT value FROM metadata WHERE key=?`, "process_handoff:"+id).Scan(&raw); errors.Is(err, sql.ErrNoRows) {
+		return h, ErrExecHandoffConflict
+	} else if err != nil {
+		return h, err
+	}
+	if err = json.Unmarshal([]byte(raw), &h); err != nil {
+		return h, err
+	}
+	if h.ID != id || h.Service != service || instance == "" || (h.SourceInstance == instance) != reclaim || time.Since(h.Created) > 5*time.Minute || h.Created.After(time.Now()) {
+		return h, ErrExecHandoffConflict
+	}
+	if h.SessionID != "" {
+		var rev int64
+		if err = tx.QueryRowContext(ctx, `SELECT transcript_rev FROM sessions WHERE id=?`, h.SessionID).Scan(&rev); err != nil {
+			return h, err
+		}
+		if rev != h.Revision {
+			return h, ErrExecHandoffConflict
+		}
+	}
+	if _, err = tx.ExecContext(ctx, `DELETE FROM metadata WHERE key=?`, "process_handoff:"+id); err != nil {
+		return h, err
+	}
+	return h, tx.Commit()
+}
+
+func (s *SQLiteStore) DiscardCommandHandoff(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM metadata WHERE key=?`, "process_handoff:"+id)
+	return err
+}

--- a/internal/session/command_handoff_test.go
+++ b/internal/session/command_handoff_test.go
@@ -1,0 +1,103 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCommandHandoffExplicitOneShot(t *testing.T) {
+	for _, variant := range []string{"consume", "same instance", "wrong service", "advanced", "discarded"} {
+		t.Run(variant, func(t *testing.T) {
+			store, ctx, sid := newAttentionTestStore(t)
+			h := CommandHandoff{ID: "restart-id", Service: "chat-service", SourceInstance: "old", SessionID: sid, Payload: json.RawMessage(`{"draft":"unsent","continue":true}`)}
+			if err := store.SaveCommandHandoff(ctx, h); err != nil {
+				t.Fatal(err)
+			}
+			instance, service := "new", h.Service
+			switch variant {
+			case "same instance":
+				instance = "old"
+			case "wrong service":
+				service = "another"
+			case "advanced":
+				if _, err := store.db.ExecContext(ctx, `UPDATE sessions SET transcript_rev=transcript_rev+1 WHERE id=?`, sid); err != nil {
+					t.Fatal(err)
+				}
+			case "discarded":
+				if err := store.DiscardCommandHandoff(ctx, h.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := store.ConsumeCommandHandoff(ctx, h.ID, service, instance)
+			if variant != "consume" {
+				if !errors.Is(err, ErrExecHandoffConflict) {
+					t.Fatalf("invalid claim accepted: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got.Payload) != string(h.Payload) || got.SessionID != sid {
+				t.Fatalf("lost payload: %+v", got)
+			}
+			if _, err := store.ConsumeCommandHandoff(ctx, h.ID, service, "third"); !errors.Is(err, ErrExecHandoffConflict) {
+				t.Fatalf("claim replayed: %v", err)
+			}
+		})
+	}
+}
+
+func TestCommandHandoffReclaimOnlyOriginalInstance(t *testing.T) {
+	for _, variant := range []string{"original", "other-instance", "wrong-service", "advanced", "expired"} {
+		t.Run(variant, func(t *testing.T) {
+			store, ctx, sid := newAttentionTestStore(t)
+			h := CommandHandoff{ID: "failed-replacement", Service: "jobs", SourceInstance: "source", SessionID: sid, Payload: json.RawMessage(`{}`)}
+			if err := store.SaveCommandHandoff(ctx, h); err != nil {
+				t.Fatal(err)
+			}
+			source, service := "source", "jobs"
+			switch variant {
+			case "other-instance":
+				source = "replacement"
+			case "wrong-service":
+				service = "other"
+			case "advanced":
+				if _, err := store.db.ExecContext(ctx, `UPDATE sessions SET transcript_rev=transcript_rev+1 WHERE id=?`, sid); err != nil {
+					t.Fatal(err)
+				}
+			case "expired":
+				var raw string
+				if err := store.db.QueryRowContext(ctx, `SELECT value FROM metadata WHERE key=?`, "process_handoff:"+h.ID).Scan(&raw); err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal([]byte(raw), &h); err != nil {
+					t.Fatal(err)
+				}
+				h.Created = h.Created.Add(-10 * time.Minute)
+				payload, _ := json.Marshal(h)
+				if _, err := store.db.ExecContext(ctx, `UPDATE metadata SET value=? WHERE key=?`, string(payload), "process_handoff:"+h.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := store.ReclaimCommandHandoff(ctx, h.ID, service, source)
+			if variant != "original" {
+				if !errors.Is(err, ErrExecHandoffConflict) {
+					t.Fatalf("invalid reclaim: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = store.ReclaimCommandHandoff(ctx, h.ID, service, source); !errors.Is(err, ErrExecHandoffConflict) {
+				t.Fatalf("reclaim replayed: %v", err)
+			}
+			if _, err = store.ConsumeCommandHandoff(ctx, h.ID, service, "new"); !errors.Is(err, ErrExecHandoffConflict) {
+				t.Fatalf("reclaimed grant adopted again: %v", err)
+			}
+		})
+	}
+}

--- a/internal/session/exec_handoff.go
+++ b/internal/session/exec_handoff.go
@@ -1,0 +1,161 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ExecHandoff is an explicit, one-shot hot-reload intent, not crash recovery.
+// Request contains orchestration options, never an executable stack or pending
+// tool calls. The source remains leased until exec; failed exec can discard the
+// intent without cancelling or fencing the parked invocation.
+type ExecHandoff struct {
+	ID, ServiceID, SourceOwnerID, SessionID, SourceResponseID string
+	SourceFence, CheckpointRev                                int64
+	Request                                                   []byte
+}
+
+var ErrExecHandoffConflict = errors.New("session: stale or consumed self-exec handoff")
+
+type ExecHandoffStore interface {
+	PrepareExecHandoff(context.Context, []ExecHandoff) error
+	ReadExecHandoff(context.Context, string, string) ([]ExecHandoff, error)
+	DiscardExecHandoff(context.Context, string, string) error
+	ExecContinuation(context.Context, string, string) (string, error)
+}
+
+func AsExecHandoffStore(store Store) (ExecHandoffStore, bool) {
+	if logging, ok := store.(*LoggingStore); ok {
+		return AsExecHandoffStore(logging.Store)
+	}
+	if sqlite, ok := store.(*SQLiteStore); ok && (sqlite.cfg.ReadOnly || strings.TrimSpace(sqlite.cfg.Path) == ":memory:") {
+		return nil, false
+	}
+	result, ok := store.(ExecHandoffStore)
+	return result, ok
+}
+
+const execHandoffSchemaV58 = `
+CREATE TABLE IF NOT EXISTS serve_exec_handoffs (
+ restart_id TEXT NOT NULL,
+ service_id TEXT NOT NULL,
+ source_owner_id TEXT NOT NULL,
+ session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+ source_response_id TEXT NOT NULL UNIQUE,
+ source_fence INTEGER NOT NULL,
+ checkpoint_rev INTEGER NOT NULL,
+ request BLOB NOT NULL,
+ consumed INTEGER NOT NULL DEFAULT 0,
+ replacement_response_id TEXT NOT NULL DEFAULT '',
+ created_at INTEGER NOT NULL,
+ PRIMARY KEY(restart_id, session_id)
+);
+`
+
+func (s *SQLiteStore) PrepareExecHandoff(ctx context.Context, entries []ExecHandoff) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	// Acquire the writer lock before validating any transcript/lease.
+	if _, err = tx.ExecContext(ctx, `UPDATE metadata SET value=value WHERE key='serve_response_fencing_token'`); err != nil {
+		return err
+	}
+	for _, h := range entries {
+		first := entries[0]
+		if h.ID != first.ID || h.ServiceID != first.ServiceID || h.SourceOwnerID != first.SourceOwnerID || !json.Valid(h.Request) {
+			return ErrExecHandoffConflict
+		}
+		if h.ID == "" || h.ServiceID == "" || h.SourceOwnerID == "" {
+			return ErrExecHandoffConflict
+		}
+		if err = validateExecSource(ctx, tx, h); err != nil {
+			return err
+		}
+		if _, err = tx.ExecContext(ctx, `INSERT INTO serve_exec_handoffs(restart_id,service_id,source_owner_id,session_id,source_response_id,source_fence,checkpoint_rev,request,created_at) VALUES(?,?,?,?,?,?,?,?,CAST((julianday('now')-2440587.5)*86400000 AS INTEGER))`, h.ID, h.ServiceID, h.SourceOwnerID, h.SessionID, h.SourceResponseID, h.SourceFence, h.CheckpointRev, h.Request); err != nil {
+			return fmt.Errorf("prepare self-exec: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+func validateExecSource(ctx context.Context, tx *sql.Tx, h ExecHandoff) error {
+	var valid int
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM sessions s JOIN serve_response_lifecycle r ON r.session_id=s.id WHERE s.id=? AND s.transcript_rev=? AND r.response_id=? AND r.owner_instance_id=? AND r.fencing_token=? AND r.state='running' AND r.lease_expires_at>CAST((julianday('now')-2440587.5)*86400000 AS INTEGER) AND NOT EXISTS(SELECT 1 FROM session_pending_steering p WHERE p.session_id=s.id) AND NOT EXISTS(SELECT 1 FROM session_rush_operations q WHERE q.session_id=s.id AND q.status IN ('interrupting','waiting_for_settlement','starting')) AND NOT EXISTS(SELECT 1 FROM serve_response_lifecycle n WHERE n.session_id=s.id AND n.fencing_token>r.fencing_token)`, h.SessionID, h.CheckpointRev, h.SourceResponseID, h.SourceOwnerID, h.SourceFence).Scan(&valid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrExecHandoffConflict
+	}
+	return err
+}
+
+func (s *SQLiteStore) ReadExecHandoff(ctx context.Context, id, service string) ([]ExecHandoff, error) {
+	rows, err := s.queryDB().QueryContext(ctx, `SELECT restart_id,service_id,source_owner_id,session_id,source_response_id,source_fence,checkpoint_rev,request FROM serve_exec_handoffs WHERE restart_id=? AND service_id=? AND consumed=0 AND created_at>CAST((julianday('now')-2440587.5)*86400000 AS INTEGER)-300000`, id, service)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []ExecHandoff
+	for rows.Next() {
+		var h ExecHandoff
+		if err := rows.Scan(&h.ID, &h.ServiceID, &h.SourceOwnerID, &h.SessionID, &h.SourceResponseID, &h.SourceFence, &h.CheckpointRev, &h.Request); err != nil {
+			return nil, err
+		}
+		result = append(result, h)
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) DiscardExecHandoff(ctx context.Context, id, owner string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM serve_exec_handoffs WHERE restart_id=? AND source_owner_id=? AND consumed=0`, id, owner)
+	return err
+}
+
+// consumeExecHandoffTx is called inside response admission's writer transaction.
+// An absent environment hint never calls this path; neither a PID nor a lookup
+// UUID alone authorizes adoption. Service, boot, lease and transcript must match.
+func consumeExecHandoffTx(ctx context.Context, tx *sql.Tx, a ResponseRunAdmission) error {
+	var h ExecHandoff
+	err := tx.QueryRowContext(ctx, `SELECT restart_id,service_id,source_owner_id,session_id,source_response_id,source_fence,checkpoint_rev FROM serve_exec_handoffs WHERE restart_id=? AND service_id=? AND session_id=? AND consumed=0 AND created_at>CAST((julianday('now')-2440587.5)*86400000 AS INTEGER)-300000`, a.ExecRestartID, a.ExecServiceID, a.SessionID).Scan(&h.ID, &h.ServiceID, &h.SourceOwnerID, &h.SessionID, &h.SourceResponseID, &h.SourceFence, &h.CheckpointRev)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrExecHandoffConflict
+	}
+	if err != nil {
+		return err
+	}
+	if h.SourceOwnerID == a.OwnerInstanceID {
+		return ErrExecHandoffConflict
+	}
+	if err = validateExecSource(ctx, tx, h); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE serve_exec_handoffs SET consumed=1,replacement_response_id=? WHERE restart_id=? AND session_id=?`, a.ResponseID, h.ID, h.SessionID); err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `UPDATE serve_response_lifecycle SET state='orphaned',lease_expires_at=0 WHERE response_id=?`, h.SourceResponseID)
+	return err
+}
+
+// ExecContinuation follows only explicit accepted replacement edges. It never
+// resolves to an unrelated newer user response in the same session.
+func (s *SQLiteStore) ExecContinuation(ctx context.Context, source, service string) (string, error) {
+	for depth := 0; depth < 64; depth++ {
+		var next string
+		err := s.queryDB().QueryRowContext(ctx, `SELECT replacement_response_id FROM serve_exec_handoffs WHERE source_response_id=? AND service_id=? AND consumed=1`, source, service).Scan(&next)
+		if errors.Is(err, sql.ErrNoRows) {
+			return source, nil
+		}
+		if err != nil {
+			return "", err
+		}
+		if next == "" || next == source {
+			return "", ErrExecHandoffConflict
+		}
+		source = next
+	}
+	return "", ErrExecHandoffConflict
+}

--- a/internal/session/exec_handoff.go
+++ b/internal/session/exec_handoff.go
@@ -19,12 +19,26 @@ type ExecHandoff struct {
 	Request                                                   []byte
 }
 
+// ExecRequestState is orchestration metadata in the saved request envelope.
+// Preparation can authorize an interruption, but only settlement can seal it.
+type ExecRequestState struct {
+	Interrupted bool `json:"restart_interrupted,omitempty"`
+	Settled     bool `json:"restart_settled,omitempty"`
+}
+
+func execRequestState(raw []byte) ExecRequestState {
+	var state ExecRequestState
+	_ = json.Unmarshal(raw, &state)
+	return state
+}
+
 var ErrExecHandoffConflict = errors.New("session: stale or consumed self-exec handoff")
 
 type ExecHandoffStore interface {
 	PrepareExecHandoff(context.Context, []ExecHandoff) error
 	ReadExecHandoff(context.Context, string, string) ([]ExecHandoff, error)
 	DiscardExecHandoff(context.Context, string, string) error
+	SealExecInterruption(context.Context, []ExecHandoff) error
 	ExecContinuation(context.Context, string, string) (string, error)
 }
 
@@ -74,6 +88,9 @@ func (s *SQLiteStore) PrepareExecHandoff(ctx context.Context, entries []ExecHand
 		if h.ID == "" || h.ServiceID == "" || h.SourceOwnerID == "" {
 			return ErrExecHandoffConflict
 		}
+		if execRequestState(h.Request).Settled {
+			return ErrExecHandoffConflict
+		}
 		if err = validateExecSource(ctx, tx, h); err != nil {
 			return err
 		}
@@ -86,7 +103,9 @@ func (s *SQLiteStore) PrepareExecHandoff(ctx context.Context, entries []ExecHand
 
 func validateExecSource(ctx context.Context, tx *sql.Tx, h ExecHandoff) error {
 	var valid int
-	err := tx.QueryRowContext(ctx, `SELECT 1 FROM sessions s JOIN serve_response_lifecycle r ON r.session_id=s.id WHERE s.id=? AND s.transcript_rev=? AND r.response_id=? AND r.owner_instance_id=? AND r.fencing_token=? AND r.state='running' AND r.lease_expires_at>CAST((julianday('now')-2440587.5)*86400000 AS INTEGER) AND NOT EXISTS(SELECT 1 FROM session_pending_steering p WHERE p.session_id=s.id) AND NOT EXISTS(SELECT 1 FROM session_rush_operations q WHERE q.session_id=s.id AND q.status IN ('interrupting','waiting_for_settlement','starting')) AND NOT EXISTS(SELECT 1 FROM serve_response_lifecycle n WHERE n.session_id=s.id AND n.fencing_token>r.fencing_token)`, h.SessionID, h.CheckpointRev, h.SourceResponseID, h.SourceOwnerID, h.SourceFence).Scan(&valid)
+	state := execRequestState(h.Request)
+	interrupted := state.Interrupted && state.Settled
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM sessions s JOIN serve_response_lifecycle r ON r.session_id=s.id WHERE s.id=? AND s.transcript_rev=? AND r.response_id=? AND r.owner_instance_id=? AND r.fencing_token=? AND ((?=0 AND r.state='running' AND r.lease_expires_at>CAST((julianday('now')-2440587.5)*86400000 AS INTEGER)) OR (?=1 AND r.state='cancelled')) AND NOT EXISTS(SELECT 1 FROM session_pending_steering p WHERE p.session_id=s.id) AND NOT EXISTS(SELECT 1 FROM session_rush_operations q WHERE q.session_id=s.id AND q.status IN ('interrupting','waiting_for_settlement','starting')) AND NOT EXISTS(SELECT 1 FROM serve_response_lifecycle n WHERE n.session_id=s.id AND n.fencing_token>r.fencing_token)`, h.SessionID, h.CheckpointRev, h.SourceResponseID, h.SourceOwnerID, h.SourceFence, interrupted, interrupted).Scan(&valid)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrExecHandoffConflict
 	}
@@ -120,12 +139,16 @@ func (s *SQLiteStore) DiscardExecHandoff(ctx context.Context, id, owner string) 
 // UUID alone authorizes adoption. Service, boot, lease and transcript must match.
 func consumeExecHandoffTx(ctx context.Context, tx *sql.Tx, a ResponseRunAdmission) error {
 	var h ExecHandoff
-	err := tx.QueryRowContext(ctx, `SELECT restart_id,service_id,source_owner_id,session_id,source_response_id,source_fence,checkpoint_rev FROM serve_exec_handoffs WHERE restart_id=? AND service_id=? AND session_id=? AND consumed=0 AND created_at>CAST((julianday('now')-2440587.5)*86400000 AS INTEGER)-300000`, a.ExecRestartID, a.ExecServiceID, a.SessionID).Scan(&h.ID, &h.ServiceID, &h.SourceOwnerID, &h.SessionID, &h.SourceResponseID, &h.SourceFence, &h.CheckpointRev)
+	err := tx.QueryRowContext(ctx, `SELECT restart_id,service_id,source_owner_id,session_id,source_response_id,source_fence,checkpoint_rev,request FROM serve_exec_handoffs WHERE restart_id=? AND service_id=? AND session_id=? AND consumed=0 AND created_at>CAST((julianday('now')-2440587.5)*86400000 AS INTEGER)-300000`, a.ExecRestartID, a.ExecServiceID, a.SessionID).Scan(&h.ID, &h.ServiceID, &h.SourceOwnerID, &h.SessionID, &h.SourceResponseID, &h.SourceFence, &h.CheckpointRev, &h.Request)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrExecHandoffConflict
 	}
 	if err != nil {
 		return err
+	}
+	state := execRequestState(h.Request)
+	if state.Interrupted && !state.Settled {
+		return ErrExecHandoffConflict
 	}
 	if h.SourceOwnerID == a.OwnerInstanceID {
 		return ErrExecHandoffConflict
@@ -158,4 +181,39 @@ func (s *SQLiteStore) ExecContinuation(ctx context.Context, source, service stri
 		source = next
 	}
 	return "", ErrExecHandoffConflict
+}
+
+// SealExecInterruption advances only an already authorized interruption, after
+// the source transcript and actual execution have settled. Merely encountering
+// a cancelled response never authorizes restart continuation.
+func (s *SQLiteStore) SealExecInterruption(ctx context.Context, entries []ExecHandoff) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `UPDATE metadata SET value=value WHERE key='serve_response_fencing_token'`); err != nil {
+		return err
+	}
+	for _, h := range entries {
+		var stored []byte
+		err := tx.QueryRowContext(ctx, `SELECT request FROM serve_exec_handoffs WHERE restart_id=? AND service_id=? AND source_owner_id=? AND session_id=? AND source_response_id=? AND source_fence=? AND consumed=0`, h.ID, h.ServiceID, h.SourceOwnerID, h.SessionID, h.SourceResponseID, h.SourceFence).Scan(&stored)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrExecHandoffConflict
+		}
+		if err != nil {
+			return err
+		}
+		before, after := execRequestState(stored), execRequestState(h.Request)
+		if !before.Interrupted || before.Settled || !after.Interrupted || !after.Settled {
+			return ErrExecHandoffConflict
+		}
+		if err := validateExecSource(ctx, tx, h); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE serve_exec_handoffs SET checkpoint_rev=?,request=? WHERE restart_id=? AND session_id=? AND consumed=0`, h.CheckpointRev, h.Request, h.ID, h.SessionID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }

--- a/internal/session/exec_handoff_test.go
+++ b/internal/session/exec_handoff_test.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"errors"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"testing"
+	"time"
+)
+
+func TestExecHandoffAdmission(t *testing.T) {
+	for _, variant := range []string{"consume", "same boot", "wrong service", "advance", "cancel", "new run", "discard", "expired", "rush", "steering"} {
+		t.Run(variant, func(t *testing.T) {
+			store, ctx, sid := newAttentionTestStore(t)
+			lease := admitAttentionRun(t, store, ctx, sid, "source", "boot-A", 0)
+			h := ExecHandoff{ID: "restart", ServiceID: "service", SourceOwnerID: "boot-A", SessionID: sid, SourceResponseID: "source", SourceFence: lease.FencingToken, CheckpointRev: 0, Request: []byte(`{}`)}
+			if err := store.PrepareExecHandoff(ctx, []ExecHandoff{h}); err != nil {
+				t.Fatal(err)
+			}
+			// Preparing cannot cancel or fence the live invocation: exec may fail.
+			if err := store.ValidateResponseRunLease(ctx, "source", "boot-A", lease.FencingToken); err != nil {
+				t.Fatal(err)
+			}
+			a := ResponseRunAdmission{ResponseID: "replacement", SessionID: sid, OwnerInstanceID: "boot-B", ExecRestartID: h.ID, ExecServiceID: h.ServiceID}
+			switch variant {
+			case "same boot":
+				a.OwnerInstanceID = "boot-A"
+			case "wrong service":
+				a.ExecServiceID = "other"
+			case "advance":
+				if _, err := store.db.ExecContext(ctx, `UPDATE sessions SET transcript_rev=transcript_rev+1 WHERE id=?`, sid); err != nil {
+					t.Fatal(err)
+				}
+			case "cancel":
+				if _, err := store.FinalizeResponseRun(ctx, ResponseRunTerminal{ResponseID: "source", OwnerInstanceID: "boot-A", FencingToken: lease.FencingToken, Outcome: ResponseRunCancelled}); err != nil {
+					t.Fatal(err)
+				}
+			case "new run":
+				admitAttentionRun(t, store, ctx, sid, "newer", "boot-A", 0)
+			case "discard":
+				if err := store.DiscardExecHandoff(ctx, h.ID, h.SourceOwnerID); err != nil {
+					t.Fatal(err)
+				}
+			case "steering":
+				if err := store.SavePendingSteering(ctx, PendingSteering{SessionID: sid, ID: "queued", Message: llm.UserText("wait"), CreatedAt: time.Now(), Origin: llm.SteeringOriginUser}); err != nil {
+					t.Fatal(err)
+				}
+			case "rush":
+				if _, err := store.db.ExecContext(ctx, `INSERT INTO session_rush_operations(session_id,request_id,source_response_id,source_epoch,status,owner_fence,created_at,updated_at) VALUES(?, 'rush', 'source', 1, 'starting', 1, 1, 1)`, sid); err != nil {
+					t.Fatal(err)
+				}
+			case "expired":
+				if _, err := store.db.ExecContext(ctx, `UPDATE serve_exec_handoffs SET created_at=0`); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := store.AdmitResponseRun(ctx, a)
+			if variant != "consume" {
+				if !errors.Is(err, ErrExecHandoffConflict) {
+					t.Fatalf("admission error=%v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.ValidateResponseRunLease(ctx, "source", "boot-A", lease.FencingToken); !errors.Is(err, ErrResponseRunLeaseLost) {
+				t.Fatalf("source fence: %v", err)
+			}
+			next, err := store.ExecContinuation(ctx, "source", h.ServiceID)
+			if err != nil || next != "replacement" {
+				t.Fatalf("cancel continuation=%q err=%v", next, err)
+			}
+			other, err := store.ExecContinuation(ctx, "source", "other-service")
+			if err != nil || other != "source" {
+				t.Fatalf("cross-service continuation=%q err=%v", other, err)
+			}
+			a.ResponseID = "duplicate"
+			if _, err := store.AdmitResponseRun(ctx, a); !errors.Is(err, ErrExecHandoffConflict) {
+				t.Fatalf("duplicate=%v", err)
+			}
+			entries, err := store.ReadExecHandoff(ctx, h.ID, h.ServiceID)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("consumed entries=%v err=%v", entries, err)
+			}
+		})
+	}
+}
+
+func TestExecHandoffBatchPrepareRollsBack(t *testing.T) {
+	store, ctx, sid := newAttentionTestStore(t)
+	lease := admitAttentionRun(t, store, ctx, sid, "source", "boot-A", 0)
+	h := ExecHandoff{ID: "restart", ServiceID: "service", SourceOwnerID: "boot-A", SessionID: sid, SourceResponseID: "source", SourceFence: lease.FencingToken, Request: []byte(`{}`)}
+	bad := h
+	bad.SessionID = "missing"
+	if err := store.PrepareExecHandoff(ctx, []ExecHandoff{h, bad}); !errors.Is(err, ErrExecHandoffConflict) {
+		t.Fatalf("prepare: %v", err)
+	}
+	entries, err := store.ReadExecHandoff(ctx, h.ID, h.ServiceID)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("partial commit=%v err=%v", entries, err)
+	}
+}
+
+func TestExecHandoffRejectsMemoryStore(t *testing.T) {
+	store, err := NewSQLiteStore(Config{Enabled: true, Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, ok := AsExecHandoffStore(store); ok {
+		t.Fatal("in-memory store advertised durable exec handoff")
+	}
+}

--- a/internal/session/exec_handoff_test.go
+++ b/internal/session/exec_handoff_test.go
@@ -111,3 +111,54 @@ func TestExecHandoffRejectsMemoryStore(t *testing.T) {
 		t.Fatal("in-memory store advertised durable exec handoff")
 	}
 }
+
+func TestExecInterruptedHandoffRequiresPreparedAndSettledSource(t *testing.T) {
+	for _, variant := range []string{"resume", "unsealed", "unprepared", "discarded", "user advanced"} {
+		t.Run(variant, func(t *testing.T) {
+			store, ctx, sid := newAttentionTestStore(t)
+			lease := admitAttentionRun(t, store, ctx, sid, "source", "boot-A", 0)
+			h := ExecHandoff{ID: "restart", ServiceID: "service", SourceOwnerID: "boot-A", SessionID: sid, SourceResponseID: "source", SourceFence: lease.FencingToken, Request: []byte(`{"restart_interrupted":true}`)}
+			if variant != "unprepared" {
+				if err := store.PrepareExecHandoff(ctx, []ExecHandoff{h}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			a := ResponseRunAdmission{ResponseID: "replacement", SessionID: sid, OwnerInstanceID: "boot-B", ExecRestartID: h.ID, ExecServiceID: h.ServiceID}
+			if _, err := store.AdmitResponseRun(ctx, a); !errors.Is(err, ErrExecHandoffConflict) {
+				t.Fatalf("unsettled source accepted: %v", err)
+			}
+			if _, err := store.FinalizeResponseRun(ctx, ResponseRunTerminal{ResponseID: "source", OwnerInstanceID: "boot-A", FencingToken: lease.FencingToken, Outcome: ResponseRunCancelled}); err != nil {
+				t.Fatal(err)
+			}
+			if variant == "discarded" {
+				if err := store.DiscardExecHandoff(ctx, h.ID, h.SourceOwnerID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if variant == "user advanced" {
+				admitAttentionRun(t, store, ctx, sid, "new-user-run", "boot-A", 0)
+			}
+			if variant != "unsealed" {
+				h.Request = []byte(`{"restart_interrupted":true,"restart_settled":true}`)
+				err := store.SealExecInterruption(ctx, []ExecHandoff{h})
+				if variant != "resume" {
+					if !errors.Is(err, ErrExecHandoffConflict) {
+						t.Fatalf("invalid seal: %v", err)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := store.AdmitResponseRun(ctx, a)
+			if variant == "unsealed" {
+				if !errors.Is(err, ErrExecHandoffConflict) {
+					t.Fatalf("cancel without seal accepted: %v", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/session/sqlite.go
+++ b/internal/session/sqlite.go
@@ -435,7 +435,7 @@ CREATE INDEX IF NOT EXISTS session_attention_unseen
     WHERE latest_attention_seq > seen_through_seq;
 `
 
-const canonicalSessionSchema = schema + projectsSchemaV47 + changeLogSchemaV52 + attentionSchemaV54 + rushSchemaV57
+const canonicalSessionSchema = schema + projectsSchemaV47 + changeLogSchemaV52 + attentionSchemaV54 + rushSchemaV57 + execHandoffSchemaV58
 
 func sqliteFileURI(path string) string {
 	slashPath := filepath.ToSlash(path)
@@ -584,7 +584,7 @@ func NewSQLiteStore(cfg Config) (*SQLiteStore, error) {
 // Increment when adding new migrations.
 const (
 	projectSchemaVersion = 47
-	schemaVersion        = 57
+	schemaVersion        = 58
 )
 
 // migration represents a schema migration.
@@ -1675,6 +1675,10 @@ var migrations = []migration{
 			return err
 		},
 	},
+	{version: 58, description: "explicit self-exec handoffs", up: func(db schemaExecutor) error {
+		_, err := db.Exec(execHandoffSchemaV58)
+		return err
+	}},
 }
 
 // Keep in sync with llm.IsInternalCompactionSummaryText. SQLite migrations and

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -158,6 +158,8 @@ var (
 
 // ResponseRunAdmission durably accounts for a run before provider work starts.
 type ResponseRunAdmission struct {
+	ExecRestartID   string
+	ExecServiceID   string
 	ResponseID      string
 	SessionID       string
 	RunEpoch        int64

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -27,6 +27,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/mcp"
 	"github.com/samsaffron/term-llm/internal/mentions"
+	"github.com/samsaffron/term-llm/internal/process"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/runboundary"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -387,6 +388,8 @@ type Model struct {
 
 	// reloadRequested signals the caller to re-exec the binary (e.g. after an upgrade).
 	// The session ID to resume is stored in reloadSessionID.
+	processReload   processReload
+	processResume   bool
 	reloadRequested bool
 	reloadSessionID string
 
@@ -1927,6 +1930,10 @@ func (m *Model) startupWorkspaceApprovalCmd() tea.Cmd {
 }
 
 func (m *Model) initialAutoSendCmd() tea.Cmd {
+	if m.processResume || m.processReload.state.Draft != "" || len(m.processReload.state.Files) > 0 || len(m.processReload.state.Images) > 0 {
+		return func() tea.Msg { return processResumeMsg{} }
+	}
+
 	// Branch command auto-send: submit only when the command included a message.
 	// When path notes are active Init moves this into queuedBranchSend instead.
 	if m.branchAutoSend != "" {
@@ -2135,7 +2142,7 @@ func (m *Model) waitStreamDone(cancelBranch bool) bool {
 		case <-time.After(streamCancelMaxWait):
 		}
 	}
-	return m.runtimeOperations.sealAndWait(streamCancelMaxWait)
+	return m.runtimeOperations.sealAndWait(streamCancelMaxWait) && (m.engine == nil || m.engine.ActiveToolExecutions() == 0)
 }
 
 // WaitRuntimeOperations waits without a deadline after the gate was sealed.
@@ -2327,6 +2334,25 @@ func (m *Model) flushBeforeExternalUI(done chan<- struct{}) (tea.Model, tea.Cmd)
 
 // Update handles messages
 func (m *Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
+	if key, ok := msg.(tea.KeyPressMsg); ok && m.processReload.pending && (key.String() == "esc" || key.String() == "ctrl+c") {
+		m.processReload.pending = false
+		m.processReload.state.Continue = false
+		process.State("chat", "ready", "restart cancelled by user")
+	}
+	switch msg.(type) {
+	case ProcessReloadMsg:
+		if m.processReload.pending || m.processReload.owner.OperationID != "" || m.reloadRequested {
+			return m, nil
+		}
+		m.processReload = processReload{pending: true, started: time.Now()}
+		process.State("chat", "draining", "")
+		return m.handleProcessReload()
+	case processReloadTick:
+		return m.handleProcessReload()
+	case processResumeMsg:
+		return m.resumeAfterProcessReload()
+	}
+
 	if failed, ok := msg.(steeringStartFailedMsg); ok {
 		if failed.generation != m.streamGeneration || failed.operationID != m.steeringHandoff {
 			return m, nil

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -1312,6 +1312,9 @@ func (m *Model) cmdQuit() (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) cmdReload() (tea.Model, tea.Cmd) {
+	if m.mainRunManager.ActiveCount() > 0 && !m.streaming {
+		return m.showFooterWarning("Wait for background sessions to finish before reloading.")
+	}
 	if m.branchContextInFlight() {
 		return m.showSystemMessage("Cannot reload while path notes are being created. Cancel first (Esc).")
 	}

--- a/internal/tui/chat/process_reload.go
+++ b/internal/tui/chat/process_reload.go
@@ -1,0 +1,139 @@
+package chat
+
+import (
+	"context"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/google/uuid"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/process"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+// ProcessReloadMsg enters the existing /reload path from the process signal
+// owner. All model/UI access remains serialized by Bubble Tea.
+type ProcessReloadMsg struct{}
+type processReloadTick struct{}
+type processResumeMsg struct{}
+
+type ProcessReloadState struct {
+	Draft     string               `json:"draft"`
+	ShellMode bool                 `json:"shell_mode,omitempty"`
+	Files     []FileAttachment     `json:"files,omitempty"`
+	Images    []ImageAttachment    `json:"images,omitempty"`
+	Continue  bool                 `json:"continue,omitempty"`
+	Pending   []llm.QueuedSteering `json:"pending,omitempty"`
+}
+
+type processReload struct {
+	pending   bool
+	started   time.Time
+	cancelled bool
+	owner     llm.SteeringTransition
+	state     ProcessReloadState
+}
+
+func (m *Model) ProcessReloadState() ProcessReloadState { return m.processReload.state }
+func (m *Model) SetProcessReloadState(state ProcessReloadState) {
+	m.processReload.state = state
+	m.branchPrefill = state.Draft
+	m.processResume = state.Continue
+}
+func processReloadTickCmd() tea.Cmd {
+	return tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg { return processReloadTick{} })
+}
+
+func (m *Model) processReloadBusy() bool {
+	return m.streaming || m.branchContextInFlight() || m.activeSkillRunCount() > 0 || m.directShellRun != nil || m.runtimeOperations.activeCount() > 0 || (m.engine != nil && m.engine.ActiveToolExecutions() > 0) || m.mainRunManager.ActiveCount() > 0
+}
+
+func (m *Model) handleProcessReload() (tea.Model, tea.Cmd) {
+	if !m.processReload.pending {
+		// User Stop and failed settlement revoke continuation, but must not
+		// leave the engine permanently fenced once its actual work returns.
+		if m.processReload.owner.OperationID != "" {
+			if m.processReloadBusy() {
+				return m, processReloadTickCmd()
+			}
+			m.engine.ReleaseSteeringFreeze(m.processReload.owner, false)
+			m.processReload.owner = llm.SteeringTransition{}
+		}
+		return m, nil
+	}
+	if !m.processReloadBusy() {
+		m.processReload.state.Draft = m.expandedPastePlaceholders(m.textarea.Value())
+		m.processReload.state.ShellMode = m.directShellComposerActive()
+		m.processReload.state.Files = append([]FileAttachment(nil), m.files...)
+		m.processReload.state.Images = append([]ImageAttachment(nil), m.images...)
+		m.processReload.pending = false
+		process.State("chat", "replacing", "")
+		return m.cmdReload()
+	}
+	if time.Since(m.processReload.started) >= 10*time.Second && !m.processReload.cancelled {
+		foreground := 0
+		if m.streaming {
+			foreground = 1
+		}
+		if m.mainRunManager.ActiveCount() > foreground {
+			m.processReload.pending = false
+			process.State("chat", "failed", "background sessions need resumable handoffs")
+			return m.showFooterError("Restart deferred: background sessions are still working; nothing was cancelled.")
+		}
+		owner := llm.SteeringTransition{OperationID: uuid.NewString(), Fence: 1}
+		pending, err := m.engine.FreezeExecutionSnapshot(owner)
+		if err != nil {
+			m.processReload.pending = false
+			process.State("chat", "failed", err.Error())
+			return m.showFooterError("Restart could not freeze execution: " + err.Error())
+		}
+		m.processReload.owner = owner
+		m.processReload.state.Pending = pending
+		m.processReload.cancelled = true
+		m.processReload.state.Continue = m.streaming
+		// Use ordinary interruption, including approval prompts, direct shells and
+		// isolated skill/branch work. Completion accounting still gates replacement.
+		_, cmd := m.cancelActiveForInterrupt()
+		process.State("chat", "cancelling", "restart grace elapsed")
+		return m, tea.Batch(cmd, processReloadTickCmd())
+	}
+	if m.processReload.cancelled && time.Since(m.processReload.started) >= 20*time.Second {
+		m.processReload.pending = false
+		m.processReload.state.Continue = false
+		process.State("chat", "failed", "runtime work did not settle after cancellation")
+		_, cmd := m.showFooterError("Restart refused: cancelled work has not finished cleanup.")
+		return m, tea.Batch(cmd, processReloadTickCmd())
+	}
+	return m, processReloadTickCmd()
+}
+
+func (m *Model) resumeAfterProcessReload() (tea.Model, tea.Cmd) {
+	state := m.processReload.state
+	m.files, m.images = state.Files, state.Images
+	m.restoreComposerSnapshot(composerSnapshot{body: state.Draft, shellMode: state.ShellMode})
+	if !m.processResume {
+		return m, nil
+	}
+	m.processResume = false
+	notice := llm.SteeringInterruptionNotice + "\nThe process was replaced after its restart grace period. Continue the unfinished task; verify interrupted effects before repeating them. This is an internal event, not a new user message. Do not restart again."
+	message := &session.Message{SessionID: m.SessionID(), Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: notice}}, TextContent: notice, CreatedAt: time.Now(), Sequence: -1}
+	if m.store == nil {
+		return m.showFooterError("Restart recovery requires session persistence")
+	}
+	if err := m.store.AddMessage(context.Background(), m.SessionID(), message); err != nil {
+		return m.showFooterError(err.Error())
+	}
+	m.messages = append(m.messages, *message)
+	for _, pending := range state.Pending {
+		row := &session.Message{SessionID: m.SessionID(), Role: pending.Message.Role, Parts: pending.Message.Parts, TextContent: llm.MessageText(pending.Message), CreatedAt: time.Now(), Sequence: -1}
+		if err := m.store.AddMessage(context.Background(), m.SessionID(), row); err != nil {
+			return m.showFooterError(err.Error())
+		}
+		m.messages = append(m.messages, *row)
+	}
+	m.invalidateHistoryCache()
+	model, cmd := m.beginUserResponse("", "", nil)
+	m.files, m.images = state.Files, state.Images
+	m.restoreComposerSnapshot(composerSnapshot{body: state.Draft, shellMode: state.ShellMode})
+	return model, cmd
+}

--- a/internal/tui/chat/process_reload_test.go
+++ b/internal/tui/chat/process_reload_test.go
@@ -1,0 +1,125 @@
+package chat
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestProcessReloadIdlePreservesDraft(t *testing.T) {
+	m := newTestChatModel(false)
+	m.setTextareaValue("unsent draft")
+	updated, cmd := m.Update(ProcessReloadMsg{})
+	m = updated.(*Model)
+	if cmd == nil || !m.WantsReload() {
+		t.Fatal("idle signal did not use reload")
+	}
+	if state := m.ProcessReloadState(); state.Draft != "unsent draft" || state.Continue {
+		t.Fatalf("state: %+v", state)
+	}
+	if _, cmd := m.Update(ProcessReloadMsg{}); cmd != nil {
+		t.Fatal("duplicate reload was not coalesced")
+	}
+}
+
+func TestProcessReloadGraceUsesNormalCancellation(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	cancelled := 0
+	m.streamCancelFunc = func() { cancelled++ }
+	_, _ = m.Update(ProcessReloadMsg{})
+	if cancelled != 0 {
+		t.Fatal("cancelled before grace expired")
+	}
+	m.processReload.started = time.Now().Add(-11 * time.Second)
+	_, _ = m.Update(processReloadTick{})
+	if cancelled != 1 || !m.processReload.state.Continue {
+		t.Fatal("grace did not cancel and retain continuation")
+	}
+	if !m.engine.SteeringTransitioning() {
+		t.Fatal("dispatch was not frozen")
+	}
+	if err := m.engine.FreezeExecution(llm.SteeringTransition{OperationID: "another", Fence: 2}); err == nil {
+		t.Fatal("second owner entered")
+	}
+	m.engine.ReleaseSteeringFreeze(m.processReload.owner, false)
+}
+
+func TestProcessReloadUserStopCancelsRestart(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.streamCancelFunc = func() {}
+	_, _ = m.Update(ProcessReloadMsg{})
+	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.processReload.pending || m.processReload.state.Continue {
+		t.Fatal("user Stop retained automatic restart")
+	}
+}
+
+func TestProcessResumeAddsNoFakeUserTurn(t *testing.T) {
+	m := newTestChatModel(true)
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "session.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	m.store = store
+	m.sess = &session.Session{ID: "resume-test", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := store.Create(context.Background(), m.sess); err != nil {
+		t.Fatal(err)
+	}
+	m.SetProcessReloadState(ProcessReloadState{Draft: "preserve me", Continue: true})
+	users := m.sess.UserTurns
+	_, _ = m.resumeAfterProcessReload()
+	if m.sess.UserTurns != users {
+		t.Fatal("internal resume counted as user input")
+	}
+	if m.textarea.Value() != "preserve me" {
+		t.Fatal("continuation cleared draft")
+	}
+	rows, err := m.store.GetMessages(context.Background(), m.SessionID(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, row := range rows {
+		if row.Role == llm.RoleDeveloper {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing durable internal recovery event")
+	}
+}
+
+func TestProcessReloadStoppedAfterGraceReleasesFenceOnlyAfterSettlement(t *testing.T) {
+	m := newTestChatModel(false)
+	m.streaming = true
+	m.streamCancelFunc = func() {}
+	m.processReload = processReload{pending: true, started: time.Now().Add(-11 * time.Second)}
+	_, _ = m.handleProcessReload()
+	owner := m.processReload.owner
+	if owner.OperationID == "" {
+		t.Fatal("grace did not freeze engine")
+	}
+	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	_, _ = m.handleProcessReload()
+	if m.processReload.owner.OperationID == "" {
+		t.Fatal("released fence before stream settled")
+	}
+	m.streaming = false
+	_, _ = m.handleProcessReload()
+	if m.processReload.owner.OperationID != "" {
+		t.Fatal("settled Stop left stale fence")
+	}
+	next := llm.SteeringTransition{OperationID: "next-restart", Fence: 2}
+	if err := m.engine.FreezeExecution(next); err != nil {
+		t.Fatal("engine remains unusable after Stop", err)
+	}
+	m.engine.ReleaseSteeringFreeze(next, false)
+}

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -510,6 +510,10 @@ func (m *Model) ensureContextMessages() {
 }
 
 func (m *Model) sendMessage(content string) (tea.Model, tea.Cmd) {
+	if m.processReload.pending || m.processReload.owner.OperationID != "" {
+		return m.showFooterWarning("Restart cleanup is still draining; draft retained.")
+	}
+
 	if m.directShellRun != nil {
 		return m.showFooterWarning("Wait for the shell command to finish or press Esc to cancel it.")
 	}

--- a/internal/widgets/manager.go
+++ b/internal/widgets/manager.go
@@ -205,8 +205,7 @@ func (m *Manager) StopMount(mount string) error {
 	if !ok {
 		return fmt.Errorf("widget %q not found", mount)
 	}
-	e.stopProcess()
-	return nil
+	return e.stopProcess()
 }
 
 // StopAll stops every loaded widget process without closing the manager. Widgets
@@ -593,14 +592,14 @@ func (e *widgetEntry) startProcess(ctx context.Context, basePath string) error {
 	return nil
 }
 
-func (e *widgetEntry) stopProcess() {
+func (e *widgetEntry) stopProcess() error {
 	e.startMu.Lock()
 	defer e.startMu.Unlock()
-	e.stopProcessLocked()
+	return e.stopProcessLocked()
 }
 
 // stopProcessLocked requires startMu to be held.
-func (e *widgetEntry) stopProcessLocked() {
+func (e *widgetEntry) stopProcessLocked() error {
 	e.mu.Lock()
 	proc := e.proc
 	done := e.procDone
@@ -615,17 +614,35 @@ func (e *widgetEntry) stopProcessLocked() {
 	defer removeSocket(mode, socketID)
 
 	if proc == nil {
-		return
+		return nil
 	}
 	killProcessGroup(proc, syscall.SIGTERM)
 	if done == nil {
-		return
+		e.mu.Lock()
+		e.proc, e.procDone, e.state, e.errMsg = proc, done, stateError, "widget process has no exit acknowledgement"
+		e.mu.Unlock()
+		return fmt.Errorf("widget process has no exit acknowledgement")
 	}
 	select {
 	case <-done:
+		return nil
 	case <-time.After(3 * time.Second):
 		killProcessGroup(proc, syscall.SIGKILL)
 	}
+	select {
+	case <-done:
+		return nil
+	case <-time.After(3 * time.Second):
+		// Retain ownership if even SIGKILL has not produced a wait acknowledgement.
+		e.mu.Lock()
+		e.proc = proc
+		e.procDone = done
+		e.state = stateError
+		e.errMsg = "widget process did not acknowledge exit"
+		e.mu.Unlock()
+		return fmt.Errorf("widget process did not acknowledge exit")
+	}
+
 }
 
 func removeSocket(mode, widgetID string) {
@@ -730,4 +747,32 @@ func freePort() (int, error) {
 	}
 	defer l.Close()
 	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// StopAllAndWait is the restart form of StopAll: it reports whether every child
+// actually exited. It does not close the manager; failed exec retains lazy start.
+// The caller must fence proxied request admission while taking this checkpoint.
+func (m *Manager) StopAllAndWait(ctx context.Context) error {
+	m.mu.RLock()
+	entries := make([]*widgetEntry, 0, len(m.entries))
+	for _, e := range m.entries {
+		entries = append(entries, e)
+	}
+	m.mu.RUnlock()
+	results := make(chan error, len(entries))
+	for _, e := range entries {
+		go func() { results <- e.stopProcess() }()
+	}
+	var first error
+	for range entries {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-results:
+			if first == nil && err != nil {
+				first = err
+			}
+		}
+	}
+	return first
 }


### PR DESCRIPTION
## Work in progress: universal Unix process restart

This same PR is being expanded to the requested process-wide SIGUSR2 lifecycle. **It is not complete or ready to merge.** Standalone HTTP restart is prior working evidence, not an acceptable substitute for jobs/web/Hub/Telegram/TUI/CLI/MCP support. No production deployment, configuration changes or signals were performed.

### Current increment

- Register one Unix SIGUSR2 dispatcher at executable command entry, before argument parsing/configuration. Existing web owners bind through it instead of independently subscribing to the signal.
- Modes without a resumable owner get nonfatal, coalesced `deferred` logging and finish the original invocation without replay. Completion logs `finished`. This is a safety floor, not long-lived-mode restart support or an authoritative status API.
- Owner unbinding joins dispatch; competing owners must use a combined coordinator rather than multiple subscribers. INT/TERM/HUP/USR1 handlers are unchanged.
- Give the reverse Hub connector a joinable, idempotent stop handle. Cancellation wakes socket reads/writes; completion joins reconnect, ping and forwarded-request goroutines. An expired stop context reports failure, never permission to exec/kill work.
- Add a blocked-transport regression: cancellation alone cannot report a successful join. Migrate existing reverse tests to joined cleanup; a race run exposed their reconnect-delay reset racing unjoined connectors, now fixed by ownership cleanup.
- Update `docs/signals.md` with actual current semantics and explicit missing mode integration.

### Preserved prior implementation

Request-scoped LLM boundaries after durable tool results; standalone web mutation admission/drain; fenced atomic SQLite v58 handoff batch; same-PID kernel exec of the captured installed pathname; early scrubbed hints and durable service/owner/cancel/dedup checks; tool-capable continuation without fake user turns; exact source-response Stop forwarding; failed-exec intent discard/rollback or quarantine on discard failure.

Current safe re-exec eligibility remains narrow: standalone direct HTTP web, fenced SQLite, automatic title work disabled, widgets disabled and a restricted concrete tool set. These restrictions are **remaining work to remove through ownership contracts**, not the final scope of this PR.

### Required before completion

- Owner-private generic process registry/discovery and safe targeting: PID + OS start identity, boot UUID per exec, executable build identity, requested restart ID and phase; same-identity/new-boot/intended-build readiness waits. No argv/token exposure or signaling unrelated/old binaries. Linux pidfd targeting where practical; explicit non-Linux safe scope. Exclude helper itself.
- Process-wide admission/checkpoint/rollback coordinating every selected serve component. Reverse client join is implemented, but client completion does not prove the backend mutation handler has joined.
- Jobs: checkpoint actual running LLM work; preserve durable run ownership, leases, cancellations, retries, completions and notification dedup when producer and consumer both restart. Never blindly replay a job with completed side effects.
- WebRTC outer owner join; restart-safe widget process ownership; reversible failed-exec transport recovery; native provider/tool/subprocess ownership contract instead of permanent blanket tool rejection.
- Hub delegation/reverse ownership; Telegram poll cursor/queue/send durability; TUI terminal restoration and real session/draft/stream reopen without synthetic user input; ask/exec/chat/loop/proxy/MCP integration. Short-lived nonresumable mutations must explicitly finish/defer, never replay invocation.
- New-build same-PID proofs across concurrent isolated jobs+web(+Hub), repeated signals during drain/boot, stuck-tool safe state, exec failure, PTY TUI, and deployed route-shaped reverse+WebRTC+widgets browser sandbox.
- Resolve CI failures below; do not assume baseline or raise budgets merely to pass.

## Measured verification

Current increment, Go 1.25.8 (Node 24.15.0 explicitly selected for build):
- PASS focused dispatch/web/reverse suite, including real child-process SIGUSR2 tests.
- PASS same focused suite with `-race`, after fixing reverse-test owner cleanup.
- PASS `make build`; initial invocation lacked npm on PATH, then used the already provisioned Node installation. No user configuration changed.
- PASS `go vet ./...` and Darwin/amd64 CGO-disabled cross-build.
- Isolated HOME/XDG `go test ./...`: only failure is `TestProductionBundleSizeBudgets`: app.js raw 495327 > 488000; app.css raw 174184 > 174000. No budget exemptions or generated-artifact edits committed.
- Real built-executable stdio MCP sandbox: PID 872964, three SIGUSR2 signals, valid protocol pings afterward, clean EOF completion with deferred/finished reporting and no replay. This proves nonfatal entry-point semantics, **not MCP re-exec**.
- No frontend source or nested-module changes; frontend quality suite/nested checks not rerun. New multi-mode/PTY/deployed-browser proofs remain pending.

Preserved **previous-head-only** direct HTTP Chromium proof: same PID 792142 A→B, two chats in one durable handoff batch, distinct boot owners, before/after tools once, unsent draft and next user preserved, child hints scrubbed. Separate PID 792535 source Stop canceled continuation. This evidence is not re-attributed to the current increment and does not prove combined mode support. Private fixture homes, databases, transcripts and screenshots remain local.

## CI diagnosis

Starting-head run [33978281826](https://github.com/SamSaffron/term-llm/actions/runs/33978281826): changes/passkey-smoke/cross-build/race passed; **test and frontend failed**.

- Test: the bundle-size failure above, reproduced locally with isolated configuration.
- Frontend: three real WebRTC tests (`webrtc.spec.ts:54` and `:113`, desktop/mobile) passed signaling offer/answer progress but timed out waiting for Go `webrtc_diagnostics.active > 0`. Peer logs show ICE Checking with no candidate pairs, then ICE accept deadline cancellation (before DTLS establishment). Candidate discovery/resolution and base attribution remain unresolved; separate TLS unknown-certificate logs are not an established root cause. This is not labeled a baseline flake.

Current-head run [33993610439](https://github.com/SamSaffron/term-llm/actions/runs/33993610439) completed at `e45da53db368791f31a338311a95d90a3dd2c245`: changes, cross-build, passkey-smoke and race **passed**; test and frontend **failed with the same budget and three active-peer failures**. The production-shaped Hub browser step was skipped after chat-smoke failure. CI is verified red, not pending or green.

Do not interpret PID survival, deferred logs, mergeability or earlier scoped proof as universal restart readiness.


## Process operator primitives — 83381221

Implemented the exact CLI: `term-llm process list [--json]`, `term-llm process restart PID`, and `term-llm process restart-all`, with `--timeout` and explicit unverified `--no-wait`. Linux owner-private advisory registry validates OS-start identity and zombies, cleans stale records, uses pidfd signalling and checks new instance UUID + installed Go build + ready mode. Restart-all snapshots once, excludes itself and requests concurrently. **This does not remove the mode limitations above; deferred/unsupported is an error, not successful restart.**

Registry publication is asynchronous after a **25 ms** grace period. A command exiting before publication starts does not wait for publisher I/O; durable restart intents remain synchronous. Matched warm-cache `version` lifetime benchmark (same source/toolchain/link flags, overlay disables only publisher Start/Stop; 20 warmups + 150 samples per binary, alternating AB/BA): median **12.45 ms baseline / 12.70 ms publisher** (~0.25 ms delta), p95 **16.14 / 15.46 ms**. This is an observed short-command measurement, not proof of zero startup cost or all-mode readiness performance.

Final-source real-browser sandbox exercised the actual CLI: A→B restart retained PID **913300**, resumed the same conversation with subsequent tools, preserved draft/history, accepted the next message; `restart-all` performed a quiet reload without replay. Registry self-exec/rude-kill/stale-instance/rapid-exit tests pass under race; full `cmd` tests pass with isolated HOME; affected-package vet passes. The nonisolated cmd run was confounded by local skills; no user config was modified. No production deployment/signals.
