### PR TITLE
Fix MCP discovery in the ask runner handoff

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -863,6 +863,7 @@ func runAsk(cmd *cobra.Command, args []string) error {
 		DisableExternalWebFetch:     askNoWebFetch,
 		ExtraTools:                  append([]llm.ToolSpec(nil), req.Tools...),
 		IncludeConfiguredTools:      &includeConfiguredTools,
+		EnableToolDiscovery:         req.EnableToolDiscovery,
 		OnAssistantSnapshot:         assistantSnapshotCallback,
 		OnResponseCompleted:         responseCompletedCallback,
 		OnTurnCompleted:             turnCompletedCallback,

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -421,7 +421,7 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 		Tools:                    toolSpecs,
 		ToolChoice:               toolChoice,
 		LastTurnToolChoice:       lastTurnToolChoice,
-		EnableToolDiscovery:      strings.TrimSpace(settings.MCP) != "",
+		EnableToolDiscovery:      req.EnableToolDiscovery || strings.TrimSpace(settings.MCP) != "",
 		ParallelToolCalls:        true,
 		Search:                   settings.Search,
 		ForceExternalSearch:      forceExternalSearch,

--- a/cmd/runner_test.go
+++ b/cmd/runner_test.go
@@ -296,3 +296,76 @@ func TestCmdRunnerPrepareUsesBorrowedEngineProvider(t *testing.T) {
 		t.Fatal("borrowed engine should preserve provider conversation state")
 	}
 }
+
+// cmdRunnerDiscoveryPlanner stands in for a connected MCP planner: its schema
+// is deliberately absent from the engine's static registry.
+type cmdRunnerDiscoveryPlanner struct {
+	llm.ToolSurfacePlanner
+}
+
+func (*cmdRunnerDiscoveryPlanner) BeginRun(_ context.Context, _ llm.Provider, req *llm.Request, _ string) (string, error) {
+	req.Tools = append(req.Tools, llm.ToolSpec{Name: "mcp_status", Description: "Read MCP status", Schema: map[string]any{"type": "object"}})
+	return "", nil
+}
+
+func (*cmdRunnerDiscoveryPlanner) PrepareTurn(context.Context, llm.Provider, *llm.Request, string, int, int) (string, error) {
+	return "", nil
+}
+
+func (*cmdRunnerDiscoveryPlanner) EndRun(string) {}
+
+func TestCmdRunnerBorrowedEngineDiscovery(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		configuredTools   bool
+		explicitDiscovery bool
+		wantTool          bool
+	}{
+		{name: "ask handoff", explicitDiscovery: true, wantTool: true},
+		{name: "auxiliary request stays tool free"},
+		{name: "configured MCP still enables discovery", configuredTools: true, wantTool: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{DefaultProvider: "mock", Providers: map[string]config.ProviderConfig{"mock": {Model: "mock-model"}}}
+			provider := llm.NewMockProvider("mock").AddTextResponse("ok")
+			engine := newEngine(provider, cfg)
+			engine.SetToolSurfacePlanner(&cmdRunnerDiscoveryPlanner{})
+			runner := newCmdRunner(cfg, cmdRunnerOptions{}).(*cmdRunner)
+			_, err := runner.Run(context.Background(), runpkg.Request{
+				Platform:               runpkg.PlatformConsole,
+				Messages:               []llm.Message{llm.UserText("check status")},
+				Engine:                 engine,
+				ProviderInstance:       provider,
+				Cwd:                    t.TempDir(),
+				DeferSession:           true,
+				MCP:                    "already-connected",
+				NoSearch:               true,
+				IncludeConfiguredTools: &tc.configuredTools,
+				EnableToolDiscovery:    tc.explicitDiscovery,
+			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			requests := provider.RecordedRequests()
+			if len(requests) != 1 {
+				t.Fatalf("provider requests = %d, want 1", len(requests))
+			}
+			found := false
+			for _, tool := range requests[0].Tools {
+				found = found || tool.Name == "mcp_status"
+			}
+			if found != tc.wantTool {
+				t.Fatalf("MCP tool visible = %v, want %v; provider tools = %+v", found, tc.wantTool, requests[0].Tools)
+			}
+			if !tc.configuredTools {
+				wantCount := 0
+				if tc.wantTool {
+					wantCount = 1
+				}
+				if len(requests[0].Tools) != wantCount {
+					t.Fatalf("unexpected configured tools: %+v", requests[0].Tools)
+				}
+			}
+		})
+	}
+}

