### PR TITLE
fix: Telegram discards compacted context and resurrects the full history on the next message

### DIFF
--- a/internal/serve/telegram.go
+++ b/internal/serve/telegram.go
@@ -636,7 +636,8 @@ type telegramSession struct {
 	mu                    sync.Mutex
 	activityMu            sync.Mutex // protects lastActivity without blocking behind an active stream
 	runtime               *SessionRuntime
-	history               []llm.Message
+	history               []llm.Message // full transcript for persistence/reconciliation
+	activeHistory         []llm.Message // non-nil after compaction; provider context only
 	systemPromptPersisted bool
 	runtimeStale          atomic.Bool // a detached runner may still own runtime; reset before reuse
 	cleanupOnce           sync.Once
@@ -1712,9 +1713,13 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 	// Extract text from the user message for persistence and display.
 	userText := collectUserText(userMsg)
 
-	// Build full message list: system + history + new user turn.
-	messages := make([]llm.Message, 0, len(sess.history)+3)
-	historyHasSystem := containsSystemMsg(sess.history)
+	// Build provider context independently of the durable transcript.
+	history := sess.history
+	if sess.activeHistory != nil {
+		history = sess.activeHistory
+	}
+	messages := make([]llm.Message, 0, len(history)+3)
+	historyHasSystem := containsSystemMsg(history)
 	if m.settings.SystemPrompt != "" && !historyHasSystem {
 		messages = append(messages, llm.SystemText(m.settings.SystemPrompt))
 	}
@@ -1731,7 +1736,7 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 	if devText := m.settings.PlatformMessages.For("telegram"); devText != "" {
 		messages = append(messages, llm.Message{Role: llm.RoleDeveloper, Parts: []llm.Part{{Type: llm.PartText, Text: devText}}})
 	}
-	messages = append(messages, sess.history...)
+	messages = append(messages, history...)
 	messages = append(messages, userMsg)
 
 	sessionID := ""
@@ -1815,6 +1820,34 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		turnMetrics                llm.TurnMetrics
 		turnCount                  int
 	)
+	// Keep all produced messages for the transcript, but only append messages
+	// produced after the latest compaction to the replacement provider context.
+	var activeHistory []llm.Message
+	activeProducedStart := 0
+	if sess.activeHistory != nil {
+		activeHistory = append(append([]llm.Message{}, sess.activeHistory...), normalizeUserMessageForHistory(userMsg))
+	}
+	compactionCB := func(_ context.Context, result *llm.CompactionResult) error {
+		if result == nil {
+			return nil
+		}
+		producedMu.Lock()
+		defer producedMu.Unlock()
+		activeHistory = append([]llm.Message{}, result.NewMessages...)
+		activeProducedStart = len(produced)
+		return nil
+	}
+	updateActiveHistory := func(fallback string) {
+		producedMu.Lock()
+		defer producedMu.Unlock()
+		if activeHistory == nil {
+			return
+		}
+		sess.activeHistory = append(append([]llm.Message{}, activeHistory...), produced[activeProducedStart:]...)
+		if fallback != "" {
+			sess.activeHistory = append(sess.activeHistory, llm.AssistantText(fallback))
+		}
+	}
 	var callbackStoreQueue *telegramStoreOpQueue
 	if m.store != nil && sess.meta != nil {
 		callbackStoreQueue = newTelegramStoreOpQueue(m, sess.meta.ID)
@@ -1961,6 +1994,7 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 				ForceExternalSearch:       &forceExternalSearch,
 				OnResponseCompleted:       responseCompletedCB,
 				OnTurnCompleted:           turnCompletedCB,
+				OnCompaction:              compactionCB,
 				OnEngineReady: func(engine *llm.Engine) {
 					sess.cancelMu.Lock()
 					if sess.streamToken == streamToken {
@@ -2397,6 +2431,7 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 		queueDrained := drainCallbackStoreQueue()
 		queueDegraded := callbackStoreQueue != nil && callbackStoreQueue.isDegraded()
 		if partial == "" && len(producedSnapshot) == 0 && !turnPersistenceDegraded && !queueDegraded {
+			updateActiveHistory("")
 			return
 		}
 
@@ -2420,6 +2455,11 @@ func (m *telegramSessionMgr) streamReplyWithAdmission(ctx context.Context, bot b
 				newHistory = append(newHistory, assistantMsg)
 			}
 		}
+		activeFallback := ""
+		if !assistantTextCaptured {
+			activeFallback = partial
+		}
+		updateActiveHistory(activeFallback)
 		sess.history = newHistory
 		sess.activityMu.Lock()
 		sess.lastActivity = time.Now()
@@ -2755,6 +2795,11 @@ loop:
 		}
 		newHistory = append(newHistory, llm.AssistantText(full))
 	}
+	activeFallback := ""
+	if len(produced) == 0 {
+		activeFallback = full
+	}
+	updateActiveHistory(activeFallback)
 	sess.history = newHistory
 	sess.activityMu.Lock()
 	sess.lastActivity = time.Now()

