### PR TITLE
feat: use GPT Image 2.5 for ChatGPT images

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -25,6 +25,9 @@ var (
 	imageProvider    string
 	imageOutput      string
 	imageSize        string
+	imageAspectRatio string
+	imageQuality     string
+	imageBackground  string
 	imageNoDisplay   bool
 	imageNoClipboard bool
 	imageNoSave      bool
@@ -69,6 +72,9 @@ func init() {
 	imageCmd.Flags().StringVarP(&imageProvider, "provider", "p", "", "Override image provider (built-in or configured openai_compatible name)")
 	imageCmd.Flags().StringVarP(&imageOutput, "output", "o", "", "Custom output path")
 	imageCmd.Flags().StringVarP(&imageSize, "size", "s", "", "Image resolution (must be 1K, 2K, or 4K)")
+	imageCmd.Flags().StringVar(&imageAspectRatio, "aspect-ratio", "", "Image aspect ratio (for example 1:1, 16:9, or 9:16)")
+	imageCmd.Flags().StringVarP(&imageQuality, "quality", "q", "", "Image quality (auto, low, medium, high, xhigh, or max)")
+	imageCmd.Flags().StringVar(&imageBackground, "background", "", "Image background (auto, opaque, or transparent)")
 	imageCmd.Flags().BoolVar(&imageNoDisplay, "no-display", false, "Skip terminal display")
 	imageCmd.Flags().BoolVar(&imageNoClipboard, "no-clipboard", false, "Skip clipboard copy")
 	imageCmd.Flags().BoolVar(&imageNoSave, "no-save", false, "Don't save to default location (use with -o)")
@@ -110,6 +116,15 @@ func runImage(cmd *cobra.Command, args []string) error {
 
 	// Validate --size flag
 	if err := image.ValidateSize(imageSize); err != nil {
+		return err
+	}
+	if err := image.ValidateAspectRatio(imageAspectRatio); err != nil {
+		return err
+	}
+	if err := image.ValidateQuality(imageQuality); err != nil {
+		return err
+	}
+	if err := image.ValidateBackground(imageBackground); err != nil {
 		return err
 	}
 
@@ -176,6 +191,9 @@ func runImage(cmd *cobra.Command, args []string) error {
 				Prompt:      prompt,
 				InputImages: inputImages,
 				Size:        imageSize,
+				AspectRatio: imageAspectRatio,
+				Quality:     imageQuality,
+				Background:  imageBackground,
 				Debug:       imageDebug,
 				DebugRaw:    debugRaw,
 			})
@@ -190,10 +208,13 @@ func runImage(cmd *cobra.Command, args []string) error {
 		// Generate mode
 		result, err = runImageWithSpinner(ctx, provider, func(generateCtx context.Context) (*image.ImageResult, error) {
 			return provider.Generate(generateCtx, image.GenerateRequest{
-				Prompt:   prompt,
-				Size:     imageSize,
-				Debug:    imageDebug,
-				DebugRaw: debugRaw,
+				Prompt:      prompt,
+				Size:        imageSize,
+				AspectRatio: imageAspectRatio,
+				Quality:     imageQuality,
+				Background:  imageBackground,
+				Debug:       imageDebug,
+				DebugRaw:    debugRaw,
 			})
 		}, "Generating image")
 		if err != nil {

--- a/docs-site/content/guides/image-generation.md
+++ b/docs-site/content/guides/image-generation.md
@@ -40,7 +40,7 @@ By default, images are:
 term-llm image "cyberpunk cityscape at night"
 term-llm image "minimalist logo" --provider flux
 term-llm image "futuristic city" --provider xai              # uses Grok image model
-term-llm image "storybook fox in the snow" --provider chatgpt:gpt-5.4
+term-llm image "storybook fox in the snow" --provider chatgpt:gpt-image-2.5-sunburst
 term-llm image "watercolor painting" -o ./art.png
 
 # Edit existing image (not supported by xAI)
@@ -60,8 +60,8 @@ term-llm image "landscape" --no-display         # don't show in terminal
 | Provider | Models | Environment Variable | Config Key |
 |----------|--------|---------------------|------------|
 | Gemini (default) | gemini-2.5-flash-image | `GEMINI_API_KEY` | `image.gemini.api_key` |
-| OpenAI | gpt-image-2, gpt-image-1.5, gpt-image-1-mini | `OPENAI_API_KEY` | `image.openai.api_key` |
-| ChatGPT | gpt-5.4-mini, gpt-5.4 | — (uses ChatGPT OAuth) | `image.chatgpt.model` |
+| OpenAI | gpt-image-2.5-flare, gpt-image-2.5-sunburst, gpt-image-2, gpt-image-1.5, gpt-image-1-mini | `OPENAI_API_KEY` | `image.openai.api_key` |
+| ChatGPT | gpt-image-2.5-flare (default), gpt-image-2.5-sunburst, gpt-image-2 | — (uses ChatGPT OAuth) | `image.chatgpt.model` |
 | xAI | grok-2-image-1212 | `XAI_API_KEY` | `image.xai.api_key` |
 | Venice | nano-banana-pro | `VENICE_API_KEY` | `image.venice.api_key` |
 | Flux | flux-2-pro, flux-2-max, flux-kontext-pro | `BFL_API_KEY` | `image.flux.api_key` |
@@ -69,7 +69,7 @@ term-llm image "landscape" --no-display         # don't show in terminal
 
 Image generation has its own provider selection and config. Where supported, image-specific keys can differ from text-provider keys; normal environment/config fallback still applies. ChatGPT reuses the same OAuth login as text. The listed model names are shipped defaults or examples, not a live availability or pricing guarantee.
 
-**ChatGPT image provider:** log in with `term-llm auth login chatgpt`, then you can use `term-llm image --provider chatgpt:gpt-5.4 "..."` for subscription-backed image generation without an API key.
+**ChatGPT image provider:** log in with `term-llm auth login chatgpt`, then use `term-llm image --provider chatgpt "..."` for subscription-backed GPT Image 2.5 Flare generation without an API key. Select Sunburst for more precise, slower work with `--provider chatgpt:gpt-image-2.5-sunburst`. Existing `gpt-5.4-mini` and `gpt-5.4` image settings are migrated to the Flare default because those language-model values belonged to the retired Responses API hop.
 
 **Editing limits:** xAI does not support editing. ChatGPT accepts one input image. Venice supports one-image editing and multi-image editing with up to three inputs, subject to the selected model. Venice uses `image.venice.edit_model` when set; otherwise it derives the edit model by appending `-edit` to the generation model (unless already present). Gemini and OpenRouter also expose multi-image editing; upstream model limits still apply.
 

--- a/docs-site/content/guides/image-generation.md
+++ b/docs-site/content/guides/image-generation.md
@@ -27,6 +27,9 @@ By default, images are:
 | `--provider` | `-p` | Override a built-in image provider or configured OpenAI-compatible provider name |
 | `--output` | `-o` | Custom output path; `-` writes image bytes to stdout for pipelines. |
 | `--size` | `-s` | Requested resolution: `1K`, `2K`, or `4K`; provider/model support varies. |
+| `--aspect-ratio` | | Requested ratio such as `1:1`, `16:9`, or `9:16`; provider/model support varies. |
+| `--quality` | `-q` | `auto`, `low`, `medium`, `high`, `xhigh`, or `max`; provider/model support varies. |
+| `--background` | | `auto`, `opaque`, or `transparent`; provider/model support varies. |
 | `--no-spinner` | | Disable the interactive progress display. |
 | `--no-display` | | Skip terminal display |
 | `--no-clipboard` | | Skip clipboard copy |
@@ -41,6 +44,8 @@ term-llm image "cyberpunk cityscape at night"
 term-llm image "minimalist logo" --provider flux
 term-llm image "futuristic city" --provider xai              # uses Grok image model
 term-llm image "storybook fox in the snow" --provider chatgpt:gpt-image-2.5-sunburst
+term-llm image "fast transparent icon" --provider chatgpt --quality low --background transparent
+term-llm image "cinematic skyline" --provider chatgpt --aspect-ratio 16:9 --quality high
 term-llm image "watercolor painting" -o ./art.png
 
 # Edit existing image (not supported by xAI)
@@ -70,6 +75,8 @@ term-llm image "landscape" --no-display         # don't show in terminal
 Image generation has its own provider selection and config. Where supported, image-specific keys can differ from text-provider keys; normal environment/config fallback still applies. ChatGPT reuses the same OAuth login as text. The listed model names are shipped defaults or examples, not a live availability or pricing guarantee.
 
 **ChatGPT image provider:** log in with `term-llm auth login chatgpt`, then use `term-llm image --provider chatgpt "..."` for subscription-backed GPT Image 2.5 Flare generation without an API key. Select Sunburst for more precise, slower work with `--provider chatgpt:gpt-image-2.5-sunburst`. Existing `gpt-5.4-mini` and `gpt-5.4` image settings are migrated to the Flare default because those language-model values belonged to the retired Responses API hop.
+
+Both the CLI and the `image_generate` tool can request quality, background mode, size, and aspect ratio. The built-in ChatGPT and OpenAI image providers pass quality and background through; other providers retain their provider-specific defaults. Size and aspect ratio remain requests rather than guarantees: the ChatGPT subscription backend may return its native dimensions.
 
 **Editing limits:** xAI does not support editing. ChatGPT accepts one input image. Venice supports one-image editing and multi-image editing with up to three inputs, subject to the selected model. Venice uses `image.venice.edit_model` when set; otherwise it derives the edit model by appending `-edit` to the generation model (unless already present). Gemini and OpenRouter also expose multi-image editing; upstream model limits still apply.
 

--- a/docs-site/content/reference/provider-setup-details.md
+++ b/docs-site/content/reference/provider-setup-details.md
@@ -95,7 +95,7 @@ If you have a ChatGPT Plus or Pro subscription, you can use the `chatgpt` provid
 term-llm ask --provider chatgpt "explain this code"
 term-llm ask --provider chatgpt:gpt-5.6-sol-max "hard code question"
 term-llm ask --provider chatgpt:gpt-5.6-luna-medium "quick code question"
-term-llm image --provider chatgpt:gpt-5.4 "storybook fox in the snow"
+term-llm image --provider chatgpt:gpt-image-2.5-sunburst "storybook fox in the snow"
 ```
 
 On first use, you'll be prompted to authenticate via browser. Credentials are stored locally and refreshed automatically.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -982,10 +982,10 @@ type ImageOpenAIConfig struct {
 	Model  string `mapstructure:"model"`
 }
 
-// ImageChatGPTConfig configures ChatGPT image generation via the chatgpt.com
-// backend's built-in image_generation tool (OAuth, no API key required).
+// ImageChatGPTConfig configures subscription-backed image generation through
+// the ChatGPT Codex Images API (OAuth, no API key required).
 type ImageChatGPTConfig struct {
-	Model string `mapstructure:"model"` // e.g., gpt-5.4-mini (default) or gpt-5.4
+	Model string `mapstructure:"model"` // e.g., gpt-image-2.5-flare (default) or gpt-image-2.5-sunburst
 }
 
 // ImageXAIConfig configures xAI (Grok) image generation

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1491,8 +1491,8 @@ func TestGetDefaultsIncludeChatGPTImageModel(t *testing.T) {
 	if !ok {
 		t.Fatalf("image.chatgpt.model default has unexpected type %T", defaults["image.chatgpt.model"])
 	}
-	if got != "gpt-5.4-mini" {
-		t.Fatalf("image.chatgpt.model = %q, want %q", got, "gpt-5.4-mini")
+	if got != "gpt-image-2.5-flare" {
+		t.Fatalf("image.chatgpt.model = %q, want %q", got, "gpt-image-2.5-flare")
 	}
 	if !KnownKeys["image.chatgpt.model"] {
 		t.Fatal("KnownKeys missing image.chatgpt.model")

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -66,7 +66,7 @@ const (
 	DefaultImageOutputDir        = "~/Pictures/term-llm"
 	DefaultImageGeminiModel      = "gemini-2.5-flash-image"
 	DefaultImageOpenAIModel      = "gpt-image-2"
-	DefaultImageChatGPTModel     = "gpt-5.4-mini"
+	DefaultImageChatGPTModel     = "gpt-image-2.5-flare"
 	DefaultImageXAIModel         = "grok-2-image-1212"
 	DefaultImageVeniceModel      = "nano-banana-pro"
 	DefaultImageVeniceResolution = "2K"

--- a/internal/contain/images/agent/entrypoint.sh
+++ b/internal/contain/images/agent/entrypoint.sh
@@ -102,7 +102,7 @@ providers:
   chatgpt:
     model: gpt-5.6-sol-medium
 image:
-  provider: "chatgpt:gpt-5.4-mini"
+  provider: "chatgpt:gpt-image-2.5-flare"
 CONFIG_YAML
     fi
     if [ "$provider" = "claude-bin" ]; then

--- a/internal/contain/images_test.go
+++ b/internal/contain/images_test.go
@@ -79,7 +79,7 @@ func TestSyncImageWritesAgentAsset(t *testing.T) {
 		if rel == "entrypoint.sh" && (!strings.Contains(string(data), "skills:") || !strings.Contains(string(data), "enabled: true") || !strings.Contains(string(data), "auto_invoke: true")) {
 			t.Fatalf("entrypoint missing first-boot skills config generation")
 		}
-		if rel == "entrypoint.sh" && !strings.Contains(string(data), "chatgpt:gpt-5.4-mini") {
+		if rel == "entrypoint.sh" && !strings.Contains(string(data), "chatgpt:gpt-image-2.5-flare") {
 			t.Fatalf("entrypoint missing ChatGPT image provider bootstrap")
 		}
 		if rel == "entrypoint.sh" && !strings.Contains(string(data), "model: gpt-5.6-sol-medium") {

--- a/internal/image/chatgpt.go
+++ b/internal/image/chatgpt.go
@@ -3,50 +3,63 @@ package image
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"io"
+	"net/http"
 	"strings"
+	"time"
 
+	"github.com/samsaffron/term-llm/internal/buildinfo"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/credentials"
-	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/providerhttp"
 )
 
-var chatGPTImageDefaultModel = config.DefaultImageChatGPTModel
+const (
+	chatGPTImageGenerateEndpoint = "https://chatgpt.com/backend-api/codex/images/generations"
+	chatGPTImageEditEndpoint     = "https://chatgpt.com/backend-api/codex/images/edits"
+	chatGPTImageHTTPTimeout      = 10 * time.Minute
+	chatGPTImageQualityAuto      = "auto"
+	chatGPTImageBackgroundAuto   = "auto"
+)
 
-// ChatGPTProvider implements ImageProvider using the chatgpt.com backend's
-// built-in image_generation tool, authenticated via the user's existing
-// ChatGPT OAuth login (same as the chatgpt LLM provider).
+var (
+	chatGPTImageDefaultModel = config.DefaultImageChatGPTModel
+	chatGPTImageHTTPClient   = &http.Client{Timeout: chatGPTImageHTTPTimeout}
+)
+
+// ChatGPTProvider implements ImageProvider using the Codex Images API,
+// authenticated via the user's existing ChatGPT OAuth login.
 type ChatGPTProvider struct {
-	creds  *credentials.ChatGPTCredentials
-	client *llm.ResponsesClient
-	model  string
+	creds            *credentials.ChatGPTCredentials
+	client           *http.Client
+	model            string
+	generateEndpoint string
+	editEndpoint     string
 }
 
-// NewChatGPTProvider builds a ChatGPT image provider. The user must already
-// be logged in via `term-llm ask --provider chatgpt`; this constructor does
-// not prompt for interactive auth because the image command runs without a
-// full TTY lifecycle.
+// NewChatGPTProvider builds a ChatGPT image provider. The user must already be
+// logged in with ChatGPT OAuth; image generation never starts an interactive
+// authentication flow.
 func NewChatGPTProvider(model string) (*ChatGPTProvider, error) {
-	actualModel, _ := llm.ParseModelEffort(strings.TrimSpace(model))
-	if actualModel == "" {
-		actualModel = chatGPTImageDefaultModel
-	}
+	model = normalizeChatGPTImageModel(model)
 
 	creds, err := credentials.GetChatGPTCredentials()
 	if err != nil {
-		return nil, fmt.Errorf("chatgpt image provider requires ChatGPT login — run 'term-llm ask --provider chatgpt \"hi\"' first: %w", err)
+		return nil, fmt.Errorf("chatgpt image provider requires ChatGPT login — run 'term-llm auth login chatgpt' first: %w", err)
 	}
 	if creds.IsExpired() {
 		if err := credentials.RefreshChatGPTCredentials(creds); err != nil {
-			return nil, fmt.Errorf("ChatGPT token refresh failed — re-run 'term-llm ask --provider chatgpt' to re-authenticate: %w", err)
+			return nil, fmt.Errorf("ChatGPT token refresh failed — run 'term-llm auth login chatgpt' to re-authenticate: %w", err)
 		}
 	}
 
 	return &ChatGPTProvider{
-		creds:  creds,
-		client: llm.NewChatGPTResponsesClient(creds),
-		model:  actualModel,
+		creds:            creds,
+		client:           chatGPTImageHTTPClient,
+		model:            model,
+		generateEndpoint: chatGPTImageGenerateEndpoint,
+		editEndpoint:     chatGPTImageEditEndpoint,
 	}, nil
 }
 
@@ -55,7 +68,17 @@ func (p *ChatGPTProvider) SupportsEdit() bool       { return true }
 func (p *ChatGPTProvider) SupportsMultiImage() bool { return false }
 
 func (p *ChatGPTProvider) Generate(ctx context.Context, req GenerateRequest) (*ImageResult, error) {
-	return p.run(ctx, decorateChatGPTPrompt(req.Prompt, req.Size, req.AspectRatio), nil, req.DebugRaw)
+	payload := chatGPTImageGenerationRequest{
+		Model:      p.model,
+		Prompt:     req.Prompt,
+		Background: chatGPTImageBackgroundAuto,
+		Quality:    chatGPTImageQualityAuto,
+		Size:       chatGPTImageSize(req.Size, req.AspectRatio),
+	}
+	debug := req.Debug || req.DebugRaw
+	debugRawImageLog(debug, "ChatGPT Image Request", "POST %s\nmodel=%s prompt=%q quality=%s size=%s",
+		p.generateEndpoint, payload.Model, payload.Prompt, payload.Quality, payload.Size)
+	return p.doRequest(ctx, p.generateEndpoint, payload, debug)
 }
 
 func (p *ChatGPTProvider) Edit(ctx context.Context, req EditRequest) (*ImageResult, error) {
@@ -65,94 +88,106 @@ func (p *ChatGPTProvider) Edit(ctx context.Context, req EditRequest) (*ImageResu
 	if len(req.InputImages) > 1 {
 		return nil, fmt.Errorf("ChatGPT image provider only supports single image editing, got %d", len(req.InputImages))
 	}
-	return p.run(ctx, decorateChatGPTPrompt(req.Prompt, req.Size, req.AspectRatio), &req.InputImages[0], req.DebugRaw)
-}
 
-// decorateChatGPTPrompt appends plain-English hints for --size and --aspect-ratio
-// to the prompt. The chatgpt.com backend's image_generation tool does not expose
-// a dedicated size/ratio parameter we can rely on, so we let the model interpret
-// the request via prompt engineering rather than silently dropping the flags.
-func decorateChatGPTPrompt(prompt, size, aspectRatio string) string {
-	var hints []string
-	if s := strings.TrimSpace(size); s != "" {
-		if h := chatGPTSizeHint(s); h != "" {
-			hints = append(hints, h)
-		}
-	}
-	if ar := strings.TrimSpace(aspectRatio); ar != "" {
-		hints = append(hints, fmt.Sprintf("Aspect ratio: %s.", ar))
-	}
-	if len(hints) == 0 {
-		return prompt
-	}
-	return prompt + "\n\n" + strings.Join(hints, " ")
-}
-
-// chatGPTSizeHint maps a normalized size (1K/2K/4K) to a human-readable
-// resolution target the model can interpret.
-func chatGPTSizeHint(size string) string {
-	switch strings.ToUpper(size) {
-	case "1K":
-		return "Target resolution: approximately 1024×1024 pixels (1K)."
-	case "2K":
-		return "Target resolution: approximately 2048×2048 pixels (2K)."
-	case "4K":
-		return "Target resolution: approximately 4096×4096 pixels (4K)."
-	default:
-		return ""
-	}
-}
-
-func (p *ChatGPTProvider) run(ctx context.Context, prompt string, src *InputImage, debugRaw bool) (*ImageResult, error) {
-	content := []llm.ResponsesContentPart{{Type: "input_text", Text: prompt}}
-	instructions := "You are an image generation assistant. Generate exactly one image matching the user's prompt by calling the image_generation tool."
-	if src != nil {
-		mime := getMimeType(src.Path)
-		dataURL := "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(src.Data)
-		content = append(content, llm.ResponsesContentPart{Type: "input_image", ImageURL: dataURL})
-		instructions = "You are an image editing assistant. The user provides an input image and instructions to modify it. Call the image_generation tool to produce exactly one edited image."
-	}
-
-	responsesReq := llm.ResponsesRequest{
-		Model:        p.model,
-		Instructions: instructions,
-		Input: []llm.ResponsesInputItem{{
-			Type:    "message",
-			Role:    "user",
-			Content: content,
+	input := req.InputImages[0]
+	payload := chatGPTImageEditRequest{
+		Images: []chatGPTImageURL{{
+			ImageURL: "data:" + getMimeType(input.Path) + ";base64," + base64.StdEncoding.EncodeToString(input.Data),
 		}},
-		Tools:      []any{llm.ResponsesImageGenerationTool{Type: "image_generation", OutputFormat: "png"}},
-		ToolChoice: map[string]any{"type": "image_generation"},
-		Store:      boolPtr(false),
-		Stream:     true,
+		Model:      p.model,
+		Prompt:     req.Prompt,
+		Background: chatGPTImageBackgroundAuto,
+		Quality:    chatGPTImageQualityAuto,
+		Size:       chatGPTImageSize(req.Size, req.AspectRatio),
 	}
+	debug := req.Debug || req.DebugRaw
+	debugRawImageLog(debug, "ChatGPT Image Request", "POST %s\nmodel=%s prompt=%q quality=%s size=%s images=1 image_bytes=%d",
+		p.editEndpoint, payload.Model, payload.Prompt, payload.Quality, payload.Size, len(input.Data))
+	return p.doRequest(ctx, p.editEndpoint, payload, debug)
+}
 
-	stream, err := p.client.Stream(ctx, responsesReq, debugRaw)
+func (p *ChatGPTProvider) doRequest(ctx context.Context, endpoint string, payload any, debug bool) (*ImageResult, error) {
+	headers := make(http.Header)
+	if p.creds.AccountID != "" {
+		headers.Set("ChatGPT-Account-ID", p.creds.AccountID)
+	}
+	headers.Set("originator", "term-llm")
+	headers.Set("User-Agent", buildinfo.UserAgent())
+	headers.Set("Accept", "application/json")
+
+	body, _, err := providerhttp.DoJSONRequest(ctx, providerhttp.JSONRequestOptions{
+		Client:         p.client,
+		Method:         http.MethodPost,
+		URL:            endpoint,
+		APIKey:         p.creds.AccessToken,
+		Payload:        payload,
+		Provider:       "ChatGPT image",
+		Headers:        headers,
+		ExpectedStatus: http.StatusOK,
+		OnResponse: func(status int, contentType string, body []byte) {
+			debugRawImageLog(debug, "ChatGPT Image Response", "status=%d content-type=%s body_len=%d", status, contentType, len(body))
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer stream.Close()
 
-	for {
-		ev, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				return nil, fmt.Errorf("stream ended without image")
-			}
-			return nil, err
-		}
-		switch ev.Type {
-		case llm.EventImageGenerated:
-			return &ImageResult{Data: ev.ImageData, MimeType: ev.ImageMimeType}, nil
-		case llm.EventError:
-			if ev.Err != nil {
-				return nil, fmt.Errorf("chatgpt image generation error: %w", ev.Err)
-			}
-			return nil, fmt.Errorf("chatgpt image generation error: %s", ev.Text)
-		case llm.EventDone:
-			return nil, fmt.Errorf("stream completed without image")
-		}
+	var response chatGPTImageResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse ChatGPT image response: %w", err)
+	}
+	if len(response.Data) == 0 || response.Data[0].B64JSON == "" {
+		return nil, fmt.Errorf("no image data in ChatGPT image response")
+	}
+	imageData, err := base64.StdEncoding.DecodeString(response.Data[0].B64JSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode ChatGPT image: %w", err)
+	}
+	return &ImageResult{Data: imageData, MimeType: "image/png"}, nil
+}
+
+func normalizeChatGPTImageModel(model string) string {
+	model = strings.TrimSpace(model)
+	switch model {
+	case "", "gpt-5.4-mini", "gpt-5.4":
+		// These language models selected the old Responses API hop. Preserve old
+		// configs while moving them to the dedicated Images API default.
+		return chatGPTImageDefaultModel
+	default:
+		return model
 	}
 }
 
-func boolPtr(b bool) *bool { return &b }
+func chatGPTImageSize(size, aspectRatio string) string {
+	if strings.TrimSpace(size) == "" && strings.TrimSpace(aspectRatio) == "" {
+		return "auto"
+	}
+	return openaiSizeFromRequest("gpt-image-2", size, aspectRatio)
+}
+
+type chatGPTImageGenerationRequest struct {
+	Model      string `json:"model"`
+	Prompt     string `json:"prompt"`
+	Background string `json:"background"`
+	Quality    string `json:"quality"`
+	Size       string `json:"size"`
+}
+
+type chatGPTImageEditRequest struct {
+	Images     []chatGPTImageURL `json:"images"`
+	Model      string            `json:"model"`
+	Prompt     string            `json:"prompt"`
+	Background string            `json:"background"`
+	Quality    string            `json:"quality"`
+	Size       string            `json:"size"`
+}
+
+type chatGPTImageURL struct {
+	ImageURL string `json:"image_url"`
+}
+
+type chatGPTImageResponse struct {
+	Data []struct {
+		B64JSON string `json:"b64_json"`
+	} `json:"data"`
+}

--- a/internal/image/chatgpt.go
+++ b/internal/image/chatgpt.go
@@ -71,8 +71,8 @@ func (p *ChatGPTProvider) Generate(ctx context.Context, req GenerateRequest) (*I
 	payload := chatGPTImageGenerationRequest{
 		Model:      p.model,
 		Prompt:     req.Prompt,
-		Background: chatGPTImageBackgroundAuto,
-		Quality:    chatGPTImageQualityAuto,
+		Background: imageOption(req.Background, chatGPTImageBackgroundAuto),
+		Quality:    imageOption(req.Quality, chatGPTImageQualityAuto),
 		Size:       chatGPTImageSize(req.Size, req.AspectRatio),
 	}
 	debug := req.Debug || req.DebugRaw
@@ -96,8 +96,8 @@ func (p *ChatGPTProvider) Edit(ctx context.Context, req EditRequest) (*ImageResu
 		}},
 		Model:      p.model,
 		Prompt:     req.Prompt,
-		Background: chatGPTImageBackgroundAuto,
-		Quality:    chatGPTImageQualityAuto,
+		Background: imageOption(req.Background, chatGPTImageBackgroundAuto),
+		Quality:    imageOption(req.Quality, chatGPTImageQualityAuto),
 		Size:       chatGPTImageSize(req.Size, req.AspectRatio),
 	}
 	debug := req.Debug || req.DebugRaw

--- a/internal/image/chatgpt_test.go
+++ b/internal/image/chatgpt_test.go
@@ -57,6 +57,8 @@ func TestChatGPTProviderGenerateUsesCodexImagesEndpoint(t *testing.T) {
 		Prompt:      "a blue square",
 		Size:        "2K",
 		AspectRatio: "16:9",
+		Quality:     "low",
+		Background:  "transparent",
 	})
 	if err != nil {
 		t.Fatalf("Generate returned error: %v", err)
@@ -88,7 +90,7 @@ func TestChatGPTProviderGenerateUsesCodexImagesEndpoint(t *testing.T) {
 	if payload.Model != "gpt-image-2.5-flare" || payload.Prompt != "a blue square" {
 		t.Fatalf("unexpected payload: %+v", payload)
 	}
-	if payload.Background != "auto" || payload.Quality != "auto" || payload.Size != "2560x1440" {
+	if payload.Background != "transparent" || payload.Quality != "low" || payload.Size != "2560x1440" {
 		t.Fatalf("unexpected image options: %+v", payload)
 	}
 }
@@ -107,6 +109,8 @@ func TestChatGPTProviderEditUsesJSONImageURLs(t *testing.T) {
 	result, err := provider.Edit(context.Background(), EditRequest{
 		Prompt:      "make it red",
 		InputImages: []InputImage{{Data: input, Path: "input.png"}},
+		Quality:     "high",
+		Background:  "opaque",
 	})
 	if err != nil {
 		t.Fatalf("Edit returned error: %v", err)
@@ -126,7 +130,7 @@ func TestChatGPTProviderEditUsesJSONImageURLs(t *testing.T) {
 	if payload.Images[0].ImageURL != wantURL {
 		t.Fatalf("image URL = %q, want %q", payload.Images[0].ImageURL, wantURL)
 	}
-	if payload.Size != "auto" || payload.Model != "gpt-image-2.5-flare" {
+	if payload.Size != "auto" || payload.Model != "gpt-image-2.5-flare" || payload.Quality != "high" || payload.Background != "opaque" {
 		t.Fatalf("unexpected payload: %+v", payload)
 	}
 }

--- a/internal/image/chatgpt_test.go
+++ b/internal/image/chatgpt_test.go
@@ -3,13 +3,13 @@ package image
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/credentials"
 )
 
 type chatGPTImageRoundTripper func(*http.Request) (*http.Response, error)
@@ -18,239 +18,179 @@ func (f chatGPTImageRoundTripper) RoundTrip(r *http.Request) (*http.Response, er
 	return f(r)
 }
 
-// newMockChatGPTProvider builds a ChatGPTProvider wired to an in-memory HTTP
-// round-tripper that returns the given SSE body. Used for unit tests that
-// exercise generate/edit without touching real credentials.
-func newMockChatGPTProvider(sseBody string) *ChatGPTProvider {
-	client := &llm.ResponsesClient{
-		BaseURL:            "https://example.test/responses",
-		GetAuthHeader:      func() string { return "Bearer test-token" },
-		DisableServerState: true,
-		HTTPClient: &http.Client{
-			Transport: chatGPTImageRoundTripper(func(*http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Status:     "200 OK",
-					Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
-					Body:       io.NopCloser(strings.NewReader(sseBody)),
-				}, nil
-			}),
-		},
-	}
+func newMockChatGPTProvider(roundTrip chatGPTImageRoundTripper) *ChatGPTProvider {
 	return &ChatGPTProvider{
-		client: client,
-		model:  "gpt-5.4-mini",
+		creds:            &credentials.ChatGPTCredentials{AccessToken: "test-token", AccountID: "test-account"},
+		client:           &http.Client{Transport: roundTrip},
+		model:            "gpt-image-2.5-flare",
+		generateEndpoint: "https://example.test/images/generations",
+		editEndpoint:     "https://example.test/images/edits",
 	}
 }
 
-func TestChatGPTProvider_Generate_ReturnsDecodedImage(t *testing.T) {
-	payload := []byte("mock-png-bytes")
-	encoded := base64.StdEncoding.EncodeToString(payload)
-	sse := "event: response.output_item.done\n" +
-		"data: {\"item\":{\"type\":\"image_generation_call\",\"status\":\"completed\",\"result\":\"" + encoded + "\",\"revised_prompt\":\"a blue square\"}}\n\n" +
-		"event: response.completed\n" +
-		"data: {\"response\":{\"id\":\"resp_1\"}}\n\n" +
-		"data: [DONE]\n\n"
-
-	p := newMockChatGPTProvider(sse)
-	result, err := p.Generate(context.Background(), GenerateRequest{Prompt: "a blue square"})
-	if err != nil {
-		t.Fatalf("Generate returned error: %v", err)
-	}
-	if string(result.Data) != string(payload) {
-		t.Errorf("decoded data mismatch: got %q, want %q", string(result.Data), string(payload))
-	}
-	if result.MimeType != "image/png" {
-		t.Errorf("mime type: got %q, want image/png", result.MimeType)
-	}
-}
-
-func TestChatGPTProvider_Edit_RequiresInputImage(t *testing.T) {
-	p := newMockChatGPTProvider("data: [DONE]\n\n")
-	_, err := p.Edit(context.Background(), EditRequest{Prompt: "make it red"})
-	if err == nil {
-		t.Fatal("expected error when no input image provided")
-	}
-}
-
-func TestChatGPTProvider_Edit_RejectsMultipleImages(t *testing.T) {
-	p := newMockChatGPTProvider("data: [DONE]\n\n")
-	_, err := p.Edit(context.Background(), EditRequest{
-		Prompt: "combine these",
-		InputImages: []InputImage{
-			{Data: []byte("a"), Path: "a.png"},
-			{Data: []byte("b"), Path: "b.png"},
-		},
+func chatGPTImageSuccess(data []byte) *http.Response {
+	body, _ := json.Marshal(map[string]any{
+		"created": 1,
+		"data": []map[string]string{{
+			"b64_json": base64.StdEncoding.EncodeToString(data),
+		}},
+		"output_format": "png",
 	})
-	if err == nil {
-		t.Fatal("expected error when more than one input image provided")
-	}
-	if !strings.Contains(err.Error(), "single") {
-		t.Errorf("error %q should mention 'single image'", err.Error())
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(string(body))),
 	}
 }
 
-func TestChatGPTProvider_Edit_SendsInputImageDataURL(t *testing.T) {
+func TestChatGPTProviderGenerateUsesCodexImagesEndpoint(t *testing.T) {
+	var captured *http.Request
 	var capturedBody []byte
-	client := &llm.ResponsesClient{
-		BaseURL:            "https://example.test/responses",
-		GetAuthHeader:      func() string { return "Bearer test-token" },
-		DisableServerState: true,
-		HTTPClient: &http.Client{
-			Transport: chatGPTImageRoundTripper(func(req *http.Request) (*http.Response, error) {
-				if req.Body != nil {
-					b, _ := io.ReadAll(req.Body)
-					capturedBody = b
-				}
-				resultB64 := base64.StdEncoding.EncodeToString([]byte("edited"))
-				sse := "event: response.output_item.done\n" +
-					"data: {\"item\":{\"type\":\"image_generation_call\",\"result\":\"" + resultB64 + "\"}}\n\n" +
-					"event: response.completed\n" +
-					"data: {\"response\":{\"id\":\"resp_edit\"}}\n\n" +
-					"data: [DONE]\n\n"
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Status:     "200 OK",
-					Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
-					Body:       io.NopCloser(strings.NewReader(sse)),
-				}, nil
-			}),
-		},
-	}
-	p := &ChatGPTProvider{client: client, model: "gpt-5.4-mini"}
-
-	src := []byte("original-bytes")
-	_, err := p.Edit(context.Background(), EditRequest{
-		Prompt:      "make it red",
-		InputImages: []InputImage{{Data: src, Path: "input.png"}},
+	provider := newMockChatGPTProvider(func(req *http.Request) (*http.Response, error) {
+		captured = req
+		capturedBody, _ = io.ReadAll(req.Body)
+		return chatGPTImageSuccess([]byte("mock-png-bytes")), nil
 	})
-	if err != nil {
-		t.Fatalf("Edit returned error: %v", err)
-	}
-	body := string(capturedBody)
-	if !strings.Contains(body, "input_image") {
-		t.Error("request body should include input_image content part")
-	}
-	wantDataURL := fmt.Sprintf("data:image/png;base64,%s", base64.StdEncoding.EncodeToString(src))
-	if !strings.Contains(body, wantDataURL) {
-		t.Errorf("request body missing expected data URL\nwant fragment: %s", wantDataURL)
-	}
-	if !strings.Contains(body, "\"tool_choice\":{\"type\":\"image_generation\"}") {
-		t.Errorf("request body missing image_generation tool_choice; got: %s", body)
-	}
-}
 
-func TestDecorateChatGPTPrompt(t *testing.T) {
-	base := "a red square"
-	tests := []struct {
-		name        string
-		size        string
-		aspectRatio string
-		wantEqual   string
-		wantContain []string
-	}{
-		{name: "no hints", wantEqual: base},
-		{name: "whitespace only", size: "   ", aspectRatio: "\t", wantEqual: base},
-		{name: "unknown size dropped", size: "8K", wantEqual: base},
-		{
-			name:        "size only",
-			size:        "2K",
-			wantContain: []string{base, "2048×2048", "(2K)"},
-		},
-		{
-			name:        "aspect ratio only",
-			aspectRatio: "16:9",
-			wantContain: []string{base, "Aspect ratio: 16:9."},
-		},
-		{
-			name:        "size and aspect ratio",
-			size:        "4K",
-			aspectRatio: "1:1",
-			wantContain: []string{base, "4096×4096", "Aspect ratio: 1:1."},
-		},
-		{
-			name:        "lowercase size normalized",
-			size:        "1k",
-			wantContain: []string{base, "1024×1024", "(1K)"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := decorateChatGPTPrompt(base, tt.size, tt.aspectRatio)
-			if tt.wantEqual != "" && got != tt.wantEqual {
-				t.Errorf("decorateChatGPTPrompt(%q, %q, %q) = %q, want %q",
-					base, tt.size, tt.aspectRatio, got, tt.wantEqual)
-			}
-			for _, sub := range tt.wantContain {
-				if !strings.Contains(got, sub) {
-					t.Errorf("decorateChatGPTPrompt output missing %q\ngot: %q", sub, got)
-				}
-			}
-		})
-	}
-}
-
-func TestChatGPTSizeHint(t *testing.T) {
-	tests := map[string]string{
-		"1K":  "Target resolution: approximately 1024×1024 pixels (1K).",
-		"2K":  "Target resolution: approximately 2048×2048 pixels (2K).",
-		"4K":  "Target resolution: approximately 4096×4096 pixels (4K).",
-		"1k":  "Target resolution: approximately 1024×1024 pixels (1K).",
-		"8K":  "",
-		"":    "",
-		"foo": "",
-	}
-	for in, want := range tests {
-		t.Run(in, func(t *testing.T) {
-			if got := chatGPTSizeHint(in); got != want {
-				t.Errorf("chatGPTSizeHint(%q) = %q, want %q", in, got, want)
-			}
-		})
-	}
-}
-
-func TestChatGPTProvider_Generate_IncludesSizeHintInRequestBody(t *testing.T) {
-	var capturedBody []byte
-	client := &llm.ResponsesClient{
-		BaseURL:            "https://example.test/responses",
-		GetAuthHeader:      func() string { return "Bearer test-token" },
-		DisableServerState: true,
-		HTTPClient: &http.Client{
-			Transport: chatGPTImageRoundTripper(func(req *http.Request) (*http.Response, error) {
-				if req.Body != nil {
-					b, _ := io.ReadAll(req.Body)
-					capturedBody = b
-				}
-				resultB64 := base64.StdEncoding.EncodeToString([]byte("png"))
-				sse := "event: response.output_item.done\n" +
-					"data: {\"item\":{\"type\":\"image_generation_call\",\"result\":\"" + resultB64 + "\"}}\n\n" +
-					"event: response.completed\n" +
-					"data: {\"response\":{\"id\":\"resp_size\"}}\n\n" +
-					"data: [DONE]\n\n"
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Status:     "200 OK",
-					Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
-					Body:       io.NopCloser(strings.NewReader(sse)),
-				}, nil
-			}),
-		},
-	}
-	p := &ChatGPTProvider{client: client, model: "gpt-5.4-mini"}
-
-	_, err := p.Generate(context.Background(), GenerateRequest{
-		Prompt:      "a red square",
-		Size:        "4K",
+	result, err := provider.Generate(context.Background(), GenerateRequest{
+		Prompt:      "a blue square",
+		Size:        "2K",
 		AspectRatio: "16:9",
 	})
 	if err != nil {
 		t.Fatalf("Generate returned error: %v", err)
 	}
-	body := string(capturedBody)
-	if !strings.Contains(body, "4096") {
-		t.Errorf("request body missing 4K resolution hint; got: %s", body)
+	if string(result.Data) != "mock-png-bytes" || result.MimeType != "image/png" {
+		t.Fatalf("unexpected result: %+v", result)
 	}
-	if !strings.Contains(body, "16:9") {
-		t.Errorf("request body missing aspect ratio hint; got: %s", body)
+	if captured.URL.String() != provider.generateEndpoint {
+		t.Fatalf("URL = %q, want %q", captured.URL, provider.generateEndpoint)
+	}
+	for key, want := range map[string]string{
+		"Authorization":      "Bearer test-token",
+		"ChatGPT-Account-ID": "test-account",
+		"originator":         "term-llm",
+		"Accept":             "application/json",
+	} {
+		if got := captured.Header.Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if got := captured.Header.Get("User-Agent"); !strings.HasPrefix(got, "term-llm/") {
+		t.Errorf("User-Agent = %q, want term-llm version", got)
+	}
+
+	var payload chatGPTImageGenerationRequest
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if payload.Model != "gpt-image-2.5-flare" || payload.Prompt != "a blue square" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.Background != "auto" || payload.Quality != "auto" || payload.Size != "2560x1440" {
+		t.Fatalf("unexpected image options: %+v", payload)
+	}
+}
+
+func TestChatGPTProviderEditUsesJSONImageURLs(t *testing.T) {
+	var capturedBody []byte
+	provider := newMockChatGPTProvider(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != "https://example.test/images/edits" {
+			t.Fatalf("URL = %q", req.URL)
+		}
+		capturedBody, _ = io.ReadAll(req.Body)
+		return chatGPTImageSuccess([]byte("edited")), nil
+	})
+
+	input := []byte("original-bytes")
+	result, err := provider.Edit(context.Background(), EditRequest{
+		Prompt:      "make it red",
+		InputImages: []InputImage{{Data: input, Path: "input.png"}},
+	})
+	if err != nil {
+		t.Fatalf("Edit returned error: %v", err)
+	}
+	if string(result.Data) != "edited" {
+		t.Fatalf("result = %q", result.Data)
+	}
+
+	var payload chatGPTImageEditRequest
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if len(payload.Images) != 1 {
+		t.Fatalf("images = %d, want 1", len(payload.Images))
+	}
+	wantURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(input)
+	if payload.Images[0].ImageURL != wantURL {
+		t.Fatalf("image URL = %q, want %q", payload.Images[0].ImageURL, wantURL)
+	}
+	if payload.Size != "auto" || payload.Model != "gpt-image-2.5-flare" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+}
+
+func TestChatGPTProviderEditValidatesInputCount(t *testing.T) {
+	provider := newMockChatGPTProvider(func(*http.Request) (*http.Response, error) {
+		t.Fatal("unexpected HTTP request")
+		return nil, nil
+	})
+	if _, err := provider.Edit(context.Background(), EditRequest{Prompt: "red"}); err == nil {
+		t.Fatal("expected missing input error")
+	}
+	_, err := provider.Edit(context.Background(), EditRequest{
+		Prompt: "combine",
+		InputImages: []InputImage{
+			{Data: []byte("a"), Path: "a.png"},
+			{Data: []byte("b"), Path: "b.png"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "single image") {
+		t.Fatalf("expected single-image error, got %v", err)
+	}
+}
+
+func TestChatGPTProviderReturnsStatusError(t *testing.T) {
+	provider := newMockChatGPTProvider(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     "400 Bad Request",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"detail":"unsupported model"}`)),
+		}, nil
+	})
+	_, err := provider.Generate(context.Background(), GenerateRequest{Prompt: "test"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported model") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNormalizeChatGPTImageModel(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{"", "gpt-image-2.5-flare"},
+		{"gpt-5.4-mini", "gpt-image-2.5-flare"},
+		{"gpt-5.4", "gpt-image-2.5-flare"},
+		{"gpt-image-2.5-sunburst", "gpt-image-2.5-sunburst"},
+	} {
+		if got := normalizeChatGPTImageModel(tc.input); got != tc.want {
+			t.Errorf("normalizeChatGPTImageModel(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestChatGPTImageSize(t *testing.T) {
+	for _, tc := range []struct {
+		size, aspectRatio, want string
+	}{
+		{"", "", "auto"},
+		{"1K", "", "1024x1024"},
+		{"", "16:9", "1280x720"},
+		{"2K", "16:9", "2560x1440"},
+		{"4K", "9:16", "2160x3840"},
+	} {
+		if got := chatGPTImageSize(tc.size, tc.aspectRatio); got != tc.want {
+			t.Errorf("chatGPTImageSize(%q, %q) = %q, want %q", tc.size, tc.aspectRatio, got, tc.want)
+		}
 	}
 }

--- a/internal/image/openai.go
+++ b/internal/image/openai.go
@@ -79,7 +79,8 @@ func (p *OpenAIProvider) Generate(ctx context.Context, req GenerateRequest) (*Im
 		Model:        p.model,
 		Prompt:       req.Prompt,
 		Size:         openaiSizeFromRequest(p.model, req.Size, req.AspectRatio),
-		Quality:      openaiQualityAuto,
+		Quality:      imageOption(req.Quality, openaiQualityAuto),
+		Background:   req.Background,
 		OutputFormat: openaiFormatPNG,
 		N:            1,
 	}
@@ -126,11 +127,15 @@ func (p *OpenAIProvider) Edit(ctx context.Context, req EditRequest) (*ImageResul
 		"model":         p.model,
 		"prompt":        req.Prompt,
 		"size":          openaiSizeFromRequest(p.model, req.Size, req.AspectRatio),
-		"quality":       openaiQualityAuto,
+		"quality":       imageOption(req.Quality, openaiQualityAuto),
+		"background":    req.Background,
 		"output_format": openaiFormatPNG,
 		"n":             "1",
 	}
 	for key, value := range fields {
+		if value == "" {
+			continue
+		}
 		if err := writer.WriteField(key, value); err != nil {
 			return nil, fmt.Errorf("failed to write form field %q: %w", key, err)
 		}
@@ -228,6 +233,7 @@ type openaiGenerateRequest struct {
 	Prompt       string `json:"prompt"`
 	Size         string `json:"size"`
 	Quality      string `json:"quality"`
+	Background   string `json:"background,omitempty"`
 	OutputFormat string `json:"output_format"`
 	N            int    `json:"n"`
 }
@@ -246,6 +252,13 @@ type openaiError struct {
 	Message string `json:"message"`
 	Type    string `json:"type"`
 	Code    string `json:"code"`
+}
+
+func imageOption(value, fallback string) string {
+	if value = strings.TrimSpace(value); value != "" {
+		return value
+	}
+	return fallback
 }
 
 func openaiSizeFromRequest(model, size, aspectRatio string) string {

--- a/internal/image/openai_test.go
+++ b/internal/image/openai_test.go
@@ -100,6 +100,8 @@ func TestOpenAIProviderGenerateUsesConfiguredModel(t *testing.T) {
 		Prompt:      "a neon fox",
 		Size:        "4K",
 		AspectRatio: "16:9",
+		Quality:     "xhigh",
+		Background:  "transparent",
 	})
 	if err != nil {
 		t.Fatalf("Generate returned error: %v", err)
@@ -109,6 +111,9 @@ func TestOpenAIProviderGenerateUsesConfiguredModel(t *testing.T) {
 	}
 	if captured.Size != "3840x2160" {
 		t.Fatalf("size = %q, want %q", captured.Size, "3840x2160")
+	}
+	if captured.Quality != "xhigh" || captured.Background != "transparent" {
+		t.Fatalf("quality/background = %q/%q", captured.Quality, captured.Background)
 	}
 }
 
@@ -153,6 +158,8 @@ func TestOpenAIProviderEditUsesConfiguredModelAndMultipleImages(t *testing.T) {
 		},
 		Size:        "2K",
 		AspectRatio: "9:16",
+		Quality:     "high",
+		Background:  "opaque",
 	})
 	if err != nil {
 		t.Fatalf("Edit returned error: %v", err)
@@ -170,6 +177,8 @@ func TestOpenAIProviderEditUsesConfiguredModelAndMultipleImages(t *testing.T) {
 	var (
 		model      string
 		size       string
+		quality    string
+		background string
 		imageCount int
 	)
 	for {
@@ -189,6 +198,10 @@ func TestOpenAIProviderEditUsesConfiguredModelAndMultipleImages(t *testing.T) {
 			model = string(data)
 		case "size":
 			size = string(data)
+		case "quality":
+			quality = string(data)
+		case "background":
+			background = string(data)
 		case "image[]":
 			imageCount++
 		}
@@ -198,6 +211,9 @@ func TestOpenAIProviderEditUsesConfiguredModelAndMultipleImages(t *testing.T) {
 	}
 	if size != "1440x2560" {
 		t.Fatalf("multipart size = %q, want %q", size, "1440x2560")
+	}
+	if quality != "high" || background != "opaque" {
+		t.Fatalf("multipart quality/background = %q/%q", quality, background)
 	}
 	if imageCount != 2 {
 		t.Fatalf("image count = %d, want 2", imageCount)

--- a/internal/image/provider.go
+++ b/internal/image/provider.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/samsaffron/term-llm/internal/config"
@@ -19,6 +20,8 @@ type GenerateRequest struct {
 	Prompt      string
 	Size        string // Normalized resolution: "1K", "2K", "4K"; providers translate or ignore
 	AspectRatio string // e.g. "1:1", "16:9", "9:16"; providers translate or ignore
+	Quality     string // "auto", "low", "medium", "high", "xhigh", or "max"; provider/model support varies
+	Background  string // "auto", "opaque", or "transparent"; provider/model support varies
 	Debug       bool
 	DebugRaw    bool
 }
@@ -35,6 +38,8 @@ type EditRequest struct {
 	InputImages []InputImage // Input images for editing (supports multiple for some providers)
 	Size        string       // Normalized resolution: "1K", "2K", "4K"; providers translate or ignore
 	AspectRatio string       // e.g. "1:1", "16:9", "9:16"; providers translate or ignore
+	Quality     string       // "auto", "low", "medium", "high", "xhigh", or "max"; provider/model support varies
+	Background  string       // "auto", "opaque", or "transparent"; provider/model support varies
 	Debug       bool
 	DebugRaw    bool
 }
@@ -178,6 +183,51 @@ func parseImageProviderModel(s string) (string, string) {
 
 // ValidSizes are the normalized image size values accepted by the system.
 var ValidSizes = []string{"1K", "2K", "4K"}
+
+// ValidateAspectRatio checks for a positive W:H ratio.
+func ValidateAspectRatio(aspectRatio string) error {
+	if aspectRatio == "" {
+		return nil
+	}
+	parts := strings.Split(aspectRatio, ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid aspect ratio %q (expected W:H, for example 16:9)", aspectRatio)
+	}
+	width, widthErr := strconv.Atoi(parts[0])
+	height, heightErr := strconv.Atoi(parts[1])
+	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
+		return fmt.Errorf("invalid aspect ratio %q (dimensions must be positive integers)", aspectRatio)
+	}
+	return nil
+}
+
+// ValidQualities are the image quality values accepted by the CLI and tool.
+var ValidQualities = []string{"auto", "low", "medium", "high", "xhigh", "max"}
+
+// ValidateQuality checks that quality is a recognized normalized value.
+func ValidateQuality(quality string) error {
+	return validateImageOption("quality", quality, ValidQualities)
+}
+
+// ValidBackgrounds are the image background modes accepted by the CLI and tool.
+var ValidBackgrounds = []string{"auto", "opaque", "transparent"}
+
+// ValidateBackground checks that background is a recognized mode.
+func ValidateBackground(background string) error {
+	return validateImageOption("background", background, ValidBackgrounds)
+}
+
+func validateImageOption(name, value string, valid []string) error {
+	if value == "" {
+		return nil
+	}
+	for _, candidate := range valid {
+		if value == candidate {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid %s %q (valid: %s)", name, value, strings.Join(valid, ", "))
+}
 
 // ValidateSize checks that size is a recognized normalized value.
 // Returns nil for empty string (no size requested). Returns an error for invalid values.

--- a/internal/image/provider_test.go
+++ b/internal/image/provider_test.go
@@ -109,6 +109,32 @@ func TestNewImageProviderGrokAliasRemainsXAIAPIKeyProvider(t *testing.T) {
 	}
 }
 
+func TestValidateImageOptions(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		value   string
+		valid   func(string) error
+		wantErr bool
+	}{
+		{"empty quality", "", ValidateQuality, false},
+		{"max quality", "max", ValidateQuality, false},
+		{"bad quality", "ultra", ValidateQuality, true},
+		{"transparent background", "transparent", ValidateBackground, false},
+		{"bad background", "checkerboard", ValidateBackground, true},
+		{"empty ratio", "", ValidateAspectRatio, false},
+		{"landscape ratio", "16:9", ValidateAspectRatio, false},
+		{"wide ratio", "4:1", ValidateAspectRatio, false},
+		{"zero ratio", "16:0", ValidateAspectRatio, true},
+		{"malformed ratio", "wide", ValidateAspectRatio, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.valid(tc.value); (err != nil) != tc.wantErr {
+				t.Fatalf("validation error = %v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateSize(t *testing.T) {
 	tests := []struct {
 		size    string

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -371,8 +371,8 @@ var ProviderFastModels = config.DefaultProviderFastModels()
 var ImageProviderModels = map[string][]string{
 	"debug":      {"random"},
 	"gemini":     {"gemini-2.5-flash-image", "gemini-3-pro-image-preview", "gemini-3.1-flash-image-preview"},
-	"openai":     {"gpt-image-2", "gpt-image-1.5", "gpt-image-1-mini"},
-	"chatgpt":    {"gpt-5.4-mini", "gpt-5.4"},
+	"openai":     {"gpt-image-2.5-flare", "gpt-image-2.5-sunburst", "gpt-image-2", "gpt-image-1.5", "gpt-image-1-mini"},
+	"chatgpt":    {"gpt-image-2.5-flare", "gpt-image-2.5-sunburst", "gpt-image-2"},
 	"xai":        {"grok-2-image", "grok-2-image-1212"},
 	"venice":     {"nano-banana-pro", "nano-banana-2", "flux-2-pro", "flux-2-max", "gpt-image-1-5", "imagineart-1.5-pro", "recraft-v4", "recraft-v4-pro", "seedream-v4", "seedream-v5-lite", "qwen-image", "qwen-image-2", "qwen-image-2-pro", "grok-imagine-image", "grok-imagine-image-pro", "hunyuan-image-v3", "venice-sd35", "hidream", "chroma", "z-image-turbo", "wan-2-7-text-to-image", "wan-2-7-pro-text-to-image", "lustify-sdxl", "lustify-v7", "lustify-v8", "wai-Illustrious", "bria-bg-remover", "qwen-edit", "nano-banana-pro-edit", "nano-banana-2-edit", "flux-2-max-edit", "gpt-image-1-5-edit", "seedream-v4-edit", "seedream-v5-lite-edit", "qwen-image-2-edit", "qwen-image-2-pro-edit", "grok-imagine-edit", "firered-image-edit"},
 	"flux":       {"flux-2-pro", "flux-kontext-pro", "flux-2-max"},

--- a/internal/tools/image_gen.go
+++ b/internal/tools/image_gen.go
@@ -54,6 +54,8 @@ type ImageGenerateArgs struct {
 	InputImages     []string `json:"input_images,omitempty"`      // Multiple paths for multi-image editing
 	Size            string   `json:"size,omitempty"`              // Resolution: "1K", "2K", "4K"
 	AspectRatio     string   `json:"aspect_ratio,omitempty"`      // e.g., "16:9", "4:3"
+	Quality         string   `json:"quality,omitempty"`           // auto, low, medium, high, xhigh, max
+	Background      string   `json:"background,omitempty"`        // auto, opaque, transparent
 	OutputPath      string   `json:"output_path,omitempty"`       // Save location
 	ShowImage       *bool    `json:"show_image,omitempty"`        // Display via icat (default: true)
 	CopyToClipboard *bool    `json:"copy_to_clipboard,omitempty"` // Copy to clipboard (default: true)
@@ -81,8 +83,17 @@ func (t *ImageGenerateTool) Spec() llm.ToolSpec {
 		},
 		"aspect_ratio": map[string]interface{}{
 			"type":        "string",
-			"description": "Aspect ratio, e.g., '1:1', '16:9', '4:3' (default: '1:1')",
-			"default":     "1:1",
+			"description": "Aspect ratio, e.g. '1:1', '16:9', '4:3' (default: provider choice)",
+		},
+		"quality": map[string]interface{}{
+			"type":        "string",
+			"enum":        image.ValidQualities,
+			"description": "Image quality; provider/model support varies",
+		},
+		"background": map[string]interface{}{
+			"type":        "string",
+			"enum":        image.ValidBackgrounds,
+			"description": "Image background mode; transparent requires provider/model support",
 		},
 		"output_path": map[string]interface{}{
 			"type":        "string",
@@ -140,6 +151,15 @@ func (t *ImageGenerateTool) Execute(ctx context.Context, args json.RawMessage) (
 	}
 
 	if err := image.ValidateSize(a.Size); err != nil {
+		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, err.Error()))), nil
+	}
+	if err := image.ValidateAspectRatio(a.AspectRatio); err != nil {
+		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, err.Error()))), nil
+	}
+	if err := image.ValidateQuality(a.Quality); err != nil {
+		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, err.Error()))), nil
+	}
+	if err := image.ValidateBackground(a.Background); err != nil {
 		return llm.TextOutput(formatToolError(NewToolError(ErrInvalidParams, err.Error()))), nil
 	}
 
@@ -295,6 +315,8 @@ func (t *ImageGenerateTool) Execute(ctx context.Context, args json.RawMessage) (
 			InputImages: inputImages,
 			Size:        a.Size,
 			AspectRatio: a.AspectRatio,
+			Quality:     a.Quality,
+			Background:  a.Background,
 		})
 		if err != nil {
 			return llm.TextOutput(formatToolError(NewToolErrorf(ErrImageGenFailed, "image edit failed: %v", err))), nil
@@ -305,6 +327,8 @@ func (t *ImageGenerateTool) Execute(ctx context.Context, args json.RawMessage) (
 			Prompt:      a.Prompt,
 			Size:        a.Size,
 			AspectRatio: a.AspectRatio,
+			Quality:     a.Quality,
+			Background:  a.Background,
 		})
 		if err != nil {
 			return llm.TextOutput(formatToolError(NewToolErrorf(ErrImageGenFailed, "image generation failed: %v", err))), nil

--- a/internal/tools/image_gen_test.go
+++ b/internal/tools/image_gen_test.go
@@ -118,6 +118,25 @@ func TestImageGenAutoApprove_SymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestImageGenerateToolRejectsInvalidImageOptions(t *testing.T) {
+	cfg := &config.Config{Image: config.ImageConfig{Provider: "debug", OutputDir: t.TempDir()}}
+	tool := NewImageGenerateTool(nil, cfg, "debug", nil, "", "")
+	for _, args := range []ImageGenerateArgs{
+		{Prompt: "test", Quality: "ultra"},
+		{Prompt: "test", Background: "checkerboard"},
+		{Prompt: "test", AspectRatio: "16:0"},
+	} {
+		raw, _ := json.Marshal(args)
+		out, err := tool.Execute(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if !strings.Contains(out.Content, "INVALID_PARAMS") {
+			t.Fatalf("expected invalid params for %+v, got %q", args, out.Content)
+		}
+	}
+}
+
 func TestImageGenerateTool_RequiresApprovalForDefaultOutputDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.Config{


### PR DESCRIPTION
## Summary

- replace the ChatGPT image provider's Responses API language-model hop with the dedicated Codex Images API
- default subscription-backed image generation to `gpt-image-2.5-flare`
- expose `gpt-image-2.5-sunburst` and retain `gpt-image-2` as selectable models
- migrate legacy `gpt-5.4-mini` and `gpt-5.4` image settings to the new Flare default
- add `--quality`, `--background`, and `--aspect-ratio` CLI controls and matching `image_generate` tool arguments
- pass quality/background through the built-in ChatGPT and OpenAI generation/edit paths
- preserve single-image editing through the dedicated JSON edit endpoint
- update config completions, container bootstrap defaults, tests, and docs

The endpoint and request shape follow OpenAI Codex's current image-generation implementation. Both `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` were probed successfully with ChatGPT OAuth before implementation.

## Verification

- `go test ./internal/image ./internal/tools ./internal/config ./internal/contain ./internal/llm`
- `go test ./cmd -run 'Image|ChatGPTImage|ConfigCompletion'`
- `go build ./...`
- CLI help exposes all three new flags
- live generation smoke with Flare, `quality=low`, `background=transparent`, `size=1K`, and `aspect-ratio=16:9`: HTTP 200 and a valid RGBA PNG
- live edit smoke using that generated PNG with `quality=low`, `background=opaque`, `size=1K`, and `aspect-ratio=1:1`: HTTP 200 and a valid RGB PNG; the requested red-to-blue edit was visibly applied

The subscription backend accepted the explicit 16:9 size request but returned its native 1254×1254 canvas. Size and aspect ratio are therefore documented as requests rather than guarantees; quality and transparent/opaque background passthrough were verified.

A prior full `go test ./...` run reached the affected packages successfully but was not globally green in this mounted development environment: two unrelated command tests discovered the host's user-global skills, and the freshly rebuilt existing frontend exceeded its gzip budget (`147164 > 143500`). GitHub's Go, race, cross-build, and passkey checks passed on the first revision; the frontend job had three unrelated browser-smoke timeouts and is rerunning with this update.
