### PR TITLE
Preserve independent /learn hosting across docs deploys

### DIFF
--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -95,12 +95,14 @@ jobs:
             mkdir -p /var/www/term-llm /etc/nginx/sites-available /etc/nginx/sites-enabled
             rsync -a --delete /root/term-llm-release/site/ /var/www/term-llm/
 
-            cp /root/term-llm-release/ops/nginx/term-llm-http.conf /etc/nginx/sites-available/term-llm.conf
-            ln -sfn /etc/nginx/sites-available/term-llm.conf /etc/nginx/sites-enabled/term-llm.conf
-            nginx -t
-            systemctl reload nginx
-
+            # Only bootstrap HTTP on first install; ordinary deploys retain HTTPS.
+            # App snippets and their webroots are owned by independent deploys.
+            mkdir -p /etc/nginx/term-llm-locations.d
             if [ ! -f /etc/letsencrypt/live/term-llm.com/fullchain.pem ]; then
+              cp /root/term-llm-release/ops/nginx/term-llm-http.conf /etc/nginx/sites-available/term-llm.conf
+              ln -sfn /etc/nginx/sites-available/term-llm.conf /etc/nginx/sites-enabled/term-llm.conf
+              nginx -t
+              systemctl reload nginx
               certbot certonly \
                 --webroot \
                 -w /var/www/term-llm \
@@ -111,5 +113,6 @@ jobs:
             fi
 
             cp /root/term-llm-release/ops/nginx/term-llm.conf /etc/nginx/sites-available/term-llm.conf
+            ln -sfn /etc/nginx/sites-available/term-llm.conf /etc/nginx/sites-enabled/term-llm.conf
             nginx -t
             systemctl reload nginx

--- a/ops/nginx/term-llm.conf
+++ b/ops/nginx/term-llm.conf
@@ -35,6 +35,9 @@ server {
         try_files $uri =404;
     }
 
+    # Independently deployed apps live outside the docs webroot.
+    include /etc/nginx/term-llm-locations.d/*.conf;
+
     location = /robots.txt {
         add_header Content-Type text/plain;
         return 200 "User-agent: *\nAllow: /\n";


### PR DESCRIPTION
Add a permanent wildcard include for independently deployed app routes outside the docs rsync webroot. Only install the HTTP bootstrap vhost when issuing the first certificate, rather than briefly removing HTTPS on every deployment. Validated this exact HTTPS vhost with nginx -t on the origin and deployed /learn independently. Tutorial CI and payloads remain in the private tutorial repository.