--- a/internal/serve/telegram_test.go
+++ b/internal/serve/telegram_test.go
@@ -4275,3 +4275,146 @@ func TestHandleMessage_PhotoInterruptCancelsAndPreservesImage(t *testing.T) {
 		}
 	}
 }
+
+// Exercise the Telegram/runner handoff directly; the runtime's compaction
+// algorithm is covered separately by TestServeRuntimeCompactionCallbackUpdatesActiveContext.
+type telegramCompactionRunner struct {
+	requests  [][]llm.Message
+	failFirst bool
+}
+
+func (r *telegramCompactionRunner) Run(ctx context.Context, req runpkg.Request, sink runpkg.EventSink) (runpkg.Result, error) {
+	r.requests = append(r.requests, append([]llm.Message(nil), req.Messages...))
+	emit := func(text string) error {
+		msg := llm.AssistantText(text)
+		if err := req.OnResponseCompleted(ctx, 0, msg, llm.TurnMetrics{}); err != nil {
+			return err
+		}
+		return req.OnTurnCompleted(ctx, 0, []llm.Message{msg}, llm.TurnMetrics{})
+	}
+	if len(r.requests) == 1 {
+		if err := emit("before compaction"); err != nil {
+			return runpkg.Result{}, err
+		}
+		if req.OnCompaction != nil {
+			// Two compactions in one run must use the latest boundary, without
+			// dropping pre-boundary output from the transcript.
+			for _, summary := range []string{"superseded summary", "[Context Compaction] compact summary"} {
+				if err := req.OnCompaction(ctx, &llm.CompactionResult{NewMessages: []llm.Message{
+					llm.SystemText("be helpful"), llm.UserText(summary), llm.AssistantText("retained tail"),
+				}}); err != nil {
+					return runpkg.Result{}, err
+				}
+			}
+		}
+		if r.failFirst {
+			return runpkg.Result{}, errors.New("failure after compaction")
+		}
+	}
+	text := fmt.Sprintf("answer %d", len(r.requests))
+	if err := emit(text); err != nil {
+		return runpkg.Result{}, err
+	}
+	sink.Event(llm.Event{Type: llm.EventTextDelta, Text: text})
+	return runpkg.Result{}, nil
+}
+
+func TestStreamReply_RetainsCompactedContextAndFullTranscript(t *testing.T) {
+	for _, tc := range []struct {
+		failFirst       bool
+		failPersistence bool
+	}{{}, {failFirst: true}, {failPersistence: true}, {failFirst: true, failPersistence: true}} {
+		t.Run(fmt.Sprintf("error=%v/persistence_failure=%v", tc.failFirst, tc.failPersistence), func(t *testing.T) {
+			h := testutil.NewEngineHarness()
+			store, err := session.NewStore(session.Config{Enabled: true, Path: filepath.Join(t.TempDir(), "test.db")})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			runner := &telegramCompactionRunner{failFirst: tc.failFirst}
+			var turnStore session.Store = store
+			if tc.failPersistence {
+				turnStore = &failingTelegramTurnStore{Store: store, failRole: llm.RoleAssistant, failAfter: 1}
+			}
+			mgr := &telegramSessionMgr{
+				sessions: make(map[int64]*telegramSession), store: turnStore, tickerInterval: 10 * time.Millisecond,
+				settings: Settings{MaxTurns: 5, Store: turnStore, SystemPrompt: "be helpful", Runner: runner,
+					NewSession: func(context.Context) (*SessionRuntime, error) {
+						return &SessionRuntime{Engine: h.Engine, ProviderName: "mock", ModelName: "test"}, nil
+					},
+				},
+			}
+			ctx := context.Background()
+			sess, err := mgr.getOrCreate(ctx, 42)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bot := &fakeBotSender{}
+			prefix := strings.Repeat("oversized historical prefix ", 2000)
+			firstErr := mgr.streamReply(ctx, bot, sess, 42, llm.UserText(prefix))
+			if !tc.failFirst && firstErr != nil {
+				t.Fatal(firstErr)
+			}
+			for _, input := range []string{"second input", "third input"} {
+				if err := mgr.streamReply(ctx, bot, sess, 42, llm.UserText(input)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			textOf := func(messages []llm.Message) string {
+				var b strings.Builder
+				for _, msg := range messages {
+					b.WriteString(telegramMessageVisibleText(msg))
+					b.WriteByte('\n')
+				}
+				return b.String()
+			}
+			for i, req := range runner.requests[1:] {
+				text := textOf(req)
+				for _, want := range []string{"be helpful", "[Context Compaction] compact summary", "retained tail", "second input"} {
+					if !strings.Contains(text, want) {
+						t.Fatalf("request %d missing %q: %s", i+2, want, text)
+					}
+				}
+				for _, stale := range []string{"oversized historical prefix", "before compaction", "superseded summary"} {
+					if strings.Contains(text, stale) {
+						t.Fatalf("request %d resurrected %q", i+2, stale)
+					}
+				}
+				if len(text) > 1000 {
+					t.Fatalf("next request remains oversized: %d bytes", len(text))
+				}
+			}
+			if !tc.failFirst && strings.Count(textOf(runner.requests[1]), "answer 1") != 1 {
+				t.Fatal("post-compaction assistant response lost or duplicated")
+			}
+			t.Logf("provider context text: first=%d bytes, second=%d bytes", len(textOf(runner.requests[0])), len(textOf(runner.requests[1])))
+			third := textOf(runner.requests[2])
+			if strings.Count(third, "answer 2") != 1 || !strings.Contains(third, "third input") {
+				t.Fatalf("subsequent turn lost or duplicated: %s", third)
+			}
+			msgs, err := store.GetMessages(ctx, sess.meta.ID, 0, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var transcript []llm.Message
+			for _, msg := range msgs {
+				transcript = append(transcript, msg.ToLLMMessage())
+			}
+			text := textOf(transcript)
+			for _, want := range []string{prefix, "before compaction", "second input", "answer 2", "third input", "answer 3"} {
+				if strings.Count(text, want) != 1 {
+					t.Fatalf("transcript lost or duplicated %q", want[:min(len(want), 50)])
+				}
+			}
+			if tc.failPersistence {
+				failed, replacements := turnStore.(*failingTelegramTurnStore).stats()
+				if !failed || replacements == 0 {
+					t.Fatal("test did not exercise transcript reconciliation")
+				}
+			}
+			if strings.Contains(text, "compact summary") {
+				t.Fatal("active-context replacement leaked into transcript")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Wire Telegram's runner request to `OnCompaction` and retain a separate, per-session active provider-context snapshot.
- Replace that snapshot on each compaction and record the produced-message offset at the boundary. Subsequent requests append only post-compaction output and new user input, rather than resurrecting the original prefix or duplicating retained turns.
- Update active context on both normal completion and partial/error recovery.
- Keep the existing full transcript and callback persistence queue independent of active context. Pre-compaction messages remain available for SQLite persistence and degraded-write reconciliation.

This is intentionally scoped to an ongoing Telegram session. It does not change session replacement/carryover, introduce durable compaction boundaries, or reduce full-transcript memory retention. Keeping transcript persistence unchanged avoids mixing compacted replacement rows into Telegram's independently queued transcript writes.

## Why this is high-value

Long-lived Telegram conversations are an ordinary Sam/Jarvis provider path. Previously, each fresh runner received Telegram's full history even after successful engine compaction: `DisableRuntimePersistence` disables the shared runtime's store, its active-context update is invocation-local, and Telegram supplied no compaction callback. The existing shared-runtime regression test does not cover this ownership handoff. None of the listed/open PRs covers this issue.

This removes repeated provider input processing and prevents the stale historical prefix from driving unnecessary re-compaction on every subsequent message. The deterministic test starts with 56,012 bytes of context text; the next request contains only 84 bytes after normal completion (75 after an injected error), including summary, retained tail, and new input. These are synthetic payload measurements, not token counts or a provider-latency benchmark.

## Validation

- Added `TestStreamReply_RetainsCompactedContextAndFullTranscript`, exercising three Telegram replies through a scripted runner and real SQLite storage. Covers two compaction callbacks in one run, post-boundary output, a runner error after compaction, and failed assistant writes requiring full-transcript reconciliation. Later requests exclude the old prefix and superseded summary; the durable transcript retains original messages exactly once.
- Red/green check: removing the new callback wiring makes the regression fail with the original oversized prefix in request two; restoring it passes.
- `make frontend` — pass (required embedded assets were absent in the prepared worktree).
- `go build ./...` — pass.
- `go test ./internal/serve ./cmd -run 'TestStreamReply|TestServeRuntimeCompactionCallbackUpdatesActiveContext' -count=1` — pass.
- `go test -race ./internal/serve -run TestStreamReply_RetainsCompactedContextAndFullTranscript -count=1` — pass, including all four error/persistence combinations.
- `go test ./...` — run twice; three unrelated failures, reproduced with the original production Telegram file restored:
  - `TestResolveChatRuntimeSystemContextUsesExplicitDirectoryWithoutChdir`: local user skills crowd out the fixture's `worktree-skill`.
  - `TestCmdRunnerPrepareUsesRequestWorkingDirForSkills`: same local skill-visibility interference.
  - `TestProductionBundleSizeBudgets`: generated `app.js` gzip size 146,221 bytes exceeds the existing 142,500-byte budget (raw size 499,955 / 500,000). Frontend/build inputs are unchanged.
- `gofmt` on changed Go files and `git diff --check` — pass.

The new regression deliberately tests the missing Telegram/runner callback boundary rather than duplicating the command runner's compaction algorithm. The existing real-runtime compaction test was also rerun. No live Telegram/provider latency test or combined real-command-runner Telegram integration test was performed.
