### PR TITLE
fix: Transport timeouts abort healthy runs instead of using the provider retry budget

### DIFF
--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -318,15 +318,15 @@ func retryCall[T any](ctx context.Context, config RetryConfig, run func() (T, er
 		if err == nil {
 			return result, nil
 		}
+		// Only the caller context tells us whether the run has expired.
+		// Transport timeouts may also wrap context.DeadlineExceeded.
+		if ctx.Err() != nil {
+			return zero, ctx.Err()
+		}
 		if !isRetryable(err) {
 			return zero, err
 		}
 		lastErr = err
-
-		// Don't retry if context is already cancelled.
-		if ctx.Err() != nil {
-			return zero, ctx.Err()
-		}
 
 		// Don't retry if this was the last count-limited attempt.
 		if config.MaxAttempts > 0 && attempt >= config.MaxAttempts {
@@ -485,9 +485,15 @@ func isRetryable(err error) bool {
 		return false
 	}
 
-	// Never retry if the context itself has been cancelled or deadline exceeded.
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+	// Explicit cancellation is not transient. Caller deadlines are checked by retryCall.
+	if errors.Is(err, context.Canceled) {
 		return false
+	}
+
+	// Attempt-level deadlines (including dial and response-header timeouts)
+	// are retryable while the caller context is still live.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
 	}
 
 	// Stream framing / terminal marker failures are transient transport failures.

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -782,5 +785,125 @@ func TestRetryProviderListModelsUnsupportedWhenInnerLacksMethod(t *testing.T) {
 	_, err := lister.ListModels(context.Background())
 	if !errors.Is(err, ErrListModelsUnsupported) {
 		t.Fatalf("got err %v, want ErrListModelsUnsupported", err)
+	}
+}
+
+func TestRetryProvider_ResponseHeaderTimeout(t *testing.T) {
+	release := make(chan struct{})
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			// Hold headers until the transport cancels the timed-out request.
+			_, _ = io.Copy(io.Discard, r.Body)
+			select {
+			case <-r.Context().Done():
+			case <-release:
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer server.Close()
+	defer close(release)
+	client := newStreamingHTTPClient()
+	client.Transport.(*http.Transport).ResponseHeaderTimeout = 50 * time.Millisecond
+	defer client.CloseIdleConnections()
+	original := defaultHTTPClient
+	defaultHTTPClient = client
+	defer func() { defaultHTTPClient = original }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	provider := WrapWithRetry(NewOpenAICompatProvider(server.URL, "", "test-model", "Test"), RetryConfig{
+		MaxAttempts: 2, BaseBackoff: time.Millisecond, MaxBackoff: time.Millisecond,
+	})
+	stream, err := provider.Stream(ctx, Request{Messages: []Message{UserText("hello")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	var text strings.Builder
+	var retries int
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if event.Type == EventError {
+			t.Fatalf("stream failed after %d requests (parent error: %v): %v", requests.Load(), ctx.Err(), event.Err)
+		}
+		if event.Type == EventTextDelta {
+			text.WriteString(event.Text)
+		}
+		if event.Type == EventRetry {
+			retries++
+		}
+	}
+	if requests.Load() != 2 || retries != 1 || text.String() != "hello" {
+		t.Fatalf("requests=%d retries=%d text=%q; want 2, 1, hello", requests.Load(), retries, text.String())
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("parent context expired: %v", ctx.Err())
+	}
+}
+
+func TestRetryCall_DeadlineErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		expired      bool
+		canceled     bool
+		committed    bool
+		budget       time.Duration
+		wantAttempts int
+	}{
+		{name: "live parent", wantAttempts: 2},
+		{name: "expired parent", expired: true, wantAttempts: 1},
+		{name: "canceled parent", canceled: true, wantAttempts: 1},
+		{name: "committed timeout", committed: true, wantAttempts: 1},
+		{name: "exhausted budget", budget: time.Nanosecond, wantAttempts: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.expired {
+				var expire context.CancelFunc
+				ctx, expire = context.WithDeadline(ctx, time.Now().Add(-time.Second))
+				defer expire()
+			}
+			var attempts, retries int
+			_, err := retryCall(ctx, RetryConfig{
+				MaxAttempts: 2, MaxElapsedTime: tc.budget, BaseBackoff: time.Millisecond, MaxBackoff: time.Millisecond,
+			}, func() (struct{}, error) {
+				attempts++
+				if attempts == 2 {
+					return struct{}{}, nil
+				}
+				if tc.canceled {
+					cancel()
+				}
+				err := fmt.Errorf("request failed: %w", context.DeadlineExceeded)
+				if tc.committed {
+					err = &committedError{err}
+				}
+				return struct{}{}, err
+			}, func(retryInfo) error { retries++; return nil })
+			if attempts != tc.wantAttempts || retries != tc.wantAttempts-1 {
+				t.Fatalf("attempts=%d retries=%d; want %d, %d", attempts, retries, tc.wantAttempts, tc.wantAttempts-1)
+			}
+			if tc.wantAttempts == 2 {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil {
+				t.Fatal("expected error")
+			}
+			if tc.canceled && !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected cancellation, got %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What changed

- Check the actual caller context before classifying a failed provider attempt.
- Treat wrapped `context.DeadlineExceeded` errors as retryable while that context remains live. Go's dial and response-header timeouts can match this sentinel without expiring the enclosing run.
- Preserve explicit-cancellation handling, the committed-output/tool-activity no-replay guard, backoff, attempt limits, and the elapsed-time retry budget.
- Add an httptest-backed OpenAI-compatible provider regression: the first request withholds headers past a 50ms transport deadline; the second supplies a valid stream. Assert two requests, one retry event, successful text, and a still-live parent.
- Add deadline tests for live, expired, and canceled parents, committed failures, and exhausted retry budgets.

## Why this is high-value

Intermittent network/provider stalls affect the core path used by daily web/Telegram turns and unattended Jarvis jobs. Previously, a single 30-second dial or two-minute response-header timeout could end an otherwise healthy run despite the configured 30-minute provider retry window. Retrying before any output or tool activity avoids manual restarts without replaying visible work.

Independently checked the negative safeguards: production factory paths use `DefaultRetryConfig`; OpenAI-compatible and Venice request errors preserve their cause with `%w`; engine uncommitted recovery only recognizes stream-incomplete/nonrecoverable-stream errors; job retry policy defaults to one attempt. None rescues this transport timeout. No overlap with the listed recent/open PRs.

## Validation

- Before the fix, the HTTP regression failed after **one request**, reporting `net/http: timeout awaiting response headers` with `parent error: <nil>`.
- After the fix, `go test ./internal/llm -run 'TestRetryProvider|TestRetryCall' -count=1 -timeout=90s` passed, including existing no-replay tests.
- `go test -race ./internal/llm -run 'TestRetryProvider|TestRetryCall' -count=10 -timeout=120s` passed.
- `go build ./...`, `make build`, and `go vet ./...` passed. Generated frontend assets were built using `make frontend` before Go validation.
- `go test ./...` with an isolated HOME/XDG environment passed all packages except the unrelated `internal/serveui` `TestProductionBundleSizeBudgets`: `dist/app.js` raw/gzip = **504273/147444**, budget **505000/143500**. Reproduced independently with `go test ./internal/serveui -run '^TestProductionBundleSizeBudgets$' -count=1`; that package does not depend on `internal/llm`, and frontend source/budget files are unchanged.
- `gofmt` on both changed files and `git diff --check` passed.
