### PR TITLE
Disable approval controls for tool-less sessions

### DIFF
--- a/cmd/serve_approval_mode_handler.go
+++ b/cmd/serve_approval_mode_handler.go
@@ -18,6 +18,7 @@ func runtimeApprovalPolicy(rt *serveRuntime) map[string]any {
 		"default_mode":            tools.ModePrompt.String(),
 		"requested_mode":          tools.ModePrompt.String(),
 		"effective_mode":          tools.ModePrompt.String(),
+		"controls_available":      false,
 		"guardian_available":      false,
 		"guardian_auto_suspended": false,
 	}
@@ -31,6 +32,7 @@ func runtimeApprovalPolicy(rt *serveRuntime) map[string]any {
 		return policy
 	}
 	mgr := rt.toolMgr.ApprovalMgr
+	policy["controls_available"] = true
 	policy["requested_mode"] = mgr.RequestedApprovalMode().String()
 	policy["effective_mode"] = mgr.ApprovalMode().String()
 	policy["guardian_available"] = mgr.GuardianReviewerAvailable()

--- a/cmd/serve_approval_mode_handler_test.go
+++ b/cmd/serve_approval_mode_handler_test.go
@@ -30,7 +30,7 @@ func TestHandleSessionApprovalModeReportsAndChangesRuntimePolicy(t *testing.T) {
 
 	get := httptest.NewRecorder()
 	server.handleSessionByID(get, httptest.NewRequest(http.MethodGet, "/v1/sessions/approval-session/runtime/approvals", nil))
-	if get.Code != http.StatusOK || !strings.Contains(get.Body.String(), `"default_mode":"auto"`) || !strings.Contains(get.Body.String(), `"effective_mode":"auto"`) {
+	if get.Code != http.StatusOK || !strings.Contains(get.Body.String(), `"default_mode":"auto"`) || !strings.Contains(get.Body.String(), `"effective_mode":"auto"`) || !strings.Contains(get.Body.String(), `"controls_available":true`) {
 		t.Fatalf("GET status/body = %d %s", get.Code, get.Body.String())
 	}
 
@@ -40,6 +40,19 @@ func TestHandleSessionApprovalModeReportsAndChangesRuntimePolicy(t *testing.T) {
 	server.handleSessionByID(post, request)
 	if post.Code != http.StatusOK || approval.ApprovalMode() != tools.ModeYolo || !strings.Contains(post.Body.String(), `"requested_mode":"yolo"`) {
 		t.Fatalf("POST status/body/mode = %d %s %s", post.Code, post.Body.String(), approval.ApprovalMode())
+	}
+}
+
+func TestHandleSessionApprovalModeReportsUnavailableWithoutManagedTools(t *testing.T) {
+	manager := newServeSessionManager(time.Minute, 10, nil)
+	defer manager.Close()
+	putTestSession(manager, "tool-less-session", &serveRuntime{})
+	server := &serveServer{sessionMgr: manager}
+
+	response := httptest.NewRecorder()
+	server.handleSessionByID(response, httptest.NewRequest(http.MethodGet, "/v1/sessions/tool-less-session/runtime/approvals", nil))
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"controls_available":false`) {
+		t.Fatalf("GET status/body = %d %s", response.Code, response.Body.String())
 	}
 }
 

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -7,6 +7,8 @@ export interface ApprovalPolicyResponse {
   default_mode: ApprovalMode;
   requested_mode: ApprovalMode;
   effective_mode: ApprovalMode;
+  /** Omitted by older servers, which always exposed these controls. */
+  controls_available?: boolean;
   guardian_available: boolean;
   guardian_auto_suspended: boolean;
 }

--- a/frontend/src/components/ApprovalsModal.tsx
+++ b/frontend/src/components/ApprovalsModal.tsx
@@ -28,7 +28,8 @@ export function ApprovalsModal() {
       : session?.approvalRequestedMode || store.config.approvalMode || 'prompt';
   const [mode, setMode] = useState(reportedMode);
   const [saving, setSaving] = useState(false);
-  const [loading, setLoading] = useState(Boolean(sessionId) && !session?.approvalRequestedMode);
+  const [loading, setLoading] = useState(Boolean(sessionId));
+  const [controlsAvailable, setControlsAvailable] = useState<boolean | null>(null);
   const [error, setError] = useState('');
   const dirty = useRef(false);
   const submitting = useRef(false);
@@ -40,12 +41,16 @@ export function ApprovalsModal() {
     }
     let live = true;
     dirty.current = false;
+    setControlsAvailable(null);
     setError('');
     setLoading(true);
     void store.endpoints
       .approvalPolicy(sessionId)
       .then((value) => {
-        if (live) applyPolicy(store, sessionId, value);
+        if (live) {
+          applyPolicy(store, sessionId, value);
+          setControlsAvailable(value.controls_available !== false);
+        }
       })
       .catch((value: unknown) => {
         if (live) setError(errorMessage(value));
@@ -61,6 +66,10 @@ export function ApprovalsModal() {
     if (!dirty.current) setMode(reportedMode);
   }, [reportedMode]);
   useEffect(() => {
+    if (!loading && controlsAvailable !== false && !dirty.current) {
+      modeInputs.current[mode]?.focus({ preventScroll: true });
+      return;
+    }
     const focused = document.activeElement;
     if (
       focused instanceof HTMLInputElement &&
@@ -68,18 +77,27 @@ export function ApprovalsModal() {
       focused.value !== mode
     )
       modeInputs.current[mode]?.focus({ preventScroll: true });
-  }, [mode]);
+  }, [mode, controlsAvailable, loading]);
   const save = async () => {
     if (submitting.current) return;
     submitting.current = true;
     setSaving(true);
     setError('');
     try {
+      if (controlsAvailable === false) return;
       const targetSessionId = sessionId || (await store.ensureSession());
       if (!targetSessionId)
         throw new Error('Could not prepare approval settings. Please try again.');
+      if (!sessionId && controlsAvailable == null) {
+        const policy = await store.endpoints.approvalPolicy(targetSessionId);
+        applyPolicy(store, targetSessionId, policy);
+        const available = policy.controls_available !== false;
+        setControlsAvailable(available);
+        if (!available) return;
+      }
       const value = await store.endpoints.setApprovalMode(targetSessionId, mode);
       applyPolicy(store, targetSessionId, value);
+      setControlsAvailable(value.controls_available !== false);
       store.modal.value = '';
     } catch (value) {
       setError(errorMessage(value));
@@ -118,15 +136,24 @@ export function ApprovalsModal() {
                 value={value}
                 checked={mode === value}
                 autoFocus={
-                  mode === value && !(value === 'auto' && session?.guardianAvailable === false)
+                  mode === value &&
+                  controlsAvailable !== false &&
+                  !(value === 'auto' && session?.guardianAvailable === false)
                 }
                 aria-describedby={
-                  value === 'auto' && session?.guardianAvailable === false
-                    ? 'approvalGuardianUnavailable'
-                    : undefined
+                  controlsAvailable === false
+                    ? 'approvalControlsUnavailable'
+                    : controlsAvailable === true &&
+                        value === 'auto' &&
+                        session?.guardianAvailable === false
+                      ? 'approvalGuardianUnavailable'
+                      : undefined
                 }
                 disabled={
-                  loading || saving || (value === 'auto' && session?.guardianAvailable === false)
+                  loading ||
+                  saving ||
+                  controlsAvailable === false ||
+                  (value === 'auto' && session?.guardianAvailable === false)
                 }
                 onChange={() => {
                   dirty.current = true;
@@ -140,12 +167,18 @@ export function ApprovalsModal() {
             </label>
           ))}
         </div>
-        {session?.guardianAutoSuspended && (
+        {controlsAvailable === true && session?.guardianAutoSuspended && (
           <div class="approval-mode-notice" role="status">
             Guardian auto-approval is paused. Select Auto and save to resume it.
           </div>
         )}
-        {session?.guardianAvailable === false && (
+        {controlsAvailable === false && (
+          <div id="approvalControlsUnavailable" class="approval-mode-notice" role="status">
+            This conversation has no tools that require approval. Choose a tool-enabled agent to
+            configure approval behavior.
+          </div>
+        )}
+        {controlsAvailable === true && session?.guardianAvailable === false && (
           <div id="approvalGuardianUnavailable" class="approval-mode-notice" role="status">
             Guardian is unavailable for this runtime, so Auto cannot be selected.
           </div>
@@ -164,7 +197,11 @@ export function ApprovalsModal() {
           >
             Cancel
           </button>
-          <button class="btn primary" type="submit" disabled={loading || saving}>
+          <button
+            class="btn primary"
+            type="submit"
+            disabled={loading || saving || controlsAvailable === false}
+          >
             {loading
               ? 'Loading…'
               : saving

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -3602,7 +3602,14 @@ describe('Preact-owned chat surfaces', () => {
     store.draftActive.value = true;
     store.prompt.value = 'Keep my unsent message';
     store.modal.value = 'approvals';
-    store.endpoints.approvalPolicy = vi.fn();
+    store.endpoints.approvalPolicy = vi.fn(async () => ({
+      default_mode: 'prompt' as const,
+      requested_mode: 'prompt' as const,
+      effective_mode: 'prompt' as const,
+      guardian_available: true,
+      guardian_auto_suspended: false,
+      controls_available: true,
+    }));
     store.endpoints.createBlankSession = vi.fn(async () => ({
       session: {
         id: 'prepared',
@@ -3631,6 +3638,7 @@ describe('Preact-owned chat surfaces', () => {
     expect(store.endpoints.approvalPolicy).not.toHaveBeenCalled();
     await userEvent.click(auto);
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(store.endpoints.approvalPolicy).toHaveBeenCalledWith('prepared'));
     await waitFor(() =>
       expect(store.endpoints.setApprovalMode).toHaveBeenCalledWith('prepared', 'auto'),
     );
@@ -3646,6 +3654,14 @@ describe('Preact-owned chat surfaces', () => {
     store.draftActive.value = true;
     store.modal.value = 'approvals';
     store.ensureSession = vi.fn(async () => '');
+    store.endpoints.approvalPolicy = vi.fn(async () => ({
+      default_mode: 'prompt' as const,
+      requested_mode: 'prompt' as const,
+      effective_mode: 'prompt' as const,
+      guardian_available: true,
+      guardian_auto_suspended: false,
+      controls_available: true,
+    }));
     store.endpoints.setApprovalMode = vi.fn(async () => {
       throw new Error('Guardian auto-approval is unavailable');
     });
@@ -3667,6 +3683,33 @@ describe('Preact-owned chat surfaces', () => {
     );
     expect(store.modal.value).toBe('approvals');
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('disables approval changes when the conversation has no approval-managed tools', async () => {
+    const store = createStore();
+    store.modal.value = 'approvals';
+    store.endpoints.approvalPolicy = vi.fn(async () => ({
+      default_mode: 'auto' as const,
+      requested_mode: 'auto' as const,
+      effective_mode: 'auto' as const,
+      guardian_available: false,
+      guardian_auto_suspended: false,
+      controls_available: false,
+    }));
+    store.endpoints.setApprovalMode = vi.fn();
+    render(
+      <StoreContext.Provider value={store}>
+        <Modals />
+      </StoreContext.Provider>,
+    );
+
+    expect(
+      await screen.findByText(/This conversation has no tools that require approval/),
+    ).toBeVisible();
+    for (const option of screen.getAllByRole('radio')) expect(option).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.queryByText(/Guardian is unavailable/)).not.toBeInTheDocument();
+    expect(store.endpoints.setApprovalMode).not.toHaveBeenCalled();
   });
 
   it('hides and rejects approval controls when the server launched in Yolo', async () => {


### PR DESCRIPTION
## Summary

- report whether a session runtime has approval-managed tools
- disable approval mode choices and Save for tool-less sessions
- replace the misleading Guardian warning and raw conflict with an actionable explanation
- check tool availability after materializing a blank session

## Testing

- make build
- go test ./cmd -run TestHandleSessionApprovalMode -count=1
- go test -p 1 ./internal/llm ./internal/webrtc
- npm --prefix frontend test (735 tests)
- npm --prefix frontend run format:check
- npm --prefix frontend run lint
- npm --prefix frontend run typecheck
- scripts/verify_nested_modules.sh
- VERIFY_RACE=1 scripts/verify_nested_modules.sh
- browser smoke test against an isolated tool-less local server

## Full-suite note

go test ./... is currently blocked by the existing TestProjectApprovals_StorageLocationHumanReadable timeout on macOS: its git rev-parse child hangs in the /home automount. The unrelated internal/llm and internal/webrtc timing failures from that concurrent run pass when rerun serially.