### PR TITLE
fix: Concurrent OAuth refresh fails healthy runs when the rejected exchange returns first

### DIFF
--- a/internal/credentials/chatgpt.go
+++ b/internal/credentials/chatgpt.go
@@ -136,13 +136,34 @@ func removeChatGPTCredentials(credPath string) error {
 }
 
 // RefreshChatGPTCredentials refreshes the access token using the refresh token.
-// Remote OAuth I/O deliberately runs outside the process and file locks. A
-// short compare-and-swap commit prevents a stale refresh from overwriting a
-// concurrent login, logout, or refresh.
-func RefreshChatGPTCredentials(creds *ChatGPTCredentials) error {
+// A separate file lock serializes refresh exchanges across goroutines and
+// processes. Remote OAuth I/O stays outside the short credential mutation lock,
+// so login and logout remain responsive. The generation-aware commit below
+// prevents a stale refresh from overwriting those concurrent mutations.
+func RefreshChatGPTCredentials(creds *ChatGPTCredentials) (err error) {
 	if creds == nil {
 		return fmt.Errorf("missing ChatGPT credentials")
 	}
+	credPath, err := getChatGPTCredentialsPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(credPath), 0700); err != nil {
+		return fmt.Errorf("failed to create credentials directory: %w", err)
+	}
+	// Acquire ownership before loading the disk generation, and retain it
+	// through commit so waiters reuse the replacement rather than exchanging
+	// the same single-use refresh token. Never wait with the mutation lock held.
+	unlock, err := lockChatGPTCredentials(credPath + ".refresh.lock")
+	if err != nil {
+		return fmt.Errorf("failed to lock ChatGPT refresh: %w", err)
+	}
+	defer func() {
+		if unlockErr := unlock(); err == nil && unlockErr != nil {
+			err = fmt.Errorf("failed to unlock ChatGPT refresh: %w", unlockErr)
+		}
+	}()
+
 	base := *creds
 	hadStored := false
 	if err := withChatGPTCredentialsLock(func(credPath string) error {

--- a/internal/credentials/chatgpt_test.go
+++ b/internal/credentials/chatgpt_test.go
@@ -1,7 +1,9 @@
 package credentials
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -287,7 +289,7 @@ func TestRefreshChatGPTCredentialsUsesDiskGenerationAsCASBaseline(t *testing.T) 
 	}
 }
 
-func TestConcurrentChatGPTInvalidGrantAdoptsSiblingRefresh(t *testing.T) {
+func TestConcurrentChatGPTRefreshCoalescesExchanges(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	initial := &ChatGPTCredentials{AccessToken: "old", RefreshToken: "refresh", ExpiresAt: time.Now().Add(-time.Hour).Unix(), AccountID: "account"}
 	if err := SaveChatGPTCredentials(initial); err != nil {
@@ -298,9 +300,7 @@ func TestConcurrentChatGPTInvalidGrantAdoptsSiblingRefresh(t *testing.T) {
 	t.Cleanup(func() { refreshChatGPTToken = oldRefresh })
 	var calls atomic.Int32
 	firstStarted := make(chan struct{})
-	secondStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})
-	releaseSecond := make(chan struct{})
 	refreshChatGPTToken = func(string) (*oauth.ChatGPTTokenResponse, error) {
 		switch calls.Add(1) {
 		case 1:
@@ -308,9 +308,8 @@ func TestConcurrentChatGPTInvalidGrantAdoptsSiblingRefresh(t *testing.T) {
 			<-releaseFirst
 			return &oauth.ChatGPTTokenResponse{AccessToken: "fresh", RefreshToken: "rotated", ExpiresIn: 3600}, nil
 		case 2:
-			close(secondStarted)
-			<-releaseSecond
-			return nil, errors.New("invalid_grant")
+			// Reject a duplicate immediately, before the winner can commit.
+			return nil, oauth.ErrChatGPTRefreshTokenInvalid
 		default:
 			return nil, errors.New("unexpected refresh")
 		}
@@ -322,28 +321,106 @@ func TestConcurrentChatGPTInvalidGrantAdoptsSiblingRefresh(t *testing.T) {
 	go func() { errA <- RefreshChatGPTCredentials(&a) }()
 	<-firstStarted
 	go func() { errB <- RefreshChatGPTCredentials(&b) }()
-	<-secondStarted
-	close(releaseFirst)
-
-	deadline := time.Now().Add(time.Second)
-	for {
-		stored, err := GetChatGPTCredentials()
-		if err == nil && stored.AccessToken == "fresh" {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("sibling refresh was not committed")
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case err := <-errB:
+		t.Errorf("sibling returned before successful refresh was released: %v", err)
+		errB <- err
+	case <-time.After(150 * time.Millisecond):
 	}
-	close(releaseSecond)
+	close(releaseFirst)
 	if err := <-errA; err != nil {
 		t.Fatal(err)
 	}
 	if err := <-errB; err != nil {
-		t.Fatalf("invalid-grant sibling did not adopt committed refresh: %v", err)
+		t.Fatalf("sibling did not adopt committed refresh: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("refresh calls = %d, want one exchange", calls.Load())
+	}
+	if a.AccessToken != "fresh" || a.RefreshToken != "rotated" {
+		t.Fatalf("winner credentials = %+v", a)
 	}
 	if b.AccessToken != "fresh" || b.RefreshToken != "rotated" {
 		t.Fatalf("sibling credentials = %+v", b)
+	}
+}
+
+func TestChatGPTRefreshCoalescesProcesses(t *testing.T) {
+	if role := os.Getenv("TERM_LLM_CHATGPT_REFRESH_HELPER"); role != "" {
+		creds, err := GetChatGPTCredentials()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stateDir := os.Getenv("TERM_LLM_CHATGPT_REFRESH_STATE")
+		oldRefresh := refreshChatGPTToken
+		defer func() { refreshChatGPTToken = oldRefresh }()
+		refreshChatGPTToken = func(string) (*oauth.ChatGPTTokenResponse, error) {
+			if role != "holder" {
+				return nil, oauth.ErrChatGPTRefreshTokenInvalid
+			}
+			if err := os.WriteFile(filepath.Join(stateDir, "started"), nil, 0600); err != nil {
+				return nil, err
+			}
+			waitForTestFile(t, filepath.Join(stateDir, "release"))
+			return &oauth.ChatGPTTokenResponse{AccessToken: "fresh", RefreshToken: "rotated", ExpiresIn: 3600}, nil
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, role+"-attempting"), nil, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := RefreshChatGPTCredentials(creds); err != nil {
+			t.Fatal(err)
+		}
+		if creds.AccessToken != "fresh" || creds.RefreshToken != "rotated" {
+			t.Fatalf("credentials = %+v, want rotated credentials", creds)
+		}
+		return
+	}
+
+	configDir, stateDir := t.TempDir(), t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	if err := SaveChatGPTCredentials(&ChatGPTCredentials{
+		AccessToken: "old", RefreshToken: "refresh", ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	start := func(role string) <-chan error {
+		t.Helper()
+		cmd := exec.Command(os.Args[0], "-test.run=^TestChatGPTRefreshCoalescesProcesses$", "-test.timeout=15s")
+		cmd.Env = append(os.Environ(),
+			"TERM_LLM_CHATGPT_REFRESH_HELPER="+role,
+			"TERM_LLM_CHATGPT_REFRESH_STATE="+stateDir,
+		)
+		var output bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &output, &output
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = cmd.Process.Kill() })
+		done := make(chan error, 1)
+		go func() {
+			err := cmd.Wait()
+			if err != nil {
+				err = fmt.Errorf("%s: %w\n%s", role, err, output.String())
+			}
+			done <- err
+		}()
+		return done
+	}
+	holder := start("holder")
+	waitForTestFile(t, filepath.Join(stateDir, "started"))
+	contender := start("contender")
+	waitForTestFile(t, filepath.Join(stateDir, "contender-attempting"))
+	select {
+	case err := <-contender:
+		t.Fatalf("contender returned before refresh commit: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "release"), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, done := range []<-chan error{holder, contender} {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## What changed

- Serialize ChatGPT OAuth refreshes with a separate `chatgpt_oauth.json.refresh.lock`, using the existing cross-platform file-lock implementation. Ownership spans disk reload, token exchange, and commit, so both goroutines and separate processes reuse the winner's credentials instead of exchanging the same refresh token twice.
- Keep the short credential mutation lock out of network I/O, and retain the existing generation-aware commit safeguards for concurrent login/logout.
- Replace the favorable-response-order concurrency test with a regression that holds the successful response while any duplicate exchange immediately returns `ErrChatGPTRefreshTokenInvalid`. Assert both callers receive rotated credentials and only one exchange occurs.
- Add a subprocess regression exercising refresh ownership and adoption of the committed token across processes.

## Why this is high-value

Overlapping ChatGPT conversations, background jobs, and provider initialization share the same on-disk account credentials. Around expiry, a duplicate refresh can be rejected before the successful rotation is saved. The existing recovery only adopted credentials already committed to disk, so that response order failed otherwise healthy runs or triggered non-interactive re-authentication.

Verified the current call paths: `ChatGPTProvider.Stream` propagates the refresh failure, and provider initialization attempts authentication on `ErrChatGPTRefreshTokenInvalid`. The previous concurrent test explicitly waited for the successful commit before releasing the rejection. Both new regressions fail against the original implementation with the invalid-token error.

This meets the daily-usage bar: ordinary overlapping provider/job activity can encounter rotation, the impact is a failed unattended run, and the production change is localized to refresh ownership. No dependency or credential-format changes. Coordination applies to processes running this fix; older clients do not participate in the new lock.

## Validation

- `gofmt -w internal/credentials/chatgpt.go internal/credentials/chatgpt_test.go`
- Both new regression tests reproduced the error against the original production implementation, then passed with the fix.
- `go test ./internal/credentials -count=1` — passed.
- Concurrency, subprocess, and save-during-network tests repeated 20 times — passed.
- `go test -race ./internal/credentials -count=3` — passed (run twice).
- Existing `TestRefreshChatGPTCredentialsDoesNotHoldLockDuringNetwork` retained unchanged and passing: saving a new login stays responsive and the refresh cannot overwrite it.
- `make build` and `go build ./...` — passed. The initial direct build required generating the embedded frontend assets via the normal Makefile first.
- `go vet ./...` — passed.
- `go test ./...` with isolated HOME/XDG directories — all packages passed except the unrelated `internal/serveui/TestProductionBundleSizeBudgets`: `dist/app.js` raw/gzip size is `498087/145656`, versus budget `499000/142000`. Reproduced the identical failure with the original production code restored; no frontend files or budgets changed.
- `git diff --check` — passed.