--- a/internal/run/types.go
+++ b/internal/run/types.go
@@ -104,6 +104,10 @@ type Request struct {
 	LastTurnForceToolName   string
 	IncludeConfiguredTools  *bool
 
+	// EnableToolDiscovery opts into an already-installed engine planner without
+	// loading configured tools or opening another MCP connection.
+	EnableToolDiscovery bool
+
 	OnAssistantSnapshot    llm.AssistantSnapshotCallback
 	OnResponseCompleted    llm.ResponseCompletedCallback
 	OnTurnCompleted        llm.TurnCompletedCallback

--- a/internal/tui/chat/streaming.go
+++ b/internal/tui/chat/streaming.go
@@ -964,6 +964,7 @@ func (m *Model) startStream(content string) tea.Cmd {
 					DisableExternalWebFetch:   m.disableExternalWebFetch,
 					ExtraTools:                reqTools,
 					IncludeConfiguredTools:    &includeConfiguredTools,
+					EnableToolDiscovery:       req.EnableToolDiscovery,
 					ServiceTier:               serviceTier,
 					ServiceTierSet:            serviceTierSet,
 					OnAssistantSnapshot:       assistantSnapshotCB,

--- a/internal/tui/chat/streaming_test.go
+++ b/internal/tui/chat/streaming_test.go
@@ -12,9 +12,11 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/mcp"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/runboundary"
 	"github.com/samsaffron/term-llm/internal/session"
+	"github.com/samsaffron/term-llm/internal/tooldiscovery"
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
@@ -1358,4 +1360,43 @@ func TestBeginUserResponseKeepsRunClockSeparateFromGoalElapsed(t *testing.T) {
 
 func withinGoalSeedTolerance(got, want time.Duration) bool {
 	return got >= want-2*time.Second && got <= want+2*time.Second
+}
+
+func TestRunnerStreamPropagatesDiscoveryOptIn(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		name := "without planner"
+		if enabled {
+			name = "with planner"
+		}
+		t.Run(name, func(t *testing.T) {
+			m := newTestChatModel(false)
+			if enabled {
+				planner, err := tooldiscovery.NewPlanner(m.config.ToolDiscovery, mcp.NewManagerWithConfig(&mcp.Config{}), m.engine)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.discoveryPlanner = planner
+			}
+			runner := &capturingChatRunner{requests: make(chan runpkg.Request, 1)}
+			m.SetRunner(runner)
+			done := make(chan any, 1)
+			go func() { done <- m.startStream("check status")() }()
+			select {
+			case req := <-runner.requests:
+				if req.EnableToolDiscovery != enabled {
+					t.Errorf("EnableToolDiscovery = %v, want %v", req.EnableToolDiscovery, enabled)
+				}
+				if req.IncludeConfiguredTools == nil || *req.IncludeConfiguredTools {
+					t.Error("chat must not reload configured tools")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("runner did not receive request")
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("stream command did not finish")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`term-llm ask --mcp ...` successfully connected and reported **10 MCP tools**, but Astra received **zero tools**. `ask` borrows its already-configured engine while disabling configured-tool loading in the shared runner. That correctly avoids duplicate setup, but also clears the MCP setting from which the runner reconstructed `EnableToolDiscovery`. Deferred MCP schemas are not present in the static tool registry, so forwarding `ExtraTools` cannot recover them.

## Fix

- Carry an explicit `EnableToolDiscovery` opt-in through the shared run request, independently of configured-tool loading.
- Forward `ask`'s existing discovery decision into its runner request (also used by progressive execution).
- Keep configured MCP behavior unchanged, without opening a second connection.
- Leave auxiliary borrowed-engine requests tool-free unless they explicitly opt in.

## Verification

- Provider-facing regression: the explicit handoff case fails before the runner fix (`provider tools = []`) and passes afterward. Also covers auxiliary-request isolation and configured MCP discovery.
- Isolated `go test -race ./cmd -run '^TestCmdRunner' -count=1`: pass.
- `mise x node@24 -- make build`: pass.
- `go vet ./...`: pass.
- Isolated `go test ./...`: all packages pass except the unchanged frontend bundle budget test: app.js gzip **146,221 bytes**, budget **142,500 bytes**. No frontend or serveui files changed. An initial non-isolated runner test also picked up local skills; the isolated run passes.
- Actual fixed CLI with `chatgpt:gpt-6-astra-medium`, no built-in tools, and OAuth-authenticated HTTPS MCP: **one successful `computer_status` call**, followed by the correct `approve` mode response. The live server is a private disposable lab; no credentials or transcripts included.

No service deployment or running-binary replacement.
