### PR TITLE
Use default sampling for Guardian reviews

### DIFF
--- a/internal/guardian/guardian.go
+++ b/internal/guardian/guardian.go
@@ -362,7 +362,8 @@ func (r *Reviewer) turnMessages(policy string, req Request, mode PromptMode) []l
 }
 
 func (r *Reviewer) runReviewRequest(ctx context.Context, messages []llm.Message) (string, llm.Usage, error) {
-	stream, err := r.Provider.Stream(ctx, llm.Request{Model: r.Model, Messages: messages, MaxOutputTokens: 2000, Temperature: 0, TemperatureSet: true})
+	// Use model defaults: some reviewer models reject explicit temperature control.
+	stream, err := r.Provider.Stream(ctx, llm.Request{Model: r.Model, Messages: messages, MaxOutputTokens: 2000})
 	if err != nil {
 		return "", llm.Usage{}, err
 	}

--- a/internal/guardian/guardian_test.go
+++ b/internal/guardian/guardian_test.go
@@ -8,6 +8,31 @@ import (
 	"github.com/samsaffron/term-llm/internal/llm"
 )
 
+func TestReviewerUsesDefaultSampling(t *testing.T) {
+	provider := llm.NewMockProvider("guardian").
+		AddTurn(llm.MockTurn{Text: `{"outcome":"allow"}`}).
+		AddTurn(llm.MockTurn{Text: `{"outcome":"deny","rationale":"not authorized"}`})
+	reviewer := &Reviewer{Provider: provider, Model: "guardian-model", Policy: "policy"}
+
+	for i, wantAllowed := range []bool{true, false} {
+		decision, err := reviewer.Review(context.Background(), Request{Command: "echo ok"})
+		if err != nil {
+			t.Fatalf("Review %d: %v", i, err)
+		}
+		if decision.Allowed() != wantAllowed {
+			t.Fatalf("Review %d allowed = %v, want %v", i, decision.Allowed(), wantAllowed)
+		}
+	}
+	if len(provider.Requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(provider.Requests))
+	}
+	for i, req := range provider.Requests {
+		if req.TemperatureSet || req.Temperature != 0 {
+			t.Errorf("request %d forces temperature; guardian must support models without temperature control", i)
+		}
+	}
+}
+
 func TestReviewerReportsProviderUsage(t *testing.T) {
 	provider := llm.NewMockProvider("guardian").AddTurn(llm.MockTurn{
 		Text:  `{"risk_level":"low","user_authorization":"high","outcome":"allow","rationale":"ok"}`,


### PR DESCRIPTION
Guardian review requests always sent `temperature: 0`, causing models that reject temperature control to fail tool approvals. Use the model's default sampling settings so these reviews can proceed.

Adds a regression test covering initial and follow-up reviews, checking that temperature is omitted and allow/deny decisions are preserved. The test failed before the fix and passes after it.

Validation:
- `gofmt` and `git diff --check` passed.
- `make build` and `go vet ./...` passed.
- `go test ./internal/guardian` passed; the full run also passed `internal/llm` and `internal/tools`.
- `go test ./...` was run with an isolated home and API-key environment. It failed outside the changed package: response timeout (`cmd`), hook timeout (`internal/gitcommit`), tmux capability (`internal/image`), bundle gzip size budget (`internal/serveui`), and ZDOTDIR handling (`internal/tui/chat`). These failures were not fixed in this PR.

Error was using GPT 5.6 sol and luna-max. Nemotron has the same issue if I remember well (not tested with this change).

No errors after this patch.