### PR TITLE
fix: Recovered streams retain abandoned drafts in successful subagent and job results

### DIFF
--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/agents"
 	"github.com/samsaffron/term-llm/internal/config"
 	"github.com/samsaffron/term-llm/internal/llm"
-	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
 	"github.com/samsaffron/term-llm/internal/restart"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -905,23 +904,18 @@ func (f eventSinkFunc) Event(ev llm.Event) {
 type runnerEventCollector struct {
 	sink runpkg.EventSink
 
-	thinking       strings.Builder
-	thinkingItemID string
-	response       strings.Builder
-	turns          int
-	input          int
-	output         int
+	runnerOutput
+	turns  int
+	input  int
+	output int
 }
 
 func (c *runnerEventCollector) Event(ev llm.Event) error {
 	if c == nil {
 		return nil
 	}
+	c.runnerOutput.Event(ev)
 	switch ev.Type {
-	case llm.EventReasoningDelta:
-		internalreasoning.AppendStreamItemText(&c.thinking, &c.thinkingItemID, ev.Text, ev.ReasoningItemID)
-	case llm.EventTextDelta:
-		c.response.WriteString(ev.Text)
 	case llm.EventUsage:
 		if ev.Use != nil {
 			c.turns++

--- a/cmd/runner_output.go
+++ b/cmd/runner_output.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
+)
+
+// runnerOutput retains earlier provider turns while allowing the current
+// attempt's provisional output to be retracted. Usage is not a commit boundary:
+// a provider can emit usage before its stream fails.
+type runnerOutput struct {
+	response          strings.Builder
+	thinking          strings.Builder
+	thinkingItemID    string
+	turn              int
+	responseStart     int
+	thinkingStart     int
+	thinkingItemStart string
+}
+
+func (o *runnerOutput) Event(ev llm.Event) {
+	// Agentic model events carry a turn index; simple streams and engine-generated
+	// retry discards may not. An untagged discard always refers to the current turn.
+	if ev.ProviderTurnIndexSet && ev.ProviderTurnIndex > o.turn {
+		o.turn = ev.ProviderTurnIndex
+		o.responseStart = o.response.Len()
+		o.thinkingStart = o.thinking.Len()
+		o.thinkingItemStart = o.thinkingItemID
+	}
+	switch ev.Type {
+	case llm.EventTextDelta:
+		o.response.WriteString(ev.Text)
+	case llm.EventReasoningDelta:
+		internalreasoning.AppendStreamItemText(&o.thinking, &o.thinkingItemID, ev.Text, ev.ReasoningItemID)
+	case llm.EventAttemptDiscard:
+		restoreOutputPrefix(&o.response, o.responseStart)
+		restoreOutputPrefix(&o.thinking, o.thinkingStart)
+		o.thinkingItemID = o.thinkingItemStart
+	}
+}
+
+func restoreOutputPrefix(builder *strings.Builder, length int) {
+	prefix := builder.String()[:length]
+	builder.Reset()
+	builder.WriteString(prefix)
+}

--- a/cmd/runner_output_test.go
+++ b/cmd/runner_output_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+)
+
+func TestResultCollectorsDiscardAbandonedAttempts(t *testing.T) {
+	for _, earlierTurn := range []bool{false, true} {
+		name := "first_turn"
+		wantText, wantThinking := "correct result", "accepted reasoning"
+		var events []llm.Event
+		if earlierTurn {
+			name = "after_tool_turn"
+			wantText = "earlier output; " + wantText
+			// Reusing the earlier item ID ensures discard restores item-boundary state.
+			wantThinking = "earlier reasoning" + wantThinking
+			events = append(events,
+				llm.Event{Type: llm.EventTextDelta, Text: "earlier output; ", ProviderTurnIndexSet: true},
+				llm.Event{Type: llm.EventReasoningDelta, Text: "earlier reasoning", ReasoningItemID: "earlier", ProviderTurnIndexSet: true},
+				llm.Event{Type: llm.EventToolCall, Tool: &llm.ToolCall{ID: "tool", Name: "test"}, ProviderTurnIndexSet: true},
+				llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 1}},
+				llm.Event{Type: llm.EventToolExecStart, ToolCallID: "tool"},
+				llm.Event{Type: llm.EventToolExecEnd, ToolCallID: "tool", ToolSuccess: true},
+			)
+		}
+		// Simple engine streams have no turn index. Agentic streams tag model
+		// events, but engine-generated retry discards can be untagged.
+		events = append(events,
+			llm.Event{Type: llm.EventTextDelta, Text: "obsolete draft", ProviderTurnIndex: 1, ProviderTurnIndexSet: earlierTurn},
+			llm.Event{Type: llm.EventReasoningDelta, Text: "obsolete reasoning", ReasoningItemID: "abandoned", ProviderTurnIndex: 1, ProviderTurnIndexSet: earlierTurn},
+			llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 2}},
+			llm.Event{Type: llm.EventAttemptDiscard},
+			llm.Event{Type: llm.EventAttemptDiscard},
+			llm.Event{Type: llm.EventTextDelta, Text: "correct result", ProviderTurnIndex: 1, ProviderTurnIndexSet: earlierTurn},
+			llm.Event{Type: llm.EventReasoningDelta, Text: "accepted reasoning", ReasoningItemID: "earlier", ProviderTurnIndex: 1, ProviderTurnIndexSet: earlierTurn},
+			llm.Event{Type: llm.EventUsage, Use: &llm.Usage{InputTokens: 3}},
+		)
+		t.Run(name, func(t *testing.T) {
+			sink := &spawnRunSink{}
+			collector := &runnerEventCollector{sink: sink}
+			for _, ev := range events {
+				if err := collector.Event(ev); err != nil {
+					t.Fatal(err)
+				}
+			}
+			result := collector.Result("session")
+			if result.Response != wantText || result.Thinking != wantThinking {
+				t.Errorf("collector result = %q / %q, want %q / %q", result.Response, result.Thinking, wantText, wantThinking)
+			}
+			output, err := completeChildAgent(nil, result, sink.Output(), "", true)
+			if err != nil || output != wantText {
+				t.Errorf("child output = %q, %v; want %q", output, err, wantText)
+			}
+
+			runner := &jobsV2LLMRunner{exec: func(_ context.Context, _ jobsV2LLMConfig, onEvent func(llm.Event)) (serveJobsExecResult, error) {
+				for _, ev := range events {
+					onEvent(ev)
+				}
+				return serveJobsExecResult{}, nil
+			}}
+			job := jobsV2Job{RunnerConfig: json.RawMessage(`{"agent_name":"test","instructions":"test","cwd":"."}`)}
+			var flushed string
+			res, err := runner.Run(context.Background(), job, func(kind, message string, _ any) {
+				if kind == "response_flush" {
+					flushed = message
+				}
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.Response != wantText || res.Thinking != wantThinking || flushed != wantText {
+				t.Errorf("job result = %q / %q, flush = %q; want %q / %q", res.Response, res.Thinking, flushed, wantText, wantThinking)
+			}
+
+			mgr := newJobsV2ManagerWithoutLoops(t)
+			storedJob, err := mgr.CreateJob(jobsV2Job{Name: "retry-result", Enabled: true, RunnerType: jobsV2RunnerLLM, RunnerConfig: job.RunnerConfig, TriggerType: jobsV2TriggerManual, TriggerConfig: json.RawMessage(`{}`)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			run, err := mgr.TriggerJob(storedJob.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := mgr.finishRun(run.ID, jobsV2RunSucceeded, res, nil, run.Attempt); err != nil {
+				t.Fatal(err)
+			}
+			var response, thinking string
+			if err := mgr.db.QueryRow(`SELECT response, thinking FROM job_runs_v2 WHERE id = ?`, run.ID).Scan(&response, &thinking); err != nil {
+				t.Fatal(err)
+			}
+			if response != wantText || thinking != wantThinking {
+				t.Errorf("persisted result = %q / %q; want %q / %q", response, thinking, wantText, wantThinking)
+			}
+		})
+	}
+}
+
+func TestRunnerOutputTaggedDiscardBeforeNewTurnOutput(t *testing.T) {
+	var output runnerOutput
+	output.Event(llm.Event{Type: llm.EventTextDelta, Text: "accepted", ProviderTurnIndexSet: true})
+	// A restart discard can identify a new turn before it has emitted text.
+	output.Event(llm.Event{Type: llm.EventAttemptDiscard, ProviderTurnIndex: 2, ProviderTurnIndexSet: true})
+	output.Event(llm.Event{Type: llm.EventTextDelta, Text: "abandoned", ProviderTurnIndex: 2, ProviderTurnIndexSet: true})
+	output.Event(llm.Event{Type: llm.EventAttemptDiscard, ProviderTurnIndex: 2, ProviderTurnIndexSet: true})
+	output.Event(llm.Event{Type: llm.EventTextDelta, Text: " replacement", ProviderTurnIndex: 2, ProviderTurnIndexSet: true})
+	if got := output.response.String(); got != "accepted replacement" {
+		t.Fatalf("response = %q, want accepted replacement", got)
+	}
+}

--- a/cmd/serve_jobs_v2.go
+++ b/cmd/serve_jobs_v2.go
@@ -23,7 +23,6 @@ import (
 	"github.com/samsaffron/term-llm/internal/jobs"
 	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/providerhttp"
-	internalreasoning "github.com/samsaffron/term-llm/internal/reasoning"
 	"github.com/samsaffron/term-llm/internal/restart"
 	runpkg "github.com/samsaffron/term-llm/internal/run"
 	"github.com/samsaffron/term-llm/internal/session"
@@ -389,18 +388,13 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 	if delegationID := hubDelegationIDFromJobLabels(job.Labels); delegationID != "" {
 		ctx = tools.WithHubDelegationID(ctx, delegationID)
 	}
-	var thinkingBuilder strings.Builder
-	var thinkingItemID string
-	var responseBuilder strings.Builder
+	var output runnerOutput
 	progressTracker := newProgressTracker()
 	execResult, err := r.exec(ctx, cfg, func(ev llm.Event) {
+		if ev.Type != llm.EventTextDelta || !cfg.Progressive {
+			output.Event(ev)
+		}
 		switch ev.Type {
-		case llm.EventReasoningDelta:
-			internalreasoning.AppendStreamItemText(&thinkingBuilder, &thinkingItemID, ev.Text, ev.ReasoningItemID)
-		case llm.EventTextDelta:
-			if !cfg.Progressive {
-				responseBuilder.WriteString(ev.Text)
-			}
 		case llm.EventToolCall:
 			if ev.Tool != nil && cfg.Progressive && isProgressToolName(ev.Tool.Name) {
 				progressTracker.observeToolCall(strings.TrimSpace(ev.Tool.ID), strings.TrimSpace(ev.Tool.Name), ev.Tool.Arguments)
@@ -413,7 +407,7 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 				// Flush accumulated response to DB after each turn so callers can see partial output.
 				if pw != nil {
 					if !cfg.Progressive {
-						pw("response_flush", responseBuilder.String(), nil)
+						pw("response_flush", output.response.String(), nil)
 					}
 					pw("turn_complete", fmt.Sprintf("turn %d complete (%d in, %d out tokens)", res.TurnCount, ev.Use.InputTokens, ev.Use.OutputTokens), map[string]any{
 						"turn":          res.TurnCount,
@@ -444,7 +438,7 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 					if message == "" {
 						message = "progress updated"
 					}
-					envelope := buildProgressiveRunResult(cfg.SessionID, "", commit.Final, commit, responseBuilder.String())
+					envelope := buildProgressiveRunResult(cfg.SessionID, "", commit.Final, commit, output.response.String())
 					pw("progress_update", message, envelope)
 				}
 				return
@@ -466,9 +460,9 @@ func (r *jobsV2LLMRunner) Run(ctx context.Context, job jobsV2Job, pw progressWri
 			}
 		}
 	})
-	res.Thinking = thinkingBuilder.String()
+	res.Thinking = output.thinking.String()
 	if !cfg.Progressive {
-		res.Response = responseBuilder.String()
+		res.Response = output.response.String()
 	}
 	if execResult.Progressive != nil {
 		if strings.TrimSpace(execResult.Progressive.SessionID) == "" {

--- a/cmd/spawn_runner.go
+++ b/cmd/spawn_runner.go
@@ -466,7 +466,7 @@ type spawnRunSink struct {
 	model    string
 
 	mu       sync.Mutex
-	output   strings.Builder
+	output   runnerOutput
 	started  bool
 	doneSent bool
 }
@@ -507,7 +507,7 @@ func (s *spawnRunSink) Output() string {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.output.String()
+	return s.output.response.String()
 }
 
 func (s *spawnRunSink) Event(event llm.Event) {
@@ -516,9 +516,7 @@ func (s *spawnRunSink) Event(event llm.Event) {
 	}
 	s.Start()
 	s.mu.Lock()
-	if event.Type == llm.EventTextDelta {
-		s.output.WriteString(event.Text)
-	}
+	s.output.Event(event)
 	s.mu.Unlock()
 	if s.cb == nil || s.callID == "" {
 		return


### PR DESCRIPTION
## What changed

- Make `spawnRunSink`, `runnerEventCollector`, and the jobs LLM runner share attempt-aware text/reasoning accumulation.
- On `EventAttemptDiscard`, restore the prefix from earlier provider turns and the prior reasoning-item identity instead of concatenating abandoned drafts with replacement output.
- Use the engine's provider-turn indices to checkpoint earlier output. Untagged simple streams and engine-generated retry discards are supported; usage events are deliberately not treated as commit boundaries.
- Preserve existing output-tool and progressive-result precedence, event forwarding, and usage accounting.

## Why this is high-value

Sam/Jarvis routinely consumes delegated prose and scheduled LLM job results. A transient stream interruption could previously produce a successful result such as `obsolete draftcorrect result`, feeding contradictory content into the parent model and completion hooks and persisting it for job callers. This is result corruption, not just a stale streaming display.

Verified the negative checks in current code: the engine retracts its own scratchpad, but all three downstream collectors were append-only; `completeChildAgent` prefers the sink's nonempty output; the jobs executor supplies no authoritative non-progressive replacement; `finishRun` persists the runner's response. Existing engine retry tests clear their accumulators explicitly. The open transport-retry PR #1125 changes retry classification, not these collectors; #1124 changes Telegram history handling.

The reported value remains high (80): ordinary delegation/jobs are daily workflows, and the localized fix prevents silent corruption after otherwise successful recovery.

## Validation

- Added a deterministic regression test that **failed before the fix** in all three collectors, child completion, job response flush, and the SQLite-persisted job result, then passed after the fix.
- Covers abandoned text and reasoning, repeated discards, usage before a failed attempt completes, successful replacement, preservation of an earlier completed tool turn, and restoration of reasoning-item boundary state.
- Additional test covers tagged discard before any new-turn output and a subsequent tagged retry discard.
- `make frontend` — passed (required to generate the checkout's embedded assets).
- `gofmt -w` on all five changed Go files — completed.
- Focused regression and uninterrupted-accumulation tests — passed, including `go test -race ./cmd -run 'TestResultCollectorsDiscardAbandonedAttempts|TestRunnerOutputTaggedDiscardBeforeNewTurnOutput|TestJobsV2LLMRunnerAccumulatesStreamingDeltas' -count=1`.
- `go build ./...` — passed.
- `go vet ./...` — passed.
- `go test ./...` — run. With the normal home, two skill-discovery tests encounter installed-user-skill interference. Re-running the full suite with isolated HOME/XDG directories clears those failures; all packages pass except the unrelated `internal/serveui/TestProductionBundleSizeBudgets`: unchanged frontend output is 505,323 raw / 147,735 gzip bytes against a 506,000 / 144,000 budget. No frontend sources or budget tests changed.
- `git diff --stat` and `git diff --check` — reviewed/clean.

No live-provider test was needed; the tests exercise the engine event contract directly and verify the durable job write. This change does not attempt to retract already-forwarded subagent display events or alter token accounting.
