### PR TITLE
UX: Identify the sending node in completion push notifications

### DIFF
--- a/cmd/serve_completion_push.go
+++ b/cmd/serve_completion_push.go
@@ -60,6 +60,26 @@ func (s *serveServer) validateCompletionPushTarget(ctx context.Context, id strin
 	return sub.ID, nil
 }
 
+// completionPushLabel returns a short label identifying the node that produced
+// a completion notification, or "" when this deployment has no node identity
+// configured.
+//
+// A Hub fronts several nodes and every node sends byte-identical notification
+// text, so once more than one node has a push subscription the notifications
+// are indistinguishable until you open one. The payload already carries a
+// node-specific URL, but the visible title does not.
+//
+// agentName is deliberately not consulted: nearly every deployment passes
+// --agent, and single-node users should keep the original wording.
+func (c serveServerConfig) completionPushLabel() string {
+	for _, candidate := range []string{c.uiTitle, c.hubNodeName, c.hubNodeID} {
+		if label := strings.TrimSpace(candidate); label != "" {
+			return label
+		}
+	}
+	return ""
+}
+
 func (s *serveServer) enqueueCompletionPush(responseID, sessionID, subscriptionID, outcome string, createdAt time.Time) {
 	outbox, ok := session.AsCompletionPushOutboxStore(s.store)
 	if !ok || strings.TrimSpace(subscriptionID) == "" || (outcome != "completed" && outcome != "failed") {
@@ -71,6 +91,9 @@ func (s *serveServer) enqueueCompletionPush(responseID, sessionID, subscriptionI
 	if outcome == "failed" {
 		title = "Response failed"
 		body = "Your term-llm response stopped with an error."
+	}
+	if label := s.cfg.completionPushLabel(); label != "" {
+		title = label + ": " + title
 	}
 	base := strings.TrimSuffix(s.cfg.basePath, "/")
 	if base == "" {

--- a/cmd/serve_completion_push_test.go
+++ b/cmd/serve_completion_push_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -110,6 +111,67 @@ func TestCompletionPushTimeoutDoesNotStarveOutbox(t *testing.T) {
 				assertRow("slow", status, attempt)
 			}
 			assertRow("healthy", "delivered", 1)
+		})
+	}
+}
+
+func TestCompletionPushTitleIdentifiesNode(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     serveServerConfig
+		outcome string
+		want    string
+	}{
+		{"no node identity keeps original wording", serveServerConfig{}, "completed", "Response complete"},
+		{"ui title labels the node", serveServerConfig{uiTitle: "workshop"}, "completed", "workshop: Response complete"},
+		{"hub node name when no title", serveServerConfig{hubNodeName: "artist"}, "completed", "artist: Response complete"},
+		{"hub node id as last resort", serveServerConfig{hubNodeID: "node-7"}, "completed", "node-7: Response complete"},
+		{"title wins over hub fields", serveServerConfig{uiTitle: "Studio", hubNodeName: "artist"}, "completed", "Studio: Response complete"},
+		{"blank title falls through", serveServerConfig{uiTitle: "   ", hubNodeName: "artist"}, "completed", "artist: Response complete"},
+		{"failures are labelled too", serveServerConfig{uiTitle: "workshop"}, "failed", "workshop: Response failed"},
+		{"failures without identity are unchanged", serveServerConfig{}, "failed", "Response failed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "sessions.db")
+			store, err := session.NewSQLiteStore(session.Config{Enabled: true, Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+
+			sub, err := store.UpsertPushSubscription(context.Background(), &session.PushSubscription{
+				Endpoint: "https://push.example/node", KeyP256DH: "key", KeyAuth: "auth",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s := &serveServer{store: store, cfg: tc.cfg}
+			s.enqueueCompletionPush("resp-1", "sess-1", sub.ID, tc.outcome, time.Now())
+
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			var raw []byte
+			if err := db.QueryRow(`SELECT payload FROM completion_push_outbox WHERE response_id = ?`, "resp-1").Scan(&raw); err != nil {
+				t.Fatalf("no push enqueued: %v", err)
+			}
+			var payload completionPushPayload
+			if err := json.Unmarshal(raw, &payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.Title != tc.want {
+				t.Errorf("title = %q, want %q", payload.Title, tc.want)
+			}
+			// The body is intentionally left alone; only the title gains the label.
+			if payload.Body == "" {
+				t.Error("body should not be empty")
+			}
 		})
 	}
 }


### PR DESCRIPTION
**Previously**, every node sent byte-identical push notification text, so anyone running a Hub with more than one subscribed node could not tell which conversation had finished without opening the notification.

**In this update**, the notification title is prefixed with the node's configured label (`uiTitle`, then `hubNodeName`, then `hubNodeID`), leaving deployments with no node identity on the original wording.

---

### Why

Push subscriptions are stored per node, so with a Hub fronting several serves each one pushes independently. The payload already carries a node-specific `url`, so tapping the notification lands in the right place, but the visible `title` and `body` are constants:

```go
title := "Response complete"
body  := "Your term-llm response is ready."
```

Two nodes finishing work produce indistinguishable notifications.

### Approach

`completionPushLabel()` resolves an identity from config the operator has already set, and returns `""` when none is configured so single-node deployments are unchanged.

`agentName` is deliberately **not** consulted: nearly every deployment passes `--agent`, so using it would change the wording for almost everyone rather than only for people who have actually labelled a node.

No frontend change is needed. `sw.js` already renders `raw.title` from the payload.

### Known gap

`frontend/src/platform/notifications.ts` builds the same payload shape for the same-device hidden-tab fallback and hardcodes the title too. Labelling that path needs the node label exposed to the browser (there is no `window.TERM_LLM_UI_TITLE` today), which felt like a separate change with a design decision attached. Happy to follow up if you want it, or to fold it in here if you would rather it land together.

### Testing

`TestCompletionPushTitleIdentifiesNode` asserts the enqueued payload rather than the helper, covering precedence, whitespace-only values falling through, failure outcomes, and the unlabelled case staying byte-identical.

```
ok  github.com/samsaffron/term-llm/cmd
```
