### PR TITLE
Show live subagent progress and bound delegation waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,9 @@ jobs:
 
       - name: Race-test Web UI lifecycle owners
         if: needs.changes.outputs.backend == 'true'
-        run: go test -race ./internal/webrtc ./internal/session ./internal/termhost ./cmd
+        run: |
+          go test -race ./internal/webrtc ./internal/session ./internal/termhost ./cmd
+          go test -race -tags browserfixture ./internal/llm -run '^TestDebugBrowserGate$'
 
       - name: Race-test nested modules
         if: needs.changes.outputs.backend == 'true'

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -161,6 +161,29 @@ func resolvedRunnerApprovalMode(defaults cmdRunnerOptions, req runpkg.Request) t
 	return tools.ModePrompt
 }
 
+func prepareRunnerAgent(agent *agents.Agent, req runpkg.Request) (*agents.Agent, string, string, string, string) {
+	if agent == nil {
+		return nil, "", "", "", ""
+	}
+	if req.HostOutputTool != nil {
+		agentCopy := *agent
+		agentCopy.Output = ""
+		agentCopy.OnComplete = ""
+		agentCopy.OutputTool = agents.OutputToolConfig{Name: req.HostOutputTool.Name, Param: req.HostOutputTool.Param, Description: req.HostOutputTool.Description, Schema: req.HostOutputTool.Schema}
+		agent = &agentCopy
+	}
+	if model := strings.TrimSpace(req.Model); model != "" {
+		agentCopy := *agent
+		agentCopy.Model = model
+		agent = &agentCopy
+	}
+	return agent, agent.Provider, agent.Model, agent.Skills, agent.Name
+}
+
+func includeConfiguredRunnerTools(req runpkg.Request) bool {
+	return req.IncludeConfiguredTools == nil || *req.IncludeConfiguredTools
+}
+
 func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg.EventSink) (*cmdRunEnvironment, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -178,25 +201,7 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 		return nil, fmt.Errorf("agent %q not found", req.AgentName)
 	}
 
