### PR TITLE
Support named OpenAI-compatible image providers

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -189,7 +189,8 @@ func providerFlagCompletionDirective(cfg *config.Config, toComplete string) cobr
 
 // ImageProviderFlagCompletion handles --provider flag completion for image commands
 func ImageProviderFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	completions := llm.GetProviderCompletions(toComplete, true, nil)
+	cfg, _ := config.Load()
+	completions := llm.GetProviderCompletions(toComplete, true, cfg)
 
 	// If completing provider name (no colon), don't add space so user can type ":"
 	if !strings.Contains(toComplete, ":") {

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func TestShellCompletionSkipsInheritedPprofServer(t *testing.T) {
@@ -332,5 +335,33 @@ func TestProviderFlagCompletionProgressiveSpacing(t *testing.T) {
 		if got := directive&cobra.ShellCompDirectiveNoSpace != 0; got != tc.noSpace {
 			t.Errorf("%s: no-space = %v, want %v", tc.prefix, got, tc.noSpace)
 		}
+	}
+}
+
+func TestImageCompletionLoadsNamedProviderConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	text := "default_provider: debug\nimage:\n  provider: janus\nproviders:\n  janus:\n    type: openai_compatible\n    base_url: http://127.0.0.1:8080/v1\n    model: Janus-Pro-1B\n"
+	if err = os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(text), 0600); err != nil {
+		t.Fatal(err)
+	}
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	got, _ := ImageProviderFlagCompletion(nil, nil, "janus")
+	if !slices.Contains(got, "janus") {
+		t.Fatalf("provider completion = %v", got)
+	}
+	got, _ = ImageProviderFlagCompletion(nil, nil, "janus:")
+	if !slices.Contains(got, "janus:Janus-Pro-1B") {
+		t.Fatalf("model completion = %v", got)
+	}
+	if got := configValueCompletions("image.provider", "janus"); !slices.Contains(got, "janus") {
+		t.Fatalf("config completion = %v", got)
 	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1265,7 +1265,7 @@ func configValueCompletions(key, toComplete string) []string {
 		return completions
 
 	case "image.provider":
-		providers := []string{"gemini", "openai", "chatgpt", "xai", "venice", "flux", "openrouter", "debug"}
+		providers := llm.GetConfiguredImageProviderNames(cfg)
 		var completions []string
 		for _, p := range providers {
 			if strings.HasPrefix(p, toComplete) {

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -56,6 +56,7 @@ Examples:
   term-llm image "add a hat" -i clipboard           # edit from clipboard
   term-llm image "combine these" -i a.png -i b.png  # multi-image (Gemini/OpenRouter)
   term-llm image "sunset over mountains" --provider flux
+  term-llm image "a pelican riding a bike" --provider local-images
   term-llm image "logo design" -o ./output.png --no-display
   term-llm image "robot cat" -o - | term-llm video "animate it" -i -
   echo "a sunset" | term-llm image                  # prompt from stdin`,
@@ -65,7 +66,7 @@ Examples:
 
 func init() {
 	imageCmd.Flags().StringArrayVarP(&imageInputs, "input", "i", nil, "Input image(s) to edit (can be specified multiple times)")
-	imageCmd.Flags().StringVarP(&imageProvider, "provider", "p", "", "Override provider (debug, gemini, openai, chatgpt, xai, venice, flux, openrouter)")
+	imageCmd.Flags().StringVarP(&imageProvider, "provider", "p", "", "Override image provider (built-in or configured openai_compatible name)")
 	imageCmd.Flags().StringVarP(&imageOutput, "output", "o", "", "Custom output path")
 	imageCmd.Flags().StringVarP(&imageSize, "size", "s", "", "Image resolution (must be 1K, 2K, or 4K)")
 	imageCmd.Flags().BoolVar(&imageNoDisplay, "no-display", false, "Skip terminal display")

--- a/docs-site/content/guides/image-generation.md
+++ b/docs-site/content/guides/image-generation.md
@@ -24,7 +24,7 @@ By default, images are:
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--input` | `-i` | Input image to edit; repeat for providers that support multiple inputs. |
-| `--provider` | `-p` | Override provider (gemini, openai, chatgpt, xai, venice, flux, openrouter) |
+| `--provider` | `-p` | Override a built-in image provider or configured OpenAI-compatible provider name |
 | `--output` | `-o` | Custom output path; `-` writes image bytes to stdout for pipelines. |
 | `--size` | `-s` | Requested resolution: `1K`, `2K`, or `4K`; provider/model support varies. |
 | `--no-spinner` | | Disable the interactive progress display. |
@@ -72,3 +72,48 @@ Image generation has its own provider selection and config. Where supported, ima
 **ChatGPT image provider:** log in with `term-llm auth login chatgpt`, then you can use `term-llm image --provider chatgpt:gpt-5.4 "..."` for subscription-backed image generation without an API key.
 
 **Editing limits:** xAI does not support editing. ChatGPT accepts one input image. Venice supports one-image editing and multi-image editing with up to three inputs, subject to the selected model. Venice uses `image.venice.edit_model` when set; otherwise it derives the edit model by appending `-edit` to the generation model (unless already present). Gemini and OpenRouter also expose multi-image editing; upstream model limits still apply.
+
+### Local and OpenAI-compatible image providers
+
+An existing named `providers` entry with `type: openai_compatible` can also
+serve images. Set its `base_url` to the API root (including `/v1` when required)
+and select it through `image.provider` or `--provider`:
+
+```yaml
+providers:
+  janus:
+    type: openai_compatible
+    base_url: http://127.0.0.1:8080/janus/v1
+    model: Janus-Pro-1B
+  demo:
+    type: openai_compatible
+    base_url: http://127.0.0.1:8080/demo/v1
+    model: demo
+
+image:
+  provider: janus
+```
+
+```sh
+term-llm image "A pelican riding a bike." -o pelican.png
+term-llm image "A cat" --provider demo -o demo.png
+term-llm config set image.provider demo
+```
+
+These are example endpoints: you must run a server implementing the Images API.
+term-llm does not bundle Janus weights or a demo server. This is normal provider
+configuration, not a different image command or an automatic fallback.
+
+The client posts to `<base_url>/images/generations` with `model`, `prompt`,
+`n: 1`, and `response_format: b64_json`. The server returns an OpenAI-format
+`data` array containing `b64_json` or an image `url`. No size is sent unless
+requested; `--size`/aspect-ratio requests are converted to pixel dimensions.
+OpenAI-specific quality and output-format options are not imposed. Editing is
+not supported by this generic adapter; built-in providers retain their existing
+editing capabilities.
+
+`api_key` is optional for local servers. When provided it uses normal provider
+credential resolution (including environment variables and deferred secrets).
+Unrelated `OPENAI_API_KEY` credentials are not forwarded. The full chat-only
+`url` field is not accepted: use `base_url`. Built-in provider names keep their
+existing image configuration, so choose a distinct custom name.

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -636,7 +636,7 @@ embed:
   provider: gemini
 ```
 
-Each feature block can hold provider-specific credentials and defaults. The image, audio, music, transcription, and embedding providers are independent of the main text provider.
+Each feature block can hold provider-specific credentials and defaults. The image, audio, music, transcription, and embedding providers are independent of the main text provider. `image.provider` also accepts a named `providers` entry with `type: openai_compatible`, an API `base_url`, and a `model`; see [local image providers](/guides/image-generation/#local-and-openai-compatible-image-providers).
 
 ## Provider-specific environment overrides
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -181,7 +181,7 @@ type ProviderConfig struct {
 	MaxOutputTokens int `mapstructure:"max_output_tokens"`
 
 	// Custom endpoint configuration
-	BaseURL string `mapstructure:"base_url"` // Base URL for Anthropic-compatible or OpenAI-compatible providers
+	BaseURL string `mapstructure:"base_url"` // API root for Anthropic/OpenAI-compatible providers, including compatible Images APIs
 
 	// OpenAI-compatible specific
 	URL               string `mapstructure:"url"`                 // Full URL - used as-is without appending endpoint
@@ -957,7 +957,7 @@ func (c *Config) ValidateApprovalModes() error {
 
 // ImageConfig configures image generation settings
 type ImageConfig struct {
-	Provider   string                `mapstructure:"provider"`   // default image provider: gemini, openai, chatgpt, xai, venice, flux, openrouter, debug
+	Provider   string                `mapstructure:"provider"`   // built-in image provider or named providers entry with type: openai_compatible
 	OutputDir  string                `mapstructure:"output_dir"` // default save directory
 	Gemini     ImageGeminiConfig     `mapstructure:"gemini"`
 	OpenAI     ImageOpenAIConfig     `mapstructure:"openai"`

--- a/internal/image/openai.go
+++ b/internal/image/openai.go
@@ -152,7 +152,11 @@ func (p *OpenAIProvider) Edit(ctx context.Context, req EditRequest) (*ImageResul
 }
 
 func (p *OpenAIProvider) doRequest(httpReq *http.Request) (*ImageResult, error) {
-	resp, err := openaiHTTPClient.Do(httpReq)
+	return doOpenAIImageRequest(openaiHTTPClient, httpReq)
+}
+
+func doOpenAIImageRequest(client *http.Client, httpReq *http.Request) (*ImageResult, error) {
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -196,7 +200,7 @@ func (p *OpenAIProvider) doRequest(httpReq *http.Request) (*ImageResult, error) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create image URL request: %w", err)
 		}
-		resp, err := openaiHTTPClient.Do(fetchReq)
+		resp, err := client.Do(fetchReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch image URL: %w", err)
 		}

--- a/internal/image/openai_compatible.go
+++ b/internal/image/openai_compatible.go
@@ -1,0 +1,85 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+// OpenAICompatibleProvider generates images through a configured Images API.
+// It deliberately does not assume support for OpenAI-specific options or editing.
+type OpenAICompatibleProvider struct {
+	name, endpoint, apiKey, model string
+}
+
+func newConfiguredImageProvider(cfg *config.Config, name, model string) (ImageProvider, error) {
+	pc := cfg.GetProviderConfig(name)
+	if pc == nil {
+		return nil, fmt.Errorf("unknown image provider: %s (use a built-in or configure a provider with type: openai_compatible)", name)
+	}
+	if config.InferProviderType(name, pc.Type) != config.ProviderTypeOpenAICompat {
+		return nil, fmt.Errorf("image provider %q must have type: openai_compatible", name)
+	}
+	pc, err := cfg.GetResolvedProviderConfig(name)
+	if err != nil {
+		return nil, fmt.Errorf("image provider %q: %w", name, err)
+	}
+	if err = pc.ResolveForInference(); err != nil {
+		return nil, fmt.Errorf("image provider %q: %w", name, err)
+	}
+	if model == "" {
+		model = pc.Model
+	}
+	if strings.TrimSpace(model) == "" {
+		return nil, fmt.Errorf("image provider %q requires a model", name)
+	}
+	// A full chat URL is not an Images API base. Never silently send to it.
+	if pc.URL != "" || pc.ResolvedURL != "" {
+		return nil, fmt.Errorf("image provider %q requires base_url, not the chat-only url field", name)
+	}
+	base, err := url.Parse(pc.BaseURL)
+	if err != nil || base == nil || (base.Scheme != "http" && base.Scheme != "https") || base.Hostname() == "" || base.User != nil || base.RawQuery != "" || base.ForceQuery || base.Fragment != "" {
+		return nil, fmt.Errorf("image provider %q requires an HTTP(S) base_url without credentials, query or fragment", name)
+	}
+	return &OpenAICompatibleProvider{name: name, endpoint: strings.TrimRight(base.String(), "/") + "/images/generations", apiKey: pc.ResolvedAPIKey, model: model}, nil
+}
+
+func (p *OpenAICompatibleProvider) Name() string             { return p.name }
+func (p *OpenAICompatibleProvider) SupportsEdit() bool       { return false }
+func (p *OpenAICompatibleProvider) SupportsMultiImage() bool { return false }
+func (p *OpenAICompatibleProvider) Edit(context.Context, EditRequest) (*ImageResult, error) {
+	return nil, fmt.Errorf("image provider %s does not support editing", p.name)
+}
+func (p *OpenAICompatibleProvider) Generate(ctx context.Context, req GenerateRequest) (*ImageResult, error) {
+	// Size is optional: local models can retain their native resolution. No GPT
+	// quality/output_format parameters are imposed on compatible implementations.
+	payload := struct {
+		Model          string `json:"model"`
+		Prompt         string `json:"prompt"`
+		N              int    `json:"n"`
+		ResponseFormat string `json:"response_format"`
+		Size           string `json:"size,omitempty"`
+	}{Model: p.model, Prompt: req.Prompt, N: 1, ResponseFormat: "b64_json"}
+	if req.Size != "" || req.AspectRatio != "" {
+		payload.Size = openaiSizeFromRequest("gpt-image-2", req.Size, req.AspectRatio)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if p.apiKey != "" {
+		request.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
+	return doOpenAIImageRequest(openaiHTTPClient, request)
+}

--- a/internal/image/openai_compatible_test.go
+++ b/internal/image/openai_compatible_test.go
@@ -1,0 +1,166 @@
+package image
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/config"
+)
+
+func TestConfiguredImageProviderSelection(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "must-not-leak-to-local-server")
+	t.Setenv("DEMO_API_KEY", "")
+	t.Setenv("JANUS_API_KEY", "")
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("request = %s %s", r.Method, r.Header.Get("Content-Type"))
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Error("unrelated OpenAI credential sent to local endpoint")
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+			w.WriteHeader(400)
+			return
+		}
+		model, _ := body["model"].(string)
+		if body["prompt"] != "a pelican riding a bike" || body["n"] != float64(1) || body["response_format"] != "b64_json" {
+			t.Errorf("unexpected payload: %v", body)
+		}
+		for _, key := range []string{"quality", "output_format", "size"} {
+			if _, ok := body[key]; ok {
+				t.Errorf("unrequested option %q sent", key)
+			}
+		}
+		requests = append(requests, r.URL.Path+":"+model)
+		// Test fixture bytes; not an assertion about real model image quality.
+		fmt.Fprintf(w, `{"data":[{"b64_json":%q}]}`, base64.StdEncoding.EncodeToString([]byte(model)))
+	}))
+	defer server.Close()
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"demo":  {Type: config.ProviderTypeOpenAICompat, BaseURL: server.URL + "/demo/v1/", Model: "demo"},
+		"janus": {Type: config.ProviderTypeOpenAICompat, BaseURL: server.URL + "/janus/v1", Model: "janus"},
+	}}
+	for _, name := range []string{"demo", "janus"} {
+		cfg.Image.Provider = name
+		p, err := NewImageProvider(cfg, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.Name() != name {
+			t.Fatalf("name = %s", p.Name())
+		}
+		result, err := p.Generate(context.Background(), GenerateRequest{Prompt: "a pelican riding a bike"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(result.Data) != name {
+			t.Fatalf("selected %s but received %s", name, result.Data)
+		}
+		if p.SupportsEdit() || p.SupportsMultiImage() {
+			t.Fatal("unsupported editing advertised")
+		}
+		if _, err := p.Edit(context.Background(), EditRequest{}); err == nil {
+			t.Fatal("editing did not fail")
+		}
+	}
+	p, err := NewImageProvider(cfg, "demo:alternate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := p.Generate(context.Background(), GenerateRequest{Prompt: "a pelican riding a bike"})
+	if err != nil || string(result.Data) != "alternate" {
+		t.Fatalf("override result=%v error=%v", result, err)
+	}
+	want := []string{"/demo/v1/images/generations:demo", "/janus/v1/images/generations:janus", "/demo/v1/images/generations:alternate"}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("requests=%v want=%v", requests, want)
+	}
+}
+
+func TestConfiguredImageProviderValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pc   config.ProviderConfig
+	}{
+		{"wrong type", config.ProviderConfig{Type: config.ProviderTypeAnthropic, BaseURL: "http://localhost/v1", Model: "x"}},
+		{"missing base", config.ProviderConfig{Type: config.ProviderTypeOpenAICompat, Model: "x"}},
+		{"missing model", config.ProviderConfig{Type: config.ProviderTypeOpenAICompat, BaseURL: "http://localhost/v1"}},
+		{"full chat URL", config.ProviderConfig{Type: config.ProviderTypeOpenAICompat, BaseURL: "http://localhost/v1", URL: "http://localhost/v1/chat/completions", Model: "x"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Providers: map[string]config.ProviderConfig{"local": tc.pc}}
+			if _, err := NewImageProvider(cfg, "local"); err == nil {
+				t.Fatal("invalid configuration accepted")
+			}
+		})
+	}
+	for _, base := range []string{"localhost:8080/v1", "file:///tmp/image", "http:///v1", "https://user:secret@example.com/v1", "https://example.com/v1?key=secret", "https://example.com/v1#fragment", "http://localhost/v1?"} {
+		cfg := &config.Config{Providers: map[string]config.ProviderConfig{"local": {Type: config.ProviderTypeOpenAICompat, BaseURL: base, Model: "x"}}}
+		if _, err := NewImageProvider(cfg, "local"); err == nil {
+			t.Fatalf("invalid base URL accepted: %q", base)
+		} else if strings.Contains(err.Error(), "secret") {
+			t.Fatalf("credential leaked in error: %s", err)
+		}
+	}
+	if _, err := NewImageProvider(&config.Config{}, "unconfigured"); err == nil {
+		t.Fatal("unknown provider accepted")
+	}
+}
+
+func TestConfiguredImageProviderResolvesOnlySelectedCredentials(t *testing.T) {
+	t.Setenv("LOCAL_IMAGES_KEY", "local-test-key")
+	t.Setenv("LOCAL_IMAGES_BASE", "http://127.0.0.1:8080/v1")
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"local":  {Type: config.ProviderTypeOpenAICompat, BaseURL: "${LOCAL_IMAGES_BASE}", APIKey: "${LOCAL_IMAGES_KEY}", Model: "local"},
+		"unused": {Type: config.ProviderTypeOpenAICompat, BaseURL: "file:///nonexistent-do-not-resolve", APIKey: "file:///nonexistent-do-not-resolve", Model: "unused"},
+	}}
+	p, err := NewImageProvider(cfg, "local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp := p.(*OpenAICompatibleProvider)
+	if cp.apiKey != "local-test-key" || cp.endpoint != "http://127.0.0.1:8080/v1/images/generations" {
+		t.Fatal("selected environment config not resolved")
+	}
+}
+
+func TestConfiguredImageProviderHTTPFailureAndCancellation(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Authorization") != "Bearer test-only-key" {
+			t.Error("explicit credential not forwarded")
+		}
+		http.Error(w, `{"error":{"message":"Janus is not loaded"}}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{"local": {Type: config.ProviderTypeOpenAICompat, BaseURL: server.URL, APIKey: "test-only-key", Model: "janus"}}}
+	p, err := NewImageProvider(cfg, "local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := p.Generate(context.Background(), GenerateRequest{Prompt: "cat"})
+	if err == nil || result != nil || !strings.Contains(err.Error(), "Janus is not loaded") || calls != 1 {
+		t.Fatalf("failure was not propagated: %v %v calls=%d", result, err, calls)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if _, err = p.Generate(ctx, GenerateRequest{Prompt: "cat"}); err == nil {
+		t.Fatal("canceled request succeeded")
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("cancellation was not prompt")
+	}
+}

--- a/internal/image/provider.go
+++ b/internal/image/provider.go
@@ -160,7 +160,7 @@ func NewImageProvider(cfg *config.Config, providerOverride string) (ImageProvide
 		return NewDebugProvider(cfg.Image.Debug.Delay), nil
 
 	default:
-		return nil, fmt.Errorf("unknown image provider: %s (valid: debug, gemini, openai, chatgpt, xai, venice, flux, openrouter)", provider)
+		return newConfiguredImageProvider(cfg, provider, model)
 	}
 }
 

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -930,15 +930,34 @@ func GetImageProviderNames() []string {
 	return []string{"debug", "gemini", "openai", "chatgpt", "xai", "venice", "flux", "openrouter"}
 }
 
+func isCustomImageProvider(name string, pc config.ProviderConfig) bool {
+	return !slices.Contains(GetImageProviderNames(), name) && name != "grok" && name != "bfl" && config.InferProviderType(name, pc.Type) == config.ProviderTypeOpenAICompat
+}
+
+// GetConfiguredImageProviderNames includes named OpenAI-compatible endpoints.
+// Built-in names (and their aliases) keep their existing image configuration.
+func GetConfiguredImageProviderNames(cfg *config.Config) []string {
+	names := GetImageProviderNames()
+	if cfg != nil {
+		for name, pc := range cfg.Providers {
+			if isCustomImageProvider(name, pc) {
+				names = append(names, name)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 // GetProviderCompletions returns completions for the --provider flag
 // It handles both provider-only and provider:model completion scenarios.
-// For LLM providers, pass a config to include custom provider names.
+// Pass a config to include custom provider names and model lists.
 func GetProviderCompletions(toComplete string, isImage bool, cfg *config.Config) []string {
 	var providerNames []string
 	var getModelIDs func(string) []string
 
 	if isImage {
-		providerNames = GetImageProviderNames()
+		providerNames = GetConfiguredImageProviderNames(cfg)
 		getModelIDs = func(p string) []string { return ImageProviderModels[p] }
 	} else {
 		providerNames = GetProviderNames(cfg)
@@ -960,7 +979,7 @@ func GetProviderCompletions(toComplete string, isImage bool, cfg *config.Config)
 		var configBaseURL string
 		var configuredProviderType config.ProviderType
 		if cfg != nil {
-			if providerCfg, ok := cfg.Providers[provider]; ok {
+			if providerCfg, ok := cfg.Providers[provider]; ok && (!isImage || isCustomImageProvider(provider, providerCfg)) {
 				configModels = providerCfg.Models
 				configModel = providerCfg.Model
 				configBaseURL = providerCfg.BaseURL

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -728,3 +728,31 @@ func TestProviderCompletionsRevealEffortsProgressively(t *testing.T) {
 		})
 	}
 }
+
+func TestImageCompletionsIncludeConfiguredEndpoints(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"janus":     {Type: config.ProviderTypeOpenAICompat, Model: "Janus-Pro-1B", Models: []string{"Janus-Pro-1B", "another-image-model"}},
+		"demo":      {Type: config.ProviderTypeOpenAICompat, Model: "canned"},
+		"text-only": {Type: config.ProviderTypeAnthropic, Model: "text-model"},
+		"openai":    {Type: config.ProviderTypeOpenAICompat, Model: "not-an-image-model", Models: []string{"not-an-image-model"}},
+	}}
+	for _, name := range []string{"janus", "demo"} {
+		got := GetProviderCompletions(name, true, cfg)
+		if !containsModelID(got, name) {
+			t.Errorf("missing custom image provider %s: %v", name, got)
+		}
+	}
+	if got := GetProviderCompletions("text-only", true, cfg); len(got) != 0 {
+		t.Errorf("non-image provider offered: %v", got)
+	}
+	got := GetProviderCompletions("janus:", true, cfg)
+	for _, want := range []string{"janus:Janus-Pro-1B", "janus:another-image-model"} {
+		if !containsModelID(got, want) {
+			t.Errorf("missing %s in %v", want, got)
+		}
+	}
+	got = GetProviderCompletions("openai:", true, cfg)
+	if containsModelID(got, "openai:not-an-image-model") {
+		t.Errorf("custom text config shadows built-in image models: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Let the normal image command use named `providers` entries with `type: openai_compatible`. This provides proper local image-provider configuration rather than intercepting/replacing the CLI image command in the browser tutorial.

```yaml
providers:
  janus:
    type: openai_compatible
    base_url: http://127.0.0.1:8080/janus/v1
    model: Janus-Pro-1B
  demo:
    type: openai_compatible
    base_url: http://127.0.0.1:8080/demo/v1
    model: demo
image:
  provider: janus
```

```sh
term-llm image "A pelican riding a bike." -o pelican.png
term-llm config set image.provider demo
term-llm image "cat" -o cat.png
```

The endpoints are supplied by the user/application; this does not bundle models or a demo service. Provider selection is exclusive: Janus produces a real image or fails, never substitutes demo output. No `--generate`/`--demo` command variants.

- POST `<base_url>/images/generations`, standard OpenAI `data[].b64_json`/`url` responses.
- Optional provider-specific credentials; unrelated `OPENAI_API_KEY` is not forwarded to custom endpoints. Existing deferred credential/endpoint resolution is reused.
- No forced size unless requested, and no GPT-specific quality/output-format arguments.
- Generic adapter is explicitly generation-only; built-in providers and their editing behavior stay unchanged.
- Command/config completion and documentation include custom provider names and configured models. No new configuration schema is needed.

## Verification

- `make build` passed.
- Focused image/provider/completion regression tests passed with `-race`.
- `go vet ./...` and `git diff --check` passed.
- Real built CLI smoke: changed only `image.provider`, saved exact fixture outputs from two local Images API endpoints, and verified failed Janus requests write no fallback image.
- **Actual native CLI → local Images API → shared-browser Janus WebGPU** also passed: a real **384×384 PNG**, 57,048 bytes, generated/saved in about 7.8 seconds after loading. The same native command used the explicitly selected demo provider separately; unloading Janus made the Janus request fail without writing an image. This was a host-native CLI integration experiment, not yet the v86 tutorial deployment.

Full `go test ./...` ran: all packages except `internal/serveui` passed. Its unchanged `TestProductionBundleSizeBudgets` rejects the built frontend gzip size: **146,221 bytes vs 142,500-byte budget** (`app.js` raw 499,955 bytes). No frontend or bundle-budget source is changed here; the failure is left visible rather than widening an unrelated limit.

The tutorial can replace its image-command wrapper with this stock functionality after merge. No tutorial deployment or production protection settings are changed by this PR.
