### PR TITLE
Fix Hub access to sessions with unsafe IDs

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -1993,15 +1993,10 @@ func (s *serveServer) handleSessionByID(w http.ResponseWriter, r *http.Request) 
 	}
 
 	requestedSessionID := parts[0]
-	sessionID := requestedSessionID
-	// If the path segment is purely numeric, resolve via session number.
-	if num, err := strconv.ParseInt(sessionID, 10, 64); err == nil && num > 0 && s.store != nil {
-		sess, err := s.store.GetByNumber(r.Context(), num)
-		if err != nil || sess == nil {
-			http.NotFound(w, r)
-			return
-		}
-		sessionID = sess.ID
+	sessionID, resolveErr := s.resolveSessionPathID(r.Context(), requestedSessionID)
+	if resolveErr != nil {
+		http.NotFound(w, r)
+		return
 	}
 	suffix := ""
 	if len(parts) > 1 {

--- a/cmd/serve_handlers_anthropic.go
+++ b/cmd/serve_handlers_anthropic.go
@@ -57,6 +57,10 @@ func (s *serveServer) handleAnthropicMessages(w http.ResponseWriter, r *http.Req
 	replaceHistory := true
 
 	sessionID := resolveRequestSessionID(r)
+	if err := s.validateRequestSessionID(ctx, sessionID); err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
 	if sessionID == "" {
 		sessionID = ensureSessionID(w)
 	}

--- a/cmd/serve_handlers_chat.go
+++ b/cmd/serve_handlers_chat.go
@@ -45,6 +45,10 @@ func (s *serveServer) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 	}
 
 	sessionID := resolveRequestSessionID(r)
+	if err := s.validateRequestSessionID(ctx, sessionID); err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
 	if sessionID == "" {
 		sessionID = ensureSessionID(w)
 	}

--- a/cmd/serve_handlers_responses.go
+++ b/cmd/serve_handlers_responses.go
@@ -262,6 +262,10 @@ func (s *serveServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	// previous_response_id continues a conversation; no previous response means a
 	// fresh conversation, even if a session_id header is reused for persistence.
 	headerSessionID := resolveRequestSessionID(r)
+	if err := s.validateRequestSessionID(ctx, headerSessionID); err != nil {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
 	draftID := strings.TrimSpace(r.Header.Get(requestDraftIDHeader))
 	if draftID != "" && (!isFirstPartyUIResponseRequest(r) || headerSessionID != "" || req.PreviousResponseID != "" || !validResponseDraftID(draftID)) {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "draft id is only valid for a first-party new conversation")

--- a/cmd/serve_session_id.go
+++ b/cmd/serve_session_id.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// validateRequestSessionID prevents API clients from creating identities that
+// cannot be addressed as a single URL path segment. Existing sessions retain
+// their identity and can be addressed by their durable session number instead.
+func (s *serveServer) validateRequestSessionID(ctx context.Context, id string) error {
+	if id != "." && id != ".." && !strings.ContainsAny(id, `/\`) && strings.IndexFunc(id, unicode.IsControl) < 0 {
+		return nil
+	}
+	if s.store != nil {
+		existing, err := s.store.Get(ctx, id)
+		if err != nil {
+			return fmt.Errorf("look up session ID: %w", err)
+		}
+		if existing != nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("new session ID must not contain path separators or control characters, or be . or ..")
+}
+
+// resolveSessionPathID is shared by both session API namespaces so numeric
+// routes address the same persisted identity, including legacy IDs with slashes.
+func (s *serveServer) resolveSessionPathID(ctx context.Context, id string) (string, error) {
+	if number, err := strconv.ParseInt(id, 10, 64); err == nil && number > 0 && s.store != nil {
+		sess, err := s.store.GetByNumber(ctx, number)
+		if err != nil {
+			return "", fmt.Errorf("resolve session number: %w", err)
+		}
+		if sess == nil {
+			return "", fmt.Errorf("session number %d not found", number)
+		}
+		return sess.ID, nil
+	}
+	return id, nil
+}

--- a/cmd/serve_session_id_test.go
+++ b/cmd/serve_session_id_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/session"
+)
+
+func TestServeRejectsNewUnsafeSessionIDs(t *testing.T) {
+	for _, endpoint := range []struct {
+		path   string
+		body   string
+		handle func(*serveServer, http.ResponseWriter, *http.Request)
+	}{
+		{"/v1/responses", `{"input":"hello"}`, (*serveServer).handleResponses},
+		{"/v1/chat/completions", `{"messages":[{"role":"user","content":"hello"}]}`, (*serveServer).handleChatCompletions},
+		{"/v1/messages", `{"model":"mock","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`, (*serveServer).handleAnthropicMessages},
+	} {
+		for _, header := range []string{"X-Term-LLM-Session-ID", "session_id"} {
+			for _, id := range []string{"chat/session", `chat\session`, ".", "..", "session\x00id"} {
+				t.Run(endpoint.path+"/"+header+"/"+id, func(t *testing.T) {
+					created := 0
+					manager := newServeSessionManager(time.Minute, 10, func(context.Context) (*serveRuntime, error) {
+						created++
+						return nil, fmt.Errorf("unexpected runtime creation")
+					})
+					defer manager.Close()
+					srv := &serveServer{sessionMgr: manager}
+					req := httptest.NewRequest(http.MethodPost, endpoint.path, strings.NewReader(endpoint.body))
+					req.Header.Set("Content-Type", "application/json")
+					req.Header.Set(header, id)
+					rr := httptest.NewRecorder()
+					endpoint.handle(srv, rr, req)
+					if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "session ID") {
+						t.Fatalf("status/body = %d %s, want invalid session ID", rr.Code, rr.Body.String())
+					}
+					if created != 0 {
+						t.Fatalf("invalid ID created %d runtimes", created)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestServeContinuesExistingUnsafeSessionID(t *testing.T) {
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	legacy := &session.Session{ID: "chat/session", Provider: "mock", ProviderKey: "mock", Model: "mock-model"}
+	if err := store.Create(context.Background(), legacy); err != nil {
+		t.Fatal(err)
+	}
+	provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+	manager := newServeSessionManager(time.Minute, 10, func(context.Context) (*serveRuntime, error) {
+		return &serveRuntime{provider: provider, engine: llm.NewEngine(provider, nil), defaultModel: "mock-model"}, nil
+	})
+	defer manager.Close()
+	srv := &serveServer{sessionMgr: manager, store: store}
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Term-LLM-Session-ID", legacy.ID)
+	rr := httptest.NewRecorder()
+	srv.handleResponses(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status/body = %d %s", rr.Code, rr.Body.String())
+	}
+	if len(provider.Requests) != 1 {
+		t.Fatalf("provider requests = %d", len(provider.Requests))
+	}
+}
+
+func TestHubLegacySessionNumberRoutes(t *testing.T) {
+	store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "sessions.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	legacy := &session.Session{ID: "chat/session", Provider: "mock", Model: "legacy-model"}
+	if err := store.Create(context.Background(), legacy); err != nil {
+		t.Fatal(err)
+	}
+	message := session.NewMessage(legacy.ID, llm.UserText("saved conversation"), -1)
+	if err := store.AddMessage(context.Background(), legacy.ID, message); err != nil {
+		t.Fatal(err)
+	}
+	manager := newServeSessionManager(time.Minute, 10, func(context.Context) (*serveRuntime, error) {
+		return nil, fmt.Errorf("read must not create a runtime")
+	})
+	defer manager.Close()
+	srv := &serveServer{store: store, sessionMgr: manager}
+	hub := hubWithBackend(t, "/chat", func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/chat")
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			srv.handleSideQuestion(w, r)
+		} else {
+			srv.handleSessionByID(w, r)
+		}
+	})
+	for _, path := range []string{
+		fmt.Sprintf("/v1/sessions/%d/state", legacy.Number),
+		fmt.Sprintf("/v1/sessions/%d/messages", legacy.Number),
+		fmt.Sprintf("/api/sessions/%d/side-question", legacy.Number),
+	} {
+		t.Run(path, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			hub.handleNodeProxy(rr, httptest.NewRequest(http.MethodGet, "/node/alpha"+path, nil))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status/body = %d %s", rr.Code, rr.Body.String())
+			}
+			if strings.HasSuffix(path, "/state") && !strings.Contains(rr.Body.String(), "legacy-model") {
+				t.Fatalf("wrong session state: %s", rr.Body.String())
+			}
+			if strings.HasSuffix(path, "/messages") && !strings.Contains(rr.Body.String(), "saved conversation") {
+				t.Fatalf("saved messages missing: %s", rr.Body.String())
+			}
+		})
+	}
+	rr := httptest.NewRecorder()
+	hub.handleNodeProxy(rr, httptest.NewRequest(http.MethodGet, "/node/alpha/v1/sessions/chat%2Fsession/state", nil))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("encoded slash protection changed: %d", rr.Code)
+	}
+}

--- a/cmd/serve_side_question.go
+++ b/cmd/serve_side_question.go
@@ -538,8 +538,8 @@ func (s *serveServer) handleSideQuestion(w http.ResponseWriter, r *http.Request)
 		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "not found")
 		return
 	}
-	sessionID := strings.TrimSpace(parts[0])
-	if sessionID == "" || s.sessionMgr == nil {
+	sessionID, err := s.resolveSessionPathID(r.Context(), strings.TrimSpace(parts[0]))
+	if err != nil || sessionID == "" || s.sessionMgr == nil {
 		writeOpenAIError(w, http.StatusNotFound, "not_found_error", "session not found")
 		return
 	}

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -9,6 +9,30 @@ const config = readInjectedConfig({
 } as Window);
 
 describe('API transport', () => {
+  it('uses numeric routes only for known legacy sessions on this server', () => {
+    const api = new APIClient(config, { getToken: () => '', onAuthRequired: vi.fn() });
+    for (const id of ['chat/session', 'chat\\session', '.', '..']) {
+      api.registerSession({ id, number: 16 });
+      expect(api.url(`/v1/sessions/${encodeURIComponent(id)}/state`)).toBe(
+        '/ui/v1/sessions/16/state',
+      );
+    }
+    api.registerSession({ id: 'safe-session', number: 17 });
+    api.registerSession({ id: 'unknown/session' });
+    api.registerSession({ id: 'zero/session', number: 0 });
+    expect(api.url('/v1/sessions/safe-session/state')).toBe('/ui/v1/sessions/safe-session/state');
+    expect(api.url('/v1/sessions/unknown%2Fsession/state')).toBe(
+      '/ui/v1/sessions/unknown%2Fsession/state',
+    );
+    expect(api.url('/v1/sessions/zero%2Fsession/state')).toBe(
+      '/ui/v1/sessions/zero%2Fsession/state',
+    );
+    const other = new APIClient(config, { getToken: () => '', onAuthRequired: vi.fn() });
+    expect(other.url('/v1/sessions/chat%2Fsession/state')).toBe(
+      '/ui/v1/sessions/chat%2Fsession/state',
+    );
+  });
+
   it('adds auth/version headers and preserves the base path', async () => {
     const request = vi.fn(
       async () =>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -195,16 +195,37 @@ export interface UploadControls {
 }
 
 export class APIClient {
+  private readonly sessionRoutes = new Map<string, string>();
+
   constructor(
     readonly config: AppConfig,
     private hooks: TransportHooks,
   ) {}
 
+  // Preserve saved identities in headers/bodies, but use the existing numeric
+  // route for legacy IDs that cannot safely occupy a URL path segment.
+  registerSession<T extends { id: string; number?: number }>(session: T): T {
+    const { id, number = 0 } = session;
+    if (/[/\\]|^\.\.?$/.test(id) && Number.isSafeInteger(number) && number > 0) {
+      this.sessionRoutes.set(encodeURIComponent(id), String(number));
+    }
+    return session;
+  }
+
   url(path: string): string {
     if (/^https?:\/\//.test(path)) return path;
     const prefix = this.config.prefix.replace(/\/+$/, '');
-    if (path === prefix || path.startsWith(`${prefix}/`)) return path;
-    return `${prefix}${path.startsWith('/') ? path : `/${path}`}`;
+    if (path === prefix) return path;
+    const relative = path.startsWith(`${prefix}/`) ? path.slice(prefix.length) : path;
+    const rooted = relative.startsWith('/') ? relative : `/${relative}`;
+    const routed = rooted.replace(
+      /^(\/(?:v1|api)\/sessions\/)([^/?#]+)/,
+      (match, base: string, id: string) => {
+        const number = this.sessionRoutes.get(id);
+        return number ? base + number : match;
+      },
+    );
+    return `${prefix}${routed}`;
   }
 
   async request(

--- a/frontend/src/stores/session-store.test.ts
+++ b/frontend/src/stores/session-store.test.ts
@@ -6,6 +6,40 @@ import { testConfig, testSession } from './store-test-fixtures';
 beforeEach(() => localStorage.clear());
 
 describe('SessionStore', () => {
+  it('routes legacy session requests by number while preserving their saved identity', async () => {
+    const fetcher = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetcher);
+    const store = new AppStore({ ...testConfig, prefix: '/node/jarvis' });
+    try {
+      const id = 'chat/session';
+      const legacy = store.sessionStore.sessionFrom({ id, number: 16 });
+      expect(legacy.id).toBe(id);
+      await store.endpoints.sessionState(id);
+      await store.endpoints.compact(id);
+      await store.endpoints.sideQuestionState(id);
+      await store.endpoints.createSessionShare(id, { scope: 'conversation' });
+      expect(fetcher.mock.calls.map((call) => (call as unknown as [string])[0])).toEqual([
+        '/node/jarvis/v1/sessions/16/state',
+        '/node/jarvis/v1/sessions/16/runtime/compact',
+        '/node/jarvis/api/sessions/16/side-question',
+        '/node/jarvis/v1/sessions/16/shares',
+      ]);
+      const [, shareInit] = fetcher.mock.calls[3] as unknown as [string, RequestInit];
+      expect((shareInit.headers as Headers).get('X-Term-LLM-Session-ID')).toBe(id);
+      expect(store.api.url('/node/jarvis/v1/sessions/chat%2Fsession/skills?path=a%2Fb')).toBe(
+        '/node/jarvis/v1/sessions/16/skills?path=a%2Fb',
+      );
+      expect(store.api.url('https://other.test/v1/sessions/chat%2Fsession/state')).toBe(
+        'https://other.test/v1/sessions/chat%2Fsession/state',
+      );
+      expect(store.api.url('/v1/projects/chat%2Fsession/worktrees')).toBe(
+        '/node/jarvis/v1/projects/chat%2Fsession/worktrees',
+      );
+    } finally {
+      store.dispose();
+    }
+  });
+
   it('merges attention watermarks monotonically without clearing a newer marker', () => {
     const store = new AppStore(testConfig);
     try {

--- a/frontend/src/stores/session-store.ts
+++ b/frontend/src/stores/session-store.ts
@@ -231,7 +231,7 @@ export class SessionStore {
   }
 
   sessionFrom(value: Record<string, unknown>): Session {
-    return sanitizeSessionFrom(this.services.config, value);
+    return this.services.api.registerSession(sanitizeSessionFrom(this.services.config, value));
   }
 
   mergeSession(


### PR DESCRIPTION
After updating the containers, opening a saved conversation for Jarvis (my container agent) through the Hub failed with "bad request: encoded path separators not allowed". The conversation's stored ID started with "chat/". The frontend encoded that slash as "%2F" in session API URLs, which the Hub rejected under its existing path protection.

This is not limited to older installations. Although server-generated IDs are safe, the inference APIs accepted client-supplied session IDs without checking whether they could be used as a URL path segment. A client could therefore create another affected session on a fresh instance.

Use existing session numbers in frontend API URLs for affected saved sessions. Preserve their original IDs in storage, headers, and request bodies so conversations remain accessible without migrating messages or changing references. Share numeric session lookup between the main session API and side-question endpoints.

Reject path separators, control characters, and reserved dot segments in IDs supplied for new sessions across Responses, Chat Completions, and Anthropic Messages. Continue accepting existing persisted IDs for compatibility, and leave the Hub's encoded-separator protection intact.

Add regression coverage for rejection before runtime creation, continuation of existing affected sessions, frontend URL routing, and Hub access to session state, saved messages, and side questions.