### PR TITLE
Accept arbitrary web uploads independently of model support

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -595,7 +595,7 @@ func (s *serveServer) handleFile(w http.ResponseWriter, r *http.Request) {
 // ensureFileServeable makes the given file available from the configured
 // files-dir when it already comes from an approved source directory. Approved
 // sources are: the files-dir itself, the image output directory, the uploads
-// directory used by saveUploadedFile, and any directory granted to tools via
+// directory used by saveUploadedBytes, and any directory granted to tools via
 // --write-dir or cfg.Tools.WriteDirs. Tool output in those locations is
 // operator- or server-sanctioned, so republishing it under /files/ respects
 // the documented --files-dir contract while still blocking tool results that
@@ -724,7 +724,7 @@ func (s *serveServer) ensureFileServeable(filePath string) (string, bool) {
 // ensureImageServeable makes the given image path servable via /images/ by
 // copying it into the configured image output directory when the source is
 // already under an approved location (image output dir itself, the uploads
-// dir used by saveUploadedFile, or any operator-granted tool write-dir).
+// dir used by saveUploadedBytes, or any operator-granted tool write-dir).
 // Tool-reported paths outside every approved dir are rejected so arbitrary
 // host files can't be republished through /images/. Returns the serveable
 // path and true on success, or ("", false) otherwise.
@@ -864,7 +864,7 @@ func (s *serveServer) ensureImageServeable(imgPath string) (string, bool) {
 }
 
 // serveUploadsDir returns the first-party uploads directory used by
-// saveUploadedFile. Returns empty string if the data dir is unavailable.
+// saveUploadedBytes. Returns empty string if the data dir is unavailable.
 func serveUploadsDir() string {
 	dataDir, err := session.GetDataDir()
 	if err != nil {

--- a/cmd/serve_projects.go
+++ b/cmd/serve_projects.go
@@ -393,8 +393,8 @@ func (s *serveServer) handleCapabilities(w http.ResponseWriter, r *http.Request)
 		"attachments": map[string]any{
 			"max_count":  maxAttachments,
 			"max_bytes":  maxAttachmentBytes,
-			"mime_types": attachmentMediaTypes(),
-			"extensions": attachmentExtensions(),
+			"mime_types": []string{"*/*"},
+			"extensions": []string{},
 		},
 	}
 	if attention, ok := session.AsAttentionStore(s.store); ok {

--- a/cmd/serve_protocol.go
+++ b/cmd/serve_protocol.go
@@ -16,7 +16,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -132,47 +131,6 @@ const (
 	maxAttachmentBytes = 20 << 20 // 20 MB per file (decoded)
 )
 
-var supportedAttachmentExtensions = map[string]struct{}{
-	".jpg": {}, ".jpeg": {}, ".png": {}, ".gif": {}, ".webp": {}, ".pdf": {},
-	".txt": {}, ".md": {}, ".markdown": {}, ".json": {}, ".csv": {}, ".yaml": {},
-	".yml": {}, ".xml": {}, ".go": {}, ".js": {}, ".jsx": {}, ".ts": {}, ".tsx": {},
-	".py": {}, ".rb": {}, ".rs": {}, ".java": {}, ".c": {}, ".h": {}, ".cpp": {},
-	".hpp": {}, ".mp3": {}, ".wav": {}, ".ogg": {}, ".mp4": {}, ".webm": {},
-}
-
-var supportedAttachmentMediaTypes = map[string]struct{}{
-	"image/jpeg": {}, "image/png": {}, "image/gif": {}, "image/webp": {},
-	"application/pdf": {}, "text/plain": {}, "text/markdown": {}, "application/json": {},
-	"text/csv": {}, "audio/mpeg": {}, "audio/wav": {}, "audio/ogg": {},
-	"video/mp4": {}, "video/webm": {},
-}
-
-func attachmentMediaTypes() []string {
-	values := make([]string, 0, len(supportedAttachmentMediaTypes))
-	for value := range supportedAttachmentMediaTypes {
-		values = append(values, value)
-	}
-	sort.Strings(values)
-	return values
-}
-
-func attachmentExtensions() []string {
-	values := make([]string, 0, len(supportedAttachmentExtensions))
-	for value := range supportedAttachmentExtensions {
-		values = append(values, value)
-	}
-	sort.Strings(values)
-	return values
-}
-
-func supportedAttachment(filename, mediaType string) bool {
-	if _, ok := supportedAttachmentExtensions[strings.ToLower(filepath.Ext(filename))]; ok {
-		return true
-	}
-	_, ok := supportedAttachmentMediaTypes[llm.NormalizeMediaType(mediaType)]
-	return ok
-}
-
 func stripBase64Newlines(b64Data string) string {
 	if !strings.ContainsAny(b64Data, "\r\n") {
 		return b64Data
@@ -213,17 +171,6 @@ func decodeUploadedFile(filename, b64Data string) ([]byte, error) {
 		return nil, fmt.Errorf("decode base64: %w", err)
 	}
 	return raw[:n], nil
-}
-
-// saveUploadedFile decodes base64 data and writes it to the uploads directory,
-// returning the full filesystem path. The final filename includes a random suffix
-// created atomically by os.CreateTemp.
-func saveUploadedFile(filename, b64Data string) (string, error) {
-	raw, err := decodeUploadedFile(filename, b64Data)
-	if err != nil {
-		return "", err
-	}
-	return saveUploadedBytes(filename, raw)
 }
 
 func uploadFilenameForMediaType(prefix, mediaType string) string {
@@ -316,14 +263,17 @@ func normalizeUploadMediaType(filename, mediaType string, raw []byte) string {
 	if mediaType == "application/octet-stream" && isTextUploadExtension(filename) && !bytes.Contains(raw, []byte{0}) && utf8.Valid(raw) {
 		mediaType = "text/plain"
 	}
+	if mediaType == "" {
+		mediaType = "application/octet-stream"
+	}
 	return mediaType
 }
 
-func uploadFallbackText(filename, mediaType string, raw []byte) string {
+func uploadFallbackText(filename, mediaType, path string, raw []byte) string {
 	if text, ok := textUploadContent(filename, mediaType, raw); ok {
 		return llm.FormatEmbeddedFileText(filename, mediaType, text)
 	}
-	return fmt.Sprintf("[User uploaded file: %s — saved locally]\n\n", llm.EmbeddedFileDisplayName(filename))
+	return llm.FormatUploadedFileNotice(filename, mediaType, path, int64(len(raw)))
 }
 
 func textUploadContent(filename, mediaType string, raw []byte) (string, bool) {
@@ -670,23 +620,15 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 						ImagePath: path,
 					})
 				} else {
-					if !supportedAttachment(filename, mt) {
-						return llm.Message{}, fmt.Errorf("unsupported attachment type %q for %q", mt, filename)
-					}
 					fileCount++
 					if fileCount > maxAttachments {
 						return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
 					}
-					if filename == "" {
-						filename = "image"
+					filePart, err := parseUploadedFilePart(filename, mt, b64)
+					if err != nil {
+						return llm.Message{}, err
 					}
-					if _, err := saveUploadedFile(filename, b64); err != nil {
-						return llm.Message{}, fmt.Errorf("save attachment %q: %w", filename, err)
-					}
-					llmParts = append(llmParts, llm.Part{
-						Type: llm.PartText,
-						Text: fmt.Sprintf("[User uploaded file: %s — saved locally]\n\n", llm.EmbeddedFileDisplayName(filename)),
-					})
+					llmParts = append(llmParts, filePart)
 				}
 			case "input_file":
 				fileData := jsonString(part["file_data"])
@@ -707,30 +649,11 @@ func parseUserMessageContent(content json.RawMessage) (llm.Message, error) {
 				if fileCount > maxAttachments {
 					return llm.Message{}, fmt.Errorf("too many attachments (max %d)", maxAttachments)
 				}
-				cleanB64 := stripBase64Newlines(b64)
-				raw, err := decodeUploadedFile(displayFilename, cleanB64)
+				filePart, err := parseUploadedFilePart(displayFilename, mt, b64)
 				if err != nil {
-					return llm.Message{}, fmt.Errorf("decode attachment %q: %w", displayFilename, err)
+					return llm.Message{}, err
 				}
-				mt = normalizeUploadMediaType(displayFilename, mt, raw)
-				if !supportedAttachment(displayFilename, mt) {
-					return llm.Message{}, fmt.Errorf("unsupported attachment type %q for %q", mt, displayFilename)
-				}
-				path, err := saveUploadedBytes(displayFilename, raw)
-				if err != nil {
-					return llm.Message{}, fmt.Errorf("save attachment %q: %w", displayFilename, err)
-				}
-				llmParts = append(llmParts, llm.Part{
-					Type: llm.PartFile,
-					Text: uploadFallbackText(displayFilename, mt, raw),
-					FileData: &llm.ToolFileData{
-						MediaType: mt,
-						Base64:    cleanB64,
-						Filename:  displayFilename,
-						SizeBytes: int64(len(raw)),
-					},
-					FilePath: path,
-				})
+				llmParts = append(llmParts, filePart)
 			}
 		}
 		if len(llmParts) > 0 {
@@ -935,4 +858,26 @@ func randomSuffix() string {
 		return fmt.Sprintf("%d", time.Now().UnixNano())
 	}
 	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// parseUploadedFilePart stores any file independently of provider comprehension.
+// Providers decide whether FileData can travel natively; Text is the safe fallback.
+func parseUploadedFilePart(filename, mediaType, b64 string) (llm.Part, error) {
+	filename = llm.EmbeddedFileDisplayName(filename)
+	b64 = stripBase64Newlines(b64)
+	raw, err := decodeUploadedFile(filename, b64)
+	if err != nil {
+		return llm.Part{}, fmt.Errorf("decode attachment %q: %w", filename, err)
+	}
+	mediaType = normalizeUploadMediaType(filename, mediaType, raw)
+	path, err := saveUploadedBytes(filename, raw)
+	if err != nil {
+		return llm.Part{}, fmt.Errorf("save attachment %q: %w", filename, err)
+	}
+	return llm.Part{
+		Type:     llm.PartFile,
+		Text:     uploadFallbackText(filename, mediaType, path, raw),
+		FileData: &llm.ToolFileData{MediaType: mediaType, Base64: b64, Filename: filename, SizeBytes: int64(len(raw))},
+		FilePath: path,
+	}, nil
 }

--- a/cmd/serve_protocol_test.go
+++ b/cmd/serve_protocol_test.go
@@ -463,3 +463,107 @@ func marshalInlineImageParts(t *testing.T, count int) json.RawMessage {
 	}
 	return content
 }
+
+func TestArbitraryUploadsPreserveFallbackAndReplay(t *testing.T) {
+	for _, tc := range []struct {
+		name, mime, kind string
+		raw              []byte
+	}{
+		{"archive.zip", "application/zip", "input_file", []byte{'P', 'K', 3, 4, 0, 255}},
+		{"unknown.weird", "application/x-unknown", "input_file", []byte{0, 255, 1, 128}},
+		{"binary", "", "input_file", []byte{0, 255, 1, 128}},
+		{"icon.svg", "image/svg+xml", "input_image", []byte("<svg></svg>")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_DATA_HOME", t.TempDir())
+			key := "file_data"
+			if tc.kind == "input_image" {
+				key = "image_url"
+			}
+			content, _ := json.Marshal([]map[string]string{{"type": tc.kind, "filename": "../../" + tc.name, key: "data:" + tc.mime + ";base64," + base64.StdEncoding.EncodeToString(tc.raw)}})
+			msg, err := parseUserMessageContent(content)
+			if err != nil {
+				t.Fatal(err)
+			}
+			part := msg.Parts[0]
+			if part.Type != llm.PartFile || part.FileData == nil || part.FileData.Filename != tc.name || part.FileData.SizeBytes != int64(len(tc.raw)) {
+				t.Fatalf("part = %+v", part)
+			}
+			if !pathWithinDir(part.FilePath, serveUploadsDir()) {
+				t.Fatalf("unsafe path: %s", part.FilePath)
+			}
+			raw, err := os.ReadFile(part.FilePath)
+			if err != nil || !bytes.Equal(raw, tc.raw) {
+				t.Fatalf("saved bytes = %v, err = %v", raw, err)
+			}
+			info, _ := os.Stat(part.FilePath)
+			if info.Mode().Perm() != 0600 {
+				t.Fatalf("permissions = %o", info.Mode().Perm())
+			}
+			for _, text := range []string{tc.name, part.FilePath, part.FileData.MediaType, fmt.Sprintf("%d bytes", len(tc.raw)), "Contents are not included"} {
+				if !strings.Contains(part.Text, text) {
+					t.Fatalf("fallback %q missing %q", part.Text, text)
+				}
+			}
+			if strings.Contains(part.Text, string(tc.raw)) {
+				t.Fatalf("raw contents embedded: %q", part.Text)
+			}
+			stored := session.NewMessage("upload-test", msg, 0)
+			encoded, err := stored.PartsJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var replay session.Message
+			if err := replay.SetPartsFromJSON(encoded); err != nil {
+				t.Fatal(err)
+			}
+			if replay.Parts[0].Text != part.Text || replay.Parts[0].FilePath != part.FilePath || replay.Parts[0].FileData.Base64 != part.FileData.Base64 {
+				t.Fatal("lost file on replay")
+			}
+			for _, policy := range []llm.FileUploadPolicy{llm.DefaultOpenAIResponsesFileUploadPolicy(), llm.DefaultPortableTextFileUploadPolicy()} {
+				input := llm.BuildResponsesInputWithFilePolicy([]llm.Message{{Role: llm.RoleUser, Parts: replay.Parts}}, &policy)
+				if len(input) != 1 || input[0].Content != part.Text {
+					t.Fatalf("provider payload = %#v", input)
+				}
+			}
+			// Retrying an interjection creates a different saved path, not a different request.
+			retry, err := parseUserMessageContent(content)
+			if err != nil {
+				t.Fatal(err)
+			}
+			first, err := steeringFingerprint(msg, "", interruptDelivery(""))
+			if err != nil {
+				t.Fatal(err)
+			}
+			second, err := steeringFingerprint(retry, "", interruptDelivery(""))
+			if err != nil || first != second {
+				t.Fatalf("unstable retry fingerprint: %v", err)
+			}
+		})
+	}
+}
+
+func TestArbitraryUploadsKeepValidationLimits(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	for _, tc := range []struct {
+		name, data, want string
+		count            int
+	}{
+		{"count", "AP8BgA==", "too many attachments", maxAttachments + 1},
+		{"size", strings.Repeat("AAAA", (maxAttachmentBytes/3)+1), "exceeds 20 MB limit", 1},
+		{"base64", "!!!!", "decode base64", 1},
+		{"empty", "", "empty or malformed", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := make([]map[string]string, tc.count)
+			for i := range parts {
+				parts[i] = map[string]string{"type": "input_file", "filename": "binary.weird", "file_data": "data:application/octet-stream;base64," + tc.data}
+			}
+			content, _ := json.Marshal(parts)
+			_, err := parseUserMessageContent(content)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -692,6 +692,10 @@ func steeringFingerprint(msg llm.Message, displayText string, delivery interrupt
 	for i := range parts {
 		// Parsing inline attachments can materialize them at a fresh temporary path
 		// on each transport retry. The content fields are the stable identity.
+		if file := parts[i].FileData; parts[i].Type == llm.PartFile && file != nil &&
+			parts[i].Text == llm.FormatUploadedFileNotice(file.Filename, file.MediaType, parts[i].FilePath, file.SizeBytes) {
+			parts[i].Text = llm.FormatUploadedFileNotice(file.Filename, file.MediaType, "", file.SizeBytes)
+		}
 		parts[i].ImagePath = ""
 		parts[i].FilePath = ""
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1563,9 +1563,9 @@ func TestParseResponsesInput_FileUploadSavesToDisk(t *testing.T) {
 	if perm := info.Mode().Perm(); perm&0o077 != 0 {
 		t.Fatalf("file permissions = %o, want no group/other access", perm)
 	}
-	// Verify prompt fallback does not leak the upload storage path.
-	if strings.Contains(msg.Parts[0].Text, dataHome) || strings.Contains(msg.Parts[0].Text, entries[0].Name()) {
-		t.Fatalf("parts[0].text leaks upload path: %q", msg.Parts[0].Text)
+	// Non-native fallback must expose a usable saved path to tools.
+	if !strings.Contains(msg.Parts[0].Text, msg.Parts[0].FilePath) {
+		t.Fatalf("parts[0].text missing upload path: %q", msg.Parts[0].Text)
 	}
 }
 
@@ -1604,20 +1604,6 @@ func TestParseResponsesInput_TextFileUploadEmbedsFallback(t *testing.T) {
 	}
 }
 
-func TestParseResponsesInput_UnsupportedImageIsRejected(t *testing.T) {
-	// image/svg+xml is not a supported LLM image type and must fail at the
-	// protocol boundary instead of silently changing into a saved-file prompt.
-	b64 := "PHN2Zz48L3N2Zz4=" // base64 of "<svg></svg>"
-	payload := json.RawMessage(`[
-		{"type":"message","role":"user","content":[
-			{"type":"input_image","image_url":"data:image/svg+xml;base64,` + b64 + `","filename":"icon.svg"}
-		]}
-	]`)
-	_, _, err := parseResponsesInput(payload)
-	if err == nil || !strings.Contains(err.Error(), `unsupported attachment type "image/svg+xml"`) {
-		t.Fatalf("parseResponsesInput error = %v, want unsupported attachment type", err)
-	}
-}
 func TestParseResponsesInput_InvalidBase64ReturnsError(t *testing.T) {
 
 	payload := json.RawMessage(`[

--- a/frontend/src/domain/attachments.test.ts
+++ b/frontend/src/domain/attachments.test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_ATTACHMENT_POLICY, attachmentAccept, validateAttachmentFile } f
 const file = (name: string, type: string, size: number) => ({ name, type, size }) as File;
 
 describe('attachment selection policy', () => {
-  it('rejects empty, oversized, unsupported, and excess files at selection', () => {
+  it('rejects empty, oversized, and excess files at selection', () => {
     expect(
       validateAttachmentFile(file('empty.txt', 'text/plain', 0), 0, DEFAULT_ATTACHMENT_POLICY)
         ?.code,
@@ -16,9 +16,6 @@ describe('attachment selection policy', () => {
         DEFAULT_ATTACHMENT_POLICY,
       )?.code,
     ).toBe('too_large');
-    expect(validateAttachmentFile(file('bad.exe', '', 1), 0, DEFAULT_ATTACHMENT_POLICY)?.code).toBe(
-      'unsupported',
-    );
     expect(
       validateAttachmentFile(
         file('ok.txt', 'text/plain', 1),
@@ -32,6 +29,15 @@ describe('attachment selection policy', () => {
     expect(
       validateAttachmentFile(file('source.go', '', 10), 0, DEFAULT_ATTACHMENT_POLICY),
     ).toBeNull();
-    expect(attachmentAccept(DEFAULT_ATTACHMENT_POLICY)).toContain('.go');
+    expect(attachmentAccept(DEFAULT_ATTACHMENT_POLICY)).toBe('');
   });
+});
+
+it.each([
+  ['archive.zip', 'application/zip'],
+  ['unknown.weird', 'application/x-unknown'],
+  ['binary', ''],
+  ['icon.svg', 'image/svg+xml'],
+])('accepts arbitrary upload %s', (name, type) => {
+  expect(validateAttachmentFile(file(name, type, 123), 0, DEFAULT_ATTACHMENT_POLICY)).toBeNull();
 });

--- a/frontend/src/domain/attachments.ts
+++ b/frontend/src/domain/attachments.ts
@@ -8,56 +8,8 @@ export interface AttachmentPolicy {
 export const DEFAULT_ATTACHMENT_POLICY: AttachmentPolicy = Object.freeze({
   maxCount: 10,
   maxBytes: 20 * 1024 * 1024,
-  mimeTypes: [
-    'image/jpeg',
-    'image/png',
-    'image/gif',
-    'image/webp',
-    'application/pdf',
-    'text/plain',
-    'text/markdown',
-    'application/json',
-    'text/csv',
-    'audio/mpeg',
-    'audio/wav',
-    'audio/ogg',
-    'video/mp4',
-    'video/webm',
-  ],
-  extensions: [
-    '.jpg',
-    '.jpeg',
-    '.png',
-    '.gif',
-    '.webp',
-    '.pdf',
-    '.txt',
-    '.md',
-    '.markdown',
-    '.json',
-    '.csv',
-    '.yaml',
-    '.yml',
-    '.xml',
-    '.go',
-    '.js',
-    '.jsx',
-    '.ts',
-    '.tsx',
-    '.py',
-    '.rb',
-    '.rs',
-    '.java',
-    '.c',
-    '.h',
-    '.cpp',
-    '.hpp',
-    '.mp3',
-    '.wav',
-    '.ogg',
-    '.mp4',
-    '.webm',
-  ],
+  mimeTypes: ['*/*'],
+  extensions: [],
 });
 
 export interface AttachmentValidationError {
@@ -89,7 +41,11 @@ export function validateAttachmentFile(
     };
   const mime = file.type.toLowerCase();
   const extension = attachmentExtension(file.name);
-  if (!policy.mimeTypes.includes(mime) && !policy.extensions.includes(extension))
+  if (
+    !policy.mimeTypes.includes('*/*') &&
+    !policy.mimeTypes.includes(mime) &&
+    !policy.extensions.includes(extension)
+  )
     return {
       code: 'unsupported',
       message: `${file.name}: this file type is not supported.`,
@@ -98,5 +54,11 @@ export function validateAttachmentFile(
 }
 
 export function attachmentAccept(policy: AttachmentPolicy): string {
+  if (policy.mimeTypes.includes('*/*')) return '';
   return [...new Set([...policy.mimeTypes, ...policy.extensions])].join(',');
+}
+
+// Only these formats are prepared and sent as native model images.
+export function isNativeImageType(type: string): boolean {
+  return ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].includes(type.toLowerCase());
 }

--- a/frontend/src/stores/composer-store.test.ts
+++ b/frontend/src/stores/composer-store.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import * as draftBlobs from '../platform/draft-blobs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readDrafts, saveDraft } from '../platform/storage';
 import { AppStore } from './app-store';
 import { testConfig, testSession } from './store-test-fixtures';
@@ -87,4 +88,45 @@ describe('ComposerStore', () => {
       store.dispose();
     }
   });
+});
+
+it.each([
+  ['archive.zip', 'application/zip', 'input_file'],
+  ['unknown.weird', 'application/octet-stream', 'input_file'],
+  ['icon.svg', 'image/svg+xml', 'input_file'],
+  ['scan.tiff', 'image/tiff', 'input_file'],
+  ['photo.png', 'image/png', 'input_image'],
+])('serializes %s with the appropriate content type', async (name, type, expected) => {
+  const store = new AppStore(testConfig);
+  try {
+    const dataURL = `data:${type};base64,AAH/`;
+    const input = await store.composer.attachmentInput({ name, type, dataURL, status: 'ready' });
+    expect(input.type).toBe(expected);
+    expect(input[expected === 'input_image' ? 'image_url' : 'file_data']).toBe(dataURL);
+    expect(input.filename).toBe(name);
+    expect(store.composer.attachmentAccept.value).toBe('');
+  } finally {
+    store.dispose();
+  }
+});
+
+it.each([
+  ['archive.zip', 'application/zip'],
+  ['unknown.weird', ''],
+  ['scan.tiff', 'image/tiff'],
+])('prepares arbitrary %s bytes without trying to decode an image', async (name, type) => {
+  vi.spyOn(draftBlobs, 'blobChecksum').mockResolvedValue('test-checksum');
+  const store = new AppStore(testConfig);
+  try {
+    store.composer.addAttachments([new File([new Uint8Array([0, 255, 1, 128])], name, { type })]);
+    await vi.waitFor(() => expect(store.composer.attachments.value[0]?.status).toBe('ready'));
+    const attachment = store.composer.attachments.value[0]!;
+    expect(attachment.previewURL).toBeFalsy();
+    expect(attachment.size).toBe(4);
+    const input = await store.composer.attachmentInput(attachment);
+    expect(input.type).toBe('input_file');
+    expect(String(input.file_data)).toMatch(/;base64,AP8BgA==$/);
+  } finally {
+    store.dispose();
+  }
 });

--- a/frontend/src/stores/composer-store.ts
+++ b/frontend/src/stores/composer-store.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ATTACHMENT_POLICY,
   attachmentAccept,
   validateAttachmentFile,
+  isNativeImageType,
   type AttachmentPolicy,
 } from '../domain/attachments';
 import { blobChecksum, blobToDataURL, DraftBlobStore } from '../platform/draft-blobs';
@@ -241,7 +242,7 @@ export class ComposerStore {
       throw new Error(attachment.error || `${attachment.name} is not ready to send.`);
     const data = attachment.dataURL || attachment.url || '';
     if (!data) throw new Error(`Could not materialize ${attachment.name}`);
-    if (attachment.type.startsWith('image/'))
+    if (isNativeImageType(attachment.type))
       return {
         type: 'input_image',
         image_url: data,
@@ -296,7 +297,7 @@ export class ComposerStore {
       this.updateAttachment(attachmentId, { progress: 0.5 });
       let width: number | undefined;
       let height: number | undefined;
-      if (source.type.startsWith('image/')) {
+      if (isNativeImageType(source.type)) {
         previewURL = URL.createObjectURL(source);
         const dimensions = await new Promise<{ width: number; height: number }>(
           (resolve, reject) => {
@@ -381,7 +382,7 @@ export class ComposerStore {
         return;
       }
       const dataURL = await blobToDataURL(record.blob);
-      const previewURL = record.mime.startsWith('image/')
+      const previewURL = isNativeImageType(record.mime)
         ? URL.createObjectURL(record.blob)
         : undefined;
       if (!owns()) {

--- a/internal/llm/file_embed.go
+++ b/internal/llm/file_embed.go
@@ -153,3 +153,17 @@ func ExtractEmbeddedFileNames(content string) []string {
 	}
 	return names
 }
+
+// FormatUploadedFileNotice describes an upload without embedding its contents.
+// The local path lets tools inspect files the model cannot consume natively.
+func FormatUploadedFileNotice(filename, mediaType, localPath string, sizeBytes int64) string {
+	mediaType = NormalizeMediaType(mediaType)
+	if mediaType == "" {
+		mediaType = "application/octet-stream"
+	}
+	notice := fmt.Sprintf("[User uploaded file: %q (MIME type: %q, size: %d bytes). Contents are not included in model context.", EmbeddedFileDisplayName(filename), mediaType, sizeBytes)
+	if localPath != "" {
+		notice += fmt.Sprintf(" Saved local path: %q. Use available file or shell tools to inspect it.", localPath)
+	}
+	return notice + "]\n\n"
+}

--- a/internal/llm/responses_api.go
+++ b/internal/llm/responses_api.go
@@ -675,14 +675,7 @@ func responseFileTextFallback(part Part, policy *FileUploadPolicy) string {
 	if active.AllowsTextEmbed(part.FileData.MediaType, toolFileSizeBytes(part.FileData)) {
 		return part.Text
 	}
-	filename := strings.TrimSpace(part.FileData.Filename)
-	if filename == "" {
-		filename = "upload"
-	}
-	if part.FilePath != "" {
-		return "[User uploaded file: " + filename + " — saved locally]\n\n"
-	}
-	return "[User uploaded file: " + filename + "]\n\n"
+	return FormatUploadedFileNotice(part.FileData.Filename, part.FileData.MediaType, part.FilePath, toolFileSizeBytes(part.FileData))
 }
 
 func buildResponsesAssistantItems(parts []Part) []ResponsesInputItem {

--- a/internal/llm/responses_api_test.go
+++ b/internal/llm/responses_api_test.go
@@ -3029,3 +3029,28 @@ func TestResponsesClient_OnAuthRetry_UsesJSONErrorMessageAfterReauth(t *testing.
 		t.Fatalf("unexpected re-authentication error:\n got: %q\nwant: %q", err.Error(), want)
 	}
 }
+
+func TestBuildResponsesInput_FileFallbackIncludesPathAndMetadata(t *testing.T) {
+	for _, mediaType := range []string{"application/zip", "application/x-unknown", "application/pdf"} {
+		t.Run(mediaType, func(t *testing.T) {
+			policy := DefaultPortableTextFileUploadPolicy()
+			part := Part{Type: PartFile, Text: "legacy fallback without a path", FilePath: "/tmp/uploads/user-file", FileData: &ToolFileData{Filename: "user-file", MediaType: mediaType, Base64: "AP8BgA==", SizeBytes: 4}}
+			input := BuildResponsesInputWithFilePolicy([]Message{{Role: RoleUser, Parts: []Part{part}}}, &policy)
+			if len(input) != 1 {
+				t.Fatalf("input = %#v", input)
+			}
+			text, ok := input[0].Content.(string)
+			if !ok {
+				t.Fatalf("unsupported native payload: %#v", input)
+			}
+			for _, want := range []string{"user-file", mediaType, "4 bytes", part.FilePath, "Contents are not included"} {
+				if !strings.Contains(text, want) {
+					t.Fatalf("text %q missing %q", text, want)
+				}
+			}
+			if strings.Contains(text, part.FileData.Base64) {
+				t.Fatalf("binary embedded: %q", text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implement Sam's request: web chat accepts **any file type**, independently of whether the selected model understands it natively.

- Replace the web upload MIME/extension allowlist with an unrestricted policy and file picker; keep older explicit policy support in the client.
- Accept ZIPs, arbitrary binary, unknown extensions, absent MIME types, and unsupported image formats. Only JPEG/PNG/GIF/WebP go through native image preparation; other images travel as files rather than failing browser decoding.
- Keep supported native file payloads and safe text embedding unchanged. Unsupported files produce a clear model-context notice containing the upload name, MIME type, byte size, and usable saved local path, explicitly stating that contents are not included and tools can inspect the saved file. Responses serialization must not discard that path or forward unsupported binary as a native file.
- Preserve file metadata/base64/path through existing session persistence and replay. Keep interjection retry fingerprints independent of newly allocated storage paths, including the generated notice.
- Retain the 10-file / 20 MiB-per-file limits, empty/malformed/base64 validation, sanitized atomic private storage (0700 directory / 0600 files), and existing serving authorization/path boundaries. Uploads are not automatically published as download URLs; no serving route or permission is broadened.

## Verification

Passed:
- `make build`
- `go vet ./...`
- `npm --prefix frontend run format` and `format:check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend test` — 62 files, 768 tests
- Focused upload/parser/provider/session tests, including `go test -race ./cmd ./internal/llm ./internal/session -run 'Test(ArbitraryUploads|ParseResponsesInput|ParseUserMessageContent|DecodeUploadedFile|BuildResponsesInput_File|MessagePreservesFile)'`
- Isolated-home `go test ./... -skip '^TestProductionBundleSizeBudgets$'`
- `git diff --check`

The full isolated-home `go test ./...` was run and has one **pre-existing** failure: `internal/serveui.TestProductionBundleSizeBudgets`. Independently rebuilt the unchanged base `4aba4d71` frontend in scratch space using the same dependencies and measured gzip with the test's Go gzip level 6:

| app.js | Raw bytes | Gzip bytes |
|---|---:|---:|
| Base | 499,955 | 146,221 |
| This PR | 499,659 | 146,096 |
| Budget | 500,000 | 142,500 |

This patch reduces raw size by 296 bytes and gzip by 125 bytes. The unrelated budget was not changed.

Regression coverage includes ZIP and unknown binary byte preservation, missing MIME/extension, unsupported SVG/TIFF handling, traversal-safe private storage, count/size/malformed/empty rejection, model-visible metadata/path without raw contents, session replay, interjection retry identity, and retained native PNG/PDF/text behavior.

## Limitations / scope

- Acceptance does not add native model comprehension, archive extraction, or new tool permissions. Tools must be available and authorized to inspect unsupported files.
- No live-provider or real-browser end-to-end test; frontend preparation/serialization is exercised in Vitest and backend/provider payloads in Go tests. Nested terminal modules are unchanged.
- No deployment, restart, or service changes.