-	agentProvider, agentModel, agentSkills, agentName := "", "", "", ""
-	if agent != nil {
-		if req.HostOutputTool != nil {
-			agentCopy := *agent
-			agentCopy.Output = ""
-			agentCopy.OnComplete = ""
-			agentCopy.OutputTool = agents.OutputToolConfig{Name: req.HostOutputTool.Name, Param: req.HostOutputTool.Param, Description: req.HostOutputTool.Description, Schema: req.HostOutputTool.Schema}
-			agent = &agentCopy
-		}
-		if model := strings.TrimSpace(req.Model); model != "" {
-			agentCopy := *agent
-			agentCopy.Model = model
-			agent = &agentCopy
-		}
-		agentProvider = agent.Provider
-		agentModel = agent.Model
-		agentSkills = agent.Skills
-		agentName = agent.Name
-	}
+	agent, agentProvider, agentModel, agentSkills, agentName := prepareRunnerAgent(agent, req)
 	providerFlag := strings.TrimSpace(req.Provider)
 	if providerFlag == "" {
 		providerFlag = strings.TrimSpace(r.defaults.Provider)
@@ -430,10 +435,7 @@ func (r *cmdRunner) prepare(ctx context.Context, req runpkg.Request, sink runpkg
 		runtime.setMCPManager(mgr)
 	}
 
-	configuredTools := true
-	if req.IncludeConfiguredTools != nil {
-		configuredTools = *req.IncludeConfiguredTools
-	}
+	configuredTools := includeConfiguredRunnerTools(req)
 	var toolSpecs []llm.ToolSpec
 	if configuredTools {
 		toolSpecs = runtime.selectTools(nil)

--- a/cmd/serve_children.go
+++ b/cmd/serve_children.go
@@ -119,6 +119,10 @@ func childSpawnProvenanceForParent(ctx context.Context, store session.Store, par
 	return provenance
 }
 
+func terminalChildStatus(status session.SessionStatus) bool {
+	return status == session.StatusComplete || status == session.StatusError || status == session.StatusInterrupted
+}
+
 func (s *serveServer) handleSessionChildren(w http.ResponseWriter, r *http.Request, parentID string) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
@@ -171,7 +175,7 @@ func (s *serveServer) handleSessionChildren(w http.ResponseWriter, r *http.Reque
 			StartedAt:         child.CreatedAt.UnixMilli(),
 			ApproximateTimes:  true,
 		}
-		terminal := child.Status == session.StatusComplete || child.Status == session.StatusError || child.Status == session.StatusInterrupted
+		terminal := terminalChildStatus(child.Status)
 		if spawn, ok := spawnProvenance[child.ID]; ok {
 			item.ParentSpawnItemID = spawn.ItemID
 			item.ParentSpawnCallID = spawn.CallID

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -936,44 +936,52 @@ func boundedWebSpawnAgentOutput(output string) string {
 	return boundedWebSpawnAgentText(output, maxWebSpawnAgentOutputBytes, "\n… (output truncated)")
 }
 
-func (s *serveServer) validatedSpawnChildID(parentSessionID, childSessionID string) string {
+func (s *serveServer) validatedSpawnChild(parentSessionID, childSessionID string) *session.Session {
 	parentSessionID = strings.TrimSpace(parentSessionID)
 	childSessionID = strings.TrimSpace(childSessionID)
 	if s == nil || s.store == nil || parentSessionID == "" || childSessionID == "" || childSessionID == parentSessionID {
-		return ""
+		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	child, err := s.store.Get(ctx, childSessionID)
 	if err != nil || child == nil || child.ParentID != parentSessionID {
-		return ""
+		return nil
 	}
-	return childSessionID
+	return child
+}
+
+func (s *serveServer) validatedSpawnChildID(parentSessionID, childSessionID string) string {
+	if child := s.validatedSpawnChild(parentSessionID, childSessionID); child != nil {
+		return child.ID
+	}
+	return ""
 }
 
 type sessionMessagePartEntry struct {
-	CreatedAt       int64                          `json:"created_at,omitempty"`
-	Type            string                         `json:"type"`
-	Text            string                         `json:"text,omitempty"`
-	SkillActivation *llm.SkillActivationProvenance `json:"skill_activation,omitempty"`
-	PathNote        *llm.PathNoteProvenance        `json:"path_note,omitempty"`
-	DiffComment     *llm.DiffComment               `json:"diff_comment,omitempty"`
-	ModelSwap       *llm.ModelSwapMarker           `json:"model_swap,omitempty"`
-	ToolName        string                         `json:"tool_name,omitempty"`
-	ToolInfo        string                         `json:"tool_info,omitempty"`
-	ToolArgs        string                         `json:"tool_arguments,omitempty"`
-	ToolCallID      string                         `json:"tool_call_id,omitempty"`
-	ToolStatus      string                         `json:"tool_status,omitempty"`
-	AskUserSummary  string                         `json:"ask_user_summary,omitempty"`
-	ImageURL        string                         `json:"image_url,omitempty"`
-	Images          []string                       `json:"images,omitempty"`
-	Media           []webMediaEntry                `json:"media,omitempty"`
-	ToolError       bool                           `json:"tool_error,omitempty"`
-	GuardianReviews []llm.GuardianReview           `json:"guardian_reviews,omitempty"`
-	SpawnAgent      *tools.SpawnAgentResult        `json:"spawn_agent,omitempty"`
-	MimeType        string                         `json:"mime_type,omitempty"`
-	Width           int                            `json:"width,omitempty"`
-	Height          int                            `json:"height,omitempty"`
+	CreatedAt           int64                          `json:"created_at,omitempty"`
+	Type                string                         `json:"type"`
+	Text                string                         `json:"text,omitempty"`
+	SkillActivation     *llm.SkillActivationProvenance `json:"skill_activation,omitempty"`
+	PathNote            *llm.PathNoteProvenance        `json:"path_note,omitempty"`
+	DiffComment         *llm.DiffComment               `json:"diff_comment,omitempty"`
+	ModelSwap           *llm.ModelSwapMarker           `json:"model_swap,omitempty"`
+	ToolName            string                         `json:"tool_name,omitempty"`
+	ToolInfo            string                         `json:"tool_info,omitempty"`
+	ToolArgs            string                         `json:"tool_arguments,omitempty"`
+	ToolCallID          string                         `json:"tool_call_id,omitempty"`
+	ToolStatus          string                         `json:"tool_status,omitempty"`
+	AskUserSummary      string                         `json:"ask_user_summary,omitempty"`
+	ImageURL            string                         `json:"image_url,omitempty"`
+	Images              []string                       `json:"images,omitempty"`
+	Media               []webMediaEntry                `json:"media,omitempty"`
+	ToolError           bool                           `json:"tool_error,omitempty"`
+	GuardianReviews     []llm.GuardianReview           `json:"guardian_reviews,omitempty"`
+	SpawnAgent          *tools.SpawnAgentResult        `json:"spawn_agent,omitempty"`
+	SpawnAgentToolCalls *int                           `json:"spawn_agent_tool_calls,omitempty"`
+	MimeType            string                         `json:"mime_type,omitempty"`
+	Width               int                            `json:"width,omitempty"`
+	Height              int                            `json:"height,omitempty"`
 }
 
 type sessionMessageEntry struct {
@@ -1954,6 +1962,7 @@ func (s *serveServer) sessionMessageEntries(msgs []session.Message) []sessionMes
 					isAskUserResult := p.ToolResult.Name == tools.AskUserToolName
 					isSpawnAgentResult := p.ToolResult.Name == tools.SpawnAgentToolName || spawnAgentToolCalls[p.ToolResult.ID]
 					var spawnResult *tools.SpawnAgentResult
+					var spawnToolCalls *int
 					if isSpawnAgentResult {
 						if parsed, err := tools.ParseSpawnAgentResult(p.ToolResult.Content); err == nil {
 							spawnResult = &parsed
@@ -1964,7 +1973,7 @@ func (s *serveServer) sessionMessageEntries(msgs []session.Message) []sessionMes
 							spawnResult.Output = boundedWebSpawnAgentOutput(spawnResult.Output)
 							spawnResult.Error = boundedWebSpawnAgentText(spawnResult.Error, 16*1024, "… (error truncated)")
 							spawnResult.AgentName = boundedWebSpawnAgentText(spawnResult.AgentName, 256, "…")
-							spawnResult.SessionID = s.validatedSpawnChildID(parentSessionID, spawnResult.SessionID)
+							spawnToolCalls = s.validatedSpawnToolCalls(parentSessionID, spawnResult)
 						}
 					}
 					includeResult := p.ToolResult.IsError || len(p.ToolResult.Images) > 0 || len(p.ToolResult.Media) > 0 || len(p.ToolResult.GuardianReviews) > 0 || isPlanResult || isAskUserResult || spawnResult != nil
@@ -1976,12 +1985,13 @@ func (s *serveServer) sessionMessageEntries(msgs []session.Message) []sessionMes
 						toolName = tools.SpawnAgentToolName
 					}
 					pe := sessionMessagePartEntry{
-						Type:            "tool_result",
-						ToolName:        toolName,
-						ToolCallID:      p.ToolResult.ID,
-						ToolError:       p.ToolResult.IsError || (spawnResult != nil && spawnResult.Error != ""),
-						GuardianReviews: append([]llm.GuardianReview(nil), p.ToolResult.GuardianReviews...),
-						SpawnAgent:      spawnResult,
+						Type:                "tool_result",
+						ToolName:            toolName,
+						ToolCallID:          p.ToolResult.ID,
+						ToolError:           p.ToolResult.IsError || (spawnResult != nil && spawnResult.Error != ""),
+						GuardianReviews:     append([]llm.GuardianReview(nil), p.ToolResult.GuardianReviews...),
+						SpawnAgent:          spawnResult,
+						SpawnAgentToolCalls: spawnToolCalls,
 					}
 					if isAskUserResult {
 						pe.AskUserSummary = askUserResultSummary(p.ToolResult.Content)
@@ -3972,3 +3982,13 @@ func (s *serveServer) handlePushSubscribe(w http.ResponseWriter, r *http.Request
 // ---------------------------------------------------------------------------
 // POST /v1/messages — Anthropic Messages API
 // ---------------------------------------------------------------------------
+
+func (s *serveServer) validatedSpawnToolCalls(parentSessionID string, result *tools.SpawnAgentResult) *int {
+	if child := s.validatedSpawnChild(parentSessionID, result.SessionID); child != nil {
+		result.SessionID = child.ID
+		count := child.ToolCalls
+		return &count
+	}
+	result.SessionID = ""
+	return nil
+}

--- a/cmd/serve_response_run_event_projection.go
+++ b/cmd/serve_response_run_event_projection.go
@@ -53,6 +53,9 @@ func (s *serveServer) appendResponseToolCall(runtime *serveRuntime, run *respons
 	// streamed segment identities remain aligned end to end.
 	if s.suppressResponseRunServerToolEvent(runtime, ev.Tool.Name) {
 		state.toolsSeen = true
+		if runtime != nil {
+			runtime.beginSubagentProgress(ev.Tool.ID, ev.Tool.Name)
+		}
 		return nil
 	}
 	state.toolsSeen = true
@@ -87,6 +90,12 @@ func (s *serveServer) appendResponseToolCall(runtime *serveRuntime, run *respons
 	done["item"] = item
 	if err := run.appendEvent("response.output_item.done", done); err != nil {
 		return err
+	}
+	if runtime != nil {
+		// EventToolCall is delivered losslessly before execution. Start delegation
+		// tracking after its recovery row exists, as a fallback for the
+		// best-effort execution-start event under engine backpressure.
+		runtime.beginSubagentProgress(ev.Tool.ID, ev.Tool.Name)
 	}
 	state.outputIndex++
 	return nil

--- a/cmd/serve_response_run_event_projection.go
+++ b/cmd/serve_response_run_event_projection.go
@@ -93,6 +93,9 @@ func (s *serveServer) appendResponseToolCall(runtime *serveRuntime, run *respons
 }
 
 func (s *serveServer) appendResponseToolExecStart(runtime *serveRuntime, run *responseRun, state *responseRunStreamState, ev llm.Event) error {
+	if runtime != nil {
+		runtime.beginSubagentProgress(ev.ToolCallID, ev.ToolName)
+	}
 	// ask_user is a user-facing control event, not tool metadata. Emit its
 	// prompt even when server-executed tool details are hidden; otherwise the
 	// live web stream stalls until a reload recovers the pending prompt.
@@ -129,6 +132,7 @@ func (s *serveServer) appendResponseToolExecStart(runtime *serveRuntime, run *re
 }
 
 func (s *serveServer) appendResponseToolExecEnd(runtime *serveRuntime, run *responseRun, state *responseRunStreamState, ev llm.Event) error {
+	runtime.finishSubagentProgress(ev.ToolCallID, ev.ToolSuccess)
 	if ev.ToolName == tools.AskUserToolName && runtime != nil {
 		runtime.clearPendingAskUser(ev.ToolCallID)
 	}

--- a/cmd/serve_response_run_execution.go
+++ b/cmd/serve_response_run_execution.go
@@ -28,23 +28,7 @@ func (s *serveServer) executeResponseRun(runCtx context.Context, releaseReload, 
 		}()
 	}
 
-	// Wire approval event callback so PromptUIFunc can emit SSE events
-	runtime.approvalMu.Lock()
-	runtime.approvalEventFunc = func(event string, data map[string]any) error {
-		return run.appendEvent(event, data)
-	}
-	runtime.approvalCtx = runCtx
-	runtime.pauseResponseTimeout = runTimer.pause
-	runtime.refreshResponseTimeout = runTimer.refresh
-	runtime.approvalMu.Unlock()
-	defer func() {
-		runtime.approvalMu.Lock()
-		runtime.approvalEventFunc = nil
-		runtime.approvalCtx = nil
-		runtime.pauseResponseTimeout = nil
-		runtime.refreshResponseTimeout = nil
-		runtime.approvalMu.Unlock()
-	}()
+	defer s.bindResponseRunCallbacks(runCtx, runtime, run, runTimer)()
 
 	if options.modelSwap != nil && options.modelSwap.plan.enabled {
 		s.executeResponseRunModelSwap(runCtx, runtime, run, stateful, replaceHistory, inputMessages, llmReq, sessionID, respID, model, created, options)
@@ -185,4 +169,40 @@ func (s *serveServer) executeResponseRun(runCtx context.Context, releaseReload, 
 		return
 	}
 	s.scheduleAutoTitle(sessionID, runtime.providerKey)
+}
+
+func (s *serveServer) bindResponseRunCallbacks(runCtx context.Context, runtime *serveRuntime, run *responseRun, runTimer *responseRunTimer) func() {
+	progress := newServeSubagentProgress(realResponseRunClock{}, func(event string, data map[string]any) error {
+		if s.suppressResponseRunServerToolEvent(runtime, stringValue(data["tool_name"])) {
+			return nil
+		}
+		return run.appendEvent(event, data)
+	}, runTimer.holdUntil)
+
+	// Wire run-scoped callbacks. Each execution gets a monotonically increasing
+	// owner so a delayed callback cannot target a later run that reused a call ID.
+	runtime.approvalMu.Lock()
+	runtime.approvalEventFunc = func(event string, data map[string]any) error {
+		return run.appendEvent(event, data)
+	}
+	runtime.approvalCtx = runCtx
+	runtime.pauseResponseTimeout = runTimer.pause
+	runtime.refreshResponseTimeout = runTimer.refresh
+	runtime.subagentProgressOwner++
+	runtime.subagentProgress = progress
+	progressOwner := runtime.subagentProgressOwner
+	runtime.approvalMu.Unlock()
+	return func() {
+		runtime.approvalMu.Lock()
+		if runtime.subagentProgress == progress && runtime.subagentProgressOwner == progressOwner {
+			runtime.subagentProgress = nil
+		}
+		runtime.approvalEventFunc = nil
+		runtime.approvalCtx = nil
+		runtime.pauseResponseTimeout = nil
+		runtime.refreshResponseTimeout = nil
+		runtime.approvalMu.Unlock()
+		progress.close()
+	}
+
 }

--- a/cmd/serve_response_run_manager.go
+++ b/cmd/serve_response_run_manager.go
@@ -57,6 +57,8 @@ const (
 	defaultResponseRunReplayLimit      = 2048
 	defaultResponseRunSubscriberBuffer = 256
 	defaultServeRequestTimeout         = 30 * time.Minute
+	responseRunHoldGrace               = 30 * time.Second
+	maxResponseRunDelegationHold       = time.Hour + responseRunHoldGrace
 )
 
 var (
@@ -81,8 +83,27 @@ func (realResponseRunClock) AfterFunc(delay time.Duration, fn func()) responseRu
 	return time.AfterFunc(delay, fn)
 }
 
+type responseRunTimerHold struct {
+	extend  func(time.Time)
+	release func()
+}
+
+type responseRunTimerHoldState struct {
+	timer       *responseRunTimer
+	resume      func()
+	handle      responseRunTimerHandle
+	expiresAt   time.Time
+	absoluteCap time.Time
+	generation  uint64
+}
+
+func noopResponseRunTimerHold() responseRunTimerHold {
+	return responseRunTimerHold{extend: func(time.Time) {}, release: func() {}}
+}
+
 // responseRunTimer bounds inactivity between the user request and each completed
-// LLM response. Interactive waits pause the current inactivity window.
+// LLM response. Interactive waits and verified, deadline-bounded delegations
+// pause the current inactivity window.
 type responseRunTimer struct {
 	mu         sync.Mutex
 	cancel     context.CancelCauseFunc
@@ -93,6 +114,7 @@ type responseRunTimer struct {
 	activeAt   time.Time
 	generation uint64
 	pauses     int
+	holds      map[*responseRunTimerHoldState]struct{}
 	stopped    bool
 }
 
@@ -208,6 +230,126 @@ func (t *responseRunTimer) resume() {
 	}
 }
 
+func (t *responseRunTimer) holdUntil(deadline time.Time) responseRunTimerHold {
+	if t == nil || deadline.IsZero() {
+		return noopResponseRunTimerHold()
+	}
+	now := t.clock.Now()
+	absoluteCap := now.Add(maxResponseRunDelegationHold)
+	expiresAt := deadline.Add(responseRunHoldGrace)
+	if expiresAt.After(absoluteCap) {
+		expiresAt = absoluteCap
+	}
+	if !expiresAt.After(now) {
+		return noopResponseRunTimerHold()
+	}
+
+	resume := t.pause()
+	state := &responseRunTimerHoldState{timer: t, resume: resume, expiresAt: expiresAt, absoluteCap: absoluteCap}
+	t.mu.Lock()
+	if t.stopped {
+		t.mu.Unlock()
+		return noopResponseRunTimerHold()
+	}
+	if t.holds == nil {
+		t.holds = make(map[*responseRunTimerHoldState]struct{})
+	}
+	t.holds[state] = struct{}{}
+	t.armHoldLocked(state)
+	t.mu.Unlock()
+
+	return responseRunTimerHold{
+		extend:  state.extend,
+		release: state.release,
+	}
+}
+
+func (t *responseRunTimer) armHoldLocked(state *responseRunTimerHoldState) {
+	state.generation++
+	generation := state.generation
+	delay := state.expiresAt.Sub(t.clock.Now())
+	if delay < 0 {
+		delay = 0
+	}
+	state.handle = t.clock.AfterFunc(delay, func() {
+		t.mu.Lock()
+		if t.stopped || state.generation != generation {
+			t.mu.Unlock()
+			return
+		}
+		if _, ok := t.holds[state]; !ok {
+			t.mu.Unlock()
+			return
+		}
+		delete(t.holds, state)
+		state.handle = nil
+		resume := state.resume
+		state.resume = nil
+		t.mu.Unlock()
+		if resume != nil {
+			resume() // Expiry preserves the frozen inactivity budget.
+		}
+	})
+}
+
+func (state *responseRunTimerHoldState) extend(deadline time.Time) {
+	if state == nil || state.timer == nil || deadline.IsZero() {
+		return
+	}
+	t := state.timer
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		return
+	}
+	if _, ok := t.holds[state]; !ok {
+		return // Released or expired holds cannot be revived.
+	}
+	if !t.clock.Now().Before(state.expiresAt) {
+		return // The deadline is final even if its scheduled callback is delayed.
+	}
+	expiresAt := deadline.Add(responseRunHoldGrace)
+	if expiresAt.After(state.absoluteCap) {
+		expiresAt = state.absoluteCap
+	}
+	if !expiresAt.After(state.expiresAt) {
+		return
+	}
+	if state.handle != nil {
+		state.handle.Stop()
+	}
+	state.expiresAt = expiresAt
+	t.armHoldLocked(state)
+}
+
+func (state *responseRunTimerHoldState) release() {
+	if state == nil || state.timer == nil {
+		return
+	}
+	t := state.timer
+	t.mu.Lock()
+	if _, ok := t.holds[state]; !ok {
+		t.mu.Unlock()
+		return
+	}
+	delete(t.holds, state)
+	state.generation++
+	if state.handle != nil {
+		state.handle.Stop()
+		state.handle = nil
+	}
+	resume := state.resume
+	state.resume = nil
+	stopped := t.stopped
+	t.mu.Unlock()
+	if stopped || resume == nil {
+		return
+	}
+	// A normally completed delegation gives the parent a fresh, finite window.
+	t.refresh()
+	resume()
+}
+
 func (t *responseRunTimer) stop() {
 	if t == nil {
 		return
@@ -221,6 +363,15 @@ func (t *responseRunTimer) stop() {
 	t.generation++
 	if t.timer != nil {
 		t.timer.Stop()
+	}
+	for hold := range t.holds {
+		hold.generation++
+		if hold.handle != nil {
+			hold.handle.Stop()
+			hold.handle = nil
+		}
+		hold.resume = nil
+		delete(t.holds, hold)
 	}
 	t.mu.Unlock()
 	t.cancel(nil)

--- a/cmd/serve_response_run_recovery.go
+++ b/cmd/serve_response_run_recovery.go
@@ -144,10 +144,8 @@ func (r *responseRun) applyRecoveryEventLocked(event string, payload map[string]
 		r.applyRecoveryResponseOutputItemAdded(event, payload)
 	case "response.output_item.done":
 		r.applyRecoveryResponseOutputItemDone(event, payload)
-	case "response.tool_exec.start":
-		r.applyRecoveryResponseToolExecStart(event, payload)
-	case "response.tool_exec.end":
-		r.applyRecoveryResponseToolExecEnd(event, payload)
+	case "response.tool_exec.start", "response.tool_exec.progress", "response.tool_exec.end":
+		r.applyRecoveryToolExec(event, payload)
 	case "response.completed":
 		r.applyRecoveryResponseCompleted(event, payload)
 	case "response.cancelled":
@@ -439,6 +437,7 @@ func (r *responseRun) recoveryPayloadLocked() map[string]any {
 				if tool.AskUserAnswer != "" {
 					toolEntry["askUserAnswer"] = tool.AskUserAnswer
 				}
+				tool.appendSubagentRecovery(toolEntry)
 				if len(tool.GuardianReviews) > 0 {
 					reviews := make([]map[string]any, 0, len(tool.GuardianReviews))
 					for _, review := range tool.GuardianReviews {
@@ -723,4 +722,20 @@ func (m *responseRunManager) latestRun(sessionID string) *responseRun {
 		}
 	}
 	return latest
+}
+
+func (tool responseRunRecoveryTool) appendSubagentRecovery(entry map[string]any) {
+	if len(tool.SubagentProgress) > 0 {
+		entry["subagentProgress"] = cloneJSONMap(tool.SubagentProgress)
+	}
+}
+func (r *responseRun) applyRecoveryToolExec(event string, payload map[string]any) {
+	switch event {
+	case "response.tool_exec.start":
+		r.applyRecoveryResponseToolExecStart(event, payload)
+	case "response.tool_exec.progress":
+		r.applyRecoveryResponseToolExecProgress(event, payload)
+	case "response.tool_exec.end":
+		r.applyRecoveryResponseToolExecEnd(event, payload)
+	}
 }

--- a/cmd/serve_response_run_recovery_events.go
+++ b/cmd/serve_response_run_recovery_events.go
@@ -267,6 +267,28 @@ func (r *responseRun) applyRecoveryResponseToolExecStart(event string, payload m
 	}
 }
 
+func (r *responseRun) applyRecoveryResponseToolExecProgress(event string, payload map[string]any) {
+	callID := stringValue(payload["call_id"])
+	if callID == "" {
+		return
+	}
+	for messageIndex := len(r.recoveryMessages) - 1; messageIndex >= 0; messageIndex-- {
+		group := &r.recoveryMessages[messageIndex]
+		if group.Role != "tool-group" {
+			continue
+		}
+		for toolIndex := range group.Tools {
+			if group.Tools[toolIndex].ID == callID {
+				currentSeq := responseRunInt64Value(group.Tools[toolIndex].SubagentProgress["seq"], 0)
+				if responseRunInt64Value(payload["seq"], 0) > currentSeq {
+					group.Tools[toolIndex].SubagentProgress = cloneJSONMap(payload)
+				}
+				return
+			}
+		}
+	}
+}
+
 func (r *responseRun) applyRecoveryResponseToolExecEnd(event string, payload map[string]any) {
 	images := stringSliceValue(payload["images"])
 	media := mediaEntriesFromValue(payload["media"])

--- a/cmd/serve_response_runs.go
+++ b/cmd/serve_response_runs.go
@@ -31,6 +31,7 @@ type responseRunRecoveryTool struct {
 	Images             []string
 	Media              []webMediaEntry
 	GuardianReviews    []map[string]any
+	SubagentProgress   map[string]any
 }
 
 type responseRunRecoveryMessage struct {

--- a/cmd/serve_responses_durable.go
+++ b/cmd/serve_responses_durable.go
@@ -152,6 +152,16 @@ func branchContextRequestValues(requested *responsesBranchContextRequest) (strin
 	return mode, focus, 0, ""
 }
 
+func (s *serveServer) recordPathNoteUsage(ctx context.Context, sourceSessionID, model string, notes *llm.PathNotesResult) {
+	if notes == nil || notes.Usage.BillableCountersZero() {
+		return
+	}
+	if rt := s.peekStatsRuntime(sourceSessionID); rt != nil {
+		rt.recordHelperStats("path_note", model, notes.Usage)
+	}
+	_ = s.store.UpdateMetrics(ctx, sourceSessionID, 0, 0, notes.Usage.InputTokens, notes.Usage.OutputTokens, notes.Usage.CachedInputTokens, notes.Usage.CacheWriteTokens)
+}
+
 func (s *serveServer) generateBranchPathNote(ctx context.Context, sourceSessionID string, source []llm.Message, mode, focus string) (*session.BranchPathNote, int, string) {
 	if mode == "" || mode == "none" || mode == "clean" || len(source) == 0 {
 		return nil, 0, ""
@@ -181,12 +191,7 @@ func (s *serveServer) generateBranchPathNote(ctx context.Context, sourceSessionI
 		return nil, http.StatusConflict, "branch context generation is unavailable"
 	}
 	notes, err := llm.GeneratePathNotes(ctx, provider, sess.Model, source, llm.PathNotesConfig{Focus: focus})
-	if notes != nil && !notes.Usage.BillableCountersZero() {
-		if rt := s.peekStatsRuntime(sourceSessionID); rt != nil {
-			rt.recordHelperStats("path_note", sess.Model, notes.Usage)
-		}
-		_ = s.store.UpdateMetrics(ctx, sourceSessionID, 0, 0, notes.Usage.InputTokens, notes.Usage.OutputTokens, notes.Usage.CachedInputTokens, notes.Usage.CacheWriteTokens)
-	}
+	s.recordPathNoteUsage(ctx, sourceSessionID, sess.Model, notes)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, http.StatusRequestTimeout, "branch context generation was cancelled"

--- a/cmd/serve_run_context.go
+++ b/cmd/serve_run_context.go
@@ -30,8 +30,13 @@ func (rt *serveRuntime) prepareRunContext(ctx context.Context, collaboration too
 	if askUser != nil {
 		ctx = tools.ContextWithAskUserUIFunc(ctx, askUser)
 	}
-	if rt.platform == "web" && strings.TrimSpace(req.SessionID) != "" {
-		ctx = tools.ContextWithQueueAgentOrigin(ctx, tools.QueueAgentOriginContext{Origin: tools.QueueAgentOriginWeb, SessionID: req.SessionID})
+	if rt.platform == "web" {
+		if callback := rt.subagentProgressCallback(); callback != nil {
+			ctx = tools.ContextWithSubagentEventCallback(ctx, callback)
+		}
+		if strings.TrimSpace(req.SessionID) != "" {
+			ctx = tools.ContextWithQueueAgentOrigin(ctx, tools.QueueAgentOriginContext{Origin: tools.QueueAgentOriginWeb, SessionID: req.SessionID})
+		}
 	}
 	model, effort := strings.TrimSpace(req.Model), strings.TrimSpace(req.ReasoningEffort)
 	if model == "" {

--- a/cmd/serve_run_persistence.go
+++ b/cmd/serve_run_persistence.go
@@ -272,16 +272,20 @@ func (p *serveRunPersistence) compactionUsageSnapshot() llm.Usage {
 	return p.compactionUsage
 }
 
+func (p *serveRunPersistence) recordCompactionStats(result *llm.CompactionResult) {
+	p.rt.recordHelperStats("compaction", result.Model, result.Usage)
+	if p.rt.statsCompactionCB != nil {
+		p.rt.statsCompactionCB(result)
+	}
+}
+
 func (p *serveRunPersistence) applyCompaction(cbCtx context.Context, result *llm.CompactionResult) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if result == nil {
 		return nil
 	}
-	p.rt.recordHelperStats("compaction", result.Model, result.Usage)
-	if p.rt.statsCompactionCB != nil {
-		p.rt.statsCompactionCB(result)
-	}
+	p.recordCompactionStats(result)
 	previousCompactionSeq := -1
 	previousCompactionCount := 0
 	if session.HasCompactionBoundary(p.rt.sessionMeta) {

--- a/cmd/serve_runtime.go
+++ b/cmd/serve_runtime.go
@@ -94,6 +94,8 @@ type serveRuntime struct {
 	approvalCtx            context.Context
 	pauseResponseTimeout   func() func()
 	refreshResponseTimeout func()
+	subagentProgress       *serveSubagentProgress
+	subagentProgressOwner  uint64
 	lastUIRunError         string
 	platform               string
 	platformMessages       agents.PlatformMessagesConfig
@@ -180,6 +182,51 @@ func (rt *serveRuntime) refreshResponseDeadline() {
 	rt.approvalMu.Unlock()
 	if refresh != nil {
 		refresh()
+	}
+}
+
+func (rt *serveRuntime) beginSubagentProgress(callID, toolName string) {
+	if rt == nil {
+		return
+	}
+	rt.approvalMu.Lock()
+	progress := rt.subagentProgress
+	rt.approvalMu.Unlock()
+	if progress != nil {
+		progress.begin(callID, toolName)
+	}
+}
+
+func (rt *serveRuntime) finishSubagentProgress(callID string, success bool) {
+	if rt == nil {
+		return
+	}
+	rt.approvalMu.Lock()
+	progress := rt.subagentProgress
+	ctx := rt.approvalCtx
+	rt.approvalMu.Unlock()
+	if progress != nil {
+		progress.finish(callID, success, ctx != nil && ctx.Err() != nil)
+	}
+}
+
+func (rt *serveRuntime) subagentProgressCallback() tools.SubagentEventCallback {
+	if rt == nil {
+		return nil
+	}
+	rt.approvalMu.Lock()
+	progress, owner := rt.subagentProgress, rt.subagentProgressOwner
+	rt.approvalMu.Unlock()
+	if progress == nil {
+		return nil
+	}
+	return func(callID string, event tools.SubagentEvent) {
+		rt.approvalMu.Lock()
+		current, currentOwner := rt.subagentProgress, rt.subagentProgressOwner
+		rt.approvalMu.Unlock()
+		if current == progress && currentOwner == owner {
+			progress.observe(callID, event)
+		}
 	}
 }
 

--- a/cmd/serve_spawn_agent_test.go
+++ b/cmd/serve_spawn_agent_test.go
@@ -25,13 +25,13 @@ func TestSessionMessageEntriesProjectsSuccessfulSpawnAgentResult(t *testing.T) {
 		*session.NewMessage("parent", llm.ToolResultMessage("spawn-1", tools.SpawnAgentToolName, string(content), nil), 1),
 	}
 	store := newServeRuntimeTestStore()
-	store.sessions["child-1"] = &session.Session{ID: "child-1", ParentID: "parent"}
+	store.sessions["child-1"] = &session.Session{ID: "child-1", ParentID: "parent", ToolCalls: 12}
 	entries := (&serveServer{store: store}).sessionMessageEntries(messages)
 	if len(entries) != 2 || len(entries[1].Parts) != 1 {
 		t.Fatalf("entries = %#v", entries)
 	}
 	part := entries[1].Parts[0]
-	if part.SpawnAgent == nil || part.SpawnAgent.Output != "durable review" || part.SpawnAgent.SessionID != "child-1" || part.ToolError {
+	if part.SpawnAgent == nil || part.SpawnAgent.Output != "durable review" || part.SpawnAgent.SessionID != "child-1" || part.ToolError || part.SpawnAgentToolCalls == nil || *part.SpawnAgentToolCalls != 12 {
 		t.Fatalf("spawn projection = %#v", part)
 	}
 }
@@ -56,8 +56,8 @@ func TestSessionMessageEntriesOmitsUnvalidatedSpawnChildLinks(t *testing.T) {
 			store.sessions[tc.childID] = &session.Session{ID: tc.childID, ParentID: tc.childParent}
 			entries := (&serveServer{store: store}).sessionMessageEntries(messages)
 			part := entries[1].Parts[0]
-			if part.SpawnAgent == nil || part.SpawnAgent.Output != "safe output" || part.SpawnAgent.SessionID != "" {
-				t.Fatalf("unvalidated link survived projection: %#v", part.SpawnAgent)
+			if part.SpawnAgent == nil || part.SpawnAgent.Output != "safe output" || part.SpawnAgent.SessionID != "" || part.SpawnAgentToolCalls != nil {
+				t.Fatalf("unvalidated link or count survived projection: %#v", part)
 			}
 		})
 	}

--- a/cmd/serve_stats.go
+++ b/cmd/serve_stats.go
@@ -61,40 +61,59 @@ func (rt *serveRuntime) finishStats() {
 	}
 	a.running = false
 }
+func (a *serveStats) startTool(s *ui.SessionStats, id string) {
+	if a.tools[id] || a.ended[id] {
+		return
+	}
+	if a.tools == nil {
+		a.tools = map[string]bool{}
+	}
+	a.tools[id] = true
+	s.ToolStart()
+}
+
+func (a *serveStats) endTool(s *ui.SessionStats, id string) {
+	// Only an observed start can close a tool interval. Duplicate or unmatched
+	// ends must not restart model timing or discard usage.
+	if !a.tools[id] {
+		return
+	}
+	if a.ended == nil {
+		a.ended = map[string]bool{}
+	}
+	a.ended[id] = true
+	delete(a.tools, id)
+	if len(a.tools) == 0 {
+		s.ToolEnd()
+	}
+	a.attempt = llm.Usage{}
+	a.attemptCalls = 0
+	a.committed = false
+}
+
+func (a *serveStats) discardAttempt(s *ui.SessionStats) {
+	// Keep time spent on a failed attempt, even when it produced no usage.
+	// DiscardUsage resets pending timing, so accrue it first. Copying the
+	// snapshot back also preserves an overlapping native-tool interval.
+	*s = s.SnapshotAt(time.Now())
+	u := a.attempt
+	s.DiscardUsage(u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens, a.attemptCalls)
+	if len(a.tools) == 0 {
+		// Some provider fallbacks discard without an EventRetry. Start the
+		// replacement attempt now; a subsequent retry reschedules past backoff.
+		s.RequestStart()
+	}
+	a.attempt = llm.Usage{}
+	a.attemptCalls = 0
+	a.committed = false
+}
+
 func (rt *serveRuntime) recordStatsEvent(e llm.Event) {
 	a := &rt.stats
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.init()
 	s := a.stats
-	start := func(id string) {
-		if a.tools[id] || a.ended[id] {
-			return
-		}
-		if a.tools == nil {
-			a.tools = map[string]bool{}
-		}
-		a.tools[id] = true
-		s.ToolStart()
-	}
-	end := func(id string) {
-		// Only an observed start can close a tool interval. Duplicate or
-		// unmatched ends must not restart model timing or discard usage.
-		if !a.tools[id] {
-			return
-		}
-		if a.ended == nil {
-			a.ended = map[string]bool{}
-		}
-		a.ended[id] = true
-		delete(a.tools, id)
-		if len(a.tools) == 0 {
-			s.ToolEnd()
-		}
-		a.attempt = llm.Usage{}
-		a.attemptCalls = 0
-		a.committed = false
-	}
 	switch e.Type {
 	case llm.EventTextDelta, llm.EventReasoningDelta:
 		a.committed = false
@@ -108,22 +127,22 @@ func (rt *serveRuntime) recordStatsEvent(e llm.Event) {
 		a.attempt = llm.Usage{}
 		a.attemptCalls = 0
 		if e.Tool != nil {
-			start(e.Tool.ID)
+			a.startTool(s, e.Tool.ID)
 		}
 	case llm.EventToolExecStart:
-		start(e.ToolCallID)
+		a.startTool(s, e.ToolCallID)
 	case llm.EventToolExecEnd:
-		end(e.ToolCallID)
+		a.endTool(s, e.ToolCallID)
 	case llm.EventDiscoveryCall:
 		if e.DiscoveryCall != nil {
 			a.committed = true
 			a.attempt = llm.Usage{}
 			a.attemptCalls = 0
-			start(e.DiscoveryCall.ID)
+			a.startTool(s, e.DiscoveryCall.ID)
 		}
 	case llm.EventDiscoveryOutput:
 		if e.DiscoveryOutput != nil {
-			end(e.DiscoveryOutput.CallID)
+			a.endTool(s, e.DiscoveryOutput.CallID)
 		}
 	case llm.EventUsage:
 		s.GenerationEnd()
@@ -139,20 +158,7 @@ func (rt *serveRuntime) recordStatsEvent(e llm.Event) {
 		a.retries++
 		s.ScheduleRetryStart(e.RetryWaitSecs)
 	case llm.EventAttemptDiscard:
-		// Keep time spent on a failed attempt, even when it produced no usage.
-		// DiscardUsage resets pending timing, so accrue it first. Copying the
-		// snapshot back also preserves an overlapping native-tool interval.
-		*s = s.SnapshotAt(time.Now())
-		u := a.attempt
-		s.DiscardUsage(u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens, a.attemptCalls)
-		if len(a.tools) == 0 {
-			// Some provider fallbacks discard without an EventRetry. Start the
-			// replacement attempt now; a subsequent retry reschedules past backoff.
-			s.RequestStart()
-		}
-		a.attempt = llm.Usage{}
-		a.attemptCalls = 0
-		a.committed = false
+		a.discardAttempt(s)
 	case llm.EventDone, llm.EventError:
 		s.Finalize()
 		a.running = false
@@ -222,40 +228,22 @@ func statsMetrics(s *ui.SessionStats) webSessionMetrics {
 	return webSessionMetrics{InputTokens: s.InputTokens, OutputTokens: s.OutputTokens, CachedInputTokens: s.CachedInputTokens, CacheWriteTokens: s.CacheWriteTokens, ToolCalls: s.ToolCallCount, LLMTurns: s.LLMCallCount}
 }
 func statsMS(d time.Duration) *int64 { n := d.Milliseconds(); return &n }
-func (rt *serveRuntime) statsSnapshot() *serveStatsResponse {
-	a := &rt.stats
-	a.mu.Lock()
-	if a.stats == nil {
-		a.mu.Unlock()
-		return nil
-	}
-	now := time.Now()
-	s := a.stats.SnapshotAt(now)
-	calls, _ := s.UsageCalls()
-	runs := a.children.Snapshots()
-	started := make(map[string]bool, len(a.childrenStarted))
-	for id, observed := range a.childrenStarted {
-		started[id] = observed
-	}
-	retries, running := a.retries, a.running
-	handoverUsage, handoverCalls := a.handoverUsage, a.handoverCalls
-	a.mu.Unlock()
-	out := &serveStatsResponse{Metrics: statsMetrics(&s), Scope: "runtime_local", Models: []serveStatsModel{}, Sections: []serveStatsSection{}, ActiveMS: statsMS(s.LLMTime + s.ToolTime), ModelMS: statsMS(s.LLMTime), ToolMS: statsMS(s.ToolTime)}
-	var ttft, gen time.Duration
+func appendMainCallStats(out *serveStatsResponse, calls []ui.UsageCall) {
+	var ttft, generation time.Duration
 	observed, tokens := 0, 0
 	var cost float64
 	priced, unpriced := 0, 0
-	for _, c := range calls {
-		if c.ObservedOutput && c.GenerationTime > 0 {
+	for _, call := range calls {
+		if call.ObservedOutput && call.GenerationTime > 0 {
 			observed++
-			ttft += c.TTFT
-			gen += c.GenerationTime
-			tokens += c.OutputTokens
+			ttft += call.TTFT
+			generation += call.GenerationTime
+			tokens += call.OutputTokens
 		}
 		one := ui.NewSessionStats()
-		one.AddSubagentUsageForModel(c.Model, c.InputTokens, c.OutputTokens, c.CachedInputTokens, c.CacheWriteTokens)
-		if v, err := ui.EstimateSessionStatsCost(one, ""); err == nil {
-			cost += v
+		one.AddSubagentUsageForModel(call.Model, call.InputTokens, call.OutputTokens, call.CachedInputTokens, call.CacheWriteTokens)
+		if value, err := ui.EstimateSessionStatsCost(one, ""); err == nil {
+			cost += value
 			priced++
 		} else {
 			unpriced++
@@ -263,13 +251,16 @@ func (rt *serveRuntime) statsSnapshot() *serveStatsResponse {
 	}
 	if observed > 0 {
 		out.TTFTMS = statsMS(ttft / time.Duration(observed))
-		v := float64(tokens) / gen.Seconds()
-		out.OutputTokensPerSecond = &v
+		value := float64(tokens) / generation.Seconds()
+		out.OutputTokensPerSecond = &value
 	}
 	if priced > 0 {
 		out.CostUSD = &cost
 	}
 	out.CostPartial = unpriced > 0
+}
+
+func appendSubagentModelStats(out *serveStatsResponse, runs []ui.SubagentProgress, started map[string]bool, now time.Time) {
 	groups := map[string]*serveStatsModel{}
 	costs := map[string]*ui.SessionStats{}
 	group := func(model string) *serveStatsModel {
@@ -299,54 +290,81 @@ func (rt *serveRuntime) statsSnapshot() *serveStatsResponse {
 				*row.ToolMS += toolTime.Milliseconds()
 			}
 		}
-		for _, c := range run.UsageCalls {
-			r := group(c.Model)
-			u := c.Usage
-			r.InputTokens += u.InputTokens
-			r.OutputTokens += u.OutputTokens
-			r.CachedInputTokens += u.CachedInputTokens
-			r.CacheWriteTokens += u.CacheWriteTokens
-			r.LLMTurns++
-			costs[r.Model].AddSubagentUsageForModel(c.Model, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
+		for _, call := range run.UsageCalls {
+			row := group(call.Model)
+			u := call.Usage
+			row.InputTokens += u.InputTokens
+			row.OutputTokens += u.OutputTokens
+			row.CachedInputTokens += u.CachedInputTokens
+			row.CacheWriteTokens += u.CacheWriteTokens
+			row.LLMTurns++
+			costs[row.Model].AddSubagentUsageForModel(call.Model, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
 		}
 	}
 	keys := make([]string, 0, len(groups))
-	for k := range groups {
-		keys = append(keys, k)
+	for key := range groups {
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	for _, k := range keys {
-		r := groups[k]
-		cs, _ := costs[k].UsageCalls()
+	for _, key := range keys {
+		row := groups[key]
+		calls, _ := costs[key].UsageCalls()
 		known, priced, missing := 0.0, 0, 0
-		for _, c := range cs {
+		for _, call := range calls {
 			one := ui.NewSessionStats()
-			one.AddSubagentUsageForModel(c.Model, c.InputTokens, c.OutputTokens, c.CachedInputTokens, c.CacheWriteTokens)
-			if v, err := ui.EstimateSessionStatsCost(one, ""); err == nil {
-				known += v
+			one.AddSubagentUsageForModel(call.Model, call.InputTokens, call.OutputTokens, call.CachedInputTokens, call.CacheWriteTokens)
+			if value, err := ui.EstimateSessionStatsCost(one, ""); err == nil {
+				known += value
 				priced++
 			} else {
 				missing++
 			}
 		}
 		if priced > 0 {
-			r.CostUSD = &known
+			row.CostUSD = &known
 		}
-		r.CostPartial = missing > 0
-		out.Models = append(out.Models, *r)
+		row.CostPartial = missing > 0
+		out.Models = append(out.Models, *row)
 	}
+}
+
+func appendHelperUsageSections(out *serveStatsResponse, calls []ui.UsageCall) {
 	for _, kind := range []string{"Private Side-Question Usage", "Guardian Usage", "Compaction Usage"} {
-		var u llm.Usage
-		n := 0
-		for _, c := range calls {
-			match := kind == "Private Side-Question Usage" && c.SideQuestion || kind == "Guardian Usage" && c.Guardian || kind == "Compaction Usage" && c.Compaction
+		var usage llm.Usage
+		count := 0
+		for _, call := range calls {
+			match := kind == "Private Side-Question Usage" && call.SideQuestion || kind == "Guardian Usage" && call.Guardian || kind == "Compaction Usage" && call.Compaction
 			if match {
-				n++
-				u.Add(llm.Usage{InputTokens: c.InputTokens, OutputTokens: c.OutputTokens, CachedInputTokens: c.CachedInputTokens, CacheWriteTokens: c.CacheWriteTokens})
+				count++
+				usage.Add(llm.Usage{InputTokens: call.InputTokens, OutputTokens: call.OutputTokens, CachedInputTokens: call.CachedInputTokens, CacheWriteTokens: call.CacheWriteTokens})
 			}
 		}
-		out.Sections = append(out.Sections, statsUsageSection(kind, n, u))
+		out.Sections = append(out.Sections, statsUsageSection(kind, count, usage))
 	}
+}
+
+func (rt *serveRuntime) statsSnapshot() *serveStatsResponse {
+	a := &rt.stats
+	a.mu.Lock()
+	if a.stats == nil {
+		a.mu.Unlock()
+		return nil
+	}
+	now := time.Now()
+	s := a.stats.SnapshotAt(now)
+	calls, _ := s.UsageCalls()
+	runs := a.children.Snapshots()
+	started := make(map[string]bool, len(a.childrenStarted))
+	for id, observed := range a.childrenStarted {
+		started[id] = observed
+	}
+	retries, running := a.retries, a.running
+	handoverUsage, handoverCalls := a.handoverUsage, a.handoverCalls
+	a.mu.Unlock()
+	out := &serveStatsResponse{Metrics: statsMetrics(&s), Scope: "runtime_local", Models: []serveStatsModel{}, Sections: []serveStatsSection{}, ActiveMS: statsMS(s.LLMTime + s.ToolTime), ModelMS: statsMS(s.LLMTime), ToolMS: statsMS(s.ToolTime)}
+	appendMainCallStats(out, calls)
+	appendSubagentModelStats(out, runs, started, now)
+	appendHelperUsageSections(out, calls)
 	out.Sections = append(out.Sections, statsUsageSection("Handover / Path-Note Usage", handoverCalls, handoverUsage))
 	out.Sections = append(out.Sections, serveStatsSection{Title: "Runtime Activity", Rows: []serveStatsRow{statsRow("Retries", retries), statsRow("Running", running), statsRow("LLM calls", s.LLMCallCount), statsRow("Tool calls", s.ToolCallCount)}})
 	return out

--- a/cmd/serve_stats_endpoint.go
+++ b/cmd/serve_stats_endpoint.go
@@ -64,12 +64,7 @@ func (s *serveServer) peekStatsRuntime(id string) *serveRuntime {
 	defer s.sessionMgr.mu.Unlock()
 	return s.sessionMgr.sessions[id]
 }
-func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request, id string) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		writeOpenAIError(w, 405, "method_not_allowed", "method not allowed")
-		return
-	}
+func (s *serveServer) loadStatsInputs(w http.ResponseWriter, r *http.Request, id string) (*session.Session, []session.Message, *serveRuntime, bool) {
 	var meta *session.Session
 	var messages []session.Message
 	if s.store != nil {
@@ -77,16 +72,16 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 		meta, err = s.store.Get(r.Context(), id)
 		if err != nil && !errors.Is(err, session.ErrNotFound) {
 			writeOpenAIError(w, 500, "server_error", "failed to read session")
-			return
+			return nil, nil, nil, false
 		}
 		if meta == nil {
 			http.NotFound(w, r)
-			return
+			return nil, nil, nil, false
 		}
 		messages, err = s.store.GetMessages(r.Context(), id, 0, 0)
 		if err != nil {
 			writeOpenAIError(w, 500, "server_error", "failed to read session history")
-			return
+			return nil, nil, nil, false
 		}
 	}
 	rt := s.peekStatsRuntime(id)
@@ -97,15 +92,19 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 		}
 		// Parts (including tool arguments/results) remain mutable after the
 		// run lock is released; detach them before estimating the snapshot.
-		for i, m := range sidequestion.CloneMessages(rt.history) {
-			messages = append(messages, *session.NewMessage(id, m, i))
+		for i, message := range sidequestion.CloneMessages(rt.history) {
+			messages = append(messages, *session.NewMessage(id, message, i))
 		}
 		rt.mu.Unlock()
 	}
 	if meta == nil && rt == nil {
 		http.NotFound(w, r)
-		return
+		return nil, nil, nil, false
 	}
+	return meta, messages, rt, true
+}
+
+func statsResponseForRuntime(rt *serveRuntime) *serveStatsResponse {
 	var out *serveStatsResponse
 	if rt != nil {
 		out = rt.statsSnapshot()
@@ -127,6 +126,18 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 			out.Unavailable = append(out.Unavailable, "cost_usd")
 		}
 	}
+	return out
+}
+
+func estimateStatsMessageTokens(messages []session.Message) int {
+	llmMessages := make([]llm.Message, 0, len(messages))
+	for _, message := range messages {
+		llmMessages = append(llmMessages, message.ToLLMMessage())
+	}
+	return llm.EstimateMessageTokens(llmMessages)
+}
+
+func appendStatsContextSections(out *serveStatsResponse, meta *session.Session, messages []session.Message, rt *serveRuntime, id string) []session.Message {
 	used, limit, soft, hard := 0, 0, 0, 0
 	compactEnabled := false
 	provider, model := "unknown", "unknown"
@@ -143,9 +154,9 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 		limit = llm.InputLimitForProviderModel(provider, model)
 		if session.HasCompactionBoundary(meta) {
 			active = nil
-			for _, m := range messages {
-				if m.Sequence >= meta.CompactionSeq {
-					active = append(active, m)
+			for _, message := range messages {
+				if message.Sequence >= meta.CompactionSeq {
+					active = append(active, message)
 				}
 			}
 		}
@@ -158,13 +169,13 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 			limit = n
 		}
 		soft, hard, compactEnabled = rt.engine.CompactionThresholds()
-		if d, ok := rt.engine.ToolDiscoveryDiagnostics(id); ok {
-			rows := []serveStatsRow{statsRow("Mode configured/resolved", d.ConfiguredMode+" / "+d.ResolvedMode), statsRow("Strategy configured/resolved", d.ConfiguredStrategy+" / "+d.Strategy), statsRow("Mode reason", d.Reason), statsRow("Strategy reason", d.StrategyReason), statsRow("Native fallback", fmt.Sprintf("%d (%s)", d.FallbackCount, d.FallbackReason)), statsRow("Pinned MCP", fmt.Sprintf("%d tools, ~%d tokens", d.PinnedCount, d.PinnedTokens)), statsRow("Active MCP", fmt.Sprintf("%d tools, ~%d tokens", d.ActiveMCPCount, d.ActiveMCPTokens)), statsRow("Deferred MCP", fmt.Sprintf("%d tools, ~%d tokens avoided", d.DeferredCount, d.DeferredTokens)), statsRow("Dynamic working set", fmt.Sprintf("%d/%d tools", d.DynamicActive, d.DynamicLimit)), statsRow("Working-set evictions", d.EvictionCount)}
-			for _, v := range d.RecentEvictions {
-				rows = append(rows, statsRow("Recent eviction", v.Name+" — "+v.Reason))
+		if diagnostics, ok := rt.engine.ToolDiscoveryDiagnostics(id); ok {
+			rows := []serveStatsRow{statsRow("Mode configured/resolved", diagnostics.ConfiguredMode+" / "+diagnostics.ResolvedMode), statsRow("Strategy configured/resolved", diagnostics.ConfiguredStrategy+" / "+diagnostics.Strategy), statsRow("Mode reason", diagnostics.Reason), statsRow("Strategy reason", diagnostics.StrategyReason), statsRow("Native fallback", fmt.Sprintf("%d (%s)", diagnostics.FallbackCount, diagnostics.FallbackReason)), statsRow("Pinned MCP", fmt.Sprintf("%d tools, ~%d tokens", diagnostics.PinnedCount, diagnostics.PinnedTokens)), statsRow("Active MCP", fmt.Sprintf("%d tools, ~%d tokens", diagnostics.ActiveMCPCount, diagnostics.ActiveMCPTokens)), statsRow("Deferred MCP", fmt.Sprintf("%d tools, ~%d tokens avoided", diagnostics.DeferredCount, diagnostics.DeferredTokens)), statsRow("Dynamic working set", fmt.Sprintf("%d/%d tools", diagnostics.DynamicActive, diagnostics.DynamicLimit)), statsRow("Working-set evictions", diagnostics.EvictionCount)}
+			for _, value := range diagnostics.RecentEvictions {
+				rows = append(rows, statsRow("Recent eviction", value.Name+" — "+value.Reason))
 			}
-			for _, v := range d.Recent {
-				rows = append(rows, statsRow("Recent activation", v.Name+" — "+v.Reason))
+			for _, value := range diagnostics.Recent {
+				rows = append(rows, statsRow("Recent activation", value.Name+" — "+value.Reason))
 			}
 			out.Sections = append(out.Sections, serveStatsSection{"Tool Discovery", rows})
 		} else {
@@ -175,19 +186,12 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 		out.Unavailable = append(out.Unavailable, "tool_discovery", "compaction_thresholds")
 		out.Sections = append(out.Sections, serveStatsSection{"Tool Discovery", []serveStatsRow{statsRow("Availability", "unavailable — no runtime retained")}})
 	}
-	estimate := func(ms []session.Message) int {
-		llmMessages := make([]llm.Message, 0, len(ms))
-		for _, m := range ms {
-			llmMessages = append(llmMessages, m.ToLLMMessage())
-		}
-		return llm.EstimateMessageTokens(llmMessages)
-	}
 	source := "last reported context"
 	if used <= 0 {
-		used = estimate(active)
+		used = estimateStatsMessageTokens(active)
 		source = "message estimate (excludes request-only tool schemas and prompt overhead)"
 	}
-	history := max(used, estimate(messages))
+	history := max(used, estimateStatsMessageTokens(messages))
 	pressure := []serveStatsRow{statsRow("Provider / model", provider+" / "+model), statsRow("Current context", used), statsRow("Context source", source), statsRow("Cumulative history (estimated)", history), statsRow("Outside context (estimated)", max(0, history-used))}
 	if limit > 0 {
 		pressure = append(pressure, statsRow("Input limit", limit), statsRow("Window used", fmt.Sprintf("%.1f%%", 100*float64(used)/float64(limit))), statsRow("Free space", max(0, limit-used)))
@@ -205,11 +209,15 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 			statsRow("Hard compact at", hard), statsRow("Hard window buffer", max(0, limit-hard)))
 	}
 	out.Sections = append(out.Sections, serveStatsSection{"Current Context / Window Pressure", pressure})
-	u := out.Metrics
-	out.Sections = append(out.Sections, statsUsageSection("Cumulative Token Usage · "+out.Scope, u.LLMTurns, llm.Usage{InputTokens: u.InputTokens, OutputTokens: u.OutputTokens, CachedInputTokens: u.CachedInputTokens, CacheWriteTokens: u.CacheWriteTokens}))
+	usage := out.Metrics
+	out.Sections = append(out.Sections, statsUsageSection("Cumulative Token Usage · "+out.Scope, usage.LLMTurns, llm.Usage{InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens, CachedInputTokens: usage.CachedInputTokens, CacheWriteTokens: usage.CacheWriteTokens}))
+	return active
+}
+
+func appendStatsActivitySections(out *serveStatsResponse, meta *session.Session, messages, active []session.Message, rt *serveRuntime) {
 	roles := map[llm.Role]int{}
-	for _, m := range active {
-		roles[m.Role]++
+	for _, message := range active {
+		roles[message.Role]++
 	}
 	activity := []serveStatsRow{statsRow("Active messages", len(active)), statsRow("User messages", roles[llm.RoleUser]), statsRow("Assistant messages", roles[llm.RoleAssistant]), statsRow("Tool messages", roles[llm.RoleTool])}
 	if meta != nil {
@@ -229,5 +237,20 @@ func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request,
 		activity = append(activity, statsRow("Compacting", rt.compacting.Load()), statsRow("Admitted activity", rt.admittedActivity.Load()))
 	}
 	out.Sections = append(out.Sections, serveStatsSection{"Cumulative Session Activity", activity}, serveStatsSection{"Availability", []serveStatsRow{statsRow("Scope", out.Scope), statsRow("Runtime accounting", "Since this runtime was created; resets on eviction, replacement or process restart. Historical detail is unavailable."), statsRow("Models", "Subagent billing models only; helper usage is attributed to its actual model. Times sum across child runs."), statsRow("Timing", "Main request and tool time only; failed-attempt time retained, idle and retry backoff excluded. Parallel tool time is wall-clock union, not summed calls. TTFT and throughput use retained observed-output calls."), statsRow("Cost", "Local per-request estimates; missing prices are unavailable, partial costs are lower bounds.")}})
+}
+
+func (s *serveServer) handleSessionStats(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		writeOpenAIError(w, 405, "method_not_allowed", "method not allowed")
+		return
+	}
+	meta, messages, rt, ok := s.loadStatsInputs(w, r, id)
+	if !ok {
+		return
+	}
+	out := statsResponseForRuntime(rt)
+	active := appendStatsContextSections(out, meta, messages, rt, id)
+	appendStatsActivitySections(out, meta, messages, active, rt)
 	writeJSON(w, 200, out)
 }

--- a/cmd/serve_subagent_progress.go
+++ b/cmd/serve_subagent_progress.go
@@ -1,0 +1,505 @@
+package cmd
+
+import (
+	"log"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/samsaffron/term-llm/internal/llm"
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+const (
+	serveSubagentMaxRoots       = 32
+	serveSubagentMaxActiveTools = 64
+	serveSubagentMaxSeenCalls   = 256
+	serveSubagentMaxChildren    = 8
+	serveSubagentToolNameBytes  = 64
+	serveSubagentFlushInterval  = 250 * time.Millisecond
+	serveSubagentTextInterval   = time.Second
+	serveQueuedProgressStale    = 15 * time.Minute
+)
+
+type serveSubagentProgress struct {
+	mu     sync.Mutex
+	emitMu sync.Mutex
+	clock  responseRunClock
+	emit   func(string, map[string]any) error
+	hold   func(time.Time) responseRunTimerHold
+	roots  map[string]*subagentProgressRoot
+	closed bool
+}
+
+type subagentProgressRoot struct {
+	callID, toolName  string
+	seq               int64
+	state, phase      string
+	callsStarted      int
+	activeTools       map[string]string
+	seenCalls         map[string]struct{}
+	currentTool       string
+	lastActivity      time.Time
+	children          map[string]*subagentProgressChild
+	childrenTruncated int
+	callsTruncated    bool
+	runID, jobID      string
+	hold              *responseRunTimerHold
+	dirty             bool
+	flush             responseRunTimerHandle
+	lastEmit          time.Time
+}
+
+type subagentProgressChild struct {
+	id, state, currentTool, runID, jobID string
+	callsStarted                         int
+	activeTools                          map[string]string
+	seenCalls                            map[string]struct{}
+	callsTruncated                       bool
+}
+
+func newServeSubagentProgress(clock responseRunClock, emit func(string, map[string]any) error, hold func(time.Time) responseRunTimerHold) *serveSubagentProgress {
+	if clock == nil {
+		clock = realResponseRunClock{}
+	}
+	return &serveSubagentProgress{clock: clock, emit: emit, hold: hold, roots: make(map[string]*subagentProgressRoot)}
+}
+
+func (s *serveSubagentProgress) begin(callID, toolName string) {
+	if s == nil || callID == "" || (toolName != tools.SpawnAgentToolName && toolName != tools.WaitForJobsToolName) {
+		return
+	}
+	s.mu.Lock()
+	root := s.rootLocked(callID)
+	if root != nil {
+		root.toolName = toolName
+		if toolName == tools.WaitForJobsToolName {
+			root.state, root.phase = "waiting", "waiting"
+		} else if root.state == "" {
+			root.state, root.phase = "starting", "starting"
+		}
+		root.dirty = true
+	}
+	s.mu.Unlock()
+	s.flushRoot(callID, false)
+}
+
+func (s *serveSubagentProgress) observe(callID string, event tools.SubagentEvent) {
+	if s == nil || callID == "" {
+		return
+	}
+	rootID, childID := splitSubagentCallID(callID)
+	var release *responseRunTimerHold
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	root := s.roots[rootID]
+	if root == nil {
+		s.mu.Unlock()
+		return
+	}
+	if !event.Timestamp.IsZero() {
+		root.lastActivity = event.Timestamp
+	} else {
+		root.lastActivity = s.clock.Now()
+	}
+	if event.RunID != "" {
+		root.runID, root.jobID = event.RunID, event.JobID
+	}
+	var boundary, known bool
+	release, boundary, known = s.reduceEventLocked(root, callID, childID, event)
+	if !known {
+		s.mu.Unlock()
+		return
+	}
+
+	if deadline, ok := s.holdDeadlineLocked(root, childID, event); ok && deadline.Add(responseRunHoldGrace).After(s.clock.Now()) {
+		if root.hold == nil && s.hold != nil {
+			h := s.hold(deadline)
+			root.hold = &h
+		} else if root.hold != nil {
+			root.hold.extend(deadline)
+		}
+	}
+	immediate := s.scheduleFlushLocked(root, rootID, boundary)
+	s.mu.Unlock()
+	if release != nil {
+		release.release()
+	}
+	if immediate {
+		s.flushRoot(rootID, false)
+	}
+}
+
+func (s *serveSubagentProgress) holdDeadlineLocked(root *subagentProgressRoot, childID string, event tools.SubagentEvent) (time.Time, bool) {
+	if root.toolName == tools.WaitForJobsToolName || event.RunID != "" {
+		// Only persisted events or the one pinned running snapshot may protect a
+		// queued wait. Their source timestamp prevents old history fetched today
+		// from reviving a stale worker.
+		if event.EventID == 0 && event.Type != tools.SubagentEventInit {
+			return time.Time{}, false
+		}
+		if event.Timestamp.IsZero() {
+			return time.Time{}, false
+		}
+		deadline := event.Timestamp.Add(serveQueuedProgressStale)
+		if !event.Deadline.IsZero() && event.Deadline.Before(deadline) {
+			deadline = event.Deadline
+		}
+		return deadline, true
+	}
+	if childID == "" && event.Type == tools.SubagentEventInit && !event.Deadline.IsZero() {
+		return event.Deadline, true
+	}
+	return time.Time{}, false
+}
+
+func (s *serveSubagentProgress) finish(callID string, success, cancelled bool) {
+	if s == nil || callID == "" {
+		return
+	}
+	s.emitMu.Lock()
+	defer s.emitMu.Unlock()
+	var payload map[string]any
+	var release *responseRunTimerHold
+	s.mu.Lock()
+	root := s.roots[callID]
+	if root != nil {
+		if root.flush != nil {
+			root.flush.Stop()
+			root.flush = nil
+		}
+		root.state = "completed"
+		if cancelled {
+			root.state = "cancelled"
+		} else if !success {
+			root.state = "failed"
+		}
+		clear(root.activeTools)
+		root.currentTool = ""
+		for _, child := range root.children {
+			clear(child.activeTools)
+			child.currentTool = ""
+			if child.state != "completed" {
+				child.state = root.state
+			}
+		}
+		release = root.hold
+		root.hold = nil
+		root.dirty = true
+		payload = s.snapshotLocked(root)
+		delete(s.roots, callID)
+	}
+	s.mu.Unlock()
+	if release != nil {
+		release.release()
+	}
+	s.emitPayload(payload)
+}
+
+func (s *serveSubagentProgress) close() {
+	if s == nil {
+		return
+	}
+	s.emitMu.Lock()
+	defer s.emitMu.Unlock()
+	var releases []*responseRunTimerHold
+	s.mu.Lock()
+	s.closed = true
+	for _, root := range s.roots {
+		if root.flush != nil {
+			root.flush.Stop()
+		}
+		if root.hold != nil {
+			releases = append(releases, root.hold)
+		}
+	}
+	clear(s.roots)
+	s.mu.Unlock()
+	for _, hold := range releases {
+		hold.release()
+	}
+}
+
+func (s *serveSubagentProgress) flushRoot(callID string, force bool) {
+	if s == nil {
+		return
+	}
+	s.emitMu.Lock()
+	defer s.emitMu.Unlock()
+	var payload map[string]any
+	s.mu.Lock()
+	root := s.roots[callID]
+	if root != nil {
+		root.flush = nil
+		if root.dirty || force {
+			payload = s.snapshotLocked(root)
+		}
+	}
+	s.mu.Unlock()
+	s.emitPayload(payload)
+}
+
+func (s *serveSubagentProgress) emitPayload(payload map[string]any) {
+	if payload == nil || s.emit == nil {
+		return
+	}
+	if err := s.emit("response.tool_exec.progress", payload); err != nil {
+		log.Printf("[serve] subagent progress event failed: %v", err)
+	}
+}
+
+func (s *serveSubagentProgress) snapshotLocked(root *subagentProgressRoot) map[string]any {
+	root.seq++
+	root.dirty = false
+	root.lastEmit = s.clock.Now()
+	payload := map[string]any{
+		"call_id": root.callID, "tool_name": root.toolName, "seq": root.seq,
+		"state": root.state, "calls_started": root.callsStarted,
+		"calls_active": len(root.activeTools),
+	}
+	if !root.lastActivity.IsZero() {
+		payload["last_activity_at"] = root.lastActivity.UnixMilli()
+	}
+	if root.phase != "" {
+		payload["phase"] = root.phase
+	}
+	if root.currentTool != "" {
+		payload["current_tool"] = root.currentTool
+	}
+	if root.callsTruncated {
+		payload["calls_truncated"] = true
+	}
+	if root.runID != "" {
+		payload["run_id"], payload["job_id"] = root.runID, root.jobID
+	}
+	children := make([]map[string]any, 0, len(root.children))
+	for _, child := range root.children {
+		entry := map[string]any{"id": child.id, "state": child.state, "calls_started": child.callsStarted, "calls_active": len(child.activeTools)}
+		if child.currentTool != "" {
+			entry["current_tool"] = child.currentTool
+		}
+		if child.runID != "" {
+			entry["run_id"], entry["job_id"] = child.runID, child.jobID
+		}
+		if child.callsTruncated {
+			entry["calls_truncated"] = true
+		}
+		children = append(children, entry)
+	}
+	if len(children) > 0 {
+		payload["children"] = children
+	}
+	if root.childrenTruncated > 0 {
+		payload["children_truncated"] = root.childrenTruncated
+	}
+	return payload
+}
+
+func (s *serveSubagentProgress) rootLocked(callID string) *subagentProgressRoot {
+	if root := s.roots[callID]; root != nil {
+		return root
+	}
+	if len(s.roots) >= serveSubagentMaxRoots {
+		return nil
+	}
+	root := &subagentProgressRoot{callID: callID, state: "starting", phase: "starting", activeTools: make(map[string]string), seenCalls: make(map[string]struct{}), children: make(map[string]*subagentProgressChild)}
+	s.roots[callID] = root
+	return root
+}
+
+func (s *serveSubagentProgress) childLocked(root *subagentProgressRoot, childID string, event tools.SubagentEvent) *subagentProgressChild {
+	if childID == "" {
+		return nil
+	}
+	if child := root.children[childID]; child != nil {
+		if event.RunID != "" {
+			child.runID, child.jobID = event.RunID, event.JobID
+		}
+		return child
+	}
+	if len(root.children) >= serveSubagentMaxChildren {
+		root.childrenTruncated = 1 // At least one distinct child is hidden; do not invent an exact count.
+		return nil
+	}
+	child := &subagentProgressChild{id: childID, state: "starting", runID: event.RunID, jobID: event.JobID, activeTools: make(map[string]string), seenCalls: make(map[string]struct{})}
+	root.children[childID] = child
+	return child
+}
+
+func reduceChildToolStart(child *subagentProgressChild, identity, name string) {
+	if _, duplicate := child.seenCalls[identity]; duplicate {
+		return
+	}
+	if len(child.seenCalls) >= serveSubagentMaxSeenCalls {
+		child.callsTruncated = true
+		return
+	}
+	child.seenCalls[identity] = struct{}{}
+	child.callsStarted++
+	if len(child.activeTools) < serveSubagentMaxActiveTools {
+		child.activeTools[identity] = name
+	} else {
+		child.callsTruncated = true
+	}
+	child.currentTool, child.state = name, "running"
+}
+
+func splitSubagentCallID(callID string) (string, string) {
+	root, rest, found := strings.Cut(callID, "/")
+	if !found {
+		return root, ""
+	}
+	child, _, _ := strings.Cut(rest, "/")
+	return root, root + "/" + child
+}
+
+func sanitizedSubagentPhase(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case strings.HasPrefix(value, strings.ToLower(llm.PhaseCompacting)):
+		return "compacting"
+	case strings.Contains(value, "think"):
+		return "thinking"
+	case value == "queued", value == "waiting", value == "starting", value == "responding":
+		return value
+	case strings.Contains(value, "tool"):
+		return "running_tools"
+	default:
+		return ""
+	}
+}
+
+func boundedSubagentToolName(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= serveSubagentToolNameBytes {
+		return value
+	}
+	value = value[:serveSubagentToolNameBytes]
+	for value != "" && !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
+}
+
+func anyActiveTool(active map[string]string) string {
+	for _, name := range active {
+		return name
+	}
+	return ""
+}
+
+func (s *serveSubagentProgress) reduceEventLocked(root *subagentProgressRoot, callID, childID string, event tools.SubagentEvent) (*responseRunTimerHold, bool, bool) {
+	child := s.childLocked(root, childID, event)
+	boundary := false
+	var release *responseRunTimerHold
+	switch event.Type {
+	case tools.SubagentEventInit:
+		if root.state == "" || root.state == "starting" {
+			root.state, root.phase = "starting", "starting"
+		}
+		if child != nil {
+			child.state = "running"
+		}
+		boundary = true
+	case tools.SubagentEventToolStart:
+		s.reduceToolStartLocked(root, child, callID, childID, event)
+		boundary = true
+	case tools.SubagentEventToolEnd:
+		identity := callID + "\x00" + event.ToolCallID
+		if childID == "" || root.toolName == tools.WaitForJobsToolName {
+			delete(root.activeTools, identity)
+			root.currentTool = anyActiveTool(root.activeTools)
+		}
+		if child != nil {
+			delete(child.activeTools, identity)
+			child.currentTool = anyActiveTool(child.activeTools)
+		}
+		boundary = true
+	case tools.SubagentEventPhase:
+		if phase := sanitizedSubagentPhase(event.Phase); phase != "" {
+			root.phase = phase
+			if child != nil {
+				child.state = phase
+			}
+			boundary = true
+		}
+	case tools.SubagentEventText:
+		root.phase = "responding"
+	case tools.SubagentEventDone:
+		if event.ProgressTruncated {
+			root.callsTruncated = true
+		}
+		if child != nil {
+			child.state = "completed"
+		} else if childID == "" {
+			release = root.hold
+			root.hold = nil
+		}
+		boundary = true
+	case tools.SubagentEventUsage:
+		// Timestamp is the only safe summary of token activity.
+	default:
+		return nil, false, false
+	}
+
+	return release, boundary, true
+}
+
+func (s *serveSubagentProgress) reduceToolStartLocked(root *subagentProgressRoot, child *subagentProgressChild, callID, childID string, event tools.SubagentEvent) {
+	name := boundedSubagentToolName(event.ToolName)
+	identity := callID + "\x00" + event.ToolCallID
+	if event.ToolCallID == "" {
+		identity = callID + "\x00" + name
+	}
+	aggregateRoot := childID == "" || root.toolName == tools.WaitForJobsToolName
+	if aggregateRoot {
+		if _, duplicate := root.seenCalls[identity]; !duplicate {
+			if len(root.seenCalls) >= serveSubagentMaxSeenCalls {
+				root.callsTruncated = true
+			} else {
+				root.seenCalls[identity] = struct{}{}
+				root.callsStarted++
+				if len(root.activeTools) < serveSubagentMaxActiveTools {
+					root.activeTools[identity] = name
+				} else {
+					root.callsTruncated = true
+				}
+			}
+		}
+		root.currentTool, root.state, root.phase = name, "running", "running_tools"
+	}
+	if child != nil {
+		reduceChildToolStart(child, identity, name)
+	}
+}
+
+func (s *serveSubagentProgress) scheduleFlushLocked(root *subagentProgressRoot, rootID string, boundary bool) bool {
+	root.dirty = true
+	delay := serveSubagentTextInterval
+	if boundary {
+		delay = serveSubagentFlushInterval
+	}
+	immediate := root.lastEmit.IsZero() || (boundary && !s.clock.Now().Before(root.lastEmit.Add(serveSubagentFlushInterval)))
+	if immediate {
+		if root.flush != nil {
+			root.flush.Stop()
+			root.flush = nil
+		}
+	} else if root.flush == nil || boundary {
+		if root.flush != nil {
+			root.flush.Stop()
+		}
+		if boundary {
+			delay = root.lastEmit.Add(serveSubagentFlushInterval).Sub(s.clock.Now())
+			if delay < 0 {
+				delay = 0
+			}
+		}
+		root.flush = s.clock.AfterFunc(delay, func() { s.flushRoot(rootID, false) })
+	}
+	return immediate
+}

--- a/cmd/serve_subagent_progress.go
+++ b/cmd/serve_subagent_progress.go
@@ -98,6 +98,9 @@ func (s *serveSubagentProgress) observe(callID string, event tools.SubagentEvent
 	}
 	root := s.roots[rootID]
 	if root == nil {
+		root = s.adoptVerifiedRootLocked(rootID, childID, event)
+	}
+	if root == nil {
 		s.mu.Unlock()
 		return
 	}
@@ -311,6 +314,30 @@ func (s *serveSubagentProgress) rootLocked(callID string) *subagentProgressRoot 
 	return root
 }
 
+func (s *serveSubagentProgress) adoptVerifiedRootLocked(rootID, childID string, event tools.SubagentEvent) *subagentProgressRoot {
+	toolName := ""
+	switch {
+	case childID == "" && event.Type == tools.SubagentEventInit && !event.Deadline.IsZero():
+		// spawn_agent stamps every direct child event with its enforced context
+		// deadline, which is not supplied by the model.
+		toolName = tools.SpawnAgentToolName
+	case childID != "" && event.RunID != "":
+		// wait_for_jobs qualifies callbacks with its pinned jobs-v2 run ID.
+		toolName = tools.WaitForJobsToolName
+	default:
+		return nil
+	}
+	root := s.rootLocked(rootID)
+	if root == nil {
+		return nil
+	}
+	root.toolName = toolName
+	if toolName == tools.WaitForJobsToolName {
+		root.state, root.phase = "waiting", "waiting"
+	}
+	return root
+}
+
 func (s *serveSubagentProgress) childLocked(root *subagentProgressRoot, childID string, event tools.SubagentEvent) *subagentProgressChild {
 	if childID == "" {
 		return nil
@@ -334,7 +361,7 @@ func reduceChildToolStart(child *subagentProgressChild, identity, name string) {
 	if _, duplicate := child.seenCalls[identity]; duplicate {
 		return
 	}
-	if len(child.seenCalls) >= serveSubagentMaxSeenCalls {
+	if child.callsStarted >= serveSubagentMaxSeenCalls {
 		child.callsTruncated = true
 		return
 	}
@@ -385,6 +412,13 @@ func boundedSubagentToolName(value string) string {
 	return value
 }
 
+func subagentToolIdentity(callID, toolCallID, toolName string) string {
+	if toolCallID != "" {
+		return callID + "\x00" + toolCallID
+	}
+	return callID + "\x00" + boundedSubagentToolName(toolName)
+}
+
 func anyActiveTool(active map[string]string) string {
 	for _, name := range active {
 		return name
@@ -409,15 +443,7 @@ func (s *serveSubagentProgress) reduceEventLocked(root *subagentProgressRoot, ca
 		s.reduceToolStartLocked(root, child, callID, childID, event)
 		boundary = true
 	case tools.SubagentEventToolEnd:
-		identity := callID + "\x00" + event.ToolCallID
-		if childID == "" || root.toolName == tools.WaitForJobsToolName {
-			delete(root.activeTools, identity)
-			root.currentTool = anyActiveTool(root.activeTools)
-		}
-		if child != nil {
-			delete(child.activeTools, identity)
-			child.currentTool = anyActiveTool(child.activeTools)
-		}
+		s.reduceToolEndLocked(root, child, callID, childID, event)
 		boundary = true
 	case tools.SubagentEventPhase:
 		if phase := sanitizedSubagentPhase(event.Phase); phase != "" {
@@ -449,16 +475,35 @@ func (s *serveSubagentProgress) reduceEventLocked(root *subagentProgressRoot, ca
 	return release, boundary, true
 }
 
+func (s *serveSubagentProgress) reduceToolEndLocked(root *subagentProgressRoot, child *subagentProgressChild, callID, childID string, event tools.SubagentEvent) {
+	identity := subagentToolIdentity(callID, event.ToolCallID, event.ToolName)
+	retireFallback := event.ToolCallID == ""
+	if childID == "" || root.toolName == tools.WaitForJobsToolName {
+		delete(root.activeTools, identity)
+		if retireFallback {
+			// Provider-native tools do not always supply call IDs. Once their
+			// matching end arrives, permit a later call with the same name to
+			// count as a distinct invocation.
+			delete(root.seenCalls, identity)
+		}
+		root.currentTool = anyActiveTool(root.activeTools)
+	}
+	if child != nil {
+		delete(child.activeTools, identity)
+		if retireFallback {
+			delete(child.seenCalls, identity)
+		}
+		child.currentTool = anyActiveTool(child.activeTools)
+	}
+}
+
 func (s *serveSubagentProgress) reduceToolStartLocked(root *subagentProgressRoot, child *subagentProgressChild, callID, childID string, event tools.SubagentEvent) {
 	name := boundedSubagentToolName(event.ToolName)
-	identity := callID + "\x00" + event.ToolCallID
-	if event.ToolCallID == "" {
-		identity = callID + "\x00" + name
-	}
+	identity := subagentToolIdentity(callID, event.ToolCallID, name)
 	aggregateRoot := childID == "" || root.toolName == tools.WaitForJobsToolName
 	if aggregateRoot {
 		if _, duplicate := root.seenCalls[identity]; !duplicate {
-			if len(root.seenCalls) >= serveSubagentMaxSeenCalls {
+			if root.callsStarted >= serveSubagentMaxSeenCalls {
 				root.callsTruncated = true
 			} else {
 				root.seenCalls[identity] = struct{}{}

--- a/cmd/serve_subagent_progress_test.go
+++ b/cmd/serve_subagent_progress_test.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samsaffron/term-llm/internal/tools"
+)
+
+func TestServeSubagentProgressParentDoesNotTimeoutWhileChildRuns(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(30*time.Minute, clock)
+	defer timer.stop()
+	var mu sync.Mutex
+	var payloads []map[string]any
+	progress := newServeSubagentProgress(clock, func(_ string, payload map[string]any) error {
+		mu.Lock()
+		payloads = append(payloads, cloneJSONMap(payload))
+		mu.Unlock()
+		return nil
+	}, timer.holdUntil)
+	defer progress.close()
+	progress.begin("spawn-1", tools.SpawnAgentToolName)
+	progress.observe("spawn-1", tools.SubagentEvent{Type: tools.SubagentEventInit, Timestamp: clock.Now(), Deadline: clock.Now().Add(time.Hour)})
+
+	clock.Advance(45 * time.Minute)
+	if ctx.Err() != nil {
+		t.Fatalf("parent timed out under verified child deadline: %v", context.Cause(ctx))
+	}
+	progress.observe("spawn-1", tools.SubagentEvent{Type: tools.SubagentEventDone, Timestamp: clock.Now()})
+	clock.Advance(29 * time.Minute)
+	if ctx.Err() != nil {
+		t.Fatalf("fresh parent window expired early: %v", context.Cause(ctx))
+	}
+	clock.Advance(2 * time.Minute)
+	if !responseRunTimedOut(ctx) {
+		t.Fatalf("parent remained unbounded after child completion: %v", context.Cause(ctx))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(payloads) == 0 {
+		t.Fatal("no progress snapshots emitted")
+	}
+}
+
+func TestServeSubagentProgressStuckChildCannotHoldPastDeadline(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(30*time.Minute, clock)
+	defer timer.stop()
+	progress := newServeSubagentProgress(clock, nil, timer.holdUntil)
+	defer progress.close()
+	progress.begin("spawn-1", tools.SpawnAgentToolName)
+	progress.observe("spawn-1", tools.SubagentEvent{Type: tools.SubagentEventInit, Timestamp: clock.Now(), Deadline: clock.Now().Add(10 * time.Minute)})
+	clock.Advance(10*time.Minute + responseRunHoldGrace)
+	if ctx.Err() != nil {
+		t.Fatalf("expiry should resume frozen budget, not immediately time out: %v", context.Cause(ctx))
+	}
+	clock.Advance(30 * time.Minute)
+	if !responseRunTimedOut(ctx) {
+		t.Fatalf("stuck child kept parent alive: %v", context.Cause(ctx))
+	}
+}
+
+func TestServeSubagentProgressCountsDeduplicateAndSanitize(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	var payloads []map[string]any
+	progress := newServeSubagentProgress(clock, func(_ string, payload map[string]any) error {
+		payloads = append(payloads, cloneJSONMap(payload))
+		return nil
+	}, nil)
+	defer progress.close()
+	progress.begin("outer", tools.SpawnAgentToolName)
+	unsafe := tools.SubagentEvent{Type: tools.SubagentEventToolStart, ToolCallID: "tool-1", ToolName: "shell", ToolArgs: []byte(`{"secret":true}`), ToolInfo: "secret info", Text: "secret reasoning"}
+	progress.observe("outer", unsafe)
+	progress.observe("outer", unsafe)
+	progress.observe("outer/inner", tools.SubagentEvent{Type: tools.SubagentEventToolStart, ToolCallID: "tool-2", ToolName: "grep"})
+	progress.finish("outer", true, false)
+	last := payloads[len(payloads)-1]
+	if got := responseRunInt64Value(last["calls_started"], -1); got != 1 {
+		t.Fatalf("direct calls_started = %d, want 1", got)
+	}
+	if got := responseRunInt64Value(last["calls_active"], -1); got != 0 {
+		t.Fatalf("calls_active = %d, want 0", got)
+	}
+	for _, forbidden := range []string{"tool_arguments", "tool_info", "output", "text", "reasoning"} {
+		if _, exists := last[forbidden]; exists {
+			t.Fatalf("snapshot leaked %q: %#v", forbidden, last)
+		}
+	}
+	children, ok := last["children"].([]map[string]any)
+	if !ok || len(children) != 1 || children[0]["id"] != "outer/inner" || responseRunInt64Value(children[0]["calls_started"], 0) != 1 {
+		t.Fatalf("children = %#v", last["children"])
+	}
+}
+
+func TestServeRuntimeSubagentCallbackRejectsPreviousExecution(t *testing.T) {
+	rt := &serveRuntime{}
+	first := newServeSubagentProgress(nil, nil, nil)
+	second := newServeSubagentProgress(nil, nil, nil)
+	defer first.close()
+	defer second.close()
+
+	rt.subagentProgress, rt.subagentProgressOwner = first, 1
+	first.begin("reused", tools.SpawnAgentToolName)
+	staleCallback := rt.subagentProgressCallback()
+	rt.subagentProgress, rt.subagentProgressOwner = second, 2
+	second.begin("reused", tools.SpawnAgentToolName)
+
+	staleCallback("reused", tools.SubagentEvent{Type: tools.SubagentEventToolStart, ToolCallID: "old", ToolName: "shell"})
+	if got := second.roots["reused"].callsStarted; got != 0 {
+		t.Fatalf("later execution received stale callback: calls_started = %d", got)
+	}
+}
+
+func TestServeSubagentProgressOverflowChildDoesNotCountAsRoot(t *testing.T) {
+	progress := newServeSubagentProgress(nil, nil, nil)
+	defer progress.close()
+	progress.begin("outer", tools.SpawnAgentToolName)
+	for i := 0; i < serveSubagentMaxChildren; i++ {
+		progress.observe(fmt.Sprintf("outer/child-%d", i), tools.SubagentEvent{Type: tools.SubagentEventInit})
+	}
+	progress.observe("outer/overflow", tools.SubagentEvent{Type: tools.SubagentEventToolStart, ToolCallID: "nested", ToolName: "shell"})
+	if root := progress.roots["outer"]; root.callsStarted != 0 || len(root.activeTools) != 0 {
+		t.Fatalf("overflow child was aggregated as root: calls_started=%d active=%d", root.callsStarted, len(root.activeTools))
+	}
+	root := progress.roots["outer"]
+	root.activeTools["outer/overflow\x00nested"] = "root-tool"
+	root.currentTool = "root-tool"
+	progress.observe("outer/overflow", tools.SubagentEvent{Type: tools.SubagentEventToolEnd, ToolCallID: "nested"})
+	if len(root.activeTools) != 1 || root.currentTool != "root-tool" {
+		t.Fatalf("overflow child tool end mutated root activity: active=%#v current=%q", root.activeTools, root.currentTool)
+	}
+}
+
+func TestServeSubagentProgressStaleThenLiveSiblingAcquiresHold(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(time.Minute, clock)
+	defer timer.stop()
+	progress := newServeSubagentProgress(clock, nil, timer.holdUntil)
+	defer progress.close()
+	progress.begin("wait-1", tools.WaitForJobsToolName)
+	progress.observe("wait-1/stale", tools.SubagentEvent{Type: tools.SubagentEventInit, Timestamp: clock.Now().Add(-time.Hour), RunID: "stale"})
+	progress.observe("wait-1/live", tools.SubagentEvent{Type: tools.SubagentEventInit, Timestamp: clock.Now(), Deadline: clock.Now().Add(time.Hour), RunID: "live"})
+	clock.Advance(time.Minute)
+	if ctx.Err() != nil {
+		t.Fatalf("live sibling failed to acquire hold after stale sibling: %v", context.Cause(ctx))
+	}
+}
+
+func TestResponseRunTimerExpiredDeadlineCannotBeExtendedBeforeCallback(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(time.Minute, clock)
+	defer timer.stop()
+	hold := timer.holdUntil(clock.Now().Add(time.Minute))
+	clock.mu.Lock()
+	clock.now = clock.now.Add(time.Minute + responseRunHoldGrace)
+	clock.mu.Unlock()
+	hold.extend(clock.Now().Add(time.Hour))
+	clock.Advance(0)
+	clock.Advance(time.Minute)
+	if !responseRunTimedOut(ctx) {
+		t.Fatalf("expired hold was revived before delayed expiry callback: %v", context.Cause(ctx))
+	}
+}
+
+func TestResponseRunRecoveryCarriesSubagentProgress(t *testing.T) {
+	run := &responseRun{
+		id: "response-1",
+		recoveryMessages: []responseRunRecoveryMessage{{
+			ID: "tools", Role: "tool-group", Tools: []responseRunRecoveryTool{{ID: "spawn-1", Name: tools.SpawnAgentToolName, Status: "running"}},
+		}},
+	}
+	run.applyRecoveryEventLocked("response.tool_exec.progress", map[string]any{
+		"call_id": "spawn-1", "tool_name": tools.SpawnAgentToolName, "seq": int64(4), "state": "running", "calls_started": 7, "calls_active": 1,
+	})
+	payload := run.recoveryPayloadLocked()
+	messages := payload["messages"].([]map[string]any)
+	toolsPayload := messages[0]["tools"].([]map[string]any)
+	progress := toolsPayload[0]["subagentProgress"].(map[string]any)
+	if responseRunInt64Value(progress["calls_started"], 0) != 7 {
+		t.Fatalf("recovery progress = %#v", progress)
+	}
+}
+
+func TestServeSubagentProgressHistoricalQueuedEventCannotReviveHold(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(time.Minute, clock)
+	defer timer.stop()
+	progress := newServeSubagentProgress(clock, nil, timer.holdUntil)
+	defer progress.close()
+	progress.begin("wait-1", tools.WaitForJobsToolName)
+	progress.observe("wait-1/run-old", tools.SubagentEvent{Type: tools.SubagentEventToolStart, EventID: 10, Timestamp: clock.Now().Add(-time.Hour), Deadline: clock.Now().Add(time.Hour), RunID: "run-old", ToolCallID: "tool", ToolName: "shell"})
+	clock.Advance(time.Minute)
+	if !responseRunTimedOut(ctx) {
+		t.Fatalf("historical queued event revived hold: %v", context.Cause(ctx))
+	}
+}
+
+func TestResponseRunTimerHoldReleaseRefreshesAndStopIsFinal(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(time.Minute, clock)
+	hold := timer.holdUntil(clock.Now().Add(time.Hour))
+	clock.Advance(30 * time.Minute)
+	if ctx.Err() != nil {
+		t.Fatalf("timer expired under hold: %v", context.Cause(ctx))
+	}
+	hold.release()
+	clock.Advance(59 * time.Second)
+	if ctx.Err() != nil {
+		t.Fatalf("released hold did not refresh window: %v", context.Cause(ctx))
+	}
+	timer.stop()
+	hold.extend(clock.Now().Add(time.Hour))
+	hold.release()
+	if !errors.Is(context.Cause(ctx), context.Canceled) {
+		t.Fatalf("stop cause = %v, want cancellation", context.Cause(ctx))
+	}
+}
+
+func TestResponseRunTimerHoldHasFixedAbsoluteCap(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(time.Minute, clock)
+	defer timer.stop()
+	hold := timer.holdUntil(clock.Now().Add(time.Hour))
+	clock.Advance(30 * time.Minute)
+	hold.extend(clock.Now().Add(time.Hour))
+	clock.Advance(maxResponseRunDelegationHold - 30*time.Minute)
+	if ctx.Err() != nil {
+		t.Fatalf("hold cap should resume frozen budget first: %v", context.Cause(ctx))
+	}
+	clock.Advance(time.Minute)
+	if !responseRunTimedOut(ctx) {
+		t.Fatalf("extended hold slid beyond acquisition cap: %v", context.Cause(ctx))
+	}
+}
+
+func TestServeSubagentProgressOverflowDoneDoesNotReleaseSiblingHold(t *testing.T) {
+	clock := newFakeResponseRunClock()
+	ctx, timer := newResponseRunTimerWithClock(time.Minute, clock)
+	defer timer.stop()
+	progress := newServeSubagentProgress(clock, nil, timer.holdUntil)
+	defer progress.close()
+	progress.begin("wait", tools.WaitForJobsToolName)
+	for i := 0; i < serveSubagentMaxChildren+1; i++ {
+		id := fmt.Sprintf("run-%d", i)
+		progress.observe("wait/"+id, tools.SubagentEvent{Type: tools.SubagentEventInit, Timestamp: clock.Now(), Deadline: clock.Now().Add(time.Hour), RunID: id})
+	}
+	progress.observe(fmt.Sprintf("wait/run-%d", serveSubagentMaxChildren), tools.SubagentEvent{Type: tools.SubagentEventDone})
+	clock.Advance(2 * time.Minute)
+	if ctx.Err() != nil {
+		t.Fatalf("overflow child's completion released sibling protection: %v", context.Cause(ctx))
+	}
+}

--- a/cmd/serve_subagent_progress_test.go
+++ b/cmd/serve_subagent_progress_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samsaffron/term-llm/internal/llm"
 	"github.com/samsaffron/term-llm/internal/tools"
 )
 
@@ -45,6 +46,130 @@ func TestServeSubagentProgressParentDoesNotTimeoutWhileChildRuns(t *testing.T) {
 	if len(payloads) == 0 {
 		t.Fatal("no progress snapshots emitted")
 	}
+}
+
+func TestResponseToolCallStartsDelegationWhenExecStartIsLost(t *testing.T) {
+	for _, toolName := range []string{tools.SpawnAgentToolName, tools.WaitForJobsToolName} {
+		t.Run(toolName, func(t *testing.T) {
+			clock := newFakeResponseRunClock()
+			ctx, timer := newResponseRunTimerWithClock(time.Minute, clock)
+			defer timer.stop()
+			run := newResponseRun("response-start-fallback", "session", "", "mock", clock.Now().Unix(), func() {})
+			progress := newServeSubagentProgress(clock, run.appendEvent, timer.holdUntil)
+			defer progress.close()
+			runtime := &serveRuntime{subagentProgress: progress, approvalCtx: context.Background()}
+			server := &serveServer{}
+			state := newResponseRunStreamState("mock", "")
+			callID := toolName + "-lossy-start"
+
+			if err := server.appendResponseRunEvent(runtime, run, state, llm.Event{Type: llm.EventToolCall, Tool: &llm.ToolCall{ID: callID, Name: toolName}}); err != nil {
+				t.Fatal(err)
+			}
+			if progress.roots[callID] == nil {
+				t.Fatal("lossless tool-call event did not create progress root")
+			}
+			event := tools.SubagentEvent{Type: tools.SubagentEventInit, Timestamp: clock.Now(), Deadline: clock.Now().Add(time.Hour)}
+			if toolName == tools.WaitForJobsToolName {
+				event.RunID = "run-1"
+				event.EventID = 1
+			}
+			progress.observe(callID, event)
+			clock.Advance(2 * time.Minute)
+			if ctx.Err() != nil {
+				t.Fatalf("lost exec-start also lost delegation hold: %v", context.Cause(ctx))
+			}
+			if err := server.appendResponseRunEvent(runtime, run, state, llm.Event{Type: llm.EventToolExecEnd, ToolCallID: callID, ToolName: toolName, ToolSuccess: true}); err != nil {
+				t.Fatal(err)
+			}
+			if progress.roots[callID] != nil {
+				t.Fatal("terminal event did not clear progress root")
+			}
+			clock.Advance(59 * time.Second)
+			if ctx.Err() != nil {
+				t.Fatalf("released hold did not grant a fresh inactivity window: %v", context.Cause(ctx))
+			}
+			clock.Advance(2 * time.Second)
+			if !responseRunTimedOut(ctx) {
+				t.Fatalf("released hold left parent unbounded: %v", context.Cause(ctx))
+			}
+		})
+	}
+}
+
+func TestServeSubagentProgressAdoptsVerifiedEventBeforeStartProjection(t *testing.T) {
+	now := time.Now()
+	for _, test := range []struct {
+		name, callID, rootID, toolName string
+		event                          tools.SubagentEvent
+	}{
+		{name: "spawn", callID: "spawn-race", rootID: "spawn-race", toolName: tools.SpawnAgentToolName, event: tools.SubagentEvent{Type: tools.SubagentEventInit, Deadline: now.Add(time.Hour)}},
+		{name: "wait", callID: "wait-race/run-1", rootID: "wait-race", toolName: tools.WaitForJobsToolName, event: tools.SubagentEvent{Type: tools.SubagentEventInit, Timestamp: now, Deadline: now.Add(time.Hour), RunID: "run-1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			progress := newServeSubagentProgress(nil, nil, func(time.Time) responseRunTimerHold { return noopResponseRunTimerHold() })
+			defer progress.close()
+			progress.observe(test.callID, test.event)
+			root := progress.roots[test.rootID]
+			if root == nil || root.toolName != test.toolName || root.hold == nil {
+				t.Fatalf("adopted root = %#v, want verified %s root with hold", root, test.toolName)
+			}
+		})
+	}
+
+	progress := newServeSubagentProgress(nil, nil, nil)
+	defer progress.close()
+	progress.observe("unverified", tools.SubagentEvent{Type: tools.SubagentEventToolStart, ToolName: "shell"})
+	if progress.roots["unverified"] != nil {
+		t.Fatal("unverified callback created a progress root")
+	}
+}
+
+func TestServeSubagentProgressNativeToolsWithoutCallIDsHaveCompleteLifecycle(t *testing.T) {
+	progress := newServeSubagentProgress(nil, nil, nil)
+	defer progress.close()
+	progress.begin("spawn-native", tools.SpawnAgentToolName)
+
+	for i := 1; i <= 2; i++ {
+		progress.observe("spawn-native", tools.SubagentEvent{Type: tools.SubagentEventToolStart, ToolName: "web_search"})
+		root := progress.roots["spawn-native"]
+		if root.callsStarted != i || len(root.activeTools) != 1 || root.currentTool != "web_search" {
+			t.Fatalf("native start %d: calls=%d active=%d current=%q", i, root.callsStarted, len(root.activeTools), root.currentTool)
+		}
+		progress.observe("spawn-native", tools.SubagentEvent{Type: tools.SubagentEventToolEnd, ToolName: "web_search", Success: true})
+		if len(root.activeTools) != 0 || root.currentTool != "" {
+			t.Fatalf("native end %d left active lifecycle: active=%#v current=%q", i, root.activeTools, root.currentTool)
+		}
+	}
+}
+
+func TestSpawnAgentFailedTerminalMatchesLiveAndRecoveryState(t *testing.T) {
+	run := newResponseRun("response-failed-spawn", "session", "", "mock", time.Now().Unix(), func() {})
+	progress := newServeSubagentProgress(nil, run.appendEvent, nil)
+	defer progress.close()
+	runtime := &serveRuntime{subagentProgress: progress, approvalCtx: context.Background()}
+	server := &serveServer{}
+	state := newResponseRunStreamState("mock", "")
+	if err := server.appendResponseRunEvent(runtime, run, state, llm.Event{Type: llm.EventToolCall, Tool: &llm.ToolCall{ID: "spawn-failed", Name: tools.SpawnAgentToolName}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.appendResponseRunEvent(runtime, run, state, llm.Event{Type: llm.EventToolExecEnd, ToolCallID: "spawn-failed", ToolName: tools.SpawnAgentToolName, ToolSuccess: false}); err != nil {
+		t.Fatal(err)
+	}
+
+	run.mu.Lock()
+	defer run.mu.Unlock()
+	for _, message := range run.recoveryMessages {
+		for _, tool := range message.Tools {
+			if tool.ID != "spawn-failed" {
+				continue
+			}
+			if tool.Status != "error" || stringValue(tool.SubagentProgress["state"]) != "failed" {
+				t.Fatalf("recovered tool status=%q progress=%#v, want error/failed", tool.Status, tool.SubagentProgress)
+			}
+			return
+		}
+	}
+	t.Fatal("failed spawn missing from recovery projection")
 }
 
 func TestServeSubagentProgressStuckChildCannotHoldPastDeadline(t *testing.T) {

--- a/docs-site/content/guides/web-ui-and-api.md
+++ b/docs-site/content/guides/web-ui-and-api.md
@@ -460,7 +460,7 @@ Relevant options include:
 - `--tools`, `--read-dir`, `--write-dir`, `--shell-allow`
 - `--base-path`
 - `--title` (overrides the web UI sidebar title; also configurable as `serve.title`)
-- `--response-timeout` (maximum inactivity before the first or next completed LLM response, default `30m`; each completed LLM response refreshes the clock, and interactive approval or `ask_user` waits pause it; also configurable as `serve.response_timeout` with Go durations like `45m` or `1h`)
+- `--response-timeout` (maximum inactivity before the first or next completed LLM response, default `30m`; each completed LLM response refreshes the clock, interactive approval or `ask_user` waits pause it, and verified deadline-bounded subagent or queued delegations pause it for at most one hour plus a 30-second completion grace each; also configurable as `serve.response_timeout` with Go durations like `45m` or `1h`)
 - `--cors-origin`
 - `--webrtc`, `--webrtc-signaling-url`, `--webrtc-token` (see [WebRTC direct routing](/guides/webrtc-direct-routing/))
 

--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -319,7 +319,10 @@ test('shell terminal fills the viewport and follows height changes', async ({ pa
 test('loads, navigates sessions, opens settings and preserves normal namespace hygiene', async ({
   page,
 }, testInfo) => {
-  test.skip(testInfo.project.name === 'mobile', 'desktop session navigation is covered separately');
+  test.skip(
+    testInfo.project.name !== 'desktop',
+    'desktop session navigation is covered separately',
+  );
   await open(page);
   await expect(page.getByRole('heading', { name: 'Second chat' })).toBeVisible();
   await page.getByRole('button', { name: 'First chat', exact: true }).click();
@@ -340,7 +343,7 @@ test('loads, navigates sessions, opens settings and preserves normal namespace h
 test('turns a durable completion indicator off only after a visible revision-gated visit', async ({
   page,
 }, testInfo) => {
-  test.skip(testInfo.project.name === 'mobile', 'desktop sidebar attention flow');
+  test.skip(testInfo.project.name !== 'desktop', 'desktop sidebar attention flow');
   const requests = await open(page, '', { attention: true });
   const ready = page.getByRole('button', {
     name: 'First chat — Completed, not yet visited',
@@ -363,7 +366,7 @@ test('turns a durable completion indicator off only after a visible revision-gat
 test('desktop shell uses authored controls, message hierarchy and diff rows', async ({
   page,
 }, testInfo) => {
-  test.skip(testInfo.project.name === 'mobile', 'desktop visual structure');
+  test.skip(testInfo.project.name !== 'desktop', 'desktop visual structure');
   await open(page);
   const sessionButton = page.getByRole('button', { name: 'First chat', exact: true });
   await expect(sessionButton).toHaveCSS('display', 'flex');
@@ -395,7 +398,7 @@ test('desktop shell uses authored controls, message hierarchy and diff rows', as
 });
 
 test('collapses file-change counts to an icon at narrow widths', async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name === 'mobile', 'narrow desktop breakpoint');
+  test.skip(testInfo.project.name !== 'desktop', 'narrow desktop breakpoint');
   await page.setViewportSize({ width: 850, height: 800 });
   await open(page);
 
@@ -584,7 +587,7 @@ test('mobile floating surfaces dismiss from their outside area and restore inter
 
 test('same-context tabs retain independent session drafts', async ({ context, page }, testInfo) => {
   test.skip(
-    testInfo.project.name === 'mobile',
+    testInfo.project.name !== 'desktop',
     'multi-tab storage is covered once in desktop Chromium',
   );
   const second = await context.newPage();

--- a/frontend/e2e/extensions.spec.ts
+++ b/frontend/e2e/extensions.spec.ts
@@ -84,9 +84,12 @@ test('creates a Dracula workspace, manages extensions, and repairs a broken them
   expect((await submission).postDataJSON().ui_context.loaded).toEqual(['dracula', 'studio-clock']);
   await expect(page.getByRole('heading', { name: 'Debug Provider Output' }).last()).toBeVisible();
 
-  // Active service workers must never retain extension assets.
+  // Active service workers must never retain extension assets. An absent worker
+  // also satisfies this boundary (for example, non-standalone iPhone mode).
   await page.evaluate(async () => {
-    if ('serviceWorker' in navigator) await navigator.serviceWorker.ready;
+    if ('serviceWorker' in navigator && (await navigator.serviceWorker.getRegistration())) {
+      await navigator.serviceWorker.ready;
+    }
   });
   await page.reload();
   await expect(page.locator('.studio-clock')).toHaveCount(1);

--- a/frontend/e2e/notifications.spec.ts
+++ b/frontend/e2e/notifications.spec.ts
@@ -5,7 +5,11 @@ for (const route of ['', 'chat/9']) {
     context,
     page,
     baseURL,
-  }) => {
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name === 'iphone',
+      'non-standalone iPhone notification enrollment is intentionally unsupported',
+    );
     const origin = new URL(baseURL!).origin;
     const expectedURL = new URL('chat/e2e-session', baseURL).href;
     await context.grantPermissions(['notifications'], { origin });

--- a/frontend/e2e/pinned-switch-jitter.repro.spec.ts
+++ b/frontend/e2e/pinned-switch-jitter.repro.spec.ts
@@ -155,7 +155,7 @@ for (const projects of [false, true]) {
     page,
   }, testInfo) => {
     test.skip(
-      testInfo.project.name === 'mobile',
+      testInfo.project.name !== 'desktop',
       'desktop sidebar remains visible while switching',
     );
     await mockCleanroomAPI(page, projects);

--- a/frontend/e2e/real-server.spec.ts
+++ b/frontend/e2e/real-server.spec.ts
@@ -395,15 +395,17 @@ for (const decision of ['Approve', 'Deny'] as const) {
   });
 }
 
-test('a suspended same-context tab resumes through authoritative reconciliation', async ({
-  context,
+test('a suspended tab resumes through authoritative reconciliation', async ({
+  browser,
   page,
+  baseURL,
 }, testInfo) => {
-  test.skip(testInfo.project.name === 'mobile', 'real same-context suspension is covered once');
-  const second = await context.newPage();
+  test.skip(testInfo.project.name !== 'desktop', 'real tab suspension is covered once');
+  const secondaryContext = await browser.newContext({ baseURL });
+  const second = await secondaryContext.newPage();
   await Promise.all([page.goto('./?new=1'), second.goto('./')]);
   const before = await second.locator('.session-row').count();
-  const cdp = await context.newCDPSession(second);
+  const cdp = await secondaryContext.newCDPSession(second);
   await cdp.send('Page.setWebLifecycleState', { state: 'frozen' });
 
   await page
@@ -422,6 +424,7 @@ test('a suspended same-context tab resumes through authoritative reconciliation'
     .poll(() => second.locator('.session-row').count(), { timeout: 15_000 })
     .toBeGreaterThan(before);
   await second.close();
+  await secondaryContext.close();
 });
 
 test('a newly sent plain HTTPS response keeps its owned stream', async ({

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -393,7 +393,12 @@ function SubagentProgressLine({ tool, labelled = false }: { tool: ToolCall; labe
   }
   return parts.length ? (
     <div class="tool-progress">
-      {labelled && <strong>{name}: </strong>}
+      {labelled && (
+        <strong>
+          {name}
+          {tool.status === 'running' ? ' · running' : ''}:{' '}
+        </strong>
+      )}
       {parts.join(' · ')}
     </div>
   ) : null;
@@ -599,10 +604,9 @@ function ToolGroup({
   const delegations = visible.filter(
     (tool) => tool.subagentProgress || tool.name === 'wait_for_jobs',
   );
-  const previews = [
-    ...delegations.filter((tool) => tool.status === 'running'),
-    ...delegations.filter((tool) => tool.status !== 'running'),
-  ];
+  const previews = delegations.slice(0, 3);
+  const hiddenPreviews = delegations.slice(previews.length);
+  const hiddenRunning = hiddenPreviews.filter((tool) => tool.status === 'running').length;
   const runningTimedStartedAt =
     runningTools.length > 0 &&
     runningTools.every(
@@ -646,11 +650,15 @@ function ToolGroup({
         </span>
       </button>
       {!expanded &&
-        previews
-          .slice(0, 3)
-          .map((tool) => <SubagentProgressLine key={tool.id} tool={tool} labelled />)}
-      {!expanded && previews.length > 3 && (
-        <div class="tool-progress">{previews.length - 3} more delegations · expand to view</div>
+        previews.map((tool) => <SubagentProgressLine key={tool.id} tool={tool} labelled />)}
+      {!expanded && hiddenPreviews.length > 0 && (
+        <div class="tool-progress">
+          <button class="text-action" type="button" onClick={toggle}>
+            {hiddenPreviews.length} more{' '}
+            {hiddenPreviews.length === 1 ? 'delegation' : 'delegations'}
+            {hiddenRunning > 0 ? ` · ${hiddenRunning} running` : ''} · expand to view
+          </button>
+        </div>
       )}
       <div class={`tool-group-details ${expanded ? 'open' : ''}`}>
         {(expanded || visited) &&

--- a/frontend/src/components/Transcript.tsx
+++ b/frontend/src/components/Transcript.tsx
@@ -332,6 +332,73 @@ function LegacyToolImages({ tool }: { tool: ToolCall }) {
   );
 }
 
+function progressJobCount(tool: ToolCall): number {
+  try {
+    const args = JSON.parse(tool.arguments || '{}') as Record<string, unknown>;
+    return (
+      (Array.isArray(args.run_ids) ? args.run_ids.length : 0) +
+      (Array.isArray(args.job_ids) ? args.job_ids.length : 0)
+    );
+  } catch {
+    return 0;
+  }
+}
+
+const progressPhaseLabels: Record<string, string> = {
+  starting: 'starting',
+  thinking: 'thinking',
+  running_tools: 'running tools',
+  responding: 'responding',
+  compacting: 'compacting',
+  queued: 'queued',
+  waiting: 'waiting',
+};
+
+function SubagentProgressLine({ tool, labelled = false }: { tool: ToolCall; labelled?: boolean }) {
+  const name = tool.name.toLowerCase();
+  const progress = tool.subagentProgress;
+  if (name === 'queue_agent') {
+    return tool.status === 'done' && tool.resultStatus !== 'error' ? (
+      <div class="tool-progress">queued as detached job</div>
+    ) : null;
+  }
+  if (name !== 'spawn_agent' && name !== 'wait_for_jobs') return null;
+  const parts: string[] = [];
+  if (progress) {
+    const count = `${progress.callsStarted.toLocaleString()}${progress.callsTruncated ? '+' : ''}`;
+    parts.push(`${count} tool ${progress.callsStarted === 1 ? 'call' : 'calls'}`);
+    if (progress.callsActive > 0) parts.push(`${progress.callsActive} active`);
+    if (progress.currentTool) parts.push(progress.currentTool);
+    else if (
+      !['completed', 'failed', 'cancelled'].includes(progress.state) &&
+      progress.phase &&
+      progressPhaseLabels[progress.phase]
+    )
+      parts.push(progressPhaseLabels[progress.phase]);
+  }
+  if (name === 'wait_for_jobs') {
+    const count = progressJobCount(tool);
+    if (count > 0) {
+      const action =
+        tool.status === 'running'
+          ? 'waiting'
+          : tool.status === 'cancelled'
+            ? 'stopped waiting'
+            : tool.status === 'error' || tool.resultStatus === 'error'
+              ? 'failed to wait'
+              : 'waited';
+      parts.unshift(`${action} for ${count} ${count === 1 ? 'job' : 'jobs'}`);
+    }
+    parts.push('jobs keep running if stopped');
+  }
+  return parts.length ? (
+    <div class="tool-progress">
+      {labelled && <strong>{name}: </strong>}
+      {parts.join(' · ')}
+    </div>
+  ) : null;
+}
+
 const Tool = memo(function Tool({
   tool,
   expanded: controlledExpanded,
@@ -432,6 +499,7 @@ const Tool = memo(function Tool({
             {status}
           </span>
         </button>
+        <SubagentProgressLine tool={tool} />
         <LegacyToolImages tool={tool} />
         {expanded && (
           <div class="tool-details open">
@@ -527,6 +595,14 @@ function ToolGroup({
   const names = [...new Set(visible.map((tool) => tool.name))];
   const stopped = !running && visible.some((tool) => tool.status === 'cancelled');
   const runningTools = visible.filter((tool) => tool.status === 'running');
+  // Delegation progress must remain visible when the ordinary tool group is collapsed.
+  const delegations = visible.filter(
+    (tool) => tool.subagentProgress || tool.name === 'wait_for_jobs',
+  );
+  const previews = [
+    ...delegations.filter((tool) => tool.status === 'running'),
+    ...delegations.filter((tool) => tool.status !== 'running'),
+  ];
   const runningTimedStartedAt =
     runningTools.length > 0 &&
     runningTools.every(
@@ -569,6 +645,13 @@ function ToolGroup({
           )}
         </span>
       </button>
+      {!expanded &&
+        previews
+          .slice(0, 3)
+          .map((tool) => <SubagentProgressLine key={tool.id} tool={tool} labelled />)}
+      {!expanded && previews.length > 3 && (
+        <div class="tool-progress">{previews.length - 3} more delegations · expand to view</div>
+      )}
       <div class={`tool-group-details ${expanded ? 'open' : ''}`}>
         {(expanded || visited) &&
           visible.map((tool) => (

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -2900,6 +2900,95 @@ describe('Preact-owned chat surfaces', () => {
     },
   );
 
+  it('renders compact spawn, wait, and detached queue progress summaries', () => {
+    const store = createStore();
+    store.sessions.value[0].messages = [
+      {
+        id: 'progress-tools',
+        role: 'tool-group',
+        content: '',
+        created: Date.now(),
+        tools: [
+          {
+            id: 'spawn-1',
+            name: 'spawn_agent',
+            status: 'running',
+            subagentProgress: {
+              seq: 3,
+              state: 'running',
+              phase: 'running_tools',
+              callsStarted: 12,
+              callsActive: 2,
+              currentTool: 'shell',
+            },
+          },
+          {
+            id: 'wait-1',
+            name: 'wait_for_jobs',
+            arguments: '{"run_ids":["r1","r2"]}',
+            status: 'cancelled',
+            subagentProgress: {
+              seq: 4,
+              state: 'cancelled',
+              callsStarted: 3,
+              callsActive: 0,
+            },
+          },
+          {
+            id: 'wait-error',
+            name: 'wait_for_jobs',
+            arguments: '{"job_ids":["j1"]}',
+            status: 'error',
+            resultStatus: 'error',
+            subagentProgress: {
+              seq: 5,
+              state: 'failed',
+              callsStarted: 0,
+              callsActive: 0,
+            },
+          },
+          {
+            id: 'queue-1',
+            name: 'queue_agent',
+            status: 'done',
+            resultStatus: 'success',
+          },
+          {
+            id: 'queue-error',
+            name: 'queue_agent',
+            status: 'error',
+            resultStatus: 'error',
+          },
+        ],
+      },
+    ];
+    const { container } = render(
+      <StoreContext.Provider value={store}>
+        <Transcript />
+      </StoreContext.Provider>,
+    );
+    expect(container.querySelector('.tool-group-card > .tool-progress')).toHaveTextContent(
+      'spawn_agent: 12 tool calls · 2 active · shell',
+    );
+    expect(container.querySelector('.tool-group-card')).toHaveTextContent(
+      'stopped waiting for 2 jobs',
+    );
+    fireEvent.click(screen.getByRole('button', { name: /5 tool calls/ }));
+    expect(container.querySelector('[data-tool-id="spawn-1"] .tool-progress')).toHaveTextContent(
+      '12 tool calls · 2 active · shell',
+    );
+    expect(container.querySelector('[data-tool-id="wait-1"] .tool-progress')).toHaveTextContent(
+      'stopped waiting for 2 jobs · 3 tool calls · jobs keep running if stopped',
+    );
+    expect(container.querySelector('[data-tool-id="wait-error"] .tool-progress')).toHaveTextContent(
+      'failed to wait for 1 job · 0 tool calls · jobs keep running if stopped',
+    );
+    expect(container.querySelector('[data-tool-id="queue-1"] .tool-progress')).toHaveTextContent(
+      'queued as detached job',
+    );
+    expect(container.querySelector('[data-tool-id="queue-error"] .tool-progress')).toBeNull();
+  });
+
   it('shows a frozen duration beside a completed spawn-agent status', () => {
     const store = createStore();
     store.sessions.value[0].messages = [

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -6,6 +6,7 @@ import { App } from '../app/App';
 import { AppStore } from '../stores/app-store';
 import { APIError } from '../api/client';
 import type { SessionShareResponse } from '../api/endpoints';
+import type { ToolCall } from '../domain/types';
 import { Transcript } from './Transcript';
 import { Composer } from './Composer';
 import { Markdown } from './Markdown';
@@ -2968,7 +2969,7 @@ describe('Preact-owned chat surfaces', () => {
       </StoreContext.Provider>,
     );
     expect(container.querySelector('.tool-group-card > .tool-progress')).toHaveTextContent(
-      'spawn_agent: 12 tool calls · 2 active · shell',
+      'spawn_agent · running: 12 tool calls · 2 active · shell',
     );
     expect(container.querySelector('.tool-group-card')).toHaveTextContent(
       'stopped waiting for 2 jobs',
@@ -2987,6 +2988,152 @@ describe('Preact-owned chat surfaces', () => {
       'queued as detached job',
     );
     expect(container.querySelector('[data-tool-id="queue-error"] .tool-progress')).toBeNull();
+  });
+
+  it('keeps collapsed delegation previews chronological as running statuses transition', async () => {
+    const store = createStore();
+    const tools: ToolCall[] = [
+      {
+        id: 'spawn-early',
+        name: 'spawn_agent',
+        status: 'running',
+        subagentProgress: {
+          seq: 1,
+          state: 'running',
+          callsStarted: 1,
+          callsActive: 1,
+          currentTool: 'alpha',
+        },
+      },
+      {
+        id: 'wait-later',
+        name: 'wait_for_jobs',
+        arguments: '{"run_ids":["r1"]}',
+        status: 'running',
+        subagentProgress: {
+          seq: 2,
+          state: 'running',
+          callsStarted: 2,
+          callsActive: 1,
+          currentTool: 'beta',
+        },
+      },
+      {
+        id: 'spawn-third',
+        name: 'spawn_agent',
+        status: 'done',
+        subagentProgress: {
+          seq: 3,
+          state: 'completed',
+          callsStarted: 3,
+          callsActive: 0,
+          currentTool: 'gamma',
+        },
+      },
+      {
+        id: 'spawn-hidden',
+        name: 'spawn_agent',
+        status: 'running',
+        subagentProgress: {
+          seq: 4,
+          state: 'running',
+          callsStarted: 4,
+          callsActive: 1,
+          currentTool: 'delta',
+        },
+      },
+    ];
+    store.sessions.value[0].messages = [
+      {
+        id: 'delegation-order',
+        role: 'tool-group',
+        content: '',
+        created: Date.now(),
+        tools,
+      },
+    ];
+    const { container } = render(
+      <StoreContext.Provider value={store}>
+        <Transcript />
+      </StoreContext.Provider>,
+    );
+    const previewText = () =>
+      Array.from(container.querySelectorAll('.tool-group-card > .tool-progress > strong')).map(
+        (label) => label.parentElement?.textContent,
+      );
+    expect(previewText()).toEqual([
+      'spawn_agent · running: 1 tool call · 1 active · alpha',
+      'wait_for_jobs · running: waiting for 1 job · 2 tool calls · 1 active · beta · jobs keep running if stopped',
+      'spawn_agent: 3 tool calls · gamma',
+    ]);
+
+    await act(() => {
+      const group = store.sessions.peek()[0].messages[0];
+      store.sessionStore.patch('s1', {
+        messages: [
+          {
+            ...group,
+            tools: [
+              {
+                ...tools[0],
+                status: 'done',
+                subagentProgress: {
+                  ...tools[0].subagentProgress!,
+                  state: 'completed',
+                  callsActive: 0,
+                },
+              },
+              ...tools.slice(1),
+            ],
+          },
+        ],
+      });
+    });
+    expect(previewText()).toEqual([
+      'spawn_agent: 1 tool call · alpha',
+      'wait_for_jobs · running: waiting for 1 job · 2 tool calls · 1 active · beta · jobs keep running if stopped',
+      'spawn_agent: 3 tool calls · gamma',
+    ]);
+  });
+
+  it('indicates active delegations hidden by the collapsed preview limit and expands them', () => {
+    const store = createStore();
+    store.sessions.value[0].messages = [
+      {
+        id: 'active-overflow',
+        role: 'tool-group',
+        content: '',
+        created: Date.now(),
+        tools: Array.from({ length: 5 }, (_, index) => ({
+          id: `spawn-${index + 1}`,
+          name: 'spawn_agent',
+          status: 'running' as const,
+          subagentProgress: {
+            seq: index + 1,
+            state: 'running' as const,
+            callsStarted: index + 1,
+            callsActive: 1,
+            currentTool: `tool-${index + 1}`,
+          },
+        })),
+      },
+    ];
+    const { container } = render(
+      <StoreContext.Provider value={store}>
+        <Transcript />
+      </StoreContext.Provider>,
+    );
+    expect(container.querySelectorAll('.tool-group-card > .tool-progress > strong')).toHaveLength(
+      3,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: '2 more delegations · 2 running · expand to view' }),
+    );
+    expect(screen.getByRole('button', { name: /5 tool calls/ })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(container.querySelectorAll('[data-tool-id^="spawn-"]')).toHaveLength(5);
   });
 
   it('shows a frozen duration beside a completed spawn-agent status', () => {

--- a/frontend/src/domain/response.test.ts
+++ b/frontend/src/domain/response.test.ts
@@ -34,6 +34,7 @@ describe('response projection', () => {
         'response.output_item.added',
         'response.function_call_arguments.delta',
         'response.tool_exec.start',
+        'response.tool_exec.progress',
         'response.tool_exec.end',
         'response.guardian.review',
         'response.compaction',
@@ -50,6 +51,48 @@ describe('response projection', () => {
       ]),
     );
     expect(new Set(RESPONSE_EVENT_TYPES).size).toBe(RESPONSE_EVENT_TYPES.length);
+  });
+
+  it('accepts early absolute subagent progress, rejects stale seq, and folds terminal state', () => {
+    let projection = reduceResponse(
+      initialProjection(run),
+      event('response.tool_exec.progress', 1, {
+        call_id: 'spawn-early',
+        tool_name: 'spawn_agent',
+        seq: 2,
+        state: 'running',
+        phase: 'running_tools',
+        calls_started: 12,
+        calls_active: 2,
+        current_tool: 'shell',
+      }),
+    );
+    expect(projection.messages[0].tools?.[0].subagentProgress).toMatchObject({
+      seq: 2,
+      callsStarted: 12,
+      callsActive: 2,
+      currentTool: 'shell',
+    });
+    projection = reduceResponse(
+      projection,
+      event('response.tool_exec.progress', 2, {
+        call_id: 'spawn-early',
+        seq: 1,
+        state: 'running',
+        calls_started: 99,
+        calls_active: 99,
+      }),
+    );
+    expect(projection.messages[0].tools?.[0].subagentProgress?.callsStarted).toBe(12);
+    projection = reduceResponse(
+      projection,
+      event('response.tool_exec.end', 3, { call_id: 'spawn-early', success: true }),
+    );
+    expect(projection.messages[0].tools?.[0].subagentProgress).toMatchObject({
+      state: 'completed',
+      callsStarted: 12,
+      callsActive: 0,
+    });
   });
 
   it('tracks authoritative tool timing without resetting the original start', () => {

--- a/frontend/src/domain/response.ts
+++ b/frontend/src/domain/response.ts
@@ -8,6 +8,7 @@ import type {
   GuardianReview,
   MediaArtifact,
   Message,
+  SubagentProgress,
   ToolCall,
   Usage,
 } from './types';
@@ -62,6 +63,69 @@ const text = (value: unknown): string =>
 const number = (value: unknown, fallback = 0): number =>
   Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
 const clone = <T>(value: T): T => structuredClone(value);
+
+const subagentStates = ['starting', 'running', 'waiting', 'completed', 'failed', 'cancelled'];
+const subagentPhases = [
+  'starting',
+  'thinking',
+  'running_tools',
+  'responding',
+  'compacting',
+  'queued',
+  'waiting',
+];
+
+export function responseSubagentProgress(value: unknown): SubagentProgress | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const source = value as Record<string, unknown>;
+  const state = text(source.state) as SubagentProgress['state'];
+  if (!subagentStates.includes(state)) return undefined;
+  const result: SubagentProgress = {
+    seq: Math.max(0, number(source.seq)),
+    state,
+    callsStarted: Math.max(0, number(source.calls_started ?? source.callsStarted)),
+    callsActive: Math.max(0, number(source.calls_active ?? source.callsActive)),
+  };
+  const phase = text(source.phase) as SubagentProgress['phase'];
+  if (phase && subagentPhases.includes(phase)) result.phase = phase;
+  const currentTool = text(source.current_tool ?? source.currentTool);
+  if (currentTool) result.currentTool = currentTool;
+  const lastActivityAt = number(source.last_activity_at ?? source.lastActivityAt);
+  if (lastActivityAt > 0) result.lastActivityAt = lastActivityAt;
+  const childrenTruncated = number(source.children_truncated ?? source.childrenTruncated);
+  if (childrenTruncated > 0) result.childrenTruncated = childrenTruncated;
+  if (source.calls_truncated === true || source.callsTruncated === true)
+    result.callsTruncated = true;
+  const runId = text(source.run_id ?? source.runId);
+  const jobId = text(source.job_id ?? source.jobId);
+  if (runId) result.runId = runId;
+  if (jobId) result.jobId = jobId;
+  if (Array.isArray(source.children)) {
+    result.children = source.children
+      .filter((child): child is Record<string, unknown> =>
+        Boolean(child && typeof child === 'object'),
+      )
+      .slice(0, 8)
+      .map((child) => {
+        const entry = {
+          id: text(child.id),
+          state: text(child.state),
+          callsStarted: Math.max(0, number(child.calls_started ?? child.callsStarted)),
+          callsActive: Math.max(0, number(child.calls_active ?? child.callsActive)),
+        } as NonNullable<SubagentProgress['children']>[number];
+        const tool = text(child.current_tool ?? child.currentTool);
+        if (tool) entry.currentTool = tool;
+        if (child.calls_truncated === true || child.callsTruncated === true)
+          entry.callsTruncated = true;
+        const childRunId = text(child.run_id ?? child.runId);
+        const childJobId = text(child.job_id ?? child.jobId);
+        if (childRunId) entry.runId = childRunId;
+        if (childJobId) entry.jobId = childJobId;
+        return entry;
+      });
+  }
+  return result;
+}
 
 function responseAttachments(value: unknown): Attachment[] | undefined {
   if (!Array.isArray(value)) return undefined;
@@ -479,6 +543,26 @@ export function reduceResponse(
         retry: undefined,
       };
     }
+    case 'response.tool_exec.progress': {
+      const id = text(event.call_id || event.tool_call_id || event.item_id);
+      let entry: ToolCall;
+      [messages, entry] = tool(
+        messages,
+        responseId,
+        id,
+        text(event.tool_name || event.name || event.tool),
+        projection.pendingGuardian,
+      );
+      const progress = responseSubagentProgress(event);
+      if (!progress || progress.seq <= (entry.subagentProgress?.seq || 0)) return next;
+      return {
+        ...next,
+        messages: patchTool(messages, id, {
+          name: text(event.tool_name || event.name || event.tool) || entry.name,
+          subagentProgress: progress,
+        }),
+      };
+    }
     case 'response.tool_exec.end': {
       const id = text(event.call_id || event.tool_call_id || event.item_id);
       let entry: ToolCall;
@@ -501,6 +585,20 @@ export function reduceResponse(
           : startedAt
             ? Math.max(0, endedAt - startedAt)
             : undefined;
+      const progress = entry.subagentProgress;
+      const terminalProgress = progress
+        ? {
+            ...progress,
+            state:
+              progress.state === 'cancelled'
+                ? ('cancelled' as const)
+                : failed
+                  ? ('failed' as const)
+                  : ('completed' as const),
+            callsActive: 0,
+            currentTool: undefined,
+          }
+        : undefined;
       messages = patchTool(messages, id, {
         name: text(event.tool_name || event.name || event.tool) || entry.name,
         arguments: text(event.tool_arguments) || entry.arguments,
@@ -510,6 +608,7 @@ export function reduceResponse(
         startedAt,
         endedAt,
         durationMs,
+        subagentProgress: terminalProgress,
         askUserAnswer:
           !failed &&
           (text(event.tool_name || event.name || event.tool) || entry.name) === 'ask_user'
@@ -834,6 +933,7 @@ export const RESPONSE_EVENT_TYPES = [
   'response.function_call_arguments.delta',
   'response.output_item.done',
   'response.tool_exec.start',
+  'response.tool_exec.progress',
   'response.tool_exec.end',
   'response.guardian.review',
   'response.steering',

--- a/frontend/src/domain/transcript.test.ts
+++ b/frontend/src/domain/transcript.test.ts
@@ -12,6 +12,35 @@ import { initialProjection, reduceResponse } from './response';
 import type { Message } from './types';
 
 describe('transcript domain', () => {
+  it('restores completed spawn tool-call totals from validated history projection', () => {
+    const messages = convertServerMessages([
+      {
+        id: 1,
+        role: 'assistant',
+        parts: [{ type: 'tool_call', tool_call_id: 'spawn-1', tool_name: 'spawn_agent' }],
+      },
+      {
+        id: 2,
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool_result',
+            tool_call_id: 'spawn-1',
+            tool_name: 'spawn_agent',
+            spawn_agent: { agent_name: 'developer', session_id: 'child' },
+            spawn_agent_tool_calls: 12,
+          },
+        ],
+      },
+    ]);
+    expect(messages.flatMap((message) => message.tools || [])[0].subagentProgress).toEqual({
+      seq: 0,
+      state: 'completed',
+      callsStarted: 12,
+      callsActive: 0,
+    });
+  });
+
   function inlineTranscript(texts = ['before', 'between', 'after'], responseId = 'inline') {
     const parts = texts.flatMap((content, index) => [
       { type: 'text', text: content },

--- a/frontend/src/domain/transcript.ts
+++ b/frontend/src/domain/transcript.ts
@@ -1,3 +1,4 @@
+import { responseSubagentProgress } from './response';
 import type {
   ApprovalMode,
   Attachment,
@@ -561,11 +562,15 @@ export function convertServerMessages(
           const endedAt = optionalTimestamp(part.ended_at ?? part.endedAt);
           const rawDuration = part.duration_ms ?? part.durationMs;
           const durationMs = rawDuration == null ? undefined : Math.max(0, Number(rawDuration));
+          const progress = responseSubagentProgress(
+            part.subagentProgress ?? part.subagent_progress,
+          );
           tool = {
             id: callID,
             name,
             arguments: text(part.tool_arguments || part.arguments),
             status: failed ? 'error' : awaitsResult ? 'running' : 'done',
+            ...(progress ? { subagentProgress: progress } : {}),
             ...(startedAt || (name === 'spawn_agent' && awaitsResult)
               ? { startedAt: startedAt || at }
               : {}),
@@ -573,12 +578,19 @@ export function convertServerMessages(
             ...(durationMs !== undefined && Number.isFinite(durationMs) ? { durationMs } : {}),
           };
           current.tools!.push(tool);
-        } else
+        } else {
+          const progress = responseSubagentProgress(
+            part.subagentProgress ?? part.subagent_progress,
+          );
           Object.assign(tool, {
             name: text(part.tool_name || part.name) || tool.name,
             arguments: text(part.tool_arguments || part.arguments) || tool.arguments,
             status: failed ? 'error' : tool.status,
+            ...(progress && progress.seq > (tool.subagentProgress?.seq || 0)
+              ? { subagentProgress: progress }
+              : {}),
           });
+        }
         const location = { group: current, tool };
         toolLocations.set(toolKey(message, callID), location);
         const prior = unscopedToolLocations.get(callID);
@@ -676,6 +688,14 @@ export function convertServerMessages(
             durationMs,
             childSessionId: text(spawn.session_id),
           };
+          if (part.spawn_agent_tool_calls != null) {
+            tool.subagentProgress = {
+              seq: 0,
+              state: tool.status === 'error' ? 'failed' : 'completed',
+              callsStarted: Math.max(0, Number(part.spawn_agent_tool_calls) || 0),
+              callsActive: 0,
+            };
+          }
         }
       }
     }

--- a/frontend/src/domain/types.ts
+++ b/frontend/src/domain/types.ts
@@ -50,6 +50,33 @@ export interface MediaArtifact {
   caption?: string;
 }
 
+export interface SubagentProgressChild {
+  id: string;
+  state: string;
+  callsStarted: number;
+  callsActive: number;
+  currentTool?: string;
+  callsTruncated?: boolean;
+  runId?: string;
+  jobId?: string;
+}
+
+export interface SubagentProgress {
+  seq: number;
+  state: 'starting' | 'running' | 'waiting' | 'completed' | 'failed' | 'cancelled';
+  phase?:
+    'starting' | 'thinking' | 'running_tools' | 'responding' | 'compacting' | 'queued' | 'waiting';
+  callsStarted: number;
+  callsActive: number;
+  currentTool?: string;
+  lastActivityAt?: number;
+  children?: SubagentProgressChild[];
+  childrenTruncated?: number;
+  callsTruncated?: boolean;
+  runId?: string;
+  jobId?: string;
+}
+
 export interface ToolCall {
   id: string;
   /** Response-local output item identity; call id remains the canonical execution identity. */
@@ -66,6 +93,7 @@ export interface ToolCall {
   media?: MediaArtifact[];
   guardianReviews?: GuardianReview[];
   subagent?: Record<string, unknown>;
+  subagentProgress?: SubagentProgress;
   /** Execution timing in milliseconds. Running recovery snapshots are re-anchored locally. */
   startedAt?: number;
   endedAt?: number;

--- a/frontend/src/stores/run-engine.ts
+++ b/frontend/src/stores/run-engine.ts
@@ -5,6 +5,7 @@ import { APIError, decodeSSE } from '../api/client';
 import {
   initialProjection,
   reduceResponse,
+  responseSubagentProgress,
   ResponseProtocolError,
   type ResponseEvent,
   type ResponseProjection,
@@ -1483,6 +1484,9 @@ export class RunEngine {
                 const durationMs =
                   rawDuration == null ? undefined : Math.max(0, Number(rawDuration));
                 const reportedStart = Number(tool.startedAt ?? tool.started_at) || undefined;
+                const subagentProgress = responseSubagentProgress(
+                  tool.subagentProgress ?? tool.subagent_progress,
+                );
                 const startedAt =
                   status === 'running' && durationMs !== undefined && Number.isFinite(durationMs)
                     ? recoveredAt - durationMs
@@ -1492,6 +1496,7 @@ export class RunEngine {
                   id: String(tool.id || ''),
                   name: String(tool.name || 'tool'),
                   status,
+                  ...(subagentProgress ? { subagentProgress } : {}),
                   ...(startedAt ? { startedAt } : {}),
                   ...(Number(tool.endedAt ?? tool.ended_at)
                     ? { endedAt: Number(tool.endedAt ?? tool.ended_at) }

--- a/frontend/src/styles/features/transcript.css
+++ b/frontend/src/styles/features/transcript.css
@@ -890,6 +890,15 @@
   font-variant-numeric: tabular-nums;
 }
 
+.tool-progress {
+  padding: 0 0.75rem 0.58rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 .tool-details {
   border-top: 1px solid var(--border);
   padding: 0.58rem 0.75rem 0.72rem;

--- a/internal/llm/engine.go
+++ b/internal/llm/engine.go
@@ -3205,19 +3205,23 @@ func toolErrorMessageWithGuardian(id, name, text string, thoughtSig []byte, revi
 	return message
 }
 
-const reliableToolTerminalName = "spawn_agent"
+const (
+	reliableSpawnAgentTerminalName  = "spawn_agent"
+	reliableWaitForJobsTerminalName = "wait_for_jobs"
+)
 
-// sendToolExecEnd keeps spawn-agent completion lossless. Its child session can
-// become terminal before the parent tool result is durable, so dropping this
-// event leaves Web clients with only an in-flight placeholder until every
-// parallel tool returns. Other tool ends remain best-effort to preserve the
-// existing worker backpressure behavior.
+// sendToolExecEnd keeps delegation completion lossless. A child session or
+// queued run can become terminal before the parent tool result is durable, so
+// dropping either event leaves Web clients with an in-flight placeholder and
+// an unreleased response timer hold. Other tool ends remain best-effort to
+// preserve the existing worker backpressure behavior.
 func sendToolExecEnd(send eventSender, event Event) {
-	if event.ToolName == reliableToolTerminalName {
+	switch event.ToolName {
+	case reliableSpawnAgentTerminalName, reliableWaitForJobsTerminalName:
 		_ = send.Send(event)
-		return
+	default:
+		send.TrySend(event)
 	}
-	send.TrySend(event)
 }
 
 // executeSingleToolCall is the historical message adapter used by focused

--- a/internal/llm/engine_test.go
+++ b/internal/llm/engine_test.go
@@ -1623,6 +1623,53 @@ func TestExecuteSingleToolCallOutcomeAllowsSuggestCommandsPassthrough(t *testing
 	}
 }
 
+func TestSendToolExecEndKeepsDelegationTerminalsUnderBackpressure(t *testing.T) {
+	for _, toolName := range []string{reliableSpawnAgentTerminalName, reliableWaitForJobsTerminalName} {
+		t.Run(toolName, func(t *testing.T) {
+			ch := make(chan Event, 1)
+			ch <- Event{Type: EventHeartbeat}
+			sender := eventSender{ctx: context.Background(), ch: ch}
+			started := make(chan struct{})
+			returned := make(chan struct{})
+			go func() {
+				close(started)
+				sendToolExecEnd(sender, Event{Type: EventToolExecEnd, ToolCallID: "call-1", ToolName: toolName})
+				close(returned)
+			}()
+			<-started
+
+			select {
+			case <-returned:
+				t.Fatal("delegation terminal was dropped from a full event channel")
+			default:
+			}
+			<-ch
+			select {
+			case event := <-ch:
+				if event.Type != EventToolExecEnd || event.ToolName != toolName {
+					t.Fatalf("terminal event = %#v", event)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("delegation terminal was not delivered after capacity became available")
+			}
+			select {
+			case <-returned:
+			case <-time.After(time.Second):
+				t.Fatal("terminal sender remained blocked after delivery")
+			}
+		})
+	}
+}
+
+func TestSendToolExecEndKeepsOrdinaryTerminalsBestEffort(t *testing.T) {
+	ch := make(chan Event, 1)
+	ch <- Event{Type: EventHeartbeat}
+	sendToolExecEnd(eventSender{ctx: context.Background(), ch: ch}, Event{Type: EventToolExecEnd, ToolName: "shell"})
+	if event := <-ch; event.Type != EventHeartbeat {
+		t.Fatalf("full channel was changed by best-effort terminal: %#v", event)
+	}
+}
+
 // namedTool is a simple tool with a configurable name for testing.
 type namedTool struct {
 	name string
@@ -2824,7 +2871,7 @@ func TestExecuteToolCallsParallelDoesNotBlockOnFullToolExecEndBuffer(t *testing.
 func TestSpawnAgentToolExecEndWaitsForEventCapacity(t *testing.T) {
 	t.Parallel()
 
-	tool := &terminalDeliveryTool{name: reliableToolTerminalName, executed: make(chan struct{})}
+	tool := &terminalDeliveryTool{name: reliableSpawnAgentTerminalName, executed: make(chan struct{})}
 	registry := NewToolRegistry()
 	registry.Register(tool)
 	engine := NewEngine(&fakeProvider{}, registry)
@@ -2837,7 +2884,7 @@ func TestSpawnAgentToolExecEndWaitsForEventCapacity(t *testing.T) {
 	go func() {
 		messages, _ := engine.executeSingleToolCall(
 			ctx,
-			ToolCall{ID: "spawn-1", Name: reliableToolTerminalName, Arguments: json.RawMessage(`{}`)},
+			ToolCall{ID: "spawn-1", Name: reliableSpawnAgentTerminalName, Arguments: json.RawMessage(`{}`)},
 			eventSender{ctx: ctx, ch: events},
 			false,
 			false,

--- a/internal/serveui/embed_test.go
+++ b/internal/serveui/embed_test.go
@@ -97,7 +97,10 @@ func TestProductionBundleSizeBudgets(t *testing.T) {
 		// to ~506.6/144.0 kB. The modal and CSS stay separately bounded below.
 		// The image viewer and its styles now load on demand. Its small loader
 		// leaves the eager shell at ~503.2/142.9 kB raw/gzip, with separate budgets below.
-		"dist/app.js":                {raw: 503_500, gzip: 143_000},
+		// Inline delegation progress is eager transcript code. Measured with the
+		// Go gzip level-6 check below: 492,084 raw / 143,629 compressed bytes.
+		// Keep the raw cap and add only 1,500 compressed bytes (871 headroom).
+		"dist/app.js":                {raw: 503_500, gzip: 144_500},
 		"dist/chunks/Lightbox.js":    {raw: 8_000, gzip: 3_200},
 		"dist/assets/Lightbox.css":   {raw: 4_000, gzip: 1_400},
 		"dist/chunks/StatsModal.js":  {raw: 8_000, gzip: 3_000},

--- a/internal/tools/queue_agent.go
+++ b/internal/tools/queue_agent.go
@@ -25,9 +25,10 @@ const (
 	defaultQueuedAgentPollInterval      = 5
 	queuedAgentTriggerReconcileTimeout  = 2 * time.Second
 	queuedAgentTriggerReconcileInterval = 50 * time.Millisecond
-	queuedAgentProgressStaleWindow      = 15 * time.Minute
 	queuedAgentProgressPageSize         = 200
 	queuedAgentProgressPagesPerPoll     = 3
+	queuedAgentTerminalDrainPasses      = 4
+	queuedAgentProgressResponseBytes    = 1 << 20
 	defaultJobsServerBaseURL            = "http://127.0.0.1:8080"
 	QueueAgentEphemeralJobLabelKey      = "term_llm_queue_agent"
 	QueueAgentEphemeralJobLabelValue    = "ephemeral"
@@ -499,20 +500,28 @@ func (c *jobsBackedAgentClient) waitForPinnedRun(ctx context.Context, run jobsV2
 	cursor := int64(0)
 	emitStatus := queuedStatusEmitter(childID, runID, jobID, timeoutSeconds, callback)
 	emitStatus(run)
+	progressTruncated := false
+	terminalDrainPasses := 0
 	for {
-		moreEvents := false
-		var progressErr error
-		if callback != nil && childID != "" {
-			cursor, moreEvents, progressErr = c.emitRunProgressEvents(ctx, run, timeoutSeconds, childID, cursor, callback)
-			// Progress is best effort. Status polling remains authoritative and
-			// preserves the tool's existing fail-fast behavior.
+		if err := ctx.Err(); err != nil {
+			return run, err
+		}
+		var moreEvents, truncatedThisPoll bool
+		cursor, moreEvents, truncatedThisPoll = c.pollRunProgressEvents(ctx, run, timeoutSeconds, childID, cursor, callback)
+		progressTruncated = progressTruncated || truncatedThisPoll
+		if err := ctx.Err(); err != nil {
+			return run, err
 		}
 		if isQueuedAgentTerminalStatus(run.Status) {
 			if moreEvents {
-				continue // Drain terminal history without sleeping so totals converge.
+				terminalDrainPasses++
+				if terminalDrainPasses < queuedAgentTerminalDrainPasses {
+					continue // Bounded, no-sleep terminal drain for accurate prefix totals.
+				}
+				progressTruncated = true
 			}
 			if callback != nil && childID != "" {
-				callback(childID, SubagentEvent{Type: SubagentEventDone, Timestamp: parseQueuedAgentTime(run.FinishedAt), RunID: runID, JobID: jobID, ProgressTruncated: progressErr != nil})
+				callback(childID, SubagentEvent{Type: SubagentEventDone, Timestamp: parseQueuedAgentTime(run.FinishedAt), RunID: runID, JobID: jobID, ProgressTruncated: progressTruncated})
 			}
 			return c.getTerminalRun(ctx, run)
 		}
@@ -530,6 +539,16 @@ func (c *jobsBackedAgentClient) waitForPinnedRun(ctx context.Context, run jobsV2
 		}
 		emitStatus(run)
 	}
+}
+
+func (c *jobsBackedAgentClient) pollRunProgressEvents(ctx context.Context, run jobsV2AgentRunResponse, timeoutSeconds int, childID string, cursor int64, callback SubagentEventCallback) (nextCursor int64, moreEvents, truncated bool) {
+	if callback == nil || childID == "" {
+		return cursor, false, false
+	}
+	nextCursor, moreEvents, err := c.emitRunProgressEvents(ctx, run, timeoutSeconds, childID, cursor, callback)
+	// Progress is best effort and status polling remains authoritative. Any
+	// skipped history is nevertheless reported on the terminal snapshot.
+	return nextCursor, moreEvents, err != nil
 }
 
 func queuedRunDeadline(startedAt time.Time, timeoutSeconds int) time.Time {
@@ -558,6 +577,9 @@ func (c *jobsBackedAgentClient) getJob(ctx context.Context, jobID string) (jobsV
 func (c *jobsBackedAgentClient) emitRunProgressEvents(ctx context.Context, run jobsV2AgentRunResponse, timeoutSeconds int, childID string, cursor int64, callback SubagentEventCallback) (int64, bool, error) {
 	initialCursor := cursor
 	for page := 0; page < queuedAgentProgressPagesPerPoll; page++ {
+		if err := ctx.Err(); err != nil {
+			return cursor, false, err
+		}
 		events, err := c.getRunEvents(ctx, run.ID, cursor)
 		if err != nil {
 			return cursor, false, err
@@ -565,6 +587,9 @@ func (c *jobsBackedAgentClient) emitRunProgressEvents(ctx context.Context, run j
 		sort.Slice(events, func(i, j int) bool { return events[i].ID < events[j].ID })
 		pageCursor := cursor
 		for _, persisted := range events {
+			if err := ctx.Err(); err != nil {
+				return cursor, false, err
+			}
 			if persisted.ID <= cursor {
 				continue
 			}
@@ -585,7 +610,7 @@ func (c *jobsBackedAgentClient) emitRunProgressEvents(ctx context.Context, run j
 func (c *jobsBackedAgentClient) getRunEvents(ctx context.Context, runID string, cursor int64) ([]jobsV2AgentRunEvent, error) {
 	var response jobsV2AgentRunEventsResponse
 	path := "/v2/runs/" + url.PathEscape(runID) + "/events?since_id=" + strconv.FormatInt(cursor, 10) + "&limit=" + strconv.Itoa(queuedAgentProgressPageSize)
-	if err := c.doJSON(ctx, http.MethodGet, path, nil, &response); err != nil {
+	if err := c.doJSONWithLimit(ctx, http.MethodGet, path, nil, &response, queuedAgentProgressResponseBytes); err != nil {
 		return nil, err
 	}
 	return response.Data, nil
@@ -743,7 +768,15 @@ func (c *jobsBackedAgentClient) doJSON(ctx context.Context, method, path string,
 	return c.doJSONWithHeaders(ctx, method, path, payload, out, nil)
 }
 
+func (c *jobsBackedAgentClient) doJSONWithLimit(ctx context.Context, method, path string, payload any, out any, maxResponseBytes int64) error {
+	return c.doJSONWithHeadersAndLimit(ctx, method, path, payload, out, nil, maxResponseBytes)
+}
+
 func (c *jobsBackedAgentClient) doJSONWithHeaders(ctx context.Context, method, path string, payload any, out any, headers map[string]string) error {
+	return c.doJSONWithHeadersAndLimit(ctx, method, path, payload, out, headers, 0)
+}
+
+func (c *jobsBackedAgentClient) doJSONWithHeadersAndLimit(ctx context.Context, method, path string, payload any, out any, headers map[string]string, maxResponseBytes int64) error {
 	var body io.Reader
 	if payload != nil {
 		data, err := json.Marshal(payload)
@@ -773,9 +806,16 @@ func (c *jobsBackedAgentClient) doJSONWithHeaders(ctx context.Context, method, p
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	responseBody := io.Reader(resp.Body)
+	if maxResponseBytes > 0 {
+		responseBody = io.LimitReader(resp.Body, maxResponseBytes+1)
+	}
+	data, err := io.ReadAll(responseBody)
 	if err != nil {
 		return err
+	}
+	if maxResponseBytes > 0 && int64(len(data)) > maxResponseBytes {
+		return fmt.Errorf("jobs %s %s response exceeds %d-byte limit", method, path, maxResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("jobs %s %s failed: %s", method, path, jobsErrorMessage(resp.StatusCode, data))

--- a/internal/tools/queue_agent.go
+++ b/internal/tools/queue_agent.go
@@ -10,9 +10,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/samsaffron/term-llm/internal/llm"
@@ -23,6 +25,9 @@ const (
 	defaultQueuedAgentPollInterval      = 5
 	queuedAgentTriggerReconcileTimeout  = 2 * time.Second
 	queuedAgentTriggerReconcileInterval = 50 * time.Millisecond
+	queuedAgentProgressStaleWindow      = 15 * time.Minute
+	queuedAgentProgressPageSize         = 200
+	queuedAgentProgressPagesPerPoll     = 3
 	defaultJobsServerBaseURL            = "http://127.0.0.1:8080"
 	QueueAgentEphemeralJobLabelKey      = "term_llm_queue_agent"
 	QueueAgentEphemeralJobLabelValue    = "ephemeral"
@@ -88,7 +93,19 @@ type jobsV2AgentJobPayload struct {
 }
 
 type jobsV2AgentJobResponse struct {
-	ID string `json:"id"`
+	ID             string `json:"id"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+type jobsV2AgentRunEvent struct {
+	ID        int64           `json:"id"`
+	EventType string          `json:"event_type"`
+	Data      json.RawMessage `json:"data"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+type jobsV2AgentRunEventsResponse struct {
+	Data []jobsV2AgentRunEvent `json:"data"`
 }
 
 type jobsV2AgentRunResponse struct {
@@ -176,14 +193,14 @@ func (t *QueueAgentTool) Spec() llm.ToolSpec {
 func (t *QueueAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
 	var a QueueAgentArgs
 	if err := json.Unmarshal(args, &a); err != nil {
-		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
+		return queuedAgentErrorOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
 	}
 	agentName := strings.TrimSpace(a.AgentName)
 	if agentName == "" {
-		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "agent_name is required")), nil
+		return queuedAgentErrorOutput(formatQueuedAgentError(ErrInvalidParams, "agent_name is required")), nil
 	}
 	if strings.TrimSpace(a.Prompt) == "" {
-		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "prompt is required")), nil
+		return queuedAgentErrorOutput(formatQueuedAgentError(ErrInvalidParams, "prompt is required")), nil
 	}
 	timeout := a.Timeout
 	if timeout <= 0 {
@@ -197,13 +214,13 @@ func (t *QueueAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 	}
 	cwd, err := queueAgentCwd(a.Cwd, t.config)
 	if err != nil {
-		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, err.Error())), nil
+		return queuedAgentErrorOutput(formatQueuedAgentError(ErrInvalidParams, err.Error())), nil
 	}
 
 	origin, _ := QueueAgentOriginFromContext(ctx)
 	job, err := t.client.createAgentJob(ctx, agentName, a.Prompt, strings.TrimSpace(a.Model), cwd, timeout, a.NotifyWhenDone, origin)
 	if err != nil {
-		return llm.TextOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
+		return queuedAgentErrorOutput(formatQueuedAgentError(ErrExecutionFailed, err.Error())), nil
 	}
 	run, err := t.client.triggerJob(ctx, job.ID)
 	if err != nil {
@@ -220,7 +237,7 @@ func (t *QueueAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 		if reconcileErr == nil && found && reconciledRun.ID != "" {
 			run = reconciledRun
 		} else {
-			return llm.TextOutput(formatQueuedAgentTriggerPartialResult(job.ID, agentName, err, reconcileErr)), nil
+			return queuedAgentErrorOutput(formatQueuedAgentTriggerPartialResult(job.ID, agentName, err, reconcileErr)), nil
 		}
 	}
 
@@ -286,10 +303,10 @@ func (t *WaitForJobsTool) Spec() llm.ToolSpec {
 func (t *WaitForJobsTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
 	var a WaitForJobsArgs
 	if err := json.Unmarshal(args, &a); err != nil {
-		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
+		return queuedAgentErrorOutput(formatQueuedAgentError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
 	}
 	if len(a.JobIDs) == 0 && len(a.RunIDs) == 0 {
-		return llm.TextOutput(formatQueuedAgentError(ErrInvalidParams, "job_ids or run_ids is required")), nil
+		return queuedAgentErrorOutput(formatQueuedAgentError(ErrInvalidParams, "job_ids or run_ids is required")), nil
 	}
 	pollInterval := time.Duration(a.PollIntervalSeconds) * time.Second
 	if pollInterval <= 0 {
@@ -300,19 +317,24 @@ func (t *WaitForJobsTool) Execute(ctx context.Context, args json.RawMessage) (ll
 	}
 
 	results := make([]QueuedJobResult, len(a.RunIDs)+len(a.JobIDs))
+	var waitFailed atomic.Bool
+	progress := SubagentEventCallbackFromContext(ctx)
+	waitCallID := llm.CallIDFromContext(ctx)
 	var wg sync.WaitGroup
 	for i, runID := range a.RunIDs {
 		runID = strings.TrimSpace(runID)
 		if runID == "" {
 			results[i] = QueuedJobResult{Status: "not_found", Error: "blank run_id"}
+			waitFailed.Store(true)
 			continue
 		}
 		wg.Add(1)
 		go func(i int, runID string) {
 			defer wg.Done()
-			run, err := t.client.waitForRun(ctx, runID, pollInterval)
+			run, err := t.client.waitForRunWithProgress(ctx, runID, pollInterval, waitCallID, progress)
 			if err != nil {
 				results[i] = QueuedJobResult{RunID: runID, Status: "failed", Error: err.Error()}
+				waitFailed.Store(true)
 				return
 			}
 			results[i] = queuedJobResultFromJobsRun("", run)
@@ -324,14 +346,16 @@ func (t *WaitForJobsTool) Execute(ctx context.Context, args json.RawMessage) (ll
 		jobID = strings.TrimSpace(jobID)
 		if jobID == "" {
 			results[i] = QueuedJobResult{Status: "not_found", Error: "blank job_id"}
+			waitFailed.Store(true)
 			continue
 		}
 		wg.Add(1)
 		go func(i int, jobID string) {
 			defer wg.Done()
-			run, err := t.client.waitForJob(ctx, jobID, pollInterval)
+			run, err := t.client.waitForJobWithProgress(ctx, jobID, pollInterval, waitCallID, progress)
 			if err != nil {
 				results[i] = QueuedJobResult{JobID: jobID, Status: "failed", Error: err.Error()}
+				waitFailed.Store(true)
 				return
 			}
 			results[i] = queuedJobResultFromJobsRun(jobID, run)
@@ -339,7 +363,9 @@ func (t *WaitForJobsTool) Execute(ctx context.Context, args json.RawMessage) (ll
 	}
 	wg.Wait()
 	data, _ := json.Marshal(results)
-	return llm.TextOutput(string(data)), nil
+	output := llm.TextOutput(string(data))
+	output.IsError = waitFailed.Load()
+	return output, nil
 }
 
 func (t *WaitForJobsTool) Preview(args json.RawMessage) string {
@@ -440,15 +466,54 @@ func (c *jobsBackedAgentClient) triggerJob(ctx context.Context, jobID string) (j
 }
 
 func (c *jobsBackedAgentClient) waitForRun(ctx context.Context, runID string, pollInterval time.Duration) (jobsV2AgentRunResponse, error) {
+	return c.waitForRunWithProgress(ctx, runID, pollInterval, "", nil)
+}
+
+func (c *jobsBackedAgentClient) waitForRunWithProgress(ctx context.Context, runID string, pollInterval time.Duration, waitCallID string, callback SubagentEventCallback) (jobsV2AgentRunResponse, error) {
+	run, err := c.getRunSummary(ctx, runID)
+	if err != nil {
+		return jobsV2AgentRunResponse{}, err
+	}
+	return c.waitForPinnedRun(ctx, run, pollInterval, waitCallID, callback)
+}
+
+func (c *jobsBackedAgentClient) waitForPinnedRun(ctx context.Context, run jobsV2AgentRunResponse, pollInterval time.Duration, waitCallID string, callback SubagentEventCallback) (jobsV2AgentRunResponse, error) {
 	if pollInterval <= 0 {
 		pollInterval = defaultQueuedAgentPollInterval * time.Second
 	}
+	runID := strings.TrimSpace(run.ID)
+	if runID == "" {
+		return jobsV2AgentRunResponse{}, fmt.Errorf("jobs server returned run without id")
+	}
+	jobID := strings.TrimSpace(run.JobID)
+	childID := waitCallID
+	if childID != "" {
+		childID += "/" + runID
+	}
+	timeoutSeconds := 0
+	if callback != nil && childID != "" && jobID != "" {
+		if job, err := c.getJob(ctx, jobID); err == nil {
+			timeoutSeconds = job.TimeoutSeconds
+		}
+	}
+	cursor := int64(0)
+	emitStatus := queuedStatusEmitter(childID, runID, jobID, timeoutSeconds, callback)
+	emitStatus(run)
 	for {
-		run, err := c.getRunSummary(ctx, runID)
-		if err != nil {
-			return jobsV2AgentRunResponse{}, err
+		moreEvents := false
+		var progressErr error
+		if callback != nil && childID != "" {
+			cursor, moreEvents, progressErr = c.emitRunProgressEvents(ctx, run, timeoutSeconds, childID, cursor, callback)
+			// Progress is best effort. Status polling remains authoritative and
+			// preserves the tool's existing fail-fast behavior.
 		}
 		if isQueuedAgentTerminalStatus(run.Status) {
+			if moreEvents {
+				continue // Drain terminal history without sleeping so totals converge.
+			}
+			if callback != nil && childID != "" {
+				callback(childID, SubagentEvent{Type: SubagentEventDone, Timestamp: parseQueuedAgentTime(run.FinishedAt), RunID: runID, JobID: jobID, ProgressTruncated: progressErr != nil})
+			}
 			return c.getTerminalRun(ctx, run)
 		}
 		timer := time.NewTimer(pollInterval)
@@ -458,7 +523,106 @@ func (c *jobsBackedAgentClient) waitForRun(ctx context.Context, runID string, po
 			return run, ctx.Err()
 		case <-timer.C:
 		}
+		var err error
+		run, err = c.getRunSummary(ctx, runID)
+		if err != nil {
+			return jobsV2AgentRunResponse{}, err
+		}
+		emitStatus(run)
 	}
+}
+
+func queuedRunDeadline(startedAt time.Time, timeoutSeconds int) time.Time {
+	if startedAt.IsZero() || timeoutSeconds <= 0 {
+		return time.Time{}
+	}
+	return startedAt.Add(time.Duration(timeoutSeconds) * time.Second)
+}
+
+func parseQueuedAgentTime(value string) time.Time {
+	parsed, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	return parsed
+}
+
+func (c *jobsBackedAgentClient) getJob(ctx context.Context, jobID string) (jobsV2AgentJobResponse, error) {
+	var job jobsV2AgentJobResponse
+	if err := c.doJSON(ctx, http.MethodGet, "/v2/jobs/"+url.PathEscape(jobID), nil, &job); err != nil {
+		return jobsV2AgentJobResponse{}, err
+	}
+	if job.ID == "" {
+		job.ID = jobID
+	}
+	return job, nil
+}
+
+func (c *jobsBackedAgentClient) emitRunProgressEvents(ctx context.Context, run jobsV2AgentRunResponse, timeoutSeconds int, childID string, cursor int64, callback SubagentEventCallback) (int64, bool, error) {
+	initialCursor := cursor
+	for page := 0; page < queuedAgentProgressPagesPerPoll; page++ {
+		events, err := c.getRunEvents(ctx, run.ID, cursor)
+		if err != nil {
+			return cursor, false, err
+		}
+		sort.Slice(events, func(i, j int) bool { return events[i].ID < events[j].ID })
+		pageCursor := cursor
+		for _, persisted := range events {
+			if persisted.ID <= cursor {
+				continue
+			}
+			if event, ok := queuedSubagentEvent(run, timeoutSeconds, persisted); ok {
+				callback(childID, event)
+			}
+			// Advance only after this event has been inspected/emitted. Unknown
+			// event types are skipped safely and never become liveness evidence.
+			cursor = persisted.ID
+		}
+		if len(events) < queuedAgentProgressPageSize || cursor == pageCursor {
+			return cursor, false, nil
+		}
+	}
+	return cursor, cursor > initialCursor, nil
+}
+
+func (c *jobsBackedAgentClient) getRunEvents(ctx context.Context, runID string, cursor int64) ([]jobsV2AgentRunEvent, error) {
+	var response jobsV2AgentRunEventsResponse
+	path := "/v2/runs/" + url.PathEscape(runID) + "/events?since_id=" + strconv.FormatInt(cursor, 10) + "&limit=" + strconv.Itoa(queuedAgentProgressPageSize)
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &response); err != nil {
+		return nil, err
+	}
+	return response.Data, nil
+}
+
+func queuedSubagentEvent(run jobsV2AgentRunResponse, timeoutSeconds int, persisted jobsV2AgentRunEvent) (SubagentEvent, bool) {
+	var data struct {
+		ID           string `json:"id"`
+		Tool         string `json:"tool"`
+		Success      bool   `json:"success"`
+		Text         string `json:"text"`
+		InputTokens  int    `json:"input_tokens"`
+		OutputTokens int    `json:"output_tokens"`
+	}
+	_ = json.Unmarshal(persisted.Data, &data)
+	event := SubagentEvent{
+		Timestamp: persisted.CreatedAt,
+		Deadline:  queuedRunDeadline(parseQueuedAgentTime(run.StartedAt), timeoutSeconds),
+		RunID:     run.ID,
+		JobID:     run.JobID,
+		EventID:   persisted.ID,
+	}
+	switch persisted.EventType {
+	case "queued", "claimed":
+		event.Type, event.Phase = SubagentEventPhase, persisted.EventType
+	case "tool_start":
+		event.Type, event.ToolCallID, event.ToolName = SubagentEventToolStart, data.ID, data.Tool
+	case "tool_end":
+		event.Type, event.ToolCallID, event.ToolName, event.Success = SubagentEventToolEnd, data.ID, data.Tool, data.Success
+	case "phase":
+		event.Type, event.Phase = SubagentEventPhase, data.Text
+	case "turn_complete":
+		event.Type, event.InputTokens, event.OutputTokens = SubagentEventUsage, data.InputTokens, data.OutputTokens
+	default:
+		return SubagentEvent{}, false
+	}
+	return event, true
 }
 
 func (c *jobsBackedAgentClient) getRun(ctx context.Context, runID string) (jobsV2AgentRunResponse, error) {
@@ -496,6 +660,10 @@ func (c *jobsBackedAgentClient) getTerminalRun(ctx context.Context, terminal job
 }
 
 func (c *jobsBackedAgentClient) waitForJob(ctx context.Context, jobID string, pollInterval time.Duration) (jobsV2AgentRunResponse, error) {
+	return c.waitForJobWithProgress(ctx, jobID, pollInterval, "", nil)
+}
+
+func (c *jobsBackedAgentClient) waitForJobWithProgress(ctx context.Context, jobID string, pollInterval time.Duration, waitCallID string, callback SubagentEventCallback) (jobsV2AgentRunResponse, error) {
 	if pollInterval <= 0 {
 		pollInterval = defaultQueuedAgentPollInterval * time.Second
 	}
@@ -504,16 +672,15 @@ func (c *jobsBackedAgentClient) waitForJob(ctx context.Context, jobID string, po
 		if err != nil {
 			return jobsV2AgentRunResponse{}, err
 		}
-		if found && isQueuedAgentTerminalStatus(run.Status) {
-			return c.getTerminalRun(ctx, run)
+		if found {
+			// Pin the first resolved run. A later trigger for the same job must not
+			// silently change which execution this wait observes.
+			return c.waitForPinnedRun(ctx, run, pollInterval, waitCallID, callback)
 		}
 		timer := time.NewTimer(pollInterval)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			if found {
-				return run, ctx.Err()
-			}
 			return jobsV2AgentRunResponse{JobID: jobID}, ctx.Err()
 		case <-timer.C:
 		}
@@ -759,4 +926,33 @@ func formatQueuedAgentError(errType ToolErrorType, message string) string {
 		},
 	})
 	return string(data)
+}
+
+// Preserve structured errors and partial job identity while marking the tool execution failed.
+func queuedAgentErrorOutput(content string) llm.ToolOutput {
+	output := llm.TextOutput(content)
+	output.IsError = true
+	return output
+}
+
+func queuedStatusEmitter(childID, runID, jobID string, timeoutSeconds int, callback SubagentEventCallback) func(jobsV2AgentRunResponse) {
+	lastStatusEvidence := ""
+	return func(current jobsV2AgentRunResponse) {
+		if callback == nil || childID == "" {
+			return
+		}
+		signature := strings.ToLower(strings.TrimSpace(current.Status)) + "|" + strings.TrimSpace(current.StartedAt)
+		if signature == lastStatusEvidence {
+			return
+		}
+		lastStatusEvidence = signature
+		timestamp := parseQueuedAgentTime(current.StartedAt)
+		deadline := queuedRunDeadline(timestamp, timeoutSeconds)
+		switch strings.ToLower(strings.TrimSpace(current.Status)) {
+		case "running":
+			callback(childID, SubagentEvent{Type: SubagentEventInit, Timestamp: timestamp, Deadline: deadline, RunID: runID, JobID: jobID})
+		case "queued", "claimed":
+			callback(childID, SubagentEvent{Type: SubagentEventPhase, Phase: strings.ToLower(strings.TrimSpace(current.Status)), Timestamp: timestamp, Deadline: deadline, RunID: runID, JobID: jobID})
+		}
+	}
 }

--- a/internal/tools/queue_agent_context.go
+++ b/internal/tools/queue_agent_context.go
@@ -25,6 +25,26 @@ type QueueAgentOriginContext struct {
 }
 
 type queueAgentOriginContextKey struct{}
+type subagentEventCallbackContextKey struct{}
+
+// ContextWithSubagentEventCallback installs a request-scoped, trusted progress
+// sink. It is used by spawn_agent and wait_for_jobs; arguments cannot replace it.
+// A nil callback masks an inherited sink at a child execution boundary.
+func ContextWithSubagentEventCallback(ctx context.Context, callback SubagentEventCallback) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, subagentEventCallbackContextKey{}, callback)
+}
+
+// SubagentEventCallbackFromContext returns the runtime-owned progress sink.
+func SubagentEventCallbackFromContext(ctx context.Context) SubagentEventCallback {
+	if ctx == nil {
+		return nil
+	}
+	callback, _ := ctx.Value(subagentEventCallbackContextKey{}).(SubagentEventCallback)
+	return callback
+}
 
 // ContextWithQueueAgentOrigin stores trusted queue_agent notification origin
 // metadata in ctx for the duration of a request.

--- a/internal/tools/queue_agent_test.go
+++ b/internal/tools/queue_agent_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -667,14 +668,14 @@ func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
 }
 
 func TestWaitForJobsDrainsTerminalProgressBeyondPollBudget(t *testing.T) {
-	const count = 701 // More than three 200-event pages; terminal counts must converge.
+	const count = 701 // More than three 200-event pages, but within the total terminal bound.
 	now := time.Now().UTC()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v2/runs/run_history/events":
 			cursor, _ := strconv.Atoi(r.URL.Query().Get("since_id"))
 			events := []jobsV2AgentRunEvent{}
-			for id := cursor + 1; id <= count && len(events) < 200; id++ {
+			for id := cursor + 1; id <= count && len(events) < queuedAgentProgressPageSize; id++ {
 				events = append(events, jobsV2AgentRunEvent{ID: int64(id), EventType: "tool_start", Data: json.RawMessage(fmt.Sprintf(`{"id":"tool-%d","tool":"shell"}`, id)), CreatedAt: now})
 			}
 			writeJSON(t, w, jobsV2AgentRunEventsResponse{Data: events})
@@ -696,11 +697,134 @@ func TestWaitForJobsDrainsTerminalProgressBeyondPollBudget(t *testing.T) {
 		if event.Type == SubagentEventDone {
 			done++
 			if event.ProgressTruncated {
-				t.Error("complete history marked truncated")
+				t.Error("complete bounded history marked truncated")
 			}
 		}
 	})
 	if err != nil || starts != count || done != 1 {
 		t.Fatalf("starts=%d done=%d err=%v", starts, done, err)
+	}
+}
+
+func TestWaitForJobsBoundsTerminalProgressReplayAndMarksCountsTruncated(t *testing.T) {
+	const available = queuedAgentProgressPageSize*queuedAgentProgressPagesPerPoll*queuedAgentTerminalDrainPasses + 1
+	const expected = available - 1
+	var eventRequests atomic.Int32
+	now := time.Now().UTC()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/runs/run_bounded/events":
+			eventRequests.Add(1)
+			cursor, _ := strconv.Atoi(r.URL.Query().Get("since_id"))
+			events := make([]jobsV2AgentRunEvent, 0, queuedAgentProgressPageSize)
+			for id := cursor + 1; id <= available && len(events) < queuedAgentProgressPageSize; id++ {
+				events = append(events, jobsV2AgentRunEvent{ID: int64(id), EventType: "tool_start", Data: json.RawMessage(fmt.Sprintf(`{"id":"tool-%d","tool":"shell"}`, id)), CreatedAt: now})
+			}
+			writeJSON(t, w, jobsV2AgentRunEventsResponse{Data: events})
+		case r.URL.Path == "/v2/jobs/job_bounded":
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_bounded", TimeoutSeconds: 3600})
+		case r.URL.Path == "/v2/runs/run_bounded":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_bounded", JobID: "job_bounded", Status: "succeeded", StartedAt: now.Format(time.RFC3339Nano)})
+		default:
+			t.Errorf("unexpected request %s", r.URL)
+		}
+	}))
+	defer server.Close()
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	starts, done := 0, 0
+	truncated := false
+	_, err := client.waitForRunWithProgress(context.Background(), "run_bounded", time.Hour, "wait", func(_ string, event SubagentEvent) {
+		switch event.Type {
+		case SubagentEventToolStart:
+			starts++
+		case SubagentEventDone:
+			done++
+			truncated = event.ProgressTruncated
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if starts != expected || done != 1 || !truncated {
+		t.Fatalf("starts=%d done=%d truncated=%v, want %d exact prefix events and explicit truncation", starts, done, truncated, expected)
+	}
+	wantRequests := int32(queuedAgentProgressPagesPerPoll * queuedAgentTerminalDrainPasses)
+	if got := eventRequests.Load(); got != wantRequests {
+		t.Fatalf("event requests=%d, want bounded %d", got, wantRequests)
+	}
+}
+
+func TestWaitForJobsBoundsProgressResponseBytes(t *testing.T) {
+	var eventRequests atomic.Int32
+	now := time.Now().UTC()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/runs/run_oversized/events":
+			eventRequests.Add(1)
+			payload := `{"data":[{"id":1,"event_type":"progress_update","data":{"message":"` + strings.Repeat("x", queuedAgentProgressResponseBytes) + `"}}]}`
+			_, _ = w.Write([]byte(payload))
+		case r.URL.Path == "/v2/jobs/job_oversized":
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_oversized", TimeoutSeconds: 3600})
+		case r.URL.Path == "/v2/runs/run_oversized":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_oversized", JobID: "job_oversized", Status: "succeeded", StartedAt: now.Format(time.RFC3339Nano)})
+		default:
+			t.Errorf("unexpected request %s", r.URL)
+		}
+	}))
+	defer server.Close()
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	done, truncated := 0, false
+	_, err := client.waitForRunWithProgress(context.Background(), "run_oversized", time.Hour, "wait", func(_ string, event SubagentEvent) {
+		if event.Type == SubagentEventDone {
+			done++
+			truncated = event.ProgressTruncated
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eventRequests.Load() != 1 || done != 1 || !truncated {
+		t.Fatalf("requests=%d done=%d truncated=%v", eventRequests.Load(), done, truncated)
+	}
+}
+
+func TestWaitForJobsTerminalReplayHonorsCancellation(t *testing.T) {
+	var eventRequests atomic.Int32
+	now := time.Now().UTC()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/runs/run_cancel/events":
+			eventRequests.Add(1)
+			events := make([]jobsV2AgentRunEvent, 0, queuedAgentProgressPageSize)
+			for id := 1; id <= queuedAgentProgressPageSize; id++ {
+				events = append(events, jobsV2AgentRunEvent{ID: int64(id), EventType: "tool_start", Data: json.RawMessage(fmt.Sprintf(`{"id":"tool-%d","tool":"shell"}`, id)), CreatedAt: now})
+			}
+			writeJSON(t, w, jobsV2AgentRunEventsResponse{Data: events})
+		case r.URL.Path == "/v2/jobs/job_cancel":
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_cancel", TimeoutSeconds: 3600})
+		case r.URL.Path == "/v2/runs/run_cancel":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_cancel", JobID: "job_cancel", Status: "succeeded", StartedAt: now.Format(time.RFC3339Nano)})
+		default:
+			t.Errorf("unexpected request %s", r.URL)
+		}
+	}))
+	defer server.Close()
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	ctx, cancel := context.WithCancel(context.Background())
+	starts, done := 0, 0
+	_, err := client.waitForRunWithProgress(ctx, "run_cancel", time.Hour, "wait", func(_ string, event SubagentEvent) {
+		if event.Type == SubagentEventToolStart {
+			starts++
+			cancel()
+		}
+		if event.Type == SubagentEventDone {
+			done++
+		}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error=%v, want cancellation", err)
+	}
+	if eventRequests.Load() != 1 || starts != 1 || done != 0 {
+		t.Fatalf("requests=%d starts=%d done=%d", eventRequests.Load(), starts, done)
 	}
 }

--- a/internal/tools/queue_agent_test.go
+++ b/internal/tools/queue_agent_test.go
@@ -3,12 +3,16 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/samsaffron/term-llm/internal/llm"
 )
 
 func TestQueueAgentCreatesAndTriggersJobsBackedLLMJob(t *testing.T) {
@@ -265,16 +269,15 @@ func TestWaitForJobsPollsUntilTerminal(t *testing.T) {
 			if r.URL.Query().Get("summary") != "true" {
 				t.Fatalf("poll should request a summary, got query %q", r.URL.RawQuery)
 			}
-			count := atomic.AddInt32(&summaryPolls, 1)
-			if count == 1 {
-				writeJSON(t, w, jobsV2AgentRunsListResponse{Data: []jobsV2AgentRunResponse{{ID: "run_123", JobID: "job_123", Status: "running"}}})
-				return
-			}
+			atomic.AddInt32(&summaryPolls, 1)
+			writeJSON(t, w, jobsV2AgentRunsListResponse{Data: []jobsV2AgentRunResponse{{ID: "run_123", JobID: "job_123", Status: "running"}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/runs/run_123" && r.URL.Query().Get("summary") == "true":
+			atomic.AddInt32(&summaryPolls, 1)
 			exitCode := 0
 			turnCount := 1
 			inputTokens := 10
 			outputTokens := 3
-			writeJSON(t, w, jobsV2AgentRunsListResponse{Data: []jobsV2AgentRunResponse{{
+			writeJSON(t, w, jobsV2AgentRunResponse{
 				ID:           "run_123",
 				JobID:        "job_123",
 				Status:       "succeeded",
@@ -285,7 +288,7 @@ func TestWaitForJobsPollsUntilTerminal(t *testing.T) {
 				ExitCode:     &exitCode,
 				StartedAt:    "2026-06-07T07:15:51.314202856Z",
 				FinishedAt:   "2026-06-07T07:16:49.259958355Z",
-			}}})
+			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/runs/run_123":
 			if r.URL.RawQuery != "" {
 				t.Fatalf("terminal output fetch should be full, got query %q", r.URL.RawQuery)
@@ -426,6 +429,151 @@ func TestWaitForRunReportsTerminalDetailFetchFailure(t *testing.T) {
 	}
 }
 
+func TestWaitForJobsMarksPollingAndCancellationFailuresAsToolErrors(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		server http.HandlerFunc
+		ctx    func() context.Context
+	}{
+		{
+			name: "polling failure",
+			server: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("unavailable"))
+			},
+			ctx: context.Background,
+		},
+		{
+			name: "caller cancellation",
+			server: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_123", JobID: "job_123", Status: "running"})
+			},
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.server)
+			defer server.Close()
+			tool := NewWaitForJobsToolWithClient(&jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()})
+			tool.pollIntervalOverride = time.Millisecond
+			out, err := tool.Execute(test.ctx(), json.RawMessage(`{"run_ids":["run_123"]}`))
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if !out.IsError {
+				t.Fatalf("poll failure returned successful tool output: %#v", out)
+			}
+			var results []QueuedJobResult
+			if err := json.Unmarshal([]byte(out.Content), &results); err != nil || len(results) != 1 || results[0].Status != "failed" || results[0].Error == "" {
+				t.Fatalf("failure JSON = %#v, decode error = %v", results, err)
+			}
+		})
+	}
+}
+
+func TestWaitForJobsEmitsSanitizedCursorProgress(t *testing.T) {
+	var summaryPolls atomic.Int32
+	var eventQueries []string
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/runs/run_progress" && r.URL.Query().Get("summary") == "true":
+			status := "running"
+			if summaryPolls.Add(1) > 1 {
+				status = "succeeded"
+			}
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_progress", JobID: "job_progress", Status: status, StartedAt: now.Format(time.RFC3339Nano), FinishedAt: now.Add(time.Second).Format(time.RFC3339Nano)})
+		case r.URL.Path == "/v2/jobs/job_progress":
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_progress", TimeoutSeconds: 60})
+		case r.URL.Path == "/v2/runs/run_progress/events":
+			eventQueries = append(eventQueries, r.URL.RawQuery)
+			if r.URL.Query().Get("since_id") == "0" {
+				writeJSON(t, w, jobsV2AgentRunEventsResponse{Data: []jobsV2AgentRunEvent{
+					{ID: 1, EventType: "tool_start", Data: json.RawMessage(`{"id":"tool-1","tool":"shell","info":"secret args"}`), CreatedAt: now},
+					{ID: 2, EventType: "progress_update", Data: json.RawMessage(`{"message":"secret output"}`), CreatedAt: now},
+					{ID: 3, EventType: "tool_end", Data: json.RawMessage(`{"id":"tool-1","tool":"shell","success":true}`), CreatedAt: now},
+				}})
+			} else {
+				writeJSON(t, w, jobsV2AgentRunEventsResponse{})
+			}
+		case r.URL.Path == "/v2/runs/run_progress" && r.URL.RawQuery == "":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_progress", JobID: "job_progress", Status: "succeeded"})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewWaitForJobsToolWithClient(client)
+	tool.pollIntervalOverride = time.Millisecond
+	var events []SubagentEvent
+	ctx := ContextWithSubagentEventCallback(llm.ContextWithCallID(context.Background(), "wait-call"), func(callID string, event SubagentEvent) {
+		if callID != "wait-call/run_progress" {
+			t.Errorf("callID = %q", callID)
+		}
+		events = append(events, event)
+	})
+	if _, err := tool.Execute(ctx, json.RawMessage(`{"run_ids":["run_progress"]}`)); err != nil {
+		t.Fatal(err)
+	}
+	var starts, ends int
+	for _, event := range events {
+		switch event.Type {
+		case SubagentEventToolStart:
+			starts++
+			if len(event.ToolArgs) != 0 || event.ToolInfo != "" || event.Text != "" {
+				t.Fatalf("translated start leaked payload: %#v", event)
+			}
+		case SubagentEventToolEnd:
+			ends++
+		}
+	}
+	if starts != 1 || ends != 1 {
+		t.Fatalf("translated starts=%d ends=%d events=%#v", starts, ends, events)
+	}
+	if len(eventQueries) < 2 || !strings.Contains(eventQueries[0], "since_id=0") || !strings.Contains(eventQueries[1], "since_id=3") {
+		t.Fatalf("event cursor queries = %#v", eventQueries)
+	}
+	for _, query := range eventQueries {
+		if strings.Contains(query, "offset=") || !strings.Contains(query, "limit=200") {
+			t.Fatalf("unbounded/rescanning event query %q", query)
+		}
+	}
+}
+
+func TestWaitForJobsPinsJobRunAfterResolution(t *testing.T) {
+	var listCalls atomic.Int32
+	var exactCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/runs":
+			listCalls.Add(1)
+			writeJSON(t, w, jobsV2AgentRunsListResponse{Data: []jobsV2AgentRunResponse{{ID: "run_first", JobID: "job_1", Status: "running"}}})
+		case r.URL.Path == "/v2/runs/run_first" && r.URL.Query().Get("summary") == "true":
+			exactCalls.Add(1)
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_first", JobID: "job_1", Status: "succeeded"})
+		case r.URL.Path == "/v2/runs/run_first":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_first", JobID: "job_1", Status: "succeeded"})
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	tool := NewWaitForJobsToolWithClient(client)
+	tool.pollIntervalOverride = time.Millisecond
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{"job_ids":["job_1"]}`)); err != nil {
+		t.Fatal(err)
+	}
+	if listCalls.Load() != 1 || exactCalls.Load() != 1 {
+		t.Fatalf("list calls=%d exact calls=%d, want pinned exact polling", listCalls.Load(), exactCalls.Load())
+	}
+}
+
 func TestWaitForJobsMultipleRunsCollectsCompletedSibling(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -482,7 +630,7 @@ func TestQueueAgentSurfacesJobsErrorBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("queue Execute() error = %v", err)
 	}
-	if !strings.Contains(out.Content, "llm runner_config.cwd is required") {
+	if !out.IsError || !strings.Contains(out.Content, "llm runner_config.cwd is required") {
 		t.Fatalf("output did not include jobs error body: %s", out.Content)
 	}
 }
@@ -515,5 +663,44 @@ func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(value); err != nil {
 		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func TestWaitForJobsDrainsTerminalProgressBeyondPollBudget(t *testing.T) {
+	const count = 701 // More than three 200-event pages; terminal counts must converge.
+	now := time.Now().UTC()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/runs/run_history/events":
+			cursor, _ := strconv.Atoi(r.URL.Query().Get("since_id"))
+			events := []jobsV2AgentRunEvent{}
+			for id := cursor + 1; id <= count && len(events) < 200; id++ {
+				events = append(events, jobsV2AgentRunEvent{ID: int64(id), EventType: "tool_start", Data: json.RawMessage(fmt.Sprintf(`{"id":"tool-%d","tool":"shell"}`, id)), CreatedAt: now})
+			}
+			writeJSON(t, w, jobsV2AgentRunEventsResponse{Data: events})
+		case r.URL.Path == "/v2/jobs/job_history":
+			writeJSON(t, w, jobsV2AgentJobResponse{ID: "job_history", TimeoutSeconds: 3600})
+		case r.URL.Path == "/v2/runs/run_history":
+			writeJSON(t, w, jobsV2AgentRunResponse{ID: "run_history", JobID: "job_history", Status: "succeeded", StartedAt: now.Format(time.RFC3339Nano)})
+		default:
+			t.Errorf("unexpected request %s", r.URL)
+		}
+	}))
+	defer server.Close()
+	client := &jobsBackedAgentClient{baseURL: server.URL, httpClient: server.Client()}
+	starts, done := 0, 0
+	_, err := client.waitForRunWithProgress(context.Background(), "run_history", time.Hour, "wait", func(_ string, event SubagentEvent) {
+		if event.Type == SubagentEventToolStart {
+			starts++
+		}
+		if event.Type == SubagentEventDone {
+			done++
+			if event.ProgressTruncated {
+				t.Error("complete history marked truncated")
+			}
+		}
+	})
+	if err != nil || starts != count || done != 1 {
+		t.Fatalf("starts=%d done=%d err=%v", starts, done, err)
 	}
 }

--- a/internal/tools/spawn_agent.go
+++ b/internal/tools/spawn_agent.go
@@ -407,23 +407,30 @@ func (t *SpawnAgentTool) PermittedAgentNames() ([]string, error) {
 	return permitted, nil
 }
 
+func spawnAgentErrorOutput(content string, timedOut bool) llm.ToolOutput {
+	output := llm.TextOutput(content)
+	output.IsError = true
+	output.TimedOut = timedOut
+	return output
+}
+
 // Execute runs the spawn_agent tool.
 func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm.ToolOutput, error) {
 	var a SpawnAgentArgs
 	if err := json.Unmarshal(args, &a); err != nil {
-		return llm.TextOutput(t.formatError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err))), nil
+		return spawnAgentErrorOutput(t.formatError(ErrInvalidParams, fmt.Sprintf("failed to parse arguments: %v", err)), false), nil
 	}
 
 	// Validate arguments
 	if a.AgentName == "" {
-		return llm.TextOutput(t.formatError(ErrInvalidParams, "agent_name is required")), nil
+		return spawnAgentErrorOutput(t.formatError(ErrInvalidParams, "agent_name is required"), false), nil
 	}
 	if a.Prompt == "" {
-		return llm.TextOutput(t.formatError(ErrInvalidParams, "prompt is required")), nil
+		return spawnAgentErrorOutput(t.formatError(ErrInvalidParams, "prompt is required"), false), nil
 	}
 	requestedModel := a.Model
 	if requestedModel != "" && !isQualifiedSpawnModel(requestedModel) {
-		return llm.TextOutput(t.formatError(ErrInvalidParams, "model must use exact provider:model format; omit it to use the configured/default model")), nil
+		return spawnAgentErrorOutput(t.formatError(ErrInvalidParams, "model must use exact provider:model format; omit it to use the configured/default model"), false), nil
 	}
 
 	runner, currentDepth, policyErr := t.localSpawnPolicy(a.AgentName)
@@ -433,7 +440,7 @@ func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 		if errors.As(policyErr, &typed) {
 			errType = typed.typeName
 		}
-		return llm.TextOutput(t.formatError(errType, policyErr.Error())), nil
+		return spawnAgentErrorOutput(t.formatError(errType, policyErr.Error()), false), nil
 	}
 
 	// Determine timeout.
@@ -456,11 +463,11 @@ func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 	case t.semaphore <- struct{}{}:
 		defer func() { <-t.semaphore }()
 	case <-ctx.Done():
-		// Distinguish between deadline exceeded (timeout) and manual cancellation
+		// Distinguish between deadline exceeded (timeout) and manual cancellation.
 		if ctx.Err() == context.DeadlineExceeded {
-			return llm.TextOutput(t.formatError(ErrTimeout, "context deadline exceeded while waiting for agent slot")), nil
+			return spawnAgentErrorOutput(t.formatError(ErrTimeout, "context deadline exceeded while waiting for agent slot"), true), nil
 		}
-		return llm.TextOutput(t.formatError(ErrExecutionFailed, "context cancelled while waiting for agent slot")), nil
+		return spawnAgentErrorOutput(t.formatError(ErrExecutionFailed, "context cancelled while waiting for agent slot"), false), nil
 	}
 
 	// Create child context with timeout
@@ -511,7 +518,12 @@ func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 	duration := time.Since(start).Milliseconds()
 
 	if err != nil {
-		return llm.TextOutput(t.formatErrorWithPartialResult(classifySpawnAgentError(err, ctx, childCtx), spawnAgentErrorMessage(err, ctx, childCtx, a.AgentName, timeout), duration, runResult)), nil
+		errType := classifySpawnAgentError(err, ctx, childCtx)
+		output := spawnAgentErrorOutput(t.formatErrorWithPartialResult(errType, spawnAgentErrorMessage(err, ctx, childCtx, a.AgentName, timeout), duration, runResult), errType == ErrTimeout)
+		mediaMu.Lock()
+		output.Media = llm.NormalizeMedia(append([]llm.MediaArtifact(nil), nestedMedia...), nil)
+		mediaMu.Unlock()
+		return output, nil
 	}
 
 	// Return success result

--- a/internal/tools/spawn_agent.go
+++ b/internal/tools/spawn_agent.go
@@ -87,6 +87,11 @@ type SubagentEvent struct {
 	Provider          string              // resolved provider for init/usage events
 	Model             string              // resolved model for init/usage events
 	Timestamp         time.Time           // authoritative child lifecycle/event time when available
+	Deadline          time.Time           // independently enforced child/run deadline when available
+	RunID             string              // queued run identity; never model-provided display text
+	JobID             string              // queued job identity
+	EventID           int64               // monotonic persisted queued-event identity; zero for synchronous events
+	ProgressTruncated bool                // queued event history could not be read completely
 }
 
 // SubagentEventCallback is called to bubble up events from a running subagent.
@@ -467,14 +472,19 @@ func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 	var runResult SpawnAgentRunResult
 	var err error
 
-	// Get callback and call ID for event bubbling. Always use the callback runner
-	// path so nested media can be retained on the parent tool result even when no
-	// live progress consumer is installed.
+	// Snapshot callbacks at execution admission. The context callback is owned by
+	// this parent execution; the tool callback is lifetime-scoped (for stats and
+	// other process-wide observers).
 	externalCallback := t.GetEventCallback()
+	executionCallback := SubagentEventCallbackFromContext(ctx)
+	// Descendants bubble through the child sink, which qualifies their IDs. Do
+	// not also deliver their raw call IDs to this parent's context callback.
+	childCtx = ContextWithSubagentEventCallback(childCtx, nil)
 	callID := llm.CallIDFromContext(ctx)
 	var mediaMu sync.Mutex
 	var nestedMedia []llm.MediaArtifact
 	cb := func(eventCallID string, event SubagentEvent) {
+		event.Deadline, _ = childCtx.Deadline()
 		if event.Type == SubagentEventToolEnd && len(event.Media) > 0 {
 			mediaMu.Lock()
 			nestedMedia = append(nestedMedia, event.Media...)
@@ -483,6 +493,7 @@ func (t *SpawnAgentTool) Execute(ctx context.Context, args json.RawMessage) (llm
 		if externalCallback != nil && callID != "" {
 			externalCallback(eventCallID, event)
 		}
+		emitExecutionSubagentEvent(executionCallback, callID, eventCallID, event)
 	}
 	modelOverride := requestedModel
 	if modelOverride == "" {
@@ -587,4 +598,10 @@ func (t *SpawnAgentTool) formatErrorWithPartialResult(errType ToolErrorType, mes
 	}
 	data, _ := json.Marshal(result)
 	return string(data)
+}
+
+func emitExecutionSubagentEvent(callback SubagentEventCallback, callID, eventCallID string, event SubagentEvent) {
+	if callback != nil && callID != "" {
+		callback(eventCallID, event)
+	}
 }

--- a/internal/tools/spawn_agent_test.go
+++ b/internal/tools/spawn_agent_test.go
@@ -405,6 +405,9 @@ func TestSpawnAgentTool_PreservesPartialRunResultOnError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if !result.IsError || result.TimedOut {
+		t.Fatalf("execution failure flags = IsError:%v TimedOut:%v, want true/false", result.IsError, result.TimedOut)
+	}
 
 	r := parseResult(t, result.Content)
 	if r.Type != string(ErrExecutionFailed) {
@@ -426,6 +429,9 @@ func TestSpawnAgentTool_PreservesPartialRunResultOnTimeoutError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if !result.IsError || !result.TimedOut {
+		t.Fatalf("timeout flags = IsError:%v TimedOut:%v, want true/true", result.IsError, result.TimedOut)
+	}
 
 	r := parseResult(t, result.Content)
 	if r.Type != string(ErrTimeout) {
@@ -436,6 +442,45 @@ func TestSpawnAgentTool_PreservesPartialRunResultOnTimeoutError(t *testing.T) {
 	}
 	if r.SessionID != "child-session-timeout" {
 		t.Fatalf("expected child session ID to be preserved, got %q", r.SessionID)
+	}
+}
+
+func TestSpawnAgentStructuredFailureEmitsUnsuccessfulEngineTerminal(t *testing.T) {
+	tool := NewSpawnAgentTool(SpawnConfig{MaxDepth: 5, MaxParallel: 1, DefaultTimeout: 300}, 0)
+	tool.SetRunner(newMockRunner().SetOutput("partial findings").SetSessionID("child-failed").SetError(errors.New("boom")))
+	provider := llm.NewMockProvider("mock").
+		AddToolCall("spawn-failed", SpawnAgentToolName, SpawnAgentArgs{AgentName: "codebase", Prompt: "inspect"}).
+		AddTextResponse("recovered")
+	engine := llm.NewEngine(provider, nil)
+	engine.RegisterTool(tool)
+	stream, err := engine.Stream(context.Background(), llm.Request{
+		Messages: []llm.Message{llm.UserText("inspect")},
+		Tools:    []llm.ToolSpec{tool.Spec()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	var terminal *llm.Event
+	for {
+		event, recvErr := stream.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+		if recvErr != nil {
+			t.Fatal(recvErr)
+		}
+		if event.Type == llm.EventToolExecEnd && event.ToolCallID == "spawn-failed" {
+			copy := event
+			terminal = &copy
+		}
+	}
+	if terminal == nil {
+		t.Fatal("missing spawn_agent terminal event")
+	}
+	if terminal.ToolSuccess || !strings.Contains(terminal.ToolOutput, `"type":"`+string(ErrExecutionFailed)+`"`) || !strings.Contains(terminal.ToolOutput, `"session_id":"child-failed"`) {
+		t.Fatalf("terminal = %#v", *terminal)
 	}
 }
 

--- a/internal/tools/spawn_agent_test.go
+++ b/internal/tools/spawn_agent_test.go
@@ -16,17 +16,54 @@ import (
 
 type mediaEventMockRunner struct {
 	*mockRunner
-	media llm.MediaArtifact
+	media             llm.MediaArtifact
+	inheritedCallback bool
 }
 
 func (r *mediaEventMockRunner) RunAgentWithCallback(ctx context.Context, agentName, prompt string, depth int, callID string, cb SubagentEventCallback) (SpawnAgentRunResult, error) {
+	r.inheritedCallback = SubagentEventCallbackFromContext(ctx) != nil
 	cb(callID, SubagentEvent{Type: SubagentEventToolEnd, ToolName: ShowMediaToolName, Media: []llm.MediaArtifact{r.media}, Success: true})
 	return r.mockRunner.RunAgent(ctx, agentName, prompt, depth)
 }
 
 func (r *mediaEventMockRunner) RunAgentWithCallbackAndOptions(ctx context.Context, agentName, prompt string, depth int, callID string, cb SubagentEventCallback, opts SpawnAgentRunOptions) (SpawnAgentRunResult, error) {
+	r.inheritedCallback = SubagentEventCallbackFromContext(ctx) != nil
 	cb(callID, SubagentEvent{Type: SubagentEventToolEnd, ToolName: ShowMediaToolName, Media: []llm.MediaArtifact{r.media}, Success: true})
 	return r.mockRunner.RunAgentWithOptions(ctx, agentName, prompt, depth, opts)
+}
+
+func TestSpawnAgentToolUsesExecutionScopedEventCallback(t *testing.T) {
+	tool := NewSpawnAgentTool(DefaultSpawnConfig(), 0)
+	runner := &mediaEventMockRunner{mockRunner: newMockRunner()}
+	tool.SetRunner(runner)
+	var event SubagentEvent
+	ctx := ContextWithSubagentEventCallback(context.Background(), func(_ string, observed SubagentEvent) { event = observed })
+	ctx = llm.ContextWithCallID(ctx, "parent-call")
+	if _, err := tool.Execute(ctx, makeSpawnArgs("reviewer", "inspect", 10)); err != nil {
+		t.Fatal(err)
+	}
+	if runner.inheritedCallback {
+		t.Fatal("child inherited raw parent callback; nested IDs must bubble through child sink")
+	}
+	if event.Type != SubagentEventToolEnd {
+		t.Fatalf("execution callback event = %#v", event)
+	}
+}
+
+func TestSpawnAgentToolAddsVerifiedDeadlineToCallbackEvents(t *testing.T) {
+	tool := NewSpawnAgentTool(DefaultSpawnConfig(), 0)
+	tool.SetRunner(&mediaEventMockRunner{mockRunner: newMockRunner()})
+	var event SubagentEvent
+	tool.SetEventCallback(func(_ string, observed SubagentEvent) { event = observed })
+	before := time.Now().Add(9 * time.Second)
+	ctx := llm.ContextWithCallID(context.Background(), "parent-call")
+	if _, err := tool.Execute(ctx, makeSpawnArgs("reviewer", "inspect", 10)); err != nil {
+		t.Fatal(err)
+	}
+	after := time.Now().Add(11 * time.Second)
+	if event.Deadline.Before(before) || event.Deadline.After(after) {
+		t.Fatalf("callback deadline = %v, want enforced child deadline between %v and %v", event.Deadline, before, after)
+	}
 }
 
 func TestSpawnAgentToolRetainsNestedMediaOnResult(t *testing.T) {

--- a/internal/tui/chat/stats.go
+++ b/internal/tui/chat/stats.go
@@ -491,6 +491,46 @@ func nonEmpty(values ...string) string {
 	return "unknown"
 }
 
+func subagentStatsCost(calls []ui.SubagentUsageCall) (string, bool, bool) {
+	known, priced, unpriced := 0.0, 0, 0
+	for _, call := range calls {
+		stats := ui.NewSessionStats()
+		u := call.Usage
+		stats.AddSubagentUsageForModel(call.Model, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
+		if cost, err := statsCostEstimator("", stats); err == nil {
+			known += cost
+			priced++
+		} else {
+			unpriced++
+		}
+	}
+	if priced == 0 {
+		return "—", false, true
+	}
+	cost := fmt.Sprintf("$%.4f", known)
+	if unpriced > 0 {
+		return "≥" + cost, true, false
+	}
+	return cost, false, false
+}
+
+func subagentStatsLegend(runCount int, running, partial, unavailable bool) string {
+	var legend []string
+	if running {
+		legend = append(legend, "* running")
+	}
+	if partial {
+		legend = append(legend, "≥ partial cost")
+	}
+	if unavailable {
+		legend = append(legend, "— unpriced")
+	}
+	if runCount > 1 {
+		legend = append(legend, "time summed across runs")
+	}
+	return strings.Join(legend, " · ")
+}
+
 // renderSubagentStats reports observed process-local runs separately from restored totals.
 func (m *Model) renderSubagentStats(b *strings.Builder) {
 	var runs []ui.SubagentProgress
@@ -593,45 +633,13 @@ func (m *Model) renderSubagentStats(b *strings.Builder) {
 		} else {
 			cells = append(cells, ui.FormatTokenCount(u.InputTokens+u.CachedInputTokens+u.CacheWriteTokens+u.OutputTokens))
 		}
-		known, priced, unpriced := 0.0, 0, 0
-		for _, call := range row.calls {
-			stats := ui.NewSessionStats()
-			u := call.Usage
-			stats.AddSubagentUsageForModel(call.Model, u.InputTokens, u.OutputTokens, u.CachedInputTokens, u.CacheWriteTokens)
-			if cost, err := statsCostEstimator("", stats); err == nil {
-				known += cost
-				priced++
-			} else {
-				unpriced++
-			}
-		}
-		cost := "—"
-		if priced > 0 {
-			cost = fmt.Sprintf("$%.4f", known)
-			if unpriced > 0 {
-				cost = "≥" + cost
-				partial = true
-			}
-		} else {
-			unavailable = true
-		}
+		cost, costPartial, costUnavailable := subagentStatsCost(row.calls)
+		partial = partial || costPartial
+		unavailable = unavailable || costUnavailable
 		writeRow(append(cells, cost))
 	}
-	var legend []string
-	if running {
-		legend = append(legend, "* running")
-	}
-	if partial {
-		legend = append(legend, "≥ partial cost")
-	}
-	if unavailable {
-		legend = append(legend, "— unpriced")
-	}
-	if len(runs) > 1 {
-		legend = append(legend, "time summed across runs")
-	}
-	if len(legend) > 0 {
-		b.WriteString(strings.Join(legend, " · ") + "\n")
+	if legend := subagentStatsLegend(len(runs), running, partial, unavailable); legend != "" {
+		b.WriteString(legend + "\n")
 	}
 }
 

--- a/internal/tui/chat/update_stream_terminal.go
+++ b/internal/tui/chat/update_stream_terminal.go
@@ -12,6 +12,12 @@ import (
 	"github.com/samsaffron/term-llm/internal/ui"
 )
 
+func (m *Model) finalizeStreamStats() {
+	if m.stats != nil {
+		m.stats.Finalize()
+	}
+}
+
 func (m *Model) handleStreamError(msg streamEventMsg, ev ui.StreamEvent, state *streamCommandBuffer, streamEventStart time.Time) (tea.Model, tea.Cmd, bool, []tea.Cmd, []tea.Cmd) {
 	var suspended *llm.SuspendedError
 	if errors.As(ev.Err, &suspended) {
@@ -20,9 +26,7 @@ func (m *Model) handleStreamError(msg streamEventMsg, ev ui.StreamEvent, state *
 	}
 	m.applyAllPendingCompactionsToUI(msg.generation)
 	if ev.Err != nil {
-		if m.stats != nil {
-			m.stats.Finalize()
-		}
+		m.finalizeStreamStats()
 		m.setRetryStatus("")
 		// Flush any buffered text on error
 		if m.smoothBuffer != nil {
@@ -136,9 +140,7 @@ func (m *Model) handleStreamError(msg streamEventMsg, ev ui.StreamEvent, state *
 }
 
 func (m *Model) handleStreamDone(msg streamEventMsg, ev ui.StreamEvent, state *streamCommandBuffer) (tea.Model, tea.Cmd, bool, []tea.Cmd, []tea.Cmd) {
-	if m.stats != nil {
-		m.stats.Finalize()
-	}
+	m.finalizeStreamStats()
 	m.applyAllPendingCompactionsToUI(msg.generation)
 	m.setRetryStatus("")
 	m.currentTokens = ev.Tokens

--- a/internal/ui/subagent_helpers.go
+++ b/internal/ui/subagent_helpers.go
@@ -11,6 +11,19 @@ import (
 	"github.com/samsaffron/term-llm/internal/tools"
 )
 
+func handleRemovedSubagentProgress(subagentTracker *SubagentTracker, callID string, event tools.SubagentEvent, p *SubagentProgress) bool {
+	if p != nil {
+		return false
+	}
+	if event.Type == tools.SubagentEventUsage {
+		subagentTracker.HandleUsageEvent(callID, event)
+	}
+	if event.Type == tools.SubagentEventGuardian && event.Guardian != nil {
+		subagentTracker.HandleGuardianEvent(callID, *event.Guardian)
+	}
+	return true
+}
+
 // HandleSubagentProgress processes subagent events and updates both the subagent tracker
 // and the corresponding spawn_agent segment's stats. This is shared logic used by both
 // the ask command (streaming mode) and the chat TUI.
@@ -39,13 +52,7 @@ func HandleSubagentProgress(tracker *ToolTracker, subagentTracker *SubagentTrack
 	p := subagentTracker.GetOrCreate(callID, agentName)
 
 	// Removed runs must not reappear inline, but late usage still belongs to accounting.
-	if p == nil {
-		if event.Type == tools.SubagentEventUsage {
-			subagentTracker.HandleUsageEvent(callID, event)
-		}
-		if event.Type == tools.SubagentEventGuardian && event.Guardian != nil {
-			subagentTracker.HandleGuardianEvent(callID, *event.Guardian)
-		}
+	if handleRemovedSubagentProgress(subagentTracker, callID, event, p) {
 		return
 	}
 	if p.Prompt == "" && prompt != "" {

--- a/scripts/browser_lifecycle_smoke.sh
+++ b/scripts/browser_lifecycle_smoke.sh
@@ -50,8 +50,9 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$root"
-# The gate implementation and its tests do not exist in production builds.
-go test -race -tags browserfixture ./internal/llm -run '^TestDebugBrowserGate$'
+# The gate implementation and its tests do not exist in production builds. Keep
+# this smoke preflight fast; CI's race job exercises the tagged gate separately.
+go test -tags browserfixture ./internal/llm -run '^TestDebugBrowserGate$'
 npm --prefix frontend run build
 mkdir -p "$home/config/term-llm"
 cat >"$home/config/term-llm/config.yaml" <<'YAML'


### PR DESCRIPTION
## Summary

- Show live subagent tool-call totals, active counts, bounded tool names, and safe phase labels in the web transcript. Absolute sequence-numbered snapshots use the existing durable response-event/recovery path; validated historical spawn sessions supply direct tool totals after cleanup.
- Keep delegation summaries visible even inside collapsed tool groups (up to three previews, running first). Distinguish queued detached jobs, successful waits, failed waits and cancelled waiting. Progress summaries never contain arguments, output or reasoning.
- Protect legitimate child waits from the parent's ordinary inactivity timer without disabling Stop, explicit context deadlines, child timeouts or stall bounds.

## Timeout and scope contract

- The ordinary default parent inactivity window remains **30 minutes**. A synchronous child retains its existing enforced timeout (default **300 seconds**, maximum **3,600 seconds**).
- Delegation holds expire at the verified deadline plus **30 seconds** of grace, capped absolutely at **one hour + 30 seconds from acquisition**. Extensions cannot slide that cap, revive an elapsed hold, or undo Stop. Expiry resumes the frozen ordinary inactivity budget; normal release starts a fresh finite window. This is not a new unlimited parent deadline.
- Queued waits use source event timestamps / the initial pinned running snapshot, not retrieval time. The queued stale bound is **15 minutes**, clamped to the job deadline when metadata is available, plus the same grace. Unknown events and unchanged status polls do not renew liveness. If job metadata is unavailable, protection remains bounded by source-age evidence rather than inventing a job deadline.
- `job_ids` resolve once and pin an exact run, so a concurrent trigger or retry cannot silently change the execution being awaited. Queue-created ephemeral jobs do not configure retries.
- Progress uses the existing authenticated cursor API, at most **three pages of 200 events per live poll**. Event responses are capped at **1 MiB**. Terminal history drains at most four passes (**2,400 inspected events**) and explicitly marks totals with `+` when more history exists or ingestion was truncated; cancellation is checked during replay. Identity tracking is independently bounded (32 roots, 8 child summaries, 256 counted calls, 64 active calls).
- **Accepted scope limitation:** queued-agent progress is observed only while `wait_for_jobs` executes. There is no post-response detached-job poller. Stopping a wait does **not** cancel detached jobs. Spawn headline/historical counts are direct-child calls, not recursively summed descendants; queued headline counts aggregate the selected runs. Completed wait totals survive response-run recovery but are not persisted as a separate durable session summary after response-run retention/server restart.

## Review fixes

Full implementation reviews were validated against source and addressed proportionately:

- Make both `spawn_agent` and `wait_for_jobs` terminal events lossless under engine backpressure, so terminal UI state and timer holds cannot be stranded.
- Establish progress roots from the lossless tool-call projection, and safely adopt only independently verified early callbacks (an enforced spawn deadline or pinned queued run identity) to close the callback/projection race.
- Bound jobs event response bytes and terminal replay work while preserving exact cursor-prefix counts, explicit truncation, and cancellation.
- Mark every structured `spawn_agent` failure as an error output (and timeout where applicable), preserving partial output, child session identity and media. Engine live events and response-run recovery now agree on failed terminal state.
- Pair provider-native tool start/end events that omit call IDs; sequential same-name calls count separately while the 256-call cap remains enforced.
- Document delegation pause semantics for `--response-timeout`.

Deferred non-critical follow-ups: reducing progress-only replay churn, rendering/removing currently bounded child-detail payloads, retry-lineage semantics for arbitrary jobs, and durable wait totals beyond response-run retention. These do not leave unbounded memory/work or incorrect terminal/hold state.

## UX verification

The production web bundle was previously recorded in Chromium with a clearly labelled deterministic synthetic backend and real timed SSE transport. Desktop/mobile frames cover start/count/phase/wait/terminal behavior, collapsed chronology, browser errors and overflow. This follow-up changes backend delivery/error/bounds semantics but no frontend, payload shape or layout, so the existing v2 demonstration remains representative and was not churned. Component/domain fixtures were rerun in full.

No deployment, production configuration change or merge is included.

## CI gate fixes and validation

The exact failed run `34727103581` was retrieved and reproduced locally.

- Resolved all 11 complexity-ratchet failures through small behavior-preserving helper extractions across runner setup, child/status projection, path-note/compaction accounting, web stats collection/rendering, TUI stream finalization, and subagent progress handling. `make complexity` now passes at 920 production files / 11,329 functions / 468 above threshold. The baseline JSON was not changed and no gate was suppressed.
- Reproduced the four reported iPhone sidebar failures under the same browser lifecycle runner. Those desktop-only fixtures skipped Pixel/mobile but accidentally ran under the iPhone project, where the sidebar is intentionally hidden. Corrected their project scoping rather than increasing timeouts.
- The first full rerun then exposed the tests hidden behind CI's five-minute cutoff: non-standalone iPhone notification fixtures waited on a service worker that product policy intentionally does not register, and pinned-switch fixtures required a persistent desktop sidebar. Scoped those fixtures to their supported projects. iPhone-specific responsive, touch/pinch, lightbox, shell, real-server, passkey, and voice coverage remains active.

Passed on final local source:

- `make complexity`
- Full `scripts/browser_lifecycle_smoke.sh`: **99 passed / 57 intentional project skips**, 1.2 minutes
- Isolated focused cmd regressions covering stats, runner, endpoint, and related lifecycle paths
- `go test ./internal/ui ./internal/tui/chat -count=1`
- Frontend `format`, `format:check`, `lint`, `typecheck`, and full Vitest: **71 files / 902 tests passed**
- Frontend network-policy check
- `make build`
- Isolated `go vet ./...`
- `git diff --check`

Exact-head run `34730025357` passed test (including root/nested tests, vet, complexity and checkptr), passkey-smoke, cross-build, race, and changes. Its frontend job exposed a separate CDP fixture flaw: freezing a same-origin tab can freeze or crash the sender renderer (reproduced as a Chromium SIGSEGV in a 10-run stress test), and the browser step spent ~2m15 on a tagged race preflight before Playwright. The suspended tab now uses a separate browser context (10/10 stress passes), and tagged race coverage moved to the dedicated race job while browser smoke retains a fast non-race preflight. Full local browser lifecycle passes in 1.2m without increasing CI timeouts.

Run `34730589377` passed browser chat smoke and every non-frontend job, then exposed the same absent-service-worker assumption in clean-room extension smoke on iPhone. That fixture now checks for a registration before awaiting readiness; absent workers satisfy the asset-isolation boundary, while full extension behavior still runs on iPhone. Local clean-room extension smoke passes 3/3.

Fresh exact-head CI is running for `644f3932`; no green conclusion is claimed until every required check completes successfully.

Bundle budget remains enforced by the existing Go gzip-level-6 test. No dependency or lazy-loading boundary changed. No deployment, merge, or production configuration change is included.